### PR TITLE
feat: lifecycle hardening — loop guards, lint evaluator, stream types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Context
 
-Acolyte is an AI coding assistant: CLI + HTTP server + native agentic loop. See `docs/architecture.md` for full architecture.
+Acolyte is a language-agnostic, terminal-first AI coding assistant: local-first, observable, and built for extension. See `docs/architecture.md` for full architecture.
 
 Key files:
 - `src/lifecycle.ts` — request lifecycle orchestrator (resolve → prepare → generate → evaluate → finalize)
@@ -22,6 +22,7 @@ Patterns to follow:
 - New post-generation behavior → implement `Evaluator` in `lifecycle-evaluators.ts`, add to `EVALUATORS` array
 - New tool guard → implement `ToolGuard` in `tool-guards.ts`, add to `GUARDS` array
 - New tool → add to the appropriate `*-toolkit.ts` file; all tools go through `runTool` in `tool-execution.ts`
+- Feature branch review → run `/review` skill (runs style, arch, and security audits against branch diff)
 
 Development:
 - Validate: `bun run verify` (format + lint + typecheck + test)

--- a/src/agent-contract.ts
+++ b/src/agent-contract.ts
@@ -20,6 +20,10 @@ export type StreamOptions = {
   temperature?: number;
   /** Max nudge re-prompts when the model stops prematurely. 0 disables. */
   maxNudges?: number;
+  /** Async lint check called after write-tool batches. Returns lint output or null. */
+  lintCheck?: (filePaths: string[]) => Promise<string | null>;
+  /** Set of tool IDs considered write/mutating tools. */
+  writeTools?: ReadonlySet<string>;
 };
 
 export type StreamOutput = {

--- a/src/agent-contract.ts
+++ b/src/agent-contract.ts
@@ -20,10 +20,6 @@ export type StreamOptions = {
   temperature?: number;
   /** Max nudge re-prompts when the model stops prematurely. 0 disables. */
   maxNudges?: number;
-  /** Async lint check called after write-tool batches. Returns lint output or null. */
-  lintCheck?: (filePaths: string[]) => Promise<string | null>;
-  /** Set of tool IDs considered write/mutating tools. */
-  writeTools?: ReadonlySet<string>;
 };
 
 export type StreamOutput = {

--- a/src/agent-instructions.ts
+++ b/src/agent-instructions.ts
@@ -14,7 +14,7 @@ const BASE_INSTRUCTIONS = [
   "Keep responses concise and outcome-first; expand only when asked.",
   "Never summarize, recap, or list what you did. The user can see your actions directly.",
   "Make reasonable assumptions to keep momentum; ask only when blocked by ambiguity or risk.",
-  "When lint or format checks fail, run the project auto-fix command before attempting manual repairs.",
+  "When lint or format checks fail, run the project auto-fix command (if available) before attempting manual repairs.",
   "When finished, state the outcome in one sentence.",
 ];
 

--- a/src/agent-instructions.ts
+++ b/src/agent-instructions.ts
@@ -6,11 +6,15 @@ import { detectLineWidth } from "./tool-utils";
 const BASE_INSTRUCTIONS = [
   "Before taking action (tool call, command, or edit), write exactly one sentence stating what you will do next.",
   "Then execute directly; avoid extra process narration.",
+  "Execute tool calls immediately in the same turn — do not describe what you will do without doing it.",
   "Keep tool calls and file changes within the current workspace and the requested scope.",
   "Prefer dedicated project tools; use shell only when no dedicated tool exists.",
+  "Prefer targeted, surgical edits. Do not rewrite or delete code beyond the scope of the request.",
+  "Never remove or modify existing code that is unrelated to the current task.",
   "Keep responses concise and outcome-first; expand only when asked.",
   "Never summarize, recap, or list what you did. The user can see your actions directly.",
   "Make reasonable assumptions to keep momentum; ask only when blocked by ambiguity or risk.",
+  "When lint or format checks fail, run the project auto-fix command before attempting manual repairs.",
   "When finished, state the outcome in one sentence.",
 ];
 

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -57,9 +57,6 @@ export function createAgentStream(
     let loopIteration = 0;
     let nudgeCount = 0;
     const maxNudges = options.maxNudges ?? 0;
-    const MAX_LINT_REFLECTIONS = 3;
-    let lintReflectionCount = 0;
-
     let streamController!: ReadableStreamDefaultController<StreamChunk>;
     const fullStream = new ReadableStream<StreamChunk>({
       start(controller) {
@@ -219,41 +216,6 @@ export function createAgentStream(
 
         messages.push({ role: "assistant", content: assistantContent });
         messages.push({ role: "tool", content: toolResultParts });
-
-        if (options.lintCheck && !batchHadError && lintReflectionCount < MAX_LINT_REFLECTIONS) {
-          const writtenPaths: string[] = [];
-          for (const tc of pendingToolCalls) {
-            if (options.writeTools?.has(tc.toolName)) {
-              const parsed = safeParseJSON(tc.input);
-              if (typeof parsed.path === "string") writtenPaths.push(parsed.path);
-            }
-          }
-          if (writtenPaths.length > 0) {
-            const lintOutput = await options.lintCheck(writtenPaths);
-            if (lintOutput) {
-              lintReflectionCount++;
-              log.debug("agent-stream.lint-reflection", {
-                files: writtenPaths.length,
-                reflection_count: lintReflectionCount,
-                iteration: loopIteration,
-              });
-              messages.push({
-                role: "user",
-                content: [
-                  {
-                    type: "text",
-                    text: `[system] Lint errors detected in files you just edited:\n${lintOutput}\nRun the project auto-fix command or fix manually before continuing.`,
-                  },
-                ],
-              });
-              streamController.enqueue({
-                type: "lint-reflection",
-                payload: { files: writtenPaths, output: lintOutput },
-              });
-              continue;
-            }
-          }
-        }
 
         if (finishReason?.unified !== "tool-calls" && finishReason !== undefined) {
           if (nudgeCount < maxNudges && batchHadError) {

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -57,6 +57,8 @@ export function createAgentStream(
     let loopIteration = 0;
     let nudgeCount = 0;
     const maxNudges = options.maxNudges ?? 0;
+    const MAX_LINT_REFLECTIONS = 3;
+    let lintReflectionCount = 0;
 
     let streamController!: ReadableStreamDefaultController<StreamChunk>;
     const fullStream = new ReadableStream<StreamChunk>({
@@ -217,6 +219,41 @@ export function createAgentStream(
 
         messages.push({ role: "assistant", content: assistantContent });
         messages.push({ role: "tool", content: toolResultParts });
+
+        if (options.lintCheck && !batchHadError && lintReflectionCount < MAX_LINT_REFLECTIONS) {
+          const writtenPaths: string[] = [];
+          for (const tc of pendingToolCalls) {
+            if (options.writeTools?.has(tc.toolName)) {
+              const parsed = safeParseJSON(tc.input);
+              if (typeof parsed.path === "string") writtenPaths.push(parsed.path);
+            }
+          }
+          if (writtenPaths.length > 0) {
+            const lintOutput = await options.lintCheck(writtenPaths);
+            if (lintOutput) {
+              lintReflectionCount++;
+              log.debug("agent-stream.lint-reflection", {
+                files: writtenPaths.length,
+                reflection_count: lintReflectionCount,
+                iteration: loopIteration,
+              });
+              messages.push({
+                role: "user",
+                content: [
+                  {
+                    type: "text",
+                    text: `[system] Lint errors detected in files you just edited:\n${lintOutput}\nRun the project auto-fix command or fix manually before continuing.`,
+                  },
+                ],
+              });
+              streamController.enqueue({
+                type: "lint-reflection",
+                payload: { files: writtenPaths, output: lintOutput },
+              });
+              continue;
+            }
+          }
+        }
 
         if (finishReason?.unified !== "tool-calls" && finishReason !== undefined) {
           if (nudgeCount < maxNudges && batchHadError) {

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -49,7 +49,6 @@ export type PromptUsage = {
   activeSkillName?: string;
   skillInstructionChars?: number;
 };
-export type StreamChunk = { type?: string; payload?: unknown };
 export type TextDeltaPayload = { text?: string };
 export type ToolCallPayload = { toolCallId?: string; toolName?: string; args?: Record<string, unknown> };
 export type ToolResultPayload = { toolCallId?: string; toolName?: string; result?: unknown };
@@ -65,6 +64,16 @@ export type ModelUsagePayload = {
   inputTokens?: number;
   outputTokens?: number;
 };
+export type LintReflectionPayload = { files: string[]; output: string };
+
+export type StreamChunk =
+  | { type: "text-delta"; payload: TextDeltaPayload }
+  | { type: "reasoning-delta"; payload: TextDeltaPayload }
+  | { type: "tool-call"; payload: ToolCallPayload }
+  | { type: "tool-result"; payload: ToolResultPayload }
+  | { type: "tool-error"; payload: ToolErrorPayload }
+  | { type: "model-usage"; payload: ModelUsagePayload }
+  | { type: "lint-reflection"; payload: LintReflectionPayload };
 export type ModeResolution = { model: string; provider: string };
 export type PhasePrepareInput = {
   request: ChatRequest;

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -64,16 +64,13 @@ export type ModelUsagePayload = {
   inputTokens?: number;
   outputTokens?: number;
 };
-export type LintReflectionPayload = { files: string[]; output: string };
-
 export type StreamChunk =
   | { type: "text-delta"; payload: TextDeltaPayload }
   | { type: "reasoning-delta"; payload: TextDeltaPayload }
   | { type: "tool-call"; payload: ToolCallPayload }
   | { type: "tool-result"; payload: ToolResultPayload }
   | { type: "tool-error"; payload: ToolErrorPayload }
-  | { type: "model-usage"; payload: ModelUsagePayload }
-  | { type: "lint-reflection"; payload: LintReflectionPayload };
+  | { type: "model-usage"; payload: ModelUsagePayload };
 export type ModeResolution = { model: string; provider: string };
 export type PhasePrepareInput = {
   request: ChatRequest;

--- a/src/lifecycle-evaluate.ts
+++ b/src/lifecycle-evaluate.ts
@@ -1,11 +1,11 @@
 import { type RecoveryAction, recoveryActionForError as resolveRecoveryAction } from "./error-handling";
 import { t } from "./i18n";
 import type { LifecycleInput, RunContext, SavedRegenerationState } from "./lifecycle-contract";
-import { type Evaluator, multiMatchEditEvaluator, verifyCycle } from "./lifecycle-evaluators";
+import { type Evaluator, lintEvaluator, multiMatchEditEvaluator, verifyCycle } from "./lifecycle-evaluators";
 import { phaseGenerate, setMode, shouldYieldNow } from "./lifecycle-generate";
 import { defaultLifecyclePolicy, type LifecyclePolicy } from "./lifecycle-policy";
 
-const EVALUATORS: Evaluator[] = [multiMatchEditEvaluator, verifyCycle];
+const EVALUATORS: Evaluator[] = [multiMatchEditEvaluator, lintEvaluator, verifyCycle];
 
 function snapshotState(ctx: RunContext): SavedRegenerationState {
   return {

--- a/src/lifecycle-evaluators.ts
+++ b/src/lifecycle-evaluators.ts
@@ -115,17 +115,22 @@ export const lintEvaluator: Evaluator = {
   id: "lint",
   evaluate(ctx) {
     if (ctx.mode !== "work" || !ctx.workspace) return { type: "done" };
+    if (!ctx.policy.lintCommand) return { type: "done" };
     const paths = writePathsForCurrentTask(ctx);
     if (paths.length === 0) return { type: "done" };
-    const result = lintFiles(ctx.workspace, paths);
+    const result = lintFiles(ctx.workspace, paths, ctx.policy.lintCommand);
     if (!result.hasErrors) return { type: "done" };
     ctx.debug("lifecycle.eval.lint", { files: paths.length });
     return {
       type: "regenerate",
-      prompt:
-        `${ctx.agentInput}\n\n` +
-        `Lint errors detected in files you edited:\n${result.output}\n\n` +
+      prompt: [
+        ctx.agentInput,
+        "",
+        "Lint errors detected in files you edited:",
+        result.output,
+        "",
         "If the project has an auto-fix command, run it first. Otherwise fix the errors manually, then stop.",
+      ].join("\n"),
     };
   },
 };

--- a/src/lifecycle-evaluators.ts
+++ b/src/lifecycle-evaluators.ts
@@ -8,6 +8,7 @@ import {
   taskScopedCallLog,
 } from "./lifecycle-contract";
 import type { LifecyclePolicy } from "./lifecycle-policy";
+import { lintFiles } from "./lint-reflection";
 import { extractReadPaths } from "./tool-arg-paths";
 import type { SessionContext } from "./tool-guards";
 import { WRITE_TOOL_SET, WRITE_TOOLS } from "./tool-registry";
@@ -109,6 +110,25 @@ function scopedVerifyPrompt(ctx: EvaluatorContext): string {
     "Do not review unrelated repository changes from earlier tasks.",
   ].join("\n");
 }
+
+export const lintEvaluator: Evaluator = {
+  id: "lint",
+  evaluate(ctx) {
+    if (ctx.mode !== "work" || !ctx.workspace) return { type: "done" };
+    const paths = writePathsForCurrentTask(ctx);
+    if (paths.length === 0) return { type: "done" };
+    const result = lintFiles(ctx.workspace, paths);
+    if (!result.hasErrors) return { type: "done" };
+    ctx.debug("lifecycle.eval.lint", { files: paths.length });
+    return {
+      type: "regenerate",
+      prompt:
+        `${ctx.agentInput}\n\n` +
+        `Lint errors detected in files you edited:\n${result.output}\n\n` +
+        "If the project has an auto-fix command, run it first. Otherwise fix the errors manually, then stop.",
+    };
+  },
+};
 
 export const verifyCycle: Evaluator = {
   id: "verify-cycle",

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -16,7 +16,6 @@ import {
 } from "./error-handling";
 import type { GenerateOptions, GenerateResult, RunContext, StreamChunk } from "./lifecycle-contract";
 import { resolveModeModel } from "./lifecycle-resolve";
-import { lintFiles } from "./lint-reflection";
 import type { StreamError } from "./stream-error";
 import type { ToolDefinition } from "./tool-contract";
 import { extractToolErrorCode, LIFECYCLE_ERROR_CODES } from "./tool-error-codes";
@@ -209,20 +208,6 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
       toolChoice: "auto",
       ...(typeof temperature === "number" ? { temperature } : {}),
       maxNudges: ctx.policy.maxNudgesPerGeneration,
-      writeTools: ctx.session.writeTools,
-      lintCheck:
-        ctx.workspace && ctx.mode === "work"
-          ? async (paths) => {
-              const workspace = ctx.workspace;
-              if (!workspace) return null;
-              const result = lintFiles(workspace, paths);
-              if (result.hasErrors) {
-                ctx.debug("lifecycle.lint.reflection", { files: paths.length });
-                return result.output;
-              }
-              return null;
-            }
-          : undefined,
     });
     const reader = streamOutput.fullStream.getReader();
     while (true) {
@@ -397,7 +382,5 @@ function processStreamChunk(ctx: RunContext, chunk: StreamChunk): void {
       });
       break;
     }
-    case "lint-reflection":
-      break;
   }
 }

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -14,17 +14,7 @@ import {
   isEditFileMultiMatchSignal,
   parseErrorInfo,
 } from "./error-handling";
-import type {
-  GenerateOptions,
-  GenerateResult,
-  ModelUsagePayload,
-  RunContext,
-  StreamChunk,
-  TextDeltaPayload,
-  ToolCallPayload,
-  ToolErrorPayload,
-  ToolResultPayload,
-} from "./lifecycle-contract";
+import type { GenerateOptions, GenerateResult, RunContext, StreamChunk } from "./lifecycle-contract";
 import { resolveModeModel } from "./lifecycle-resolve";
 import { lintFiles } from "./lint-reflection";
 import type { StreamError } from "./stream-error";
@@ -244,17 +234,16 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
         }),
       ]);
       if (result.done) break;
-      if (!result.value || typeof result.value !== "object") continue;
-      const typed = result.value as { type?: string; payload?: unknown };
+      const chunk = result.value;
       resetTimeout();
-      if (typed.type === "tool-error") {
-        const p = typed.payload as ToolErrorPayload | undefined;
+      if (chunk.type === "tool-error") {
+        const p = chunk.payload;
         if (!p?.toolName && !p?.toolCallId) {
           const parsed = parseErrorInfo(p?.error ?? p?.message);
           throw new Error(parsed.ok ? parsed.value.message : "Model stream error");
         }
       }
-      processStreamChunk(ctx, typed);
+      processStreamChunk(ctx, chunk);
     }
     return (await streamOutput.getFullOutput()) as GenerateResult;
   } finally {
@@ -314,7 +303,7 @@ function emitStreamingUsage(ctx: RunContext, chars: number): void {
 function processStreamChunk(ctx: RunContext, chunk: StreamChunk): void {
   switch (chunk.type) {
     case "text-delta": {
-      const p = chunk.payload as TextDeltaPayload | undefined;
+      const p = chunk.payload;
       if (typeof p?.text === "string" && p.text.length > 0) {
         if (ctx.mode !== "verify") ctx.emit({ type: "text-delta", text: p.text });
         emitStreamingUsage(ctx, p.text.length);
@@ -322,7 +311,7 @@ function processStreamChunk(ctx: RunContext, chunk: StreamChunk): void {
       break;
     }
     case "reasoning-delta": {
-      const p = chunk.payload as TextDeltaPayload | undefined;
+      const p = chunk.payload;
       if (typeof p?.text === "string" && p.text.length > 0) {
         ctx.emit({ type: "reasoning", text: p.text });
         emitStreamingUsage(ctx, p.text.length);
@@ -330,7 +319,7 @@ function processStreamChunk(ctx: RunContext, chunk: StreamChunk): void {
       break;
     }
     case "tool-call": {
-      const p = chunk.payload as ToolCallPayload | undefined;
+      const p = chunk.payload;
       if (p?.toolCallId && p?.toolName) {
         const toolName = p.toolName;
         ctx.observedTools.add(toolName);
@@ -350,7 +339,7 @@ function processStreamChunk(ctx: RunContext, chunk: StreamChunk): void {
       break;
     }
     case "tool-result": {
-      const p = chunk.payload as ToolResultPayload | undefined;
+      const p = chunk.payload;
       if (p?.toolCallId && p?.toolName) {
         const toolName = p.toolName;
         completeToolCall(ctx, p.toolCallId, toolName);
@@ -376,7 +365,7 @@ function processStreamChunk(ctx: RunContext, chunk: StreamChunk): void {
       break;
     }
     case "tool-error": {
-      const p = chunk.payload as ToolErrorPayload | undefined;
+      const p = chunk.payload;
       const raw = p?.error ?? p?.message;
       const parsed = parseErrorInfo(raw);
       const errorInfo = parsed.ok ? parsed.value : { message: "Tool error" };
@@ -397,7 +386,7 @@ function processStreamChunk(ctx: RunContext, chunk: StreamChunk): void {
       break;
     }
     case "model-usage": {
-      const p = chunk.payload as ModelUsagePayload | undefined;
+      const p = chunk.payload;
       if (typeof p?.inputTokens === "number") ctx.promptTokensAccum += p.inputTokens;
       if (typeof p?.outputTokens === "number") ctx.completionTokensAccum += p.outputTokens;
       ctx.modelCallCount += 1;
@@ -408,5 +397,7 @@ function processStreamChunk(ctx: RunContext, chunk: StreamChunk): void {
       });
       break;
     }
+    case "lint-reflection":
+      break;
   }
 }

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -26,6 +26,7 @@ import type {
   ToolResultPayload,
 } from "./lifecycle-contract";
 import { resolveModeModel } from "./lifecycle-resolve";
+import { lintFiles } from "./lint-reflection";
 import type { StreamError } from "./stream-error";
 import type { ToolDefinition } from "./tool-contract";
 import { extractToolErrorCode, LIFECYCLE_ERROR_CODES } from "./tool-error-codes";
@@ -218,6 +219,20 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
       toolChoice: "auto",
       ...(typeof temperature === "number" ? { temperature } : {}),
       maxNudges: ctx.policy.maxNudgesPerGeneration,
+      writeTools: ctx.session.writeTools,
+      lintCheck:
+        ctx.workspace && ctx.mode === "work"
+          ? async (paths) => {
+              const workspace = ctx.workspace;
+              if (!workspace) return null;
+              const result = lintFiles(workspace, paths);
+              if (result.hasErrors) {
+                ctx.debug("lifecycle.lint.reflection", { files: paths.length });
+                return result.output;
+              }
+              return null;
+            }
+          : undefined,
     });
     const reader = streamOutput.fullStream.getReader();
     while (true) {

--- a/src/lifecycle-policy.ts
+++ b/src/lifecycle-policy.ts
@@ -7,6 +7,7 @@ import {
   TOTAL_MAX_STEPS,
   VERIFY_MAX_STEPS,
 } from "./lifecycle-constants";
+import type { LintCommand } from "./lint-reflection";
 
 export type LifecyclePolicy = {
   totalMaxSteps: number;
@@ -16,6 +17,8 @@ export type LifecyclePolicy = {
   maxUnknownErrorsPerRequest: number;
   maxRegenerationsPerRequest: number;
   maxNudgesPerGeneration: number;
+  /** Lint command to run after writes. Undefined disables lint evaluation. */
+  lintCommand?: LintCommand;
 };
 
 export const defaultLifecyclePolicy: LifecyclePolicy = {

--- a/src/lint-reflection.test.ts
+++ b/src/lint-reflection.test.ts
@@ -1,20 +1,22 @@
 import { describe, expect, test } from "bun:test";
-import { lintFiles } from "./lint-reflection";
+import { type LintCommand, lintFiles } from "./lint-reflection";
+
+const BIOME: LintCommand = { bin: "bunx", args: ["biome", "check"] };
 
 describe("lintFiles", () => {
   test("returns no errors for empty file list", () => {
-    const result = lintFiles("/tmp", []);
+    const result = lintFiles("/tmp", [], BIOME);
     expect(result.hasErrors).toBe(false);
     expect(result.output).toBe("");
   });
 
   test("returns no errors for a clean file", () => {
-    const result = lintFiles(import.meta.dir, ["lint-reflection.ts"]);
+    const result = lintFiles(import.meta.dir, ["lint-reflection.ts"], BIOME);
     expect(result.hasErrors).toBe(false);
   });
 
   test("treats errors on missing files as lint errors", () => {
-    const result = lintFiles(import.meta.dir, ["nonexistent-file.ts"]);
+    const result = lintFiles(import.meta.dir, ["nonexistent-file.ts"], BIOME);
     // biome exits non-zero for missing files — that's a valid lint error
     expect(result.hasErrors).toBe(true);
   });

--- a/src/lint-reflection.test.ts
+++ b/src/lint-reflection.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { lintFiles } from "./lint-reflection";
+
+describe("lintFiles", () => {
+  test("returns no errors for empty file list", () => {
+    const result = lintFiles("/tmp", []);
+    expect(result.hasErrors).toBe(false);
+    expect(result.output).toBe("");
+  });
+
+  test("returns no errors for a clean file", () => {
+    const result = lintFiles(import.meta.dir, ["lint-reflection.ts"]);
+    expect(result.hasErrors).toBe(false);
+  });
+
+  test("treats errors on missing files as lint errors", () => {
+    const result = lintFiles(import.meta.dir, ["nonexistent-file.ts"]);
+    // biome exits non-zero for missing files — that's a valid lint error
+    expect(result.hasErrors).toBe(true);
+  });
+});

--- a/src/lint-reflection.ts
+++ b/src/lint-reflection.ts
@@ -1,0 +1,25 @@
+import { execSync } from "node:child_process";
+
+export type LintResult = { hasErrors: boolean; output: string };
+
+export function lintFiles(workspace: string, filePaths: string[]): LintResult {
+  if (filePaths.length === 0) return { hasErrors: false, output: "" };
+  try {
+    const quoted = filePaths.map((f) => `"${f.replace(/"/g, '\\"')}"`).join(" ");
+    execSync(`bunx biome check ${quoted}`, {
+      cwd: workspace,
+      timeout: 10_000,
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return { hasErrors: false, output: "" };
+  } catch (error) {
+    const stderr = error instanceof Error && "stderr" in error ? String((error as { stderr: unknown }).stderr) : "";
+    if (stderr.includes("not found") || stderr.includes("ENOENT")) {
+      return { hasErrors: false, output: "" };
+    }
+    const stdout =
+      error instanceof Error && "stdout" in error ? String((error as { stdout: unknown }).stdout) : String(error);
+    return { hasErrors: true, output: stdout.trim() };
+  }
+}

--- a/src/lint-reflection.ts
+++ b/src/lint-reflection.ts
@@ -1,12 +1,16 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 export type LintResult = { hasErrors: boolean; output: string };
 
-export function lintFiles(workspace: string, filePaths: string[]): LintResult {
+export type LintCommand = { bin: string; args: readonly string[] };
+
+const DEFAULT_LINT_COMMAND: LintCommand = { bin: "bunx", args: ["biome", "check"] };
+
+export function lintFiles(workspace: string, filePaths: string[], command?: LintCommand): LintResult {
   if (filePaths.length === 0) return { hasErrors: false, output: "" };
+  const { bin, args } = command ?? DEFAULT_LINT_COMMAND;
   try {
-    const quoted = filePaths.map((f) => `"${f.replace(/"/g, '\\"')}"`).join(" ");
-    execSync(`bunx biome check ${quoted}`, {
+    execFileSync(bin, [...args, ...filePaths], {
       cwd: workspace,
       timeout: 10_000,
       encoding: "utf-8",

--- a/src/lint-reflection.ts
+++ b/src/lint-reflection.ts
@@ -2,28 +2,29 @@ import { execFileSync } from "node:child_process";
 
 export type LintResult = { hasErrors: boolean; output: string };
 
-export type LintCommand = { bin: string; args: readonly string[] };
+export type LintCommand = { readonly bin: string; readonly args: readonly string[] };
 
-const DEFAULT_LINT_COMMAND: LintCommand = { bin: "bunx", args: ["biome", "check"] };
+const DEFAULT_LINT_COMMAND: LintCommand = { bin: "bunx", args: ["biome", "check"] } as const;
 
 export function lintFiles(workspace: string, filePaths: string[], command?: LintCommand): LintResult {
   if (filePaths.length === 0) return { hasErrors: false, output: "" };
   const { bin, args } = command ?? DEFAULT_LINT_COMMAND;
   try {
-    execFileSync(bin, [...args, ...filePaths], {
+    execFileSync(bin, [...args, "--", ...filePaths], {
       cwd: workspace,
       timeout: 10_000,
+      maxBuffer: 1024 * 1024,
       encoding: "utf-8",
       stdio: ["pipe", "pipe", "pipe"],
     });
     return { hasErrors: false, output: "" };
   } catch (error) {
-    const stderr = error instanceof Error && "stderr" in error ? String((error as { stderr: unknown }).stderr) : "";
+    const stderr = typeof error === "object" && error !== null && "stderr" in error ? String(error.stderr) : "";
     if (stderr.includes("not found") || stderr.includes("ENOENT")) {
       return { hasErrors: false, output: "" };
     }
     const stdout =
-      error instanceof Error && "stdout" in error ? String((error as { stdout: unknown }).stdout) : String(error);
+      typeof error === "object" && error !== null && "stdout" in error ? String(error.stdout) : String(error);
     return { hasErrors: true, output: stdout.trim() };
   }
 }

--- a/src/lint-reflection.ts
+++ b/src/lint-reflection.ts
@@ -4,11 +4,9 @@ export type LintResult = { hasErrors: boolean; output: string };
 
 export type LintCommand = { readonly bin: string; readonly args: readonly string[] };
 
-const DEFAULT_LINT_COMMAND: LintCommand = { bin: "bunx", args: ["biome", "check"] } as const;
-
-export function lintFiles(workspace: string, filePaths: string[], command?: LintCommand): LintResult {
+export function lintFiles(workspace: string, filePaths: string[], command: LintCommand): LintResult {
   if (filePaths.length === 0) return { hasErrors: false, output: "" };
-  const { bin, args } = command ?? DEFAULT_LINT_COMMAND;
+  const { bin, args } = command;
   try {
     execFileSync(bin, [...args, "--", ...filePaths], {
       cwd: workspace,

--- a/src/resource-id.ts
+++ b/src/resource-id.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import { homedir } from "node:os";
 import { resolve as resolvePath } from "node:path";
 import { z } from "zod";
@@ -20,7 +19,9 @@ export function parseResourceId(value: string | undefined): ResourceId | undefin
 }
 
 function hashValue(value: string): string {
-  return createHash("sha1").update(value).digest("hex").slice(0, 12);
+  const hasher = new Bun.CryptoHasher("sha1");
+  hasher.update(value);
+  return hasher.digest("hex").slice(0, 12);
 }
 
 export function projectResourceIdFromWorkspace(workspace: string): ProjectResourceId {

--- a/src/tool-execution.ts
+++ b/src/tool-execution.ts
@@ -1,6 +1,6 @@
 import { createId } from "./short-id";
 import { ERROR_KINDS, LIFECYCLE_ERROR_CODES } from "./tool-error-codes";
-import { recordCall, runGuards, type SessionContext } from "./tool-guards";
+import { hashResultValue, recordCall, runGuards, type SessionContext } from "./tool-guards";
 export function streamCallId(toolName: string): string {
   return `${toolName}_${createId()}`;
 }
@@ -60,25 +60,26 @@ export async function guardedExecute<T>(
     const cached = cache.get(toolId, argsRecord);
     if (cached) {
       session.onDebug?.("lifecycle.tool.cache", { tool: toolId, hit: true, ...cache.stats() });
-      recordCall(session, toolId, argsRecord);
+      recordCall(session, toolId, argsRecord, hashResultValue(cached.result));
       return cached.result as T;
     }
     session.onDebug?.("lifecycle.tool.cache", { tool: toolId, hit: false, ...cache.stats() });
   }
 
   let taskFailed = false;
+  let taskResult: unknown;
   try {
-    const result = await task();
+    taskResult = await task();
     if (cache?.isCacheable(toolId)) {
-      cache.set(toolId, argsRecord, { result });
-      cache.populateSubEntries(toolId, argsRecord, result);
+      cache.set(toolId, argsRecord, { result: taskResult });
+      cache.populateSubEntries(toolId, argsRecord, taskResult);
     }
-    return result;
+    return taskResult as T;
   } catch (error) {
     taskFailed = true;
     throw error;
   } finally {
-    recordCall(session, toolId, argsRecord);
+    recordCall(session, toolId, argsRecord, taskFailed ? undefined : hashResultValue(taskResult));
     if (cache && !cache.isCacheable(toolId) && !taskFailed) {
       cache.invalidateForWrite(toolId, argsRecord);
     }

--- a/src/tool-execution.ts
+++ b/src/tool-execution.ts
@@ -1,6 +1,15 @@
 import { createId } from "./short-id";
 import { ERROR_KINDS, LIFECYCLE_ERROR_CODES } from "./tool-error-codes";
-import { hashResultValue, recordCall, runGuards, type SessionContext } from "./tool-guards";
+import { recordCall, runGuards, type SessionContext } from "./tool-guards";
+
+export function hashResultValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const str = typeof value === "string" ? value : JSON.stringify(value);
+  if (str.length > 10_000) return undefined;
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(str);
+  return hasher.digest("hex").slice(0, 16);
+}
 export function streamCallId(toolName: string): string {
   return `${toolName}_${createId()}`;
 }

--- a/src/tool-guards.test.ts
+++ b/src/tool-guards.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { createSessionContext, hashResultValue, recordCall, resetCycleStepCount, runGuards } from "./tool-guards";
+import { hashResultValue } from "./tool-execution";
+import { createSessionContext, recordCall, resetCycleStepCount, runGuards } from "./tool-guards";
 
 describe("guard events", () => {
   test("emits GuardEvent payload when a guard blocks", () => {

--- a/src/tool-guards.test.ts
+++ b/src/tool-guards.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { createSessionContext, recordCall, resetCycleStepCount, runGuards } from "./tool-guards";
+import { createSessionContext, hashResultValue, recordCall, resetCycleStepCount, runGuards } from "./tool-guards";
 
 describe("guard events", () => {
   test("emits GuardEvent payload when a guard blocks", () => {
@@ -368,5 +368,131 @@ describe("duplicate-call guard", () => {
     recordCall(session, "git-status", {});
     session.taskId = "task_b";
     expect(() => runGuards({ toolName: "git-status", args: {}, session })).not.toThrow();
+  });
+});
+
+describe("ping-pong guard", () => {
+  test("blocks alternating tool calls with same args", () => {
+    const session = createSessionContext();
+    session.writeTools = new Set(["edit-file"]);
+    // A -> edit -> B -> A -> edit -> B -> (attempting A again)
+    // The ping-pong guard sees the A/B alternation pattern
+    recordCall(session, "read-file", { paths: [{ path: "a.ts" }] });
+    recordCall(session, "edit-file", { path: "x.ts" });
+    recordCall(session, "search-files", { patterns: ["foo"] });
+    recordCall(session, "read-file", { paths: [{ path: "a.ts" }] });
+    recordCall(session, "edit-file", { path: "y.ts" });
+    recordCall(session, "search-files", { patterns: ["foo"] });
+    expect(() => runGuards({ toolName: "read-file", args: { paths: [{ path: "a.ts" }] }, session })).toThrow(
+      /Ping-pong loop detected/,
+    );
+  });
+
+  test("does not block when args differ", () => {
+    const session = createSessionContext();
+    session.writeTools = new Set(["edit-file"]);
+    recordCall(session, "read-file", { paths: [{ path: "a.ts" }] });
+    recordCall(session, "edit-file", { path: "x.ts" });
+    recordCall(session, "search-files", { patterns: ["foo"] });
+    recordCall(session, "read-file", { paths: [{ path: "b.ts" }] });
+    recordCall(session, "edit-file", { path: "y.ts" });
+    recordCall(session, "search-files", { patterns: ["foo"] });
+    expect(() => runGuards({ toolName: "read-file", args: { paths: [{ path: "a.ts" }] }, session })).not.toThrow();
+  });
+
+  test("does not block with fewer than 2 alternations", () => {
+    const session = createSessionContext();
+    session.writeTools = new Set(["edit-file"]);
+    // Only 1 alternation: A -> B -> (attempting A) — not enough
+    recordCall(session, "search-files", { patterns: ["foo"] });
+    recordCall(session, "edit-file", { path: "a.ts" });
+    recordCall(session, "find-files", { patterns: ["bar"] });
+    expect(() => runGuards({ toolName: "search-files", args: { patterns: ["foo"] }, session })).not.toThrow();
+  });
+
+  test("does not trigger when last call is same tool (not alternating)", () => {
+    const session = createSessionContext();
+    session.writeTools = new Set(["edit-file"]);
+    // Last call is find-files, proposed is also find-files — same tool, not alternating
+    recordCall(session, "search-files", { patterns: ["foo"] });
+    recordCall(session, "edit-file", { path: "a.ts" });
+    recordCall(session, "find-files", { patterns: ["bar"] });
+    recordCall(session, "edit-file", { path: "b.ts" });
+    recordCall(session, "find-files", { patterns: ["baz"] });
+    expect(() => runGuards({ toolName: "find-files", args: { patterns: ["qux"] }, session })).not.toThrow();
+  });
+});
+
+describe("stale-result guard", () => {
+  test("blocks when same tool+args returns same result 3 times", () => {
+    const session = createSessionContext();
+    session.writeTools = new Set(["edit-file"]);
+    const args = { patterns: ["foo"] };
+    const hash = hashResultValue({ matches: ["a.ts:1"] });
+    // Interleave unique write calls to avoid duplicate-call and ping-pong guards
+    recordCall(session, "search-files", args, hash);
+    recordCall(session, "edit-file", { path: "a.ts" });
+    recordCall(session, "search-files", args, hash);
+    recordCall(session, "edit-file", { path: "b.ts" });
+    recordCall(session, "search-files", args, hash);
+    recordCall(session, "edit-file", { path: "c.ts" });
+    expect(() => runGuards({ toolName: "search-files", args, session })).toThrow(
+      /has returned the same result 3 times/,
+    );
+  });
+
+  test("does not block when results differ", () => {
+    const session = createSessionContext();
+    session.writeTools = new Set(["edit-file"]);
+    const args = { patterns: ["foo"] };
+    recordCall(session, "search-files", args, hashResultValue({ matches: ["a.ts:1"] }));
+    recordCall(session, "edit-file", { path: "a.ts" });
+    recordCall(session, "search-files", args, hashResultValue({ matches: ["b.ts:2"] }));
+    recordCall(session, "edit-file", { path: "b.ts" });
+    recordCall(session, "search-files", args, hashResultValue({ matches: ["a.ts:1"] }));
+    recordCall(session, "edit-file", { path: "c.ts" });
+    expect(() => runGuards({ toolName: "search-files", args, session })).not.toThrow();
+  });
+
+  test("does not block write tools", () => {
+    const session = createSessionContext();
+    session.writeTools = new Set(["edit-file"]);
+    const hash = hashResultValue("ok");
+    // Different args for each call to avoid duplicate-call guard
+    recordCall(session, "edit-file", { path: "a.ts" }, hash);
+    recordCall(session, "edit-file", { path: "b.ts" }, hash);
+    recordCall(session, "edit-file", { path: "c.ts" }, hash);
+    expect(() => runGuards({ toolName: "edit-file", args: { path: "d.ts" }, session })).not.toThrow();
+  });
+
+  test("does not block when fewer than threshold", () => {
+    const session = createSessionContext();
+    session.writeTools = new Set(["edit-file"]);
+    const args = { patterns: ["foo"] };
+    const hash = hashResultValue({ matches: ["a.ts:1"] });
+    recordCall(session, "search-files", args, hash);
+    recordCall(session, "edit-file", { path: "a.ts" });
+    recordCall(session, "search-files", args, hash);
+    recordCall(session, "edit-file", { path: "b.ts" });
+    expect(() => runGuards({ toolName: "search-files", args, session })).not.toThrow();
+  });
+});
+
+describe("hashResultValue", () => {
+  test("returns consistent hash for same input", () => {
+    expect(hashResultValue({ a: 1 })).toBe(hashResultValue({ a: 1 }));
+  });
+
+  test("returns different hash for different input", () => {
+    expect(hashResultValue({ a: 1 })).not.toBe(hashResultValue({ a: 2 }));
+  });
+
+  test("returns undefined for null/undefined", () => {
+    expect(hashResultValue(null)).toBeUndefined();
+    expect(hashResultValue(undefined)).toBeUndefined();
+  });
+
+  test("returns undefined for very large values", () => {
+    expect(hashResultValue("x".repeat(11_000))).toBeUndefined();
   });
 });

--- a/src/tool-guards.ts
+++ b/src/tool-guards.ts
@@ -486,12 +486,3 @@ export function recordCall(
 ): void {
   session.callLog.push({ toolName, args, taskId: session.taskId, mode: session.mode, resultHash });
 }
-
-export function hashResultValue(value: unknown): string | undefined {
-  if (value === undefined || value === null) return undefined;
-  const str = typeof value === "string" ? value : JSON.stringify(value);
-  if (str.length > 10_000) return undefined;
-  const hasher = new Bun.CryptoHasher("sha256");
-  hasher.update(str);
-  return hasher.digest("hex").slice(0, 16);
-}

--- a/src/tool-guards.ts
+++ b/src/tool-guards.ts
@@ -13,7 +13,13 @@ const DEFAULT_TOTAL_STEP_LIMIT = 200;
 
 export type GuardEvent = { guardId: string; toolName: string; action: "blocked" | "flag_set"; detail?: string };
 
-export type ToolCallRecord = { toolName: string; args: Record<string, unknown>; taskId?: string; mode?: string };
+export type ToolCallRecord = {
+  toolName: string;
+  args: Record<string, unknown>;
+  taskId?: string;
+  mode?: string;
+  resultHash?: string;
+};
 
 export type SessionFlags = {
   cycleStepCount?: number;
@@ -373,9 +379,88 @@ export function resetCycleStepCount(session: SessionContext, limit?: number): vo
   if (limit !== undefined) session.flags.cycleStepLimit = limit;
 }
 
+const PING_PONG_WINDOW = 8;
+const PING_PONG_MIN_ALTERNATIONS = 2;
+
+const pingPongGuard: ToolGuard = {
+  id: "ping-pong",
+  description: "Block alternating tool call patterns that indicate the model is stuck.",
+  check({ toolName, args, session, report }) {
+    const calls = scopedCallLog(session);
+    // Filter to non-write-tool calls only — write tools are expected between read ops
+    const readCalls = calls.filter((c) => !isWriteTool(session, c.toolName));
+    if (readCalls.length < 3) return;
+
+    const window = readCalls.slice(-(PING_PONG_WINDOW - 1));
+    const lastCall = window[window.length - 1];
+    if (!lastCall || lastCall.toolName === toolName) return;
+
+    const otherTool = lastCall.toolName;
+    const otherArgs = lastCall.args;
+    let alternations = 0;
+
+    for (let i = window.length - 1; i >= 1; i -= 2) {
+      const expectOther = window[i];
+      const expectCurrent = window[i - 1];
+      if (!expectOther || expectOther.toolName !== otherTool || !guardArgsEqual(expectOther.args, otherArgs)) break;
+      if (!expectCurrent || expectCurrent.toolName !== toolName || !guardArgsEqual(expectCurrent.args, args)) break;
+      alternations++;
+    }
+
+    if (alternations >= PING_PONG_MIN_ALTERNATIONS) {
+      report("blocked", `${toolName}<->${otherTool}`);
+      throw new Error(
+        `Ping-pong loop detected: alternating between ${toolName} and ${otherTool} with unchanged arguments. ` +
+          "Break the cycle by trying a different approach or different arguments.",
+      );
+    }
+  },
+};
+
+const STALE_RESULT_THRESHOLD = 3;
+
+const staleResultGuard: ToolGuard = {
+  id: "stale-result",
+  description: "Block tool calls that repeatedly return the same result, indicating no progress.",
+  check({ toolName, args, session, report }) {
+    if (isWriteTool(session, toolName)) return;
+
+    const calls = scopedCallLog(session);
+    let sameResultStreak = 0;
+    let lastHash: string | undefined;
+
+    for (let i = calls.length - 1; i >= 0; i--) {
+      const entry = calls[i];
+      if (!entry) break;
+      if (entry.toolName !== toolName) continue;
+      if (!guardArgsEqual(entry.args, args)) break;
+      if (!entry.resultHash) break;
+
+      if (lastHash === undefined) {
+        lastHash = entry.resultHash;
+        sameResultStreak = 1;
+      } else if (entry.resultHash === lastHash) {
+        sameResultStreak++;
+      } else {
+        break;
+      }
+    }
+
+    if (sameResultStreak >= STALE_RESULT_THRESHOLD) {
+      report("blocked", `${toolName}:${sameResultStreak}-same-results`);
+      throw new Error(
+        `${toolName} has returned the same result ${sameResultStreak} times with these arguments. ` +
+          "The state has not changed. Try a different approach or different arguments.",
+      );
+    }
+  },
+};
+
 const GUARDS: ToolGuard[] = [
   stepBudgetGuard,
   duplicateCallGuard,
+  pingPongGuard,
+  staleResultGuard,
   fileChurnGuard,
   redundantFindGuard,
   redundantSearchGuard,
@@ -392,6 +477,22 @@ export function runGuards(input: Omit<GuardInput, "report">): void {
   }
 }
 
-export function recordCall(session: SessionContext, toolName: string, args: Record<string, unknown>): void {
-  session.callLog.push({ toolName, args, taskId: session.taskId, mode: session.mode });
+export function recordCall(
+  session: SessionContext,
+  toolName: string,
+  args: Record<string, unknown>,
+  resultHash?: string,
+): void {
+  session.callLog.push({ toolName, args, taskId: session.taskId, mode: session.mode, resultHash });
+}
+
+export function hashResultValue(value: unknown): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  const str = typeof value === "string" ? value : JSON.stringify(value);
+  if (str.length > 10_000) return undefined;
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return String(hash);
 }

--- a/src/tool-guards.ts
+++ b/src/tool-guards.ts
@@ -434,7 +434,8 @@ const staleResultGuard: ToolGuard = {
       if (!entry) break;
       if (entry.toolName !== toolName) continue;
       if (!guardArgsEqual(entry.args, args)) break;
-      if (!entry.resultHash) break;
+      // Skip entries with no hash (result too large or unavailable) — can't compare
+      if (!entry.resultHash) continue;
 
       if (lastHash === undefined) {
         lastHash = entry.resultHash;
@@ -490,9 +491,7 @@ export function hashResultValue(value: unknown): string | undefined {
   if (value === undefined || value === null) return undefined;
   const str = typeof value === "string" ? value : JSON.stringify(value);
   if (str.length > 10_000) return undefined;
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
-  }
-  return String(hash);
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(str);
+  return hasher.digest("hex").slice(0, 16);
 }


### PR DESCRIPTION
## Summary
- Add ping-pong and stale-result guards to detect and break stuck tool-call loops
- Add lint evaluator that catches lint errors after writes, before the verify cycle
- Replace loose `StreamChunk` type with a discriminated union for type-safe stream processing
- Strengthen base agent instructions (immediate execution, surgical edits, auto-fix preference)
- Migrate `resource-id.ts` from `node:crypto` to `Bun.CryptoHasher` for consistency
- Update AGENTS.md: language-agnostic description, `/review` skill reference