### PR TITLE
feat(tui): custom React terminal renderer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ Development:
 ## Safety
 
 - Never run destructive git/file operations unless explicitly requested.
+- Use `--force-with-lease` instead of `--force` when force-pushing.
 - Do not discard unrelated changes without approval.
 - If unexpected changes appear, pause and confirm before continuing.
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,9 +13,8 @@
         "@ast-grep/lang-python": "^0.0.5",
         "@ast-grep/lang-rust": "^0.0.6",
         "@ast-grep/napi": "^0.41.0",
-        "ink": "^6.8.0",
-        "ink-text-input": "^6.0.0",
         "react": "^19.2.4",
+        "react-reconciler": "^0.33.0",
         "tiktoken": "^1.0.22",
         "zod": "^4.3.6",
       },
@@ -39,8 +38,6 @@
     "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
 
     "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.19", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg=="],
-
-    "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.2.5", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-3NX/MpTdroi0aKz134A6RC2Gb2iXVECN4QaAXnvCIxxIm3C3AVB1mkUe8NaaiyvOpDfsrqWhYtj+Q6a62RrTsw=="],
 
     "@ast-grep/lang-go": ["@ast-grep/lang-go@0.0.5", "", { "dependencies": { "@ast-grep/setup-lang": "0.0.6" }, "peerDependencies": { "tree-sitter-cli": "0.25.8" }, "optionalPeers": ["tree-sitter-cli"] }, "sha512-rPrTHtT2wDmyAi8tXe3xb3T94GrdXUwynt97l2AIULviQjEjzrewscUO3n0WkwQBuiKU78CDx+27PsmsykUlPQ=="],
 
@@ -98,104 +95,26 @@
 
     "@types/react-reconciler": ["@types/react-reconciler@0.33.0", "", { "peerDependencies": { "@types/react": "*" } }, "sha512-HZOXsKT0tGI9LlUw2LuedXsVeB88wFa536vVL0M6vE8zN63nI+sSr1ByxmPToP5K5bukaVscyeCJcF9guVNJ1g=="],
 
-    "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
-
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
-
-    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
-
-    "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
-
     "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
-
-    "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
-
-    "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
-
-    "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
-
-    "cli-truncate": ["cli-truncate@5.1.1", "", { "dependencies": { "slice-ansi": "^7.1.0", "string-width": "^8.0.0" } }, "sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A=="],
-
-    "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
-
-    "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
-    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
-    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
-
-    "es-toolkit": ["es-toolkit@1.44.0", "", {}, "sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg=="],
-
-    "escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
-
     "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 
-    "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
-
-    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
-
-    "ink": ["ink@6.8.0", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.2.4", "ansi-escapes": "^7.3.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.6.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^5.1.1", "code-excerpt": "^4.0.0", "es-toolkit": "^1.39.10", "indent-string": "^5.0.0", "is-in-ci": "^2.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.33.0", "scheduler": "^0.27.0", "signal-exit": "^3.0.7", "slice-ansi": "^8.0.0", "stack-utils": "^2.0.6", "string-width": "^8.1.1", "terminal-size": "^4.0.1", "type-fest": "^5.4.1", "widest-line": "^6.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=19.0.0", "react": ">=19.0.0", "react-devtools-core": ">=6.1.2" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-sbl1RdLOgkO9isK42WCZlJCFN9hb++sX9dsklOvfd1YQ3bQ2AiFu12Q6tFlr0HvEUvzraJntQCCpfEoUe9DSzA=="],
-
-    "ink-text-input": ["ink-text-input@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "type-fest": "^4.18.2" }, "peerDependencies": { "ink": ">=5", "react": ">=18" } }, "sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw=="],
-
-    "is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
-
-    "is-in-ci": ["is-in-ci@2.0.0", "", { "bin": { "is-in-ci": "cli.js" } }, "sha512-cFeerHriAnhrQSbpAxL37W1wcJKUUX07HyLWZCW1URJT/ra3GyUTzBgUnh24TMVfNTV2Hij2HLxkPHFZfOZy5w=="],
-
     "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
-
-    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
-
-    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
-
-    "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
     "react-reconciler": ["react-reconciler@0.33.0", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.0" } }, "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA=="],
 
-    "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
-
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
-    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
-
-    "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
-
-    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
-
-    "string-width": ["string-width@8.2.0", "", { "dependencies": { "get-east-asian-width": "^1.5.0", "strip-ansi": "^7.1.2" } }, "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw=="],
-
-    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
-
-    "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
-
-    "terminal-size": ["terminal-size@4.0.1", "", {}, "sha512-avMLDQpUI9I5XFrklECw1ZEUPJhqzcwSWsyyI8blhRLT+8N1jLJWLWWYQpB2q2xthq8xDvjZPISVh53T/+CLYQ=="],
-
     "tiktoken": ["tiktoken@1.0.22", "", {}, "sha512-PKvy1rVF1RibfF3JlXBSP0Jrcw2uq3yXdgcEXtKTYn3QJ/cBRBHDnrJ5jHky+MENZ6DIPwNUGWpkVx+7joCpNA=="],
-
-    "type-fest": ["type-fest@5.4.4", "", { "dependencies": { "tagged-tag": "^1.0.0" } }, "sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
-    "widest-line": ["widest-line@6.0.0", "", { "dependencies": { "string-width": "^8.1.0" } }, "sha512-U89AsyEeAsyoF0zVJBkG9zBgekjgjK7yk9sje3F4IQpXBJ10TF6ByLlIfjMhcmHMJgHZI4KHt4rdNfktzxIAMA=="],
-
-    "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
-
-    "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
-
-    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
-
     "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
-    "cli-truncate/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
-
-    "ink-text-input/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
-
-    "wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@types/bun": "^1.3.10",
         "@types/node": "^25.3.3",
         "@types/react": "^19.2.14",
+        "@types/react-reconciler": "^0.33.0",
         "typescript": "^5.9.3",
       },
     },
@@ -94,6 +95,8 @@
     "@types/node": ["@types/node@25.3.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@types/react-reconciler": ["@types/react-reconciler@0.33.0", "", { "peerDependencies": { "@types/react": "*" } }, "sha512-HZOXsKT0tGI9LlUw2LuedXsVeB88wFa536vVL0M6vE8zN63nI+sSr1ByxmPToP5K5bukaVscyeCJcF9guVNJ1g=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Developer documentation for Acolyte — a terminal-first AI coding assistant: lo
 - [Architecture](./architecture.md) — system map of runtime flow and boundaries
 - [Lifecycle](./lifecycle.md) — one request through a bounded phase loop
 - [Modes](./modes.md) — explicit operating modes that shape behavior
+- [TUI](./tui.md) — custom React reconciler for terminal rendering
 - [Tooling](./tooling.md) — layered and contract-driven tool execution
 - [Sessions and tasks](./sessions-tasks.md) — separate runtime concerns of sessions and tasks
 - [Memory](./memory.md) — invisible and reliable context carrying forward

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,15 @@ CLI →client →server →lifecycle →model + tools
 - **execution model:** one active task per session, with ordered queued tasks.
 - **yielding:** lifecycle only yields at safe checkpoints (never mid-step).
 
+## TUI
+
+```text
+React tree → reconciler → TUI DOM → serialize → terminal output
+```
+
+- custom React reconciler for terminal rendering.
+- **details:** see [TUI](./tui.md).
+
 ## Daemon flow
 
 ```text
@@ -78,7 +87,7 @@ resolve →prepare →generate →evaluate →finalize
 
 ## Modes
 
-- **overview:** explicit operating behaviors are modeled as `work` and `verify`.
+- explicit operating behaviors are modeled as `work` and `verify`.
 - **details:** see [Modes](./modes.md).
 
 ## Memory Engine
@@ -89,7 +98,7 @@ Memory Engine
   →Memory context in system prompt
 ```
 
-- **overview:** Memory Engine composes source strategy, pipeline stages, and distill behavior to provide continuity across turns.
+- Memory Engine composes source strategy, pipeline stages, and distill behavior to provide continuity across turns.
 - **source strategy:** configured source IDs and order (`memorySources`) determine source composition.
 - **pipeline seams:** normalization and selection are strategy-injectable behind registry contracts.
 - **selection default:** one continuation cue is kept; selection prefers the freshest continuation that fits budget.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -18,7 +18,7 @@ Projects compared: [Aider](https://github.com/Aider-AI/aider), [OpenCode](https:
 | OpenHands | Web platform with Docker sandboxing |
 | OpenClaw | Node.js gateway + WebSocket control plane |
 
-Acolyte runs as a headless daemon. The CLI, future editor plugins, and third-party clients all connect over the same typed RPC protocol. The optional TUI is built with Ink and provides an interactive CLI experience.
+Acolyte runs as a headless daemon. The CLI, future editor plugins, and third-party clients all connect over the same typed RPC protocol. The optional TUI is a custom React terminal renderer built on `react-reconciler` and provides an interactive CLI experience.
 ## Lifecycle pipeline
 
 Every request flows through five explicit phases, each in its own module with its own tests:
@@ -60,7 +60,7 @@ Goose has a RetryManager with shell-command success checks. OpenHands has a Crit
 
 ## Developer experience
 
-The CLI is built with [Ink](https://github.com/vadimdemedes/ink) and ships a full TUI with:
+The CLI ships a custom React terminal renderer (built on `react-reconciler`) with a full TUI:
 - Structured tool output with typed rendering (bold labels, colored diffs, dim line numbers)
 - Fuzzy search and autocomplete with suggestion and correction for file paths, sessions, commands, and skills
 - Model picker that queries provider APIs for available models

--- a/docs/features.md
+++ b/docs/features.md
@@ -20,7 +20,7 @@ Shipped, user-visible capabilities.
 - Slash command support.
 - Skill invocation via slash commands.
 - HTTP and RPC transport support.
-- Polished terminal interface with structured output.
+- Custom terminal renderer with React reconciler, static/active split, and structured output.
 
 ## Agent Execution
 

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -4,7 +4,6 @@
 
 - **AI SDK stream errors surface as unhandled rejections**: When the AI SDK rejects during `agent.stream()` (e.g. invalid model ID, auth failure), the error escapes the generate loop's promise chain and hits the global unhandled rejection handler. The lifecycle then times out after 120s instead of failing fast. Root cause: the AI SDK rejects an internal promise that isn't part of the `fullStream` reader chain.
 
-- **Window switching duplicates active rows in some terminals**: Switching terminal tabs or windows causes Ink to re-render on top of stale terminal state, duplicating the active (non-graduated) portion of the transcript. Observed in Superset; does not reproduce in iTerm2.
 
 ## Limitations
 

--- a/docs/soul.md
+++ b/docs/soul.md
@@ -3,7 +3,7 @@
 Product persona and operating principles that shape default assistant behavior.
 
 ## Purpose
-Acolyte is inspired by the Jawa — a small, resourceful helper that scavenges what's useful and gets the job done without fanfare.
+Acolyte is a small, mysterious, resourceful intergalactic helper that gets the job done.
 
 I am Acolyte, your personal AI assistant for practical execution, especially coding work. I reduce friction, protect context, and help you ship reliable outcomes.
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -33,7 +33,7 @@ React tree → reconciler → TUI DOM → serialize → terminal output
 
 ## Input handling
 
-Centralized in `input.ts`. Raw stdin bytes are parsed into `KeyEvent` objects with named flags (`return`, `tab`, `ctrl`, `meta`, `escape`, arrows, etc.). The dispatcher fans out to all registered handlers via `InputContext`.
+Centralized in `input.ts`. Raw stdin bytes are parsed into `KeyEvent` objects with named flags (`return`, `tab`, `ctrl`, `meta`, `escape`, arrows, etc.). Prefers the [Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) for unambiguous modifier reporting, with fallback to legacy escape sequences for terminals that don't support it. The dispatcher fans out to all registered handlers via `InputContext`.
 
 Components register handlers through `useInput`. Only handlers with `isActive: true` receive events.
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -28,7 +28,7 @@ React tree → reconciler → TUI DOM → serialize → terminal output
 - **reconciler:** React's `react-reconciler` drives updates against a TUI DOM tree.
 - **TUI DOM:** lightweight node tree (`tui-root`, `tui-box`, `tui-text`, `tui-static`, `tui-virtual`, text nodes).
 - **serialize:** walks the DOM, resolves flex layout, applies ANSI styles, produces a string. `serializeSplit` separates static (scrollback) from active (re-rendered) regions.
-- **render loop:** on each React commit: serialize, diff against last output, erase and rewrite the active region. Static items flush once to scrollback. Overflow is handled by skipping off-screen lines (prevents duplication on scroll).
+- **render loop:** on each React commit: serialize, diff against last output, erase and rewrite the active region. Static items flush once to scrollback. When the active region overflows the viewport, top lines are flushed to scrollback and only the bottom portion is re-rendered.
 - **resize:** terminal dimensions are read from `stdout.columns`/`stdout.rows` on each commit — no SIGWINCH handler needed.
 
 ## Input handling

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -1,0 +1,72 @@
+# TUI Renderer
+
+Custom React reconciler for terminal rendering. Replaces Ink with a minimal, zero-dependency renderer tailored to Acolyte's needs.
+
+## Why custom
+
+Ink is general-purpose and brings layout complexity (Yoga), dep weight, and behaviors we don't need. The custom renderer keeps the React component model but owns the full rendering pipeline — from tree reconciliation to terminal escape sequences.
+
+## Primitives
+
+Three components, intentionally minimal:
+
+- **`Box`** — flex container. Props: `flexDirection`, `justifyContent`, `flexWrap`, `width`.
+- **`Text`** — styled text span. Props: `color`, `dimColor`, `backgroundColor`, `bold`, `underline`, `inverse`.
+- **`Static`** — write-once scrollback region. Rendered items are flushed to terminal scrollback and never re-rendered.
+
+Hooks:
+
+- **`useApp()`** — access `{ exit }` to terminate the app.
+- **`useInput(handler, { isActive })`** — register a keyboard input handler.
+
+## Rendering pipeline
+
+```text
+React tree → reconciler → TUI DOM → serialize → terminal output
+```
+
+- **reconciler:** React's `react-reconciler` drives updates against a TUI DOM tree.
+- **TUI DOM:** lightweight node tree (`tui-root`, `tui-box`, `tui-text`, `tui-static`, `tui-virtual`, text nodes).
+- **serialize:** walks the DOM, resolves flex layout, applies ANSI styles, produces a string. `serializeSplit` separates static (scrollback) from active (re-rendered) regions.
+- **render loop:** on each React commit: serialize, diff against last output, erase and rewrite the active region. Static items flush once to scrollback. Overflow is handled by skipping off-screen lines (prevents duplication on scroll).
+- **resize:** terminal dimensions are read from `stdout.columns`/`stdout.rows` on each commit — no SIGWINCH handler needed.
+
+## Input handling
+
+Centralized in `input.ts`. Raw stdin bytes are parsed into `KeyEvent` objects with named flags (`return`, `tab`, `ctrl`, `meta`, `escape`, arrows, etc.). The dispatcher fans out to all registered handlers via `InputContext`.
+
+Components register handlers through `useInput`. Only handlers with `isActive: true` receive events.
+
+## Design constraints
+
+- **Minimal primitive set.** Every new prop becomes renderer debt. Add only what's needed.
+- **Layout rules are a product contract.** Add tests before adding layout semantics.
+- **No "Ink, but homegrown."** If a feature doesn't materially help Acolyte's UX, don't add it.
+- **Centralized input handling.** Terminal key parsing gets fragile fast — keep it in one place.
+- **Terminal edge cases.** Wide glyphs, combining characters, ANSI length vs display width all need care. `stripAnsiLength` and `padLine` in `serialize.ts` handle width calculations.
+
+## Testing
+
+- **`renderToString`** (`render-to-string.ts`) — renders a React tree to a plain string without terminal side effects.
+- **`renderPlain`** (`tui-test-utils.ts`) — wraps `renderToString` with configurable terminal width for test convenience.
+- **`serialize.test.tsx`** — layout and serialization tests against the DOM tree directly.
+
+## Extension seams
+
+- Add primitives by extending `TuiNodeType` in `dom.ts` and handling them in `serialize.ts`.
+- Add style props by extending `TuiProps` in `dom.ts` and `StyleStack` in `serialize.ts`.
+- Keep the primitive surface small — prefer composing existing primitives over adding new ones.
+
+## Key files
+
+- `src/tui/index.ts` — public API surface
+- `src/tui/components.tsx` — `Box`, `Text`, `Static` primitives
+- `src/tui/dom.ts` — TUI DOM node types
+- `src/tui/serialize.ts` — tree-to-string serialization with static/active split
+- `src/tui/render.ts` — terminal render loop, raw mode, cursor management
+- `src/tui/input.ts` — raw stdin dispatcher
+- `src/tui/context.ts` — `AppContext`, `InputContext`, `KeyEvent`
+- `src/tui/hooks.ts` — `useApp`, `useInput`
+- `src/tui/host-config.ts` — React reconciler host config
+- `src/tui/styles.ts` — ANSI escape sequences, color mapping
+- `src/tui/reconciler.ts` — React reconciler instance

--- a/package.json
+++ b/package.json
@@ -45,9 +45,8 @@
     "@ast-grep/lang-python": "^0.0.5",
     "@ast-grep/lang-rust": "^0.0.6",
     "@ast-grep/napi": "^0.41.0",
-    "ink": "^6.8.0",
-    "ink-text-input": "^6.0.0",
     "react": "^19.2.4",
+    "react-reconciler": "^0.33.0",
     "tiktoken": "^1.0.22",
     "zod": "^4.3.6"
   }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/bun": "^1.3.10",
     "@types/node": "^25.3.3",
     "@types/react": "^19.2.14",
+    "@types/react-reconciler": "^0.33.0",
     "typescript": "^5.9.3"
   },
   "dependencies": {

--- a/src/chat-commands.tui.test.tsx
+++ b/src/chat-commands.tui.test.tsx
@@ -1,10 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { ChatTranscript } from "./chat-transcript";
 import { createClient, createMessageHandlerHarness, createSession, createStore, dedent } from "./test-utils";
-import { renderInkPlain } from "./tui-test-utils";
+import { renderPlain } from "./tui-test-utils";
 
 function renderTranscript(rows: Parameters<typeof ChatTranscript>[0]["rows"], columns = 96): string {
-  return dedent(renderInkPlain(<ChatTranscript rows={rows} isWorking={false} thinkingFrame={0} />, columns));
+  return dedent(renderPlain(<ChatTranscript rows={rows} isWorking={false} thinkingFrame={0} />, columns));
 }
 
 describe("chat slash command visual regression", () => {

--- a/src/chat-content-render.tsx
+++ b/src/chat-content-render.tsx
@@ -1,7 +1,7 @@
-import { Text } from "ink";
 import React from "react";
 import { sanitizeAssistantContent, tokenizeForHighlighting, wrapAssistantContent } from "./chat-content";
 import { palette } from "./palette";
+import { Text } from "./tui";
 
 export function renderAssistantContent(content: string, wrapWidth: number): React.ReactNode {
   const cleaned = sanitizeAssistantContent(content);

--- a/src/chat-graduate.tsx
+++ b/src/chat-graduate.tsx
@@ -7,11 +7,9 @@ export function graduateHeader(
   brandColor: string,
   mascot: string,
   mascotEyes: string,
-  columns: number,
 ): void {
   const ansi = renderToString(
     <ChatHeader lines={headerLines} brandColor={brandColor} mascot={mascot} mascotEyes={mascotEyes} />,
-    { columns },
   );
   process.stdout.write(`\n${ansi}\n`);
 }

--- a/src/chat-graduate.tsx
+++ b/src/chat-graduate.tsx
@@ -1,6 +1,6 @@
-import { renderToString } from "ink";
 import type { HeaderLine } from "./chat-header";
 import { ChatHeader } from "./chat-header";
+import { renderToString } from "./tui";
 
 export function graduateHeader(
   headerLines: HeaderLine[],

--- a/src/chat-header.tsx
+++ b/src/chat-header.tsx
@@ -1,5 +1,5 @@
-import { Box, Text } from "ink";
 import type React from "react";
+import { Box, Text } from "./tui";
 
 export type HeaderLine = {
   id: string;

--- a/src/chat-input-panel.tsx
+++ b/src/chat-input-panel.tsx
@@ -1,4 +1,3 @@
-import { Text } from "ink";
 import type React from "react";
 import { clampSuggestionIndex } from "./chat-effects";
 import { borderLine, formatShortcutRows, justifyLineSpaceBetween } from "./chat-layout";
@@ -6,6 +5,7 @@ import { type PickerState, pickerHint, pickerLabel, renderPickerItems } from "./
 import { slashCommandHelp } from "./chat-slash";
 import { t } from "./i18n";
 import { PromptInput } from "./prompt-input";
+import { Text } from "./tui";
 
 type ChatInputPanelProps = {
   picker?: PickerState | null;

--- a/src/chat-input-panel.tsx
+++ b/src/chat-input-panel.tsx
@@ -1,11 +1,11 @@
 import type React from "react";
 import { clampSuggestionIndex } from "./chat-effects";
-import { borderLine, formatShortcutRows, justifyLineSpaceBetween } from "./chat-layout";
+import { borderLine, formatShortcutRows } from "./chat-layout";
 import { type PickerState, pickerHint, pickerLabel, renderPickerItems } from "./chat-picker";
 import { slashCommandHelp } from "./chat-slash";
 import { t } from "./i18n";
 import { PromptInput } from "./prompt-input";
-import { Text } from "./tui";
+import { Box, Text } from "./tui";
 
 type ChatInputPanelProps = {
   picker?: PickerState | null;
@@ -31,8 +31,9 @@ const noop = (): void => {};
 
 const SLASH_COMMAND_COLUMN_WIDTH = 16;
 
-function resolveFooterVisible(input: { showHelp: boolean; hasSuggestions: boolean; hasPicker: boolean }): boolean {
-  if (input.showHelp) return false;
+const DEFAULT_TERMINAL_WIDTH = 96;
+
+function resolveFooterVisible(input: { hasSuggestions: boolean; hasPicker: boolean }): boolean {
   if (input.hasSuggestions) return false;
   if (input.hasPicker) return false;
   return true;
@@ -110,7 +111,8 @@ export function ChatInputPanel(props: ChatInputPanelProps): React.ReactNode {
   } = props;
   const caretVisible = true;
   const hasSuggestions = atQuery !== null || slashSuggestions.length > 0;
-  const showFooter = resolveFooterVisible({ showHelp, hasSuggestions, hasPicker: Boolean(picker) });
+  const showFooter = resolveFooterVisible({ hasSuggestions, hasPicker: Boolean(picker) });
+  const termWidth = process.stdout.columns ?? DEFAULT_TERMINAL_WIDTH;
 
   if (picker) {
     return (
@@ -159,13 +161,12 @@ export function ChatInputPanel(props: ChatInputPanelProps): React.ReactNode {
         showHelp,
       })}
       {showFooter ? (
-        <Text dimColor>
-          {justifyLineSpaceBetween(
-            ctrlCPending ? t("chat.input.ctrl_c_hint") : value.length > 0 ? "" : `? ${t("chat.input.help_hint")}`,
-            footerContext,
-            2,
-          )}
-        </Text>
+        <Box justifyContent="space-between" width={termWidth}>
+          <Text dimColor>
+            {`  ${ctrlCPending ? t("chat.input.ctrl_c_hint") : showHelp ? "" : value.length > 0 ? "" : `? ${t("chat.input.help_hint")}`}`}
+          </Text>
+          <Text dimColor>{`${footerContext}  `}</Text>
+        </Box>
       ) : null}
     </>
   );

--- a/src/chat-input-panel.tsx
+++ b/src/chat-input-panel.tsx
@@ -96,13 +96,16 @@ function renderInputPanelContent(input: {
     suggestions = (
       <>
         {slashSuggestions.map((item, index) => (
-          <Text
-            key={`slash-suggestion-${item}`}
-            color={index === selectedIndex ? brandColor : undefined}
-            dimColor={index !== selectedIndex}
-          >
-            {`  ${item.padEnd(SLASH_COMMAND_COLUMN_WIDTH)}`}
-          </Text>
+          <Box key={`slash-suggestion-${item}`}>
+            <Text color={index === selectedIndex ? brandColor : undefined} dimColor={index !== selectedIndex}>
+              {"  "}
+            </Text>
+            <Box width={SLASH_COMMAND_COLUMN_WIDTH}>
+              <Text color={index === selectedIndex ? brandColor : undefined} dimColor={index !== selectedIndex}>
+                {item}
+              </Text>
+            </Box>
+          </Box>
         ))}
         {selectedHelp ? <Text dimColor>{`\n  ${selectedHelp}`}</Text> : null}
       </>

--- a/src/chat-input-panel.tsx
+++ b/src/chat-input-panel.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import { clampSuggestionIndex } from "./chat-effects";
-import { borderLine, SHORTCUT_ITEMS } from "./chat-layout";
+import { BREAKPOINT_TWO_COLUMN, borderLine, SHORTCUT_ITEMS } from "./chat-layout";
 import { type PickerState, pickerHint, pickerLabel, renderPickerItems } from "./chat-picker";
 import { slashCommandHelp } from "./chat-slash";
 import { t } from "./i18n";
@@ -39,12 +39,20 @@ function resolveFooterVisible(input: { hasSuggestions: boolean; hasPicker: boole
   return true;
 }
 
-const SHORTCUT_KEY_WIDTH = 20;
-const SHORTCUT_COL_WIDTH = 44;
-const SHORTCUT_TWO_COL_MIN = 92;
+function ShortcutItem({ label, description }: { label: string; description: string }): React.ReactNode {
+  return (
+    <Box width={44}>
+      <Text dimColor>{"  "}</Text>
+      <Box width={20}>
+        <Text dimColor>{label}</Text>
+      </Box>
+      <Text dimColor>{description}</Text>
+    </Box>
+  );
+}
 
 function renderShortcutGrid(termWidth: number): React.ReactNode {
-  const useTwoColumns = termWidth >= SHORTCUT_TWO_COL_MIN;
+  const useTwoColumns = termWidth >= BREAKPOINT_TWO_COLUMN;
   const rowsPerColumn = useTwoColumns ? Math.ceil(SHORTCUT_ITEMS.length / 2) : SHORTCUT_ITEMS.length;
   const rows: React.ReactNode[] = [];
 
@@ -53,10 +61,8 @@ function renderShortcutGrid(termWidth: number): React.ReactNode {
     const right = useTwoColumns ? SHORTCUT_ITEMS[row + rowsPerColumn] : undefined;
     rows.push(
       <Box key={left?.key ?? row}>
-        <Box width={SHORTCUT_COL_WIDTH}>
-          <Text dimColor>{`  ${(left?.key ?? "").padEnd(SHORTCUT_KEY_WIDTH)}${left?.description ?? ""}`}</Text>
-        </Box>
-        {right ? <Text dimColor>{`  ${right.key.padEnd(SHORTCUT_KEY_WIDTH)}${right.description}`}</Text> : null}
+        {left ? <ShortcutItem label={left.key} description={left.description} /> : null}
+        {right ? <ShortcutItem label={right.key} description={right.description} /> : null}
       </Box>,
     );
   }

--- a/src/chat-input-panel.tsx
+++ b/src/chat-input-panel.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import { clampSuggestionIndex } from "./chat-effects";
-import { borderLine, formatShortcutRows } from "./chat-layout";
+import { borderLine, SHORTCUT_ITEMS } from "./chat-layout";
 import { type PickerState, pickerHint, pickerLabel, renderPickerItems } from "./chat-picker";
 import { slashCommandHelp } from "./chat-slash";
 import { t } from "./i18n";
@@ -39,6 +39,31 @@ function resolveFooterVisible(input: { hasSuggestions: boolean; hasPicker: boole
   return true;
 }
 
+const SHORTCUT_KEY_WIDTH = 20;
+const SHORTCUT_COL_WIDTH = 44;
+const SHORTCUT_TWO_COL_MIN = 92;
+
+function renderShortcutGrid(termWidth: number): React.ReactNode {
+  const useTwoColumns = termWidth >= SHORTCUT_TWO_COL_MIN;
+  const rowsPerColumn = useTwoColumns ? Math.ceil(SHORTCUT_ITEMS.length / 2) : SHORTCUT_ITEMS.length;
+  const rows: React.ReactNode[] = [];
+
+  for (let row = 0; row < rowsPerColumn; row++) {
+    const left = SHORTCUT_ITEMS[row];
+    const right = useTwoColumns ? SHORTCUT_ITEMS[row + rowsPerColumn] : undefined;
+    rows.push(
+      <Box key={left?.key ?? row}>
+        <Box width={SHORTCUT_COL_WIDTH}>
+          <Text dimColor>{`  ${(left?.key ?? "").padEnd(SHORTCUT_KEY_WIDTH)}${left?.description ?? ""}`}</Text>
+        </Box>
+        {right ? <Text dimColor>{`  ${right.key.padEnd(SHORTCUT_KEY_WIDTH)}${right.description}`}</Text> : null}
+      </Box>,
+    );
+  }
+
+  return rows;
+}
+
 function renderInputPanelContent(input: {
   brandColor: string;
   atQuery: string | null;
@@ -46,10 +71,8 @@ function renderInputPanelContent(input: {
   atSuggestionIndex: number;
   slashSuggestions: string[];
   slashSuggestionIndex: number;
-  showHelp: boolean;
 }): React.ReactNode {
-  const { brandColor, atQuery, atSuggestions, atSuggestionIndex, slashSuggestions, slashSuggestionIndex, showHelp } =
-    input;
+  const { brandColor, atQuery, atSuggestions, atSuggestionIndex, slashSuggestions, slashSuggestionIndex } = input;
 
   let suggestions: React.ReactNode = null;
   if (atQuery !== null && atSuggestions.length > 0) {
@@ -78,12 +101,6 @@ function renderInputPanelContent(input: {
         {selectedHelp ? <Text dimColor>{`\n  ${selectedHelp}`}</Text> : null}
       </>
     );
-  } else if (showHelp) {
-    suggestions = formatShortcutRows().map((line) => (
-      <Text key={line} dimColor>
-        {line}
-      </Text>
-    ));
   }
 
   return suggestions;
@@ -151,23 +168,31 @@ export function ChatInputPanel(props: ChatInputPanelProps): React.ReactNode {
         key={`chat-input-${inputRevision}`}
       />
       <Text dimColor>{borderLine()}</Text>
-      {renderInputPanelContent({
-        brandColor,
-        atQuery,
-        atSuggestions,
-        atSuggestionIndex,
-        slashSuggestions,
-        slashSuggestionIndex,
-        showHelp,
-      })}
-      {showFooter ? (
-        <Box justifyContent="space-between" width={termWidth}>
-          <Text dimColor>
-            {`  ${ctrlCPending ? t("chat.input.ctrl_c_hint") : showHelp ? "" : value.length > 0 ? "" : `? ${t("chat.input.help_hint")}`}`}
-          </Text>
+      {showHelp ? (
+        <Box justifyContent="space-between" flexWrap="wrap" width={termWidth}>
+          <Box flexDirection="column">{renderShortcutGrid(termWidth)}</Box>
           <Text dimColor>{`${footerContext}  `}</Text>
         </Box>
-      ) : null}
+      ) : (
+        <>
+          {renderInputPanelContent({
+            brandColor,
+            atQuery,
+            atSuggestions,
+            atSuggestionIndex,
+            slashSuggestions,
+            slashSuggestionIndex,
+          })}
+          {showFooter ? (
+            <Box justifyContent="space-between" width={termWidth}>
+              <Text dimColor>
+                {`  ${ctrlCPending ? t("chat.input.ctrl_c_hint") : value.length > 0 ? "" : `? ${t("chat.input.help_hint")}`}`}
+              </Text>
+              <Text dimColor>{`${footerContext}  `}</Text>
+            </Box>
+          ) : null}
+        </>
+      )}
     </>
   );
 }

--- a/src/chat-input-panel.tsx
+++ b/src/chat-input-panel.tsx
@@ -178,30 +178,23 @@ export function ChatInputPanel(props: ChatInputPanelProps): React.ReactNode {
       />
       <Text dimColor>{borderLine()}</Text>
       {showHelp ? (
-        <Box justifyContent="space-between" flexWrap="wrap" width={termWidth}>
-          <Box flexDirection="column">{renderShortcutGrid(termWidth)}</Box>
+        <Box flexDirection="column">{renderShortcutGrid(termWidth)}</Box>
+      ) : (
+        renderInputPanelContent({
+          brandColor,
+          atQuery,
+          atSuggestions,
+          atSuggestionIndex,
+          slashSuggestions,
+          slashSuggestionIndex,
+        })
+      )}
+      {showFooter && !showHelp && value.length === 0 ? (
+        <Box justifyContent="space-between" width={termWidth}>
+          <Text dimColor>{`  ${ctrlCPending ? t("chat.input.ctrl_c_hint") : `? ${t("chat.input.help_hint")}`}`}</Text>
           <Text dimColor>{`${footerContext}  `}</Text>
         </Box>
-      ) : (
-        <>
-          {renderInputPanelContent({
-            brandColor,
-            atQuery,
-            atSuggestions,
-            atSuggestionIndex,
-            slashSuggestions,
-            slashSuggestionIndex,
-          })}
-          {showFooter ? (
-            <Box justifyContent="space-between" width={termWidth}>
-              <Text dimColor>
-                {`  ${ctrlCPending ? t("chat.input.ctrl_c_hint") : value.length > 0 ? "" : `? ${t("chat.input.help_hint")}`}`}
-              </Text>
-              <Text dimColor>{`${footerContext}  `}</Text>
-            </Box>
-          ) : null}
-        </>
-      )}
+      ) : null}
     </>
   );
 }

--- a/src/chat-keybindings.ts
+++ b/src/chat-keybindings.ts
@@ -169,7 +169,7 @@ export function useChatKeybindings(input: UseChatKeybindingsInput): void {
         (input.atQuery !== null || (input.atQuery === null && input.slashSuggestions.length > 0));
       const historyTriggerUp = key.upArrow || (key.ctrl && keyInput === "p");
       const historyTriggerDown = key.downArrow || (key.ctrl && keyInput === "n");
-      if (!input.isWorking && !suggestionNavActive && historyTriggerUp) {
+      if (!suggestionNavActive && historyTriggerUp) {
         if (!shouldCycleInputHistory(input.inputHistoryIndex)) return;
         const transition = resolveHistoryUp(input.inputHistory, input.inputHistoryIndex, input.value);
         if (!transition) return;
@@ -180,7 +180,7 @@ export function useChatKeybindings(input: UseChatKeybindingsInput): void {
         input.setInputRevision((current) => current + 1);
         return;
       }
-      if (!input.isWorking && !suggestionNavActive && historyTriggerDown && input.inputHistoryIndex >= 0) {
+      if (!suggestionNavActive && historyTriggerDown && input.inputHistoryIndex >= 0) {
         const transition = resolveHistoryDown(input.inputHistory, input.inputHistoryIndex, input.inputHistoryDraft);
         if (!transition) return;
         input.setInputHistoryIndex(transition.nextIndex);

--- a/src/chat-keybindings.ts
+++ b/src/chat-keybindings.ts
@@ -1,8 +1,8 @@
-import { useInput } from "ink";
 import { clampSuggestionIndex } from "./chat-effects";
 import { applyAtSuggestion, shouldAutocompleteAtSubmit } from "./chat-file-ref";
 import { PICKER_PAGE_SIZE, type PickerState, pickerItemCount } from "./chat-picker";
 import { shouldAutocompleteSlashSubmit } from "./chat-slash";
+import { useInput } from "./tui";
 
 type HistoryTransition = {
   nextIndex: number;

--- a/src/chat-layout.test.ts
+++ b/src/chat-layout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { justifyLineSpaceBetween, shownBranch } from "./chat-layout";
+import { shownBranch } from "./chat-layout";
 
 function streamFromText(text: string): ReadableStream<Uint8Array> {
   const encoder = new TextEncoder();
@@ -9,17 +9,6 @@ function streamFromText(text: string): ReadableStream<Uint8Array> {
       controller.close();
     },
   });
-}
-
-function withColumns(width: number, task: () => void): void {
-  const descriptor = Object.getOwnPropertyDescriptor(process.stdout, "columns");
-  Object.defineProperty(process.stdout, "columns", { configurable: true, value: width });
-  try {
-    task();
-  } finally {
-    if (descriptor) Object.defineProperty(process.stdout, "columns", descriptor);
-    else delete (process.stdout as { columns?: number }).columns;
-  }
 }
 
 describe("chat-layout", () => {
@@ -51,17 +40,5 @@ describe("chat-layout", () => {
     } finally {
       (Bun as { spawn: typeof Bun.spawn }).spawn = originalSpawn;
     }
-  });
-
-  test("justifyLineSpaceBetween keeps help left and context right", () => {
-    withColumns(40, () => {
-      expect(justifyLineSpaceBetween("? help", "acolyte · main")).toBe("? help                    acolyte · main");
-    });
-  });
-
-  test("justifyLineSpaceBetween falls back when line is too narrow", () => {
-    withColumns(10, () => {
-      expect(justifyLineSpaceBetween("? help", "acolyte · main")).toBe("? help · acolyte · main");
-    });
   });
 });

--- a/src/chat-layout.tsx
+++ b/src/chat-layout.tsx
@@ -3,9 +3,8 @@ import { slashCommandHelp } from "./chat-slash";
 import { t } from "./i18n";
 
 const DEFAULT_TERMINAL_WIDTH = 96;
-const SHORTCUT_TWO_COLUMN_MIN_WIDTH = 92;
 
-const SHORTCUT_ITEMS = [
+export const SHORTCUT_ITEMS = [
   { key: "@path", description: t("chat.at_ref.attach_file") },
   { key: "/new", description: slashCommandHelp("/new") },
   { key: "/resume <id>", description: slashCommandHelp("/resume") },
@@ -44,27 +43,4 @@ export async function shownBranch(cwd = process.cwd()): Promise<string | null> {
 export function borderLine(): string {
   const width = process.stdout.columns ?? DEFAULT_TERMINAL_WIDTH;
   return "─".repeat(Math.max(24, width));
-}
-
-export function formatShortcutRows(): string[] {
-  const width = process.stdout.columns ?? DEFAULT_TERMINAL_WIDTH;
-  const columns = width >= SHORTCUT_TWO_COLUMN_MIN_WIDTH ? 2 : 1;
-  const rowsPerColumn = Math.ceil(SHORTCUT_ITEMS.length / columns);
-  const colWidth = columns > 1 ? Math.min(48, Math.floor((width - 2) / columns)) : width - 2;
-  const keyWidth = 20;
-  const lines: string[] = [];
-
-  for (let row = 0; row < rowsPerColumn; row += 1) {
-    let line = "  ";
-    for (let col = 0; col < columns; col += 1) {
-      const index = row + col * rowsPerColumn;
-      const item = SHORTCUT_ITEMS[index];
-      if (!item) continue;
-      const chunk = `${item.key.padEnd(keyWidth)}${item.description}`;
-      line += col < columns - 1 ? chunk.padEnd(colWidth) : chunk;
-    }
-    lines.push(line.trimEnd());
-  }
-
-  return lines;
 }

--- a/src/chat-layout.tsx
+++ b/src/chat-layout.tsx
@@ -4,6 +4,9 @@ import { t } from "./i18n";
 
 const DEFAULT_TERMINAL_WIDTH = 96;
 
+/** Terminal width at which help pane switches from 1 to 2 columns. */
+export const BREAKPOINT_TWO_COLUMN = 92;
+
 export const SHORTCUT_ITEMS = [
   { key: "@path", description: t("chat.at_ref.attach_file") },
   { key: "/new", description: slashCommandHelp("/new") },

--- a/src/chat-layout.tsx
+++ b/src/chat-layout.tsx
@@ -41,17 +41,6 @@ export async function shownBranch(cwd = process.cwd()): Promise<string | null> {
   return branch.length > 0 ? branch : null;
 }
 
-export function justifyLineSpaceBetween(left: string, right: string, inset = 0): string {
-  const width = process.stdout.columns ?? DEFAULT_TERMINAL_WIDTH;
-  const safeInset = Math.max(0, inset);
-  const leftText = `${" ".repeat(safeInset)}${left}`;
-  const rightText = `${right}${" ".repeat(safeInset)}`;
-  const minGap = 1;
-  const required = leftText.length + minGap + rightText.length;
-  if (required > width) return `${leftText} · ${rightText}`;
-  return `${leftText}${" ".repeat(width - leftText.length - rightText.length)}${rightText}`;
-}
-
 export function borderLine(): string {
   const width = process.stdout.columns ?? DEFAULT_TERMINAL_WIDTH;
   return "─".repeat(Math.max(24, width));

--- a/src/chat-layout.tsx
+++ b/src/chat-layout.tsx
@@ -61,7 +61,7 @@ export function formatShortcutRows(): string[] {
   const width = process.stdout.columns ?? DEFAULT_TERMINAL_WIDTH;
   const columns = width >= SHORTCUT_TWO_COLUMN_MIN_WIDTH ? 2 : 1;
   const rowsPerColumn = Math.ceil(SHORTCUT_ITEMS.length / columns);
-  const colWidth = columns > 1 ? Math.min(40, Math.floor((width - 2) / columns)) : width - 2;
+  const colWidth = columns > 1 ? Math.min(48, Math.floor((width - 2) / columns)) : width - 2;
   const keyWidth = 20;
   const lines: string[] = [];
 

--- a/src/chat-picker.tsx
+++ b/src/chat-picker.tsx
@@ -6,7 +6,7 @@ import { truncateText } from "./compact-text";
 import { t } from "./i18n";
 import type { Session } from "./session-contract";
 import type { SkillMeta } from "./skills";
-import { Text } from "./tui";
+import { Box, Text } from "./tui";
 
 export type PickerState =
   | { kind: "skills"; items: SkillMeta[]; index: number }
@@ -33,16 +33,18 @@ function renderPickerRows(
   return items.map((item, index) => {
     const selected = index === selectedIndex;
     return (
-      <Text key={item.key}>
-        {selected ? "› " : "  "}
-        <Text color={selected ? brandColor : undefined}>{item.label.padEnd(PICKER_LABEL_WIDTH)}</Text>
+      <Box key={item.key}>
+        <Text>{selected ? "› " : "  "}</Text>
+        <Box width={PICKER_LABEL_WIDTH}>
+          <Text color={selected ? brandColor : undefined}>{item.label}</Text>
+        </Box>
         {item.detail ? (
           <>
             <Text> </Text>
             <Text dimColor>{item.detail}</Text>
           </>
         ) : null}
-      </Text>
+      </Box>
     );
   });
 }

--- a/src/chat-picker.tsx
+++ b/src/chat-picker.tsx
@@ -1,4 +1,3 @@
-import { Text } from "ink";
 import type React from "react";
 import type { AgentMode } from "./agent-contract";
 import { unreachable } from "./assert";
@@ -7,6 +6,7 @@ import { truncateText } from "./compact-text";
 import { t } from "./i18n";
 import type { Session } from "./session-contract";
 import type { SkillMeta } from "./skills";
+import { Text } from "./tui";
 
 export type PickerState =
   | { kind: "skills"; items: SkillMeta[]; index: number }

--- a/src/chat-picker.tui.test.tsx
+++ b/src/chat-picker.tui.test.tsx
@@ -3,10 +3,10 @@ import { ChatInputPanel } from "./chat-input-panel";
 import type { PickerState } from "./chat-picker";
 import { palette } from "./palette";
 import { createSession, dedent } from "./test-utils";
-import { renderInkPlain } from "./tui-test-utils";
+import { renderPlain } from "./tui-test-utils";
 
 function renderInputPanelWithPicker(picker: PickerState, columns = 96): string {
-  return renderInkPlain(
+  return renderPlain(
     <ChatInputPanel
       picker={picker}
       activeSessionId="sess_active"

--- a/src/chat-row-view.tsx
+++ b/src/chat-row-view.tsx
@@ -1,9 +1,9 @@
-import { Box, Text } from "ink";
 import React from "react";
 import type { ChatRow } from "./chat-commands";
 import { renderAssistantContent } from "./chat-content-render";
 import { palette } from "./palette";
 import { renderToolOutput as renderToolOutputText, type ToolOutput } from "./tool-output-content";
+import { Box, Text } from "./tui";
 
 const MARKERS: Record<ChatRow["role"], string> = {
   user: "❯ ",

--- a/src/chat-shimmer.tsx
+++ b/src/chat-shimmer.tsx
@@ -1,5 +1,5 @@
-import { Text } from "ink";
 import type React from "react";
+import { Text } from "./tui";
 
 const DIM_R = 0x55;
 const DIM_G = 0x55;

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -1,10 +1,10 @@
-import { Box, Text } from "ink";
 import React from "react";
 import type { ChatRow } from "./chat-commands";
 import { formatTokenCount } from "./chat-format";
 import { ChatRowView } from "./chat-row-view";
 import { ShimmerText } from "./chat-shimmer";
 import { palette } from "./palette";
+import { Box, Text } from "./tui";
 
 export { parseStatusLine } from "./chat-row-view";
 

--- a/src/chat-ui.tsx
+++ b/src/chat-ui.tsx
@@ -357,10 +357,7 @@ function ChatApp(props: ChatAppProps) {
   );
 }
 
-export async function runInkChat(props: ChatAppProps): Promise<void> {
-  const app = render(<ChatApp {...props} />, {
-    exitOnCtrlC: false,
-    kittyKeyboard: { mode: "enabled", flags: ["disambiguateEscapeCodes"] },
-  });
+export async function runChat(props: ChatAppProps): Promise<void> {
+  const app = render(<ChatApp {...props} />);
   await app.waitUntilExit();
 }

--- a/src/chat-ui.tsx
+++ b/src/chat-ui.tsx
@@ -1,4 +1,3 @@
-import { Box, render, Static, Text, useApp } from "ink";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ChatRow } from "./chat-commands";
 import { useAtSuggestionsEffect, useSlashSuggestionsEffect, useThinkingAnimationEffect } from "./chat-effects";
@@ -25,6 +24,7 @@ import { palette } from "./palette";
 import { formatModel } from "./provider-config";
 import type { Session, SessionState, SessionTokenUsageEntry } from "./session-contract";
 import { loadSkills } from "./skills";
+import { Box, render, Static, Text, useApp } from "./tui";
 import { clearScreen } from "./ui";
 
 const THINKING_PULSE_FRAMES = 16;

--- a/src/chat.tui.test.tsx
+++ b/src/chat.tui.test.tsx
@@ -62,11 +62,11 @@ describe("chat tui visual regression: footer and help", () => {
       ────────────────────────────────────────────────────────────────────────────────────────────────
       ❯ Ask anything…
       ────────────────────────────────────────────────────────────────────────────────────────────────
-        @path               attach file         /remember <text>    save memory note
-        /new                start new session   /memory [scope]     show memory notes
-        /resume <id>        resume session      /tokens             show token usage
-        /sessions           show sessions       /skills             show skills picker
-        /model              change model        /exit               exit chat
+        @path               attach file                /remember <text>    save memory note
+        /new                start new session          /memory [scope]     show memory notes
+        /resume <id>        resume session             /tokens             show token usage
+        /sessions           show sessions              /skills             show skills picker
+        /model              change model               /exit               exit chat
         /status             show server status
     `),
     );

--- a/src/chat.tui.test.tsx
+++ b/src/chat.tui.test.tsx
@@ -4,12 +4,12 @@ import { ChatHeader } from "./chat-header";
 import { ChatInputPanel } from "./chat-input-panel";
 import { palette } from "./palette";
 import { dedent } from "./test-utils";
-import { renderInkPlain } from "./tui-test-utils";
+import { renderPlain } from "./tui-test-utils";
 
 const DEFAULT_FOOTER_CONTEXT = "~/code/acolyte · main";
 
 function renderInputPanel(overrides: ComponentProps<typeof ChatInputPanel> = {}, columns = 96): string {
-  return renderInkPlain(
+  return renderPlain(
     <ChatInputPanel brandColor={palette.brand} footerContext={DEFAULT_FOOTER_CONTEXT} {...overrides} />,
     columns,
   );
@@ -17,7 +17,7 @@ function renderInputPanel(overrides: ComponentProps<typeof ChatInputPanel> = {},
 
 describe("chat tui visual regression: header", () => {
   test("renders stable header block", () => {
-    const out = renderInkPlain(
+    const out = renderPlain(
       <ChatHeader
         lines={[
           { id: "title", text: "Acolyte", suffix: "", dim: false, brand: true },

--- a/src/chat.tui.test.tsx
+++ b/src/chat.tui.test.tsx
@@ -62,13 +62,13 @@ describe("chat tui visual regression: footer and help", () => {
       ────────────────────────────────────────────────────────────────────────────────────────────────
       ❯ Ask anything…
       ────────────────────────────────────────────────────────────────────────────────────────────────
-        @path               attach file                /remember <text>    save memory note
-        /new                start new session          /memory [scope]     show memory notes
-        /resume <id>        resume session             /tokens             show token usage
-        /sessions           show sessions              /skills             show skills picker
-        /model              change model               /exit               exit chat
+        @path               attach file             /remember <text>    save memory note
+        /new                start new session       /memory [scope]     show memory notes
+        /resume <id>        resume session          /tokens             show token usage
+        /sessions           show sessions           /skills             show skills picker
+        /model              change model            /exit               exit chat
         /status             show server status
-                                                                               ~/code/acolyte · main
+      ~/code/acolyte · main
     `),
     );
   });
@@ -90,8 +90,7 @@ describe("chat tui visual regression: footer and help", () => {
         /memory [scope]     show memory notes
         /tokens             show token usage
         /skills             show skills picker
-        /exit               exit chat
-                                                               ~/code/acolyte · main
+        /exit               exit chat                          ~/code/acolyte · main
     `),
     );
   });

--- a/src/chat.tui.test.tsx
+++ b/src/chat.tui.test.tsx
@@ -55,43 +55,28 @@ describe("chat tui visual regression: footer and help", () => {
     );
   });
 
-  test("renders stable help pane rows", () => {
+  test("renders stable help pane rows with context", () => {
     const out = renderInputPanel({ showHelp: true });
-    expect(out).toBe(
-      dedent(`
-      ────────────────────────────────────────────────────────────────────────────────────────────────
-      ❯ Ask anything…
-      ────────────────────────────────────────────────────────────────────────────────────────────────
-        @path               attach file                /remember <text>    save memory note
-        /new                start new session          /memory [scope]     show memory notes
-        /resume <id>        resume session             /tokens             show token usage
-        /sessions           show sessions              /skills             show skills picker
-        /model              change model               /exit               exit chat
-        /status             show server status
-    `),
-    );
+    const lines = out.split("\n");
+    const lastLine = lines[lines.length - 1] ?? "";
+    // Context should appear as last line, right-aligned
+    expect(lastLine).toContain(DEFAULT_FOOTER_CONTEXT);
+    expect(lastLine.trimStart()).toBe(DEFAULT_FOOTER_CONTEXT);
+    // Help rows should still be present
+    expect(out).toContain("@path");
+    expect(out).toContain("/exit");
   });
 
-  test("renders stable single-column help pane rows at narrow width", () => {
+  test("renders stable single-column help pane rows at narrow width with context", () => {
     const out = renderInputPanel({ showHelp: true }, 80);
-    expect(out).toBe(
-      dedent(`
-      ────────────────────────────────────────────────────────────────────────────────
-      ❯ Ask anything…
-      ────────────────────────────────────────────────────────────────────────────────
-        @path               attach file
-        /new                start new session
-        /resume <id>        resume session
-        /sessions           show sessions
-        /model              change model
-        /status             show server status
-        /remember <text>    save memory note
-        /memory [scope]     show memory notes
-        /tokens             show token usage
-        /skills             show skills picker
-        /exit               exit chat
-    `),
-    );
+    const lines = out.split("\n");
+    const lastLine = lines[lines.length - 1] ?? "";
+    // Context should appear as last line, right-aligned
+    expect(lastLine).toContain(DEFAULT_FOOTER_CONTEXT);
+    expect(lastLine.trimStart()).toBe(DEFAULT_FOOTER_CONTEXT);
+    // Help rows should still be present
+    expect(out).toContain("@path");
+    expect(out).toContain("/exit");
   });
 
   test("renders slash suggestions with selected help and no footer row", () => {

--- a/src/chat.tui.test.tsx
+++ b/src/chat.tui.test.tsx
@@ -55,7 +55,7 @@ describe("chat tui visual regression: footer and help", () => {
     );
   });
 
-  test("renders stable help pane rows with context", () => {
+  test("renders help pane without context", () => {
     const out = renderInputPanel({ showHelp: true });
     expect(out).toBe(
       dedent(`
@@ -68,12 +68,11 @@ describe("chat tui visual regression: footer and help", () => {
         /sessions           show sessions           /skills             show skills picker
         /model              change model            /exit               exit chat
         /status             show server status
-      ~/code/acolyte · main
     `),
     );
   });
 
-  test("renders stable single-column help pane rows at narrow width with context", () => {
+  test("renders single-column help pane at narrow width without context", () => {
     const out = renderInputPanel({ showHelp: true }, 80);
     expect(out).toBe(
       dedent(`
@@ -90,9 +89,14 @@ describe("chat tui visual regression: footer and help", () => {
         /memory [scope]     show memory notes
         /tokens             show token usage
         /skills             show skills picker
-        /exit               exit chat                          ~/code/acolyte · main
+        /exit               exit chat
     `),
     );
+  });
+
+  test("hides context when typing", () => {
+    const out = renderInputPanel({ value: "hello" });
+    expect(out).not.toContain(DEFAULT_FOOTER_CONTEXT);
   });
 
   test("renders slash suggestions with selected help and no footer row", () => {

--- a/src/chat.tui.test.tsx
+++ b/src/chat.tui.test.tsx
@@ -57,26 +57,43 @@ describe("chat tui visual regression: footer and help", () => {
 
   test("renders stable help pane rows with context", () => {
     const out = renderInputPanel({ showHelp: true });
-    const lines = out.split("\n");
-    const lastLine = lines[lines.length - 1] ?? "";
-    // Context should appear as last line, right-aligned
-    expect(lastLine).toContain(DEFAULT_FOOTER_CONTEXT);
-    expect(lastLine.trimStart()).toBe(DEFAULT_FOOTER_CONTEXT);
-    // Help rows should still be present
-    expect(out).toContain("@path");
-    expect(out).toContain("/exit");
+    expect(out).toBe(
+      dedent(`
+      ────────────────────────────────────────────────────────────────────────────────────────────────
+      ❯ Ask anything…
+      ────────────────────────────────────────────────────────────────────────────────────────────────
+        @path               attach file                /remember <text>    save memory note
+        /new                start new session          /memory [scope]     show memory notes
+        /resume <id>        resume session             /tokens             show token usage
+        /sessions           show sessions              /skills             show skills picker
+        /model              change model               /exit               exit chat
+        /status             show server status
+                                                                               ~/code/acolyte · main
+    `),
+    );
   });
 
   test("renders stable single-column help pane rows at narrow width with context", () => {
     const out = renderInputPanel({ showHelp: true }, 80);
-    const lines = out.split("\n");
-    const lastLine = lines[lines.length - 1] ?? "";
-    // Context should appear as last line, right-aligned
-    expect(lastLine).toContain(DEFAULT_FOOTER_CONTEXT);
-    expect(lastLine.trimStart()).toBe(DEFAULT_FOOTER_CONTEXT);
-    // Help rows should still be present
-    expect(out).toContain("@path");
-    expect(out).toContain("/exit");
+    expect(out).toBe(
+      dedent(`
+      ────────────────────────────────────────────────────────────────────────────────
+      ❯ Ask anything…
+      ────────────────────────────────────────────────────────────────────────────────
+        @path               attach file
+        /new                start new session
+        /resume <id>        resume session
+        /sessions           show sessions
+        /model              change model
+        /status             show server status
+        /remember <text>    save memory note
+        /memory [scope]     show memory notes
+        /tokens             show token usage
+        /skills             show skills picker
+        /exit               exit chat
+                                                               ~/code/acolyte · main
+    `),
+    );
   });
 
   test("renders slash suggestions with selected help and no footer row", () => {

--- a/src/cli-chat.ts
+++ b/src/cli-chat.ts
@@ -1,7 +1,7 @@
 import { stdout as output } from "node:process";
 import { appConfig } from "./app-config";
 import { createMessage } from "./chat-session";
-import { runInkChat } from "./chat-ui";
+import { runChat } from "./chat-ui";
 import { resolveCliVersion } from "./cli-version";
 import { createClient } from "./client-factory";
 import { nowIso } from "./datetime";
@@ -97,7 +97,7 @@ export async function chatModeWithOptions(options: { resumeLatest: boolean; resu
 
   try {
     if (output.isTTY) clearScreen();
-    await runInkChat({
+    await runChat({
       client,
       session,
       store,

--- a/src/cli-help.test.ts
+++ b/src/cli-help.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { CliCommandHelp } from "./cli-contract";
 import { commandHelp, createUsageCommandRows, createUsageOptionRows, printLineBreak, printUsage } from "./cli-help";
-import { stripAnsi } from "./tui-test-utils";
+import { stripAnsi } from "./tui/serialize";
 
 const runHelp: CliCommandHelp = {
   command: "run <prompt>",

--- a/src/int-test-utils.ts
+++ b/src/int-test-utils.ts
@@ -2,7 +2,8 @@ import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { SessionState } from "./session-contract";
-import { stripAnsi, trimRightLines } from "./tui-test-utils";
+import { stripAnsi } from "./tui/serialize";
+import { trimRightLines } from "./tui-test-utils";
 
 type RunCliPlainOptions = {
   cwd?: string;

--- a/src/prompt-input.tsx
+++ b/src/prompt-input.tsx
@@ -1,7 +1,7 @@
-import { Box, Text, useInput } from "ink";
 import type React from "react";
 import { useCallback, useRef, useState } from "react";
 import { ESCAPE_CHAR, resolvePromptAction } from "./prompt-keymap";
+import { Box, Text, useInput } from "./tui";
 
 const META_PREFIX_WINDOW_MS = 150;
 

--- a/src/prompt-input.tsx
+++ b/src/prompt-input.tsx
@@ -1,6 +1,6 @@
 import type React from "react";
 import { useCallback, useRef, useState } from "react";
-import { ESCAPE_CHAR, resolvePromptAction } from "./prompt-keymap";
+import { resolvePromptAction } from "./prompt-keymap";
 import { Box, Text, useInput } from "./tui";
 
 const META_PREFIX_WINDOW_MS = 150;
@@ -107,10 +107,6 @@ export function PromptInput({
     const c = cursorRef.current;
     const now = Date.now();
     const hasMetaPrefix = metaPrefixAt.current !== null && now - metaPrefixAt.current <= META_PREFIX_WINDOW_MS;
-    if (input === ESCAPE_CHAR && !key.backspace && !key.delete) {
-      metaPrefixAt.current = now;
-      return;
-    }
     if (key.escape && !input) {
       metaPrefixAt.current = now;
       return;

--- a/src/prompt-input.tsx
+++ b/src/prompt-input.tsx
@@ -1,5 +1,7 @@
 import type React from "react";
 import { useCallback, useRef, useState } from "react";
+import { unreachable } from "./assert";
+import type { PromptAction } from "./prompt-keymap";
 import { resolvePromptAction } from "./prompt-keymap";
 import { Box, Text, useInput } from "./tui";
 
@@ -112,71 +114,65 @@ export function PromptInput({
       return;
     }
 
-    const action = resolvePromptAction(input, key, { hasMetaPrefix });
-    if (action.type === "noop") {
-      metaPrefixAt.current = null;
-      return;
+    const action: PromptAction = resolvePromptAction(input, key, { hasMetaPrefix });
+    switch (action.type) {
+      case "noop":
+        metaPrefixAt.current = null;
+        return;
+      case "submit":
+        onSubmitRef.current(v);
+        return;
+      case "move_home":
+        moveCursor(0);
+        return;
+      case "move_end":
+        moveCursor(v.length);
+        return;
+      case "move_word_left":
+        moveCursor(moveWordLeft(v, c));
+        return;
+      case "move_word_right":
+        moveCursor(moveWordRight(v, c));
+        return;
+      case "delete_word_back": {
+        metaPrefixAt.current = null;
+        if (c === 0) return;
+        const next = moveWordLeft(v, c);
+        emitChange(`${v.slice(0, next)}${v.slice(c)}`);
+        moveCursor(next);
+        return;
+      }
+      case "clear_line":
+        metaPrefixAt.current = null;
+        if (v.length === 0) return;
+        emitChange("");
+        moveCursor(0);
+        return;
+      case "move_left":
+        moveCursor(Math.max(0, c - 1));
+        return;
+      case "move_right":
+        moveCursor(Math.min(v.length, c + 1));
+        return;
+      case "delete_back":
+        metaPrefixAt.current = null;
+        if (c === 0) return;
+        emitChange(`${v.slice(0, c - 1)}${v.slice(c)}`);
+        moveCursor(c - 1);
+        return;
+      case "delete_forward":
+        metaPrefixAt.current = null;
+        if (c >= v.length) return;
+        emitChange(`${v.slice(0, c)}${v.slice(c + 1)}`);
+        return;
+      case "insert":
+        metaPrefixAt.current = null;
+        emitChange(`${v.slice(0, c)}${action.text}${v.slice(c)}`);
+        moveCursor(c + action.text.length);
+        return;
+      default:
+        unreachable(action);
     }
-    if (action.type === "submit") {
-      onSubmitRef.current(v);
-      return;
-    }
-    if (action.type === "move_home") {
-      moveCursor(0);
-      return;
-    }
-    if (action.type === "move_end") {
-      moveCursor(v.length);
-      return;
-    }
-    if (action.type === "move_word_left") {
-      moveCursor(moveWordLeft(v, c));
-      return;
-    }
-    if (action.type === "move_word_right") {
-      moveCursor(moveWordRight(v, c));
-      return;
-    }
-    if (action.type === "delete_word_back") {
-      metaPrefixAt.current = null;
-      if (c === 0) return;
-      const next = moveWordLeft(v, c);
-      emitChange(`${v.slice(0, next)}${v.slice(c)}`);
-      moveCursor(next);
-      return;
-    }
-    if (action.type === "clear_line") {
-      metaPrefixAt.current = null;
-      if (v.length === 0) return;
-      emitChange("");
-      moveCursor(0);
-      return;
-    }
-    if (action.type === "move_left") {
-      moveCursor(Math.max(0, c - 1));
-      return;
-    }
-    if (action.type === "move_right") {
-      moveCursor(Math.min(v.length, c + 1));
-      return;
-    }
-    if (action.type === "delete_back") {
-      metaPrefixAt.current = null;
-      if (c === 0) return;
-      emitChange(`${v.slice(0, c - 1)}${v.slice(c)}`);
-      moveCursor(c - 1);
-      return;
-    }
-    if (action.type === "delete_forward") {
-      metaPrefixAt.current = null;
-      if (c >= v.length) return;
-      emitChange(`${v.slice(0, c)}${v.slice(c + 1)}`);
-      return;
-    }
-
-    metaPrefixAt.current = null;
-    emitChange(`${v.slice(0, c)}${action.text}${v.slice(c)}`);
-    moveCursor(c + action.text.length);
   }, []);
 
   useInput(handleInput, { isActive: focus });

--- a/src/prompt-keymap.test.ts
+++ b/src/prompt-keymap.test.ts
@@ -1,26 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { resolvePromptAction } from "./prompt-keymap";
 import type { KeyEvent } from "./tui/context";
-
-function emptyKey(): KeyEvent {
-  return {
-    return: false,
-    tab: false,
-    shift: false,
-    ctrl: false,
-    meta: false,
-    super: false,
-    escape: false,
-    upArrow: false,
-    downArrow: false,
-    leftArrow: false,
-    rightArrow: false,
-    home: false,
-    end: false,
-    backspace: false,
-    delete: false,
-  };
-}
+import { emptyKey } from "./tui/input";
 
 function key(overrides: Partial<KeyEvent>): KeyEvent {
   return { ...emptyKey(), ...overrides };

--- a/src/prompt-keymap.test.ts
+++ b/src/prompt-keymap.test.ts
@@ -1,64 +1,161 @@
 import { describe, expect, test } from "bun:test";
 import { resolvePromptAction } from "./prompt-keymap";
+import type { KeyEvent } from "./tui/context";
+
+function emptyKey(): KeyEvent {
+  return {
+    return: false,
+    tab: false,
+    shift: false,
+    ctrl: false,
+    meta: false,
+    super: false,
+    escape: false,
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    home: false,
+    end: false,
+    backspace: false,
+    delete: false,
+  };
+}
+
+function key(overrides: Partial<KeyEvent>): KeyEvent {
+  return { ...emptyKey(), ...overrides };
+}
+
+const noMeta = { hasMetaPrefix: false };
 
 describe("prompt keymap", () => {
-  test("maps submit and plain insert", () => {
-    expect(resolvePromptAction("", { return: true }, { hasMetaPrefix: false })).toEqual({ type: "submit" });
-    expect(resolvePromptAction("x", {}, { hasMetaPrefix: false })).toEqual({ type: "insert", text: "x" });
+  test("submit on enter", () => {
+    expect(resolvePromptAction("", key({ return: true }), noMeta)).toEqual({ type: "submit" });
   });
 
-  test("shift+enter inserts newline instead of submitting", () => {
-    expect(resolvePromptAction("", { return: true, shift: true }, { hasMetaPrefix: false })).toEqual({
+  test("insert plain text", () => {
+    expect(resolvePromptAction("x", emptyKey(), noMeta)).toEqual({ type: "insert", text: "x" });
+  });
+
+  test("shift+enter inserts newline", () => {
+    expect(resolvePromptAction("", key({ return: true, shift: true }), noMeta)).toEqual({
       type: "insert",
       text: "\n",
     });
   });
 
-  test("maps common word navigation and deletion sequences", () => {
-    expect(resolvePromptAction("\u001bb", {}, { hasMetaPrefix: false })).toEqual({ type: "move_word_left" });
-    expect(resolvePromptAction("\u001bf", {}, { hasMetaPrefix: false })).toEqual({ type: "move_word_right" });
-    expect(resolvePromptAction("\u001b\u007f", {}, { hasMetaPrefix: false })).toEqual({ type: "delete_word_back" });
+  test("noop for arrows, tab, ctrl+c", () => {
+    expect(resolvePromptAction("", key({ upArrow: true }), noMeta)).toEqual({ type: "noop" });
+    expect(resolvePromptAction("", key({ downArrow: true }), noMeta)).toEqual({ type: "noop" });
+    expect(resolvePromptAction("", key({ tab: true }), noMeta)).toEqual({ type: "noop" });
+    expect(resolvePromptAction("c", key({ ctrl: true }), noMeta)).toEqual({ type: "noop" });
   });
 
-  test("maps line home/end style sequences often used by cmd+arrows", () => {
-    expect(resolvePromptAction("\u001b[1;9D", {}, { hasMetaPrefix: false })).toEqual({ type: "move_home" });
-    expect(resolvePromptAction("\u001b[1;9C", {}, { hasMetaPrefix: false })).toEqual({ type: "move_end" });
-    expect(resolvePromptAction("\u001b[1;10D", {}, { hasMetaPrefix: false })).toEqual({ type: "move_home" });
-    expect(resolvePromptAction("\u001b[1;10C", {}, { hasMetaPrefix: false })).toEqual({ type: "move_end" });
-    expect(resolvePromptAction("\u001b[1;13D", {}, { hasMetaPrefix: false })).toEqual({ type: "move_home" });
-    expect(resolvePromptAction("\u001b[1;13C", {}, { hasMetaPrefix: false })).toEqual({ type: "move_end" });
-    expect(resolvePromptAction("\u001b[1;9H", {}, { hasMetaPrefix: false })).toEqual({ type: "move_home" });
-    expect(resolvePromptAction("\u001b[1;9F", {}, { hasMetaPrefix: false })).toEqual({ type: "move_end" });
-    expect(resolvePromptAction("\u001b[1;10H", {}, { hasMetaPrefix: false })).toEqual({ type: "move_home" });
-    expect(resolvePromptAction("\u001b[1;10F", {}, { hasMetaPrefix: false })).toEqual({ type: "move_end" });
-  });
-
-  test("maps meta+arrow to word navigation (ink meta = Option/Alt)", () => {
-    expect(resolvePromptAction("", { meta: true, leftArrow: true }, { hasMetaPrefix: false })).toEqual({
-      type: "move_word_left",
+  describe("home/end", () => {
+    test("home key", () => {
+      expect(resolvePromptAction("", key({ home: true }), noMeta)).toEqual({ type: "move_home" });
     });
-    expect(resolvePromptAction("", { meta: true, rightArrow: true }, { hasMetaPrefix: false })).toEqual({
-      type: "move_word_right",
+
+    test("end key", () => {
+      expect(resolvePromptAction("", key({ end: true }), noMeta)).toEqual({ type: "move_end" });
+    });
+
+    test("cmd+left → home", () => {
+      expect(resolvePromptAction("", key({ super: true, leftArrow: true }), noMeta)).toEqual({ type: "move_home" });
+    });
+
+    test("cmd+right → end", () => {
+      expect(resolvePromptAction("", key({ super: true, rightArrow: true }), noMeta)).toEqual({ type: "move_end" });
+    });
+
+    test("ctrl+a → home", () => {
+      expect(resolvePromptAction("a", key({ ctrl: true }), noMeta)).toEqual({ type: "move_home" });
+    });
+
+    test("ctrl+e → end", () => {
+      expect(resolvePromptAction("e", key({ ctrl: true }), noMeta)).toEqual({ type: "move_end" });
     });
   });
 
-  test("maps modifier CSI arrows for word navigation across terminal variants", () => {
-    expect(resolvePromptAction("\u001b[1;6D", {}, { hasMetaPrefix: false })).toEqual({ type: "move_word_left" });
-    expect(resolvePromptAction("\u001b[1;6C", {}, { hasMetaPrefix: false })).toEqual({ type: "move_word_right" });
-  });
-
-  test("maps clear-line control sequence", () => {
-    expect(resolvePromptAction("\u0015", {}, { hasMetaPrefix: false })).toEqual({ type: "clear_line" });
-    expect(resolvePromptAction("u", { ctrl: true }, { hasMetaPrefix: false })).toEqual({ type: "clear_line" });
-  });
-
-  test("maps meta+backspace/delete to delete-word-back (ink meta = Option/Alt)", () => {
-    expect(resolvePromptAction("\u007f", { meta: true, backspace: true }, { hasMetaPrefix: false })).toEqual({
-      type: "delete_word_back",
+  describe("word navigation", () => {
+    test("alt+left → word left", () => {
+      expect(resolvePromptAction("", key({ meta: true, leftArrow: true }), noMeta)).toEqual({
+        type: "move_word_left",
+      });
     });
-    // ink maps \x7f (physical Backspace) to key.delete, not key.backspace
-    expect(resolvePromptAction("", { meta: true, delete: true }, { hasMetaPrefix: false })).toEqual({
-      type: "delete_word_back",
+
+    test("alt+right → word right", () => {
+      expect(resolvePromptAction("", key({ meta: true, rightArrow: true }), noMeta)).toEqual({
+        type: "move_word_right",
+      });
+    });
+
+    test("ctrl+left → word left", () => {
+      expect(resolvePromptAction("", key({ ctrl: true, leftArrow: true }), noMeta)).toEqual({
+        type: "move_word_left",
+      });
+    });
+
+    test("ctrl+right → word right", () => {
+      expect(resolvePromptAction("", key({ ctrl: true, rightArrow: true }), noMeta)).toEqual({
+        type: "move_word_right",
+      });
+    });
+
+    test("alt+b → word left", () => {
+      expect(resolvePromptAction("b", key({ meta: true }), noMeta)).toEqual({ type: "move_word_left" });
+    });
+
+    test("alt+f → word right", () => {
+      expect(resolvePromptAction("f", key({ meta: true }), noMeta)).toEqual({ type: "move_word_right" });
+    });
+  });
+
+  describe("deletion", () => {
+    test("backspace", () => {
+      expect(resolvePromptAction("", key({ backspace: true }), noMeta)).toEqual({ type: "delete_back" });
+    });
+
+    test("delete key", () => {
+      expect(resolvePromptAction("", key({ delete: true }), noMeta)).toEqual({ type: "delete_forward" });
+    });
+
+    test("alt+backspace → delete word back", () => {
+      expect(resolvePromptAction("", key({ meta: true, backspace: true }), noMeta)).toEqual({
+        type: "delete_word_back",
+      });
+    });
+
+    test("alt+delete → delete word back", () => {
+      expect(resolvePromptAction("", key({ meta: true, delete: true }), noMeta)).toEqual({
+        type: "delete_word_back",
+      });
+    });
+
+    test("ctrl+w → delete word back", () => {
+      expect(resolvePromptAction("w", key({ ctrl: true }), noMeta)).toEqual({ type: "delete_word_back" });
+    });
+
+    test("meta prefix + backspace → delete word back", () => {
+      expect(resolvePromptAction("", key({ backspace: true }), { hasMetaPrefix: true })).toEqual({
+        type: "delete_word_back",
+      });
+    });
+  });
+
+  describe("clear line", () => {
+    test("ctrl+u", () => {
+      expect(resolvePromptAction("u", key({ ctrl: true }), noMeta)).toEqual({ type: "clear_line" });
+    });
+  });
+
+  describe("simple movement", () => {
+    test("left arrow", () => {
+      expect(resolvePromptAction("", key({ leftArrow: true }), noMeta)).toEqual({ type: "move_left" });
+    });
+
+    test("right arrow", () => {
+      expect(resolvePromptAction("", key({ rightArrow: true }), noMeta)).toEqual({ type: "move_right" });
     });
   });
 });

--- a/src/prompt-keymap.ts
+++ b/src/prompt-keymap.ts
@@ -1,18 +1,4 @@
-export type PromptKey = {
-  return?: boolean;
-  tab?: boolean;
-  shift?: boolean;
-  ctrl?: boolean;
-  meta?: boolean;
-  upArrow?: boolean;
-  downArrow?: boolean;
-  leftArrow?: boolean;
-  rightArrow?: boolean;
-  home?: boolean;
-  end?: boolean;
-  backspace?: boolean;
-  delete?: boolean;
-};
+import type { KeyEvent } from "./tui/context";
 
 export type PromptAction =
   | { type: "noop" }
@@ -29,156 +15,49 @@ export type PromptAction =
   | { type: "clear_line" }
   | { type: "insert"; text: string };
 
-export const ESCAPE_CHAR = "\u001b";
-
-const CTRL = {
-  c: "c",
-  a: "a",
-  e: "e",
-  h: "\u0008",
-  u: "u",
-  clearLine: "\u0015",
-  w: "w",
-  wordDelete: "\u0017",
-} as const;
-
-const ESC = {
-  altB: `${ESCAPE_CHAR}b`,
-  altF: `${ESCAPE_CHAR}f`,
-  altBackspace: `${ESCAPE_CHAR}\u007f`,
-  altCtrlH: `${ESCAPE_CHAR}\u0008`,
-  delete: `${ESCAPE_CHAR}[3~`,
-  home: new Set([`${ESCAPE_CHAR}[H`, `${ESCAPE_CHAR}OH`, `${ESCAPE_CHAR}[1~`, `${ESCAPE_CHAR}[7~`]),
-  end: new Set([`${ESCAPE_CHAR}[F`, `${ESCAPE_CHAR}OF`, `${ESCAPE_CHAR}[4~`, `${ESCAPE_CHAR}[8~`]),
-  wordLeft: new Set([`${ESCAPE_CHAR}[1;3D`, `${ESCAPE_CHAR}[1;5D`]),
-  wordRight: new Set([`${ESCAPE_CHAR}[1;3C`, `${ESCAPE_CHAR}[1;5C`]),
-  lineLeft: new Set([`${ESCAPE_CHAR}[1;9D`, `${ESCAPE_CHAR}[1;7D`]),
-  lineRight: new Set([`${ESCAPE_CHAR}[1;9C`, `${ESCAPE_CHAR}[1;7C`]),
-} as const;
-
-const CHARS = {
-  backspace: "\u007f",
-} as const;
-
-type CsiArrowMove = {
-  kind: "word" | "line";
-  direction: "left" | "right";
-};
-
-type CsiLineMove = {
-  kind: "line";
-  direction: "left" | "right";
-};
-
-function parseCsiArrowMove(input: string): CsiArrowMove | null {
-  const prefix = `${ESCAPE_CHAR}[`;
-  if (!input.startsWith(prefix)) return null;
-  const final = input.at(-1);
-  if (final !== "C" && final !== "D") return null;
-  const payload = input.slice(prefix.length, -1);
-  if (payload.length === 0) return null;
-  const parts = payload.split(";");
-  const modifierPart = parts.length === 1 ? parts[0] : parts[1];
-  if (parts.length > 2 || (parts.length === 2 && parts[0] !== "1") || !modifierPart) return null;
-  const modifier = Number.parseInt(modifierPart, 10);
-  const direction = final === "D" ? "left" : "right";
-  if (!Number.isFinite(modifier) || modifier <= 0) return null;
-  if (modifier >= 9) return { kind: "line", direction };
-  if (modifier >= 3) return { kind: "word", direction };
-  return null;
-}
-
-function parseCsiLineMove(input: string): CsiLineMove | null {
-  const prefix = `${ESCAPE_CHAR}[`;
-  if (!input.startsWith(prefix)) return null;
-  const final = input.at(-1);
-  if (final !== "H" && final !== "F") return null;
-  const payload = input.slice(prefix.length, -1);
-  if (payload.length === 0) return null;
-  const parts = payload.split(";");
-  const modifierPart = parts.length === 1 ? parts[0] : parts[1];
-  if (parts.length > 2 || (parts.length === 2 && parts[0] !== "1") || !modifierPart) return null;
-  const modifier = Number.parseInt(modifierPart, 10);
-  if (!Number.isFinite(modifier) || modifier < 3) return null;
-  return {
-    kind: "line",
-    direction: final === "H" ? "left" : "right",
-  };
-}
-
-export function resolvePromptAction(input: string, key: PromptKey, options: { hasMetaPrefix: boolean }): PromptAction {
-  const csiArrowMove = parseCsiArrowMove(input);
-  const csiLineMove = parseCsiLineMove(input);
-
-  if (key.upArrow || key.downArrow || key.tab || (key.shift && key.tab) || (key.ctrl && input === CTRL.c))
+export function resolvePromptAction(input: string, key: KeyEvent, options: { hasMetaPrefix: boolean }): PromptAction {
+  // Noop: arrows, tab, ctrl+c
+  if (key.upArrow || key.downArrow || key.tab || (key.shift && key.tab) || (key.ctrl && input === "c"))
     return { type: "noop" };
+
+  // Submit / newline
   if (key.return && key.shift) return { type: "insert", text: "\n" };
   if (key.return) return { type: "submit" };
 
-  if (
-    key.home ||
-    ESC.home.has(input) ||
-    (key.ctrl && input === CTRL.a) ||
-    ESC.lineLeft.has(input) ||
-    (csiArrowMove?.kind === "line" && csiArrowMove.direction === "left") ||
-    csiLineMove?.direction === "left"
-  ) {
-    return { type: "move_home" };
-  }
-  if (
-    key.end ||
-    ESC.end.has(input) ||
-    (key.ctrl && input === CTRL.e) ||
-    ESC.lineRight.has(input) ||
-    (csiArrowMove?.kind === "line" && csiArrowMove.direction === "right") ||
-    csiLineMove?.direction === "right"
-  ) {
-    return { type: "move_end" };
-  }
+  // Home: Home key, Cmd+Left, Ctrl+A
+  if (key.home || (key.super && key.leftArrow) || (key.ctrl && input === "a")) return { type: "move_home" };
 
-  if (
-    (key.meta && (key.leftArrow || input === "b")) ||
-    input === ESC.altB ||
-    ESC.wordLeft.has(input) ||
-    (csiArrowMove?.kind === "word" && csiArrowMove.direction === "left")
-  ) {
-    return { type: "move_word_left" };
-  }
-  if (
-    (key.meta && (key.rightArrow || input === "f")) ||
-    input === ESC.altF ||
-    ESC.wordRight.has(input) ||
-    (csiArrowMove?.kind === "word" && csiArrowMove.direction === "right")
-  ) {
-    return { type: "move_word_right" };
-  }
+  // End: End key, Cmd+Right, Ctrl+E
+  if (key.end || (key.super && key.rightArrow) || (key.ctrl && input === "e")) return { type: "move_end" };
 
-  if (
-    (key.ctrl && input === CTRL.w) ||
-    input === CTRL.wordDelete ||
-    input === ESC.altBackspace ||
-    input === ESC.altCtrlH ||
-    (key.meta && (key.backspace || key.delete))
-  ) {
-    return { type: "delete_word_back" };
-  }
-  if ((key.ctrl && input === CTRL.u) || input === CTRL.clearLine) return { type: "clear_line" };
+  // Word left: Alt+Left, Ctrl+Left, Alt+B
+  if ((key.meta || key.ctrl) && key.leftArrow) return { type: "move_word_left" };
+  if (key.meta && input === "b") return { type: "move_word_left" };
 
+  // Word right: Alt+Right, Ctrl+Right, Alt+F
+  if ((key.meta || key.ctrl) && key.rightArrow) return { type: "move_word_right" };
+  if (key.meta && input === "f") return { type: "move_word_right" };
+
+  // Delete word back: Ctrl+W, Alt+Backspace, meta prefix + backspace
+  if (key.ctrl && input === "w") return { type: "delete_word_back" };
+  if (key.meta && (key.backspace || key.delete)) return { type: "delete_word_back" };
+  if (options.hasMetaPrefix && key.backspace) return { type: "delete_word_back" };
+
+  // Clear line: Ctrl+U
+  if (key.ctrl && input === "u") return { type: "clear_line" };
+
+  // Simple arrow movement
   if (key.leftArrow) return { type: "move_left" };
   if (key.rightArrow) return { type: "move_right" };
 
-  const isForwardDelete = input === ESC.delete;
-  if (isForwardDelete) return { type: "delete_forward" };
+  // Forward delete
+  if (key.delete) return { type: "delete_forward" };
 
-  const isBackspaceLike = key.backspace || key.delete || input === CTRL.h || input === CHARS.backspace;
-  const isMetaWordDelete =
-    (isBackspaceLike && (options.hasMetaPrefix || key.meta || input.includes(ESCAPE_CHAR))) ||
-    input === ESC.altBackspace ||
-    input === ESC.altCtrlH;
-  if (isMetaWordDelete) return { type: "delete_word_back" };
-  if (isBackspaceLike) return { type: "delete_back" };
+  // Backspace
+  if (key.backspace) return { type: "delete_back" };
 
-  if (!input || key.ctrl || key.meta || input.includes(ESCAPE_CHAR)) return { type: "noop" };
+  // No printable input or modifier held — noop
+  if (!input || key.ctrl || key.meta) return { type: "noop" };
 
   return { type: "insert", text: input };
 }

--- a/src/tool-output.tui.test.tsx
+++ b/src/tool-output.tui.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { ChatRow } from "./chat-commands";
 import { ChatTranscript } from "./chat-transcript";
 import { formatToolOutput, type ToolOutput } from "./tool-output-content";
-import { renderInkPlain } from "./tui-test-utils";
+import { renderPlain } from "./tui-test-utils";
 
 function dedent(value: string): string {
   const lines = value.split("\n");
@@ -26,7 +26,7 @@ function dedent(value: string): string {
 
 function renderChat(toolOutput: ToolOutput[]): string {
   const row: ChatRow = { id: "r1", role: "tool", content: "", toolOutput };
-  return renderInkPlain(<ChatTranscript rows={[row]} isWorking={false} thinkingFrame={0} />, 96);
+  return renderPlain(<ChatTranscript rows={[row]} isWorking={false} thinkingFrame={0} />, 96);
 }
 
 describe("tool output TUI — CLI (formatToolOutput)", () => {

--- a/src/tui-test-utils.ts
+++ b/src/tui-test-utils.ts
@@ -41,7 +41,7 @@ export function withTerminalWidth(width: number, run: () => string): string {
   }
 }
 
-export function renderInkPlain(node: ReactNode, columns = 96): string {
+export function renderPlain(node: ReactNode, columns = 96): string {
   const rendered = withTerminalWidth(columns, () => renderToString(node));
   return trimRightLines(stripAnsi(rendered)).replace(/^\n+/, "").replace(/\n+$/, "");
 }

--- a/src/tui-test-utils.ts
+++ b/src/tui-test-utils.ts
@@ -1,44 +1,6 @@
 import type { ReactNode } from "react";
 import { renderToString } from "./tui";
-
-export const stripAnsi = (value: string): string => {
-  let out = "";
-  let i = 0;
-  while (i < value.length) {
-    if (value[i] === "\u001b") {
-      i++;
-      if (i < value.length && value[i] === "[") {
-        // CSI sequence: ESC [ <params> <final byte 0x40-0x7E>
-        i++;
-        while (i < value.length) {
-          const code = value.charCodeAt(i);
-          i++;
-          if (code >= 0x40 && code <= 0x7e) break;
-        }
-      } else if (i < value.length && value[i] === "]") {
-        // OSC sequence: ESC ] ... (BEL | ESC \)
-        i++;
-        while (i < value.length) {
-          if (value[i] === "\x07") {
-            i++;
-            break;
-          }
-          if (value[i] === "\x1b" && i + 1 < value.length && value[i + 1] === "\\") {
-            i += 2;
-            break;
-          }
-          i++;
-        }
-      } else if (i < value.length) {
-        i++;
-      }
-      continue;
-    }
-    out += value[i];
-    i++;
-  }
-  return out;
-};
+import { stripAnsi } from "./tui/serialize";
 
 export const trimRightLines = (value: string): string =>
   value

--- a/src/tui-test-utils.ts
+++ b/src/tui-test-utils.ts
@@ -8,11 +8,26 @@ export const stripAnsi = (value: string): string => {
     if (value[i] === "\u001b") {
       i++;
       if (i < value.length && value[i] === "[") {
+        // CSI sequence: ESC [ <params> <final byte 0x40-0x7E>
         i++;
         while (i < value.length) {
           const code = value.charCodeAt(i);
           i++;
           if (code >= 0x40 && code <= 0x7e) break;
+        }
+      } else if (i < value.length && value[i] === "]") {
+        // OSC sequence: ESC ] ... (BEL | ESC \)
+        i++;
+        while (i < value.length) {
+          if (value[i] === "\x07") {
+            i++;
+            break;
+          }
+          if (value[i] === "\x1b" && i + 1 < value.length && value[i + 1] === "\\") {
+            i += 2;
+            break;
+          }
+          i++;
         }
       } else if (i < value.length) {
         i++;

--- a/src/tui-test-utils.ts
+++ b/src/tui-test-utils.ts
@@ -3,14 +3,24 @@ import { renderToString } from "./tui";
 
 export const stripAnsi = (value: string): string => {
   let out = "";
-  for (let i = 0; i < value.length; i += 1) {
-    const ch = value[i];
-    if (ch === "\u001b" && value[i + 1] === "[") {
-      i += 2;
-      while (i < value.length && value[i] !== "m") i += 1;
+  let i = 0;
+  while (i < value.length) {
+    if (value[i] === "\u001b") {
+      i++;
+      if (i < value.length && value[i] === "[") {
+        i++;
+        while (i < value.length) {
+          const code = value.charCodeAt(i);
+          i++;
+          if (code >= 0x40 && code <= 0x7e) break;
+        }
+      } else if (i < value.length) {
+        i++;
+      }
       continue;
     }
-    if (ch != null) out += ch;
+    out += value[i];
+    i++;
   }
   return out;
 };
@@ -32,6 +42,6 @@ export function withTerminalWidth(width: number, run: () => string): string {
 }
 
 export function renderInkPlain(node: ReactNode, columns = 96): string {
-  const rendered = withTerminalWidth(columns, () => renderToString(node, { columns }));
+  const rendered = withTerminalWidth(columns, () => renderToString(node));
   return trimRightLines(stripAnsi(rendered)).replace(/^\n+/, "").replace(/\n+$/, "");
 }

--- a/src/tui-test-utils.ts
+++ b/src/tui-test-utils.ts
@@ -1,5 +1,5 @@
-import { renderToString } from "ink";
 import type { ReactNode } from "react";
+import { renderToString } from "./tui";
 
 export const stripAnsi = (value: string): string => {
   let out = "";

--- a/src/tui/components.ts
+++ b/src/tui/components.ts
@@ -1,0 +1,38 @@
+import type React from "react";
+import { createElement } from "react";
+
+type BoxProps = {
+  flexDirection?: "row" | "column";
+  width?: number;
+  children?: React.ReactNode;
+  key?: React.Key;
+};
+
+type TextProps = {
+  color?: string;
+  dimColor?: boolean;
+  backgroundColor?: string;
+  bold?: boolean;
+  underline?: boolean;
+  inverse?: boolean;
+  children?: React.ReactNode;
+  key?: React.Key;
+};
+
+type StaticProps<T> = {
+  items: T[];
+  children: (item: T, index: number) => React.ReactNode;
+};
+
+export function Box(props: BoxProps): React.ReactElement {
+  return createElement("tui-box", props as Record<string, unknown>, props.children);
+}
+
+export function Text(props: TextProps): React.ReactElement {
+  return createElement("tui-text", props as Record<string, unknown>, props.children);
+}
+
+export function Static<T extends { id?: string }>(props: StaticProps<T>): React.ReactElement {
+  const children = props.items.map((item, index) => props.children(item, index));
+  return createElement("tui-static", { internal_static: true } as Record<string, unknown>, ...children);
+}

--- a/src/tui/components.tsx
+++ b/src/tui/components.tsx
@@ -52,5 +52,5 @@ export function Static<T extends { id?: string }>(props: StaticProps<T>): React.
     const child = props.children(item, index);
     return <tui-virtual key={key}>{child}</tui-virtual>;
   });
-  return <tui-static internal_static>{children}</tui-static>;
+  return <tui-static>{children}</tui-static>;
 }

--- a/src/tui/components.tsx
+++ b/src/tui/components.tsx
@@ -2,6 +2,8 @@ import type React from "react";
 
 type BoxProps = {
   flexDirection?: "row" | "column";
+  justifyContent?: "flex-start" | "flex-end" | "space-between";
+  flexWrap?: "nowrap" | "wrap";
   width?: number;
   children?: React.ReactNode;
   key?: React.Key;
@@ -25,7 +27,12 @@ type StaticProps<T> = {
 
 export function Box(props: BoxProps): React.ReactElement {
   return (
-    <tui-box flexDirection={props.flexDirection} width={props.width}>
+    <tui-box
+      flexDirection={props.flexDirection}
+      justifyContent={props.justifyContent}
+      flexWrap={props.flexWrap}
+      width={props.width}
+    >
       {props.children}
     </tui-box>
   );

--- a/src/tui/components.tsx
+++ b/src/tui/components.tsx
@@ -47,6 +47,10 @@ export function Text(props: TextProps): React.ReactElement {
 }
 
 export function Static<T extends { id?: string }>(props: StaticProps<T>): React.ReactElement {
-  const children = props.items.map((item, index) => props.children(item, index));
+  const children = props.items.map((item, index) => {
+    const key = item.id ?? index;
+    const child = props.children(item, index);
+    return <tui-virtual key={key}>{child}</tui-virtual>;
+  });
   return <tui-static internal_static>{children}</tui-static>;
 }

--- a/src/tui/components.tsx
+++ b/src/tui/components.tsx
@@ -1,5 +1,4 @@
 import type React from "react";
-import { createElement } from "react";
 
 type BoxProps = {
   flexDirection?: "row" | "column";
@@ -25,14 +24,29 @@ type StaticProps<T> = {
 };
 
 export function Box(props: BoxProps): React.ReactElement {
-  return createElement("tui-box", props as Record<string, unknown>, props.children);
+  return (
+    <tui-box flexDirection={props.flexDirection} width={props.width}>
+      {props.children}
+    </tui-box>
+  );
 }
 
 export function Text(props: TextProps): React.ReactElement {
-  return createElement("tui-text", props as Record<string, unknown>, props.children);
+  return (
+    <tui-text
+      color={props.color}
+      dimColor={props.dimColor}
+      backgroundColor={props.backgroundColor}
+      bold={props.bold}
+      underline={props.underline}
+      inverse={props.inverse}
+    >
+      {props.children}
+    </tui-text>
+  );
 }
 
 export function Static<T extends { id?: string }>(props: StaticProps<T>): React.ReactElement {
   const children = props.items.map((item, index) => props.children(item, index));
-  return createElement("tui-static", { internal_static: true } as Record<string, unknown>, ...children);
+  return <tui-static internal_static>{children}</tui-static>;
 }

--- a/src/tui/context.ts
+++ b/src/tui/context.ts
@@ -14,6 +14,7 @@ export type KeyEvent = {
   shift: boolean;
   ctrl: boolean;
   meta: boolean;
+  super: boolean;
   escape: boolean;
   upArrow: boolean;
   downArrow: boolean;

--- a/src/tui/context.ts
+++ b/src/tui/context.ts
@@ -1,0 +1,39 @@
+import { createContext } from "react";
+
+export type AppContextValue = {
+  exit: () => void;
+};
+
+export const AppContext = createContext<AppContextValue>({ exit: () => {} });
+
+export type InputHandler = (input: string, key: KeyEvent) => void;
+
+export type KeyEvent = {
+  return: boolean;
+  tab: boolean;
+  shift: boolean;
+  ctrl: boolean;
+  meta: boolean;
+  escape: boolean;
+  upArrow: boolean;
+  downArrow: boolean;
+  leftArrow: boolean;
+  rightArrow: boolean;
+  home: boolean;
+  end: boolean;
+  backspace: boolean;
+  delete: boolean;
+};
+
+export type InputRegistration = {
+  handler: InputHandler;
+  isActive: boolean;
+};
+
+export type InputContextValue = {
+  register: (reg: InputRegistration) => () => void;
+};
+
+export const InputContext = createContext<InputContextValue>({
+  register: () => () => {},
+});

--- a/src/tui/dom.test.ts
+++ b/src/tui/dom.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { appendChild, createElement, createTextNode, insertBefore, removeChild } from "./dom";
+
+describe("dom", () => {
+  test("createElement creates element with empty children", () => {
+    const el = createElement("tui-box", { bold: true });
+    expect(el.kind).toBe("element");
+    expect(el.type).toBe("tui-box");
+    expect(el.props.bold).toBe(true);
+    expect(el.children).toEqual([]);
+    expect(el.parent).toBeNull();
+  });
+
+  test("createTextNode creates text node", () => {
+    const node = createTextNode("hello");
+    expect(node.kind).toBe("text");
+    expect(node.value).toBe("hello");
+    expect(node.parent).toBeNull();
+  });
+
+  test("appendChild adds child and sets parent", () => {
+    const parent = createElement("tui-box", {});
+    const child = createTextNode("hi");
+    appendChild(parent, child);
+    expect(parent.children).toEqual([child]);
+    expect(child.parent).toBe(parent);
+  });
+
+  test("removeChild removes child and clears parent", () => {
+    const parent = createElement("tui-box", {});
+    const child = createTextNode("hi");
+    appendChild(parent, child);
+    removeChild(parent, child);
+    expect(parent.children).toEqual([]);
+    expect(child.parent).toBeNull();
+  });
+
+  test("removeChild does nothing for non-child node", () => {
+    const parent = createElement("tui-box", {});
+    const other = createTextNode("other");
+    other.parent = createElement("tui-text", {});
+    removeChild(parent, other);
+    // parent pointer should not be cleared since it wasn't a child
+    expect(other.parent).not.toBeNull();
+  });
+
+  test("insertBefore inserts child before reference node", () => {
+    const parent = createElement("tui-box", {});
+    const a = createTextNode("a");
+    const b = createTextNode("b");
+    appendChild(parent, b);
+    insertBefore(parent, a, b);
+    expect(parent.children).toEqual([a, b]);
+    expect(a.parent).toBe(parent);
+  });
+
+  test("insertBefore appends when reference not found", () => {
+    const parent = createElement("tui-box", {});
+    const a = createTextNode("a");
+    const b = createTextNode("b");
+    appendChild(parent, a);
+    insertBefore(parent, b, createTextNode("missing"));
+    expect(parent.children).toEqual([a, b]);
+    expect(b.parent).toBe(parent);
+  });
+});

--- a/src/tui/dom.ts
+++ b/src/tui/dom.ts
@@ -48,8 +48,10 @@ export function appendChild(parent: TuiElement, child: TuiNode): void {
 
 export function removeChild(parent: TuiElement, child: TuiNode): void {
   const index = parent.children.indexOf(child);
-  if (index !== -1) parent.children.splice(index, 1);
-  child.parent = null;
+  if (index !== -1) {
+    parent.children.splice(index, 1);
+    child.parent = null;
+  }
 }
 
 export function insertBefore(parent: TuiElement, child: TuiNode, before: TuiNode): void {

--- a/src/tui/dom.ts
+++ b/src/tui/dom.ts
@@ -3,6 +3,8 @@ export type TuiNodeType = "tui-root" | "tui-box" | "tui-text" | "tui-static" | "
 export interface TuiProps {
   // Box
   flexDirection?: "row" | "column";
+  justifyContent?: "flex-start" | "flex-end" | "space-between";
+  flexWrap?: "nowrap" | "wrap";
   width?: number;
   // Text
   color?: string;

--- a/src/tui/dom.ts
+++ b/src/tui/dom.ts
@@ -1,0 +1,63 @@
+export type TuiNodeType = "tui-root" | "tui-box" | "tui-text" | "tui-static" | "tui-virtual";
+
+export interface TuiProps {
+  // Box
+  flexDirection?: "row" | "column";
+  width?: number;
+  // Text
+  color?: string;
+  dimColor?: boolean;
+  backgroundColor?: string;
+  bold?: boolean;
+  underline?: boolean;
+  inverse?: boolean;
+  // Static
+  items?: unknown[];
+  // Internal
+  internal_static?: boolean;
+}
+
+export interface TuiElement {
+  kind: "element";
+  type: TuiNodeType;
+  props: TuiProps;
+  children: TuiNode[];
+  parent: TuiElement | null;
+}
+
+export interface TuiTextNode {
+  kind: "text";
+  value: string;
+  parent: TuiElement | null;
+}
+
+export type TuiNode = TuiElement | TuiTextNode;
+
+export function createElement(type: TuiNodeType, props: TuiProps): TuiElement {
+  return { kind: "element", type, props, children: [], parent: null };
+}
+
+export function createTextNode(value: string): TuiTextNode {
+  return { kind: "text", value, parent: null };
+}
+
+export function appendChild(parent: TuiElement, child: TuiNode): void {
+  child.parent = parent;
+  parent.children.push(child);
+}
+
+export function removeChild(parent: TuiElement, child: TuiNode): void {
+  const index = parent.children.indexOf(child);
+  if (index !== -1) parent.children.splice(index, 1);
+  child.parent = null;
+}
+
+export function insertBefore(parent: TuiElement, child: TuiNode, before: TuiNode): void {
+  child.parent = parent;
+  const index = parent.children.indexOf(before);
+  if (index === -1) {
+    parent.children.push(child);
+  } else {
+    parent.children.splice(index, 0, child);
+  }
+}

--- a/src/tui/dom.ts
+++ b/src/tui/dom.ts
@@ -13,8 +13,6 @@ export interface TuiProps {
   inverse?: boolean;
   // Static
   items?: unknown[];
-  // Internal
-  internal_static?: boolean;
 }
 
 export interface TuiElement {

--- a/src/tui/hooks.ts
+++ b/src/tui/hooks.ts
@@ -1,0 +1,21 @@
+import { useContext, useEffect, useRef } from "react";
+import { AppContext, type InputHandler, InputContext } from "./context";
+
+export function useApp(): { exit: () => void } {
+  return useContext(AppContext);
+}
+
+export function useInput(handler: InputHandler, options?: { isActive?: boolean }): void {
+  const ctx = useContext(InputContext);
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+  const isActive = options?.isActive ?? true;
+
+  useEffect(() => {
+    const unregister = ctx.register({
+      handler: (input, key) => handlerRef.current(input, key),
+      isActive,
+    });
+    return unregister;
+  }, [ctx, isActive]);
+}

--- a/src/tui/hooks.ts
+++ b/src/tui/hooks.ts
@@ -1,5 +1,5 @@
 import { useContext, useEffect, useRef } from "react";
-import { AppContext, type InputHandler, InputContext } from "./context";
+import { AppContext, InputContext, type InputHandler } from "./context";
 
 export function useApp(): { exit: () => void } {
   return useContext(AppContext);

--- a/src/tui/host-config.ts
+++ b/src/tui/host-config.ts
@@ -1,0 +1,175 @@
+import {
+  type TuiElement,
+  type TuiNode,
+  type TuiNodeType,
+  type TuiProps,
+  appendChild,
+  createElement,
+  createTextNode,
+  insertBefore,
+  removeChild,
+} from "./dom";
+
+type Props = TuiProps & { children?: unknown };
+type TextInstance = { kind: "text"; value: string; parent: TuiElement | null };
+
+function propsFromRaw(raw: Props): TuiProps {
+  const { children: _, ...rest } = raw;
+  return rest;
+}
+
+let onCommit: (() => void) | null = null;
+
+export function setOnCommit(fn: (() => void) | null): void {
+  onCommit = fn;
+}
+
+export const hostConfig = {
+  supportsMutation: true,
+  supportsPersistence: false,
+  supportsHydration: false,
+
+  createInstance(type: TuiNodeType, props: Props) {
+    return createElement(type, propsFromRaw(props));
+  },
+
+  createTextInstance(text: string): TextInstance {
+    return createTextNode(text);
+  },
+
+  appendInitialChild(parent: TuiElement, child: TuiElement | TextInstance) {
+    appendChild(parent, child as TuiNode);
+  },
+
+  appendChild(parent: TuiElement, child: TuiElement | TextInstance) {
+    appendChild(parent, child as TuiNode);
+  },
+
+  appendChildToContainer(container: TuiElement, child: TuiElement | TextInstance) {
+    appendChild(container, child as TuiNode);
+  },
+
+  removeChild(parent: TuiElement, child: TuiElement | TextInstance) {
+    removeChild(parent, child as TuiNode);
+  },
+
+  removeChildFromContainer(container: TuiElement, child: TuiElement | TextInstance) {
+    removeChild(container, child as TuiNode);
+  },
+
+  insertBefore(parent: TuiElement, child: TuiElement | TextInstance, before: TuiElement | TextInstance) {
+    insertBefore(parent, child as TuiNode, before as TuiNode);
+  },
+
+  insertInContainerBefore(container: TuiElement, child: TuiElement | TextInstance, before: TuiElement | TextInstance) {
+    insertBefore(container, child as TuiNode, before as TuiNode);
+  },
+
+  commitUpdate(instance: TuiElement, _type: TuiNodeType, _oldProps: Props, newProps: Props) {
+    instance.props = propsFromRaw(newProps);
+  },
+
+  commitTextUpdate(textInstance: TextInstance, _oldText: string, newText: string) {
+    textInstance.value = newText;
+  },
+
+  finalizeInitialChildren() {
+    return false;
+  },
+
+  prepareForCommit() {
+    return null;
+  },
+
+  resetAfterCommit() {
+    onCommit?.();
+  },
+
+  getPublicInstance(instance: TuiElement) {
+    return instance;
+  },
+
+  getRootHostContext() {
+    return {};
+  },
+
+  getChildHostContext(parentHostContext: Record<string, never>) {
+    return parentHostContext;
+  },
+
+  shouldSetTextContent() {
+    return false;
+  },
+
+  clearContainer(container: TuiElement) {
+    container.children = [];
+  },
+
+  scheduleTimeout: setTimeout,
+  cancelTimeout: clearTimeout,
+  noTimeout: -1 as const,
+  isPrimaryRenderer: true,
+  warnsIfNotActing: false,
+  supportsMicrotasks: true,
+  scheduleMicrotask: queueMicrotask,
+
+  NotPendingTransition: null as never,
+  HostTransitionContext: {
+    $$typeof: Symbol.for("react.context"),
+    _currentValue: null as never,
+    _currentValue2: null as never,
+    _threadCount: 0,
+    Consumer: null as never,
+    Provider: null as never,
+  },
+
+  setCurrentUpdatePriority() {},
+  getCurrentUpdatePriority() {
+    return 16;
+  },
+  resolveUpdatePriority() {
+    return 16;
+  },
+
+  shouldAttemptEagerTransition() {
+    return false;
+  },
+
+  requestPostPaintCallback() {},
+
+  getInstanceFromNode() {
+    return null;
+  },
+
+  beforeActiveInstanceBlur() {},
+  afterActiveInstanceBlur() {},
+
+  prepareScopeUpdate() {},
+  getInstanceFromScope() {
+    return null;
+  },
+
+  detachDeletedInstance() {},
+  preparePortalMount() {},
+
+  maySuspendCommit() {
+    return false;
+  },
+  preloadInstance() {
+    return true;
+  },
+  startSuspendingCommit() {},
+  suspendInstance() {},
+  waitForCommitToBeReady() {
+    return null;
+  },
+  resetFormInstance() {},
+
+  trackSchedulerEvent() {},
+  resolveEventType() {
+    return null;
+  },
+  resolveEventTimeStamp() {
+    return -1.1;
+  },
+};

--- a/src/tui/host-config.ts
+++ b/src/tui/host-config.ts
@@ -102,6 +102,9 @@ export const hostConfig = {
   },
 
   clearContainer(container: TuiElement) {
+    for (const child of container.children) {
+      child.parent = null;
+    }
     container.children = [];
   },
 

--- a/src/tui/host-config.ts
+++ b/src/tui/host-config.ts
@@ -1,17 +1,17 @@
 import {
-  type TuiElement,
-  type TuiNode,
-  type TuiNodeType,
-  type TuiProps,
   appendChild,
   createElement,
   createTextNode,
   insertBefore,
   removeChild,
+  type TuiElement,
+  type TuiNode,
+  type TuiNodeType,
+  type TuiProps,
+  type TuiTextNode,
 } from "./dom";
 
 type Props = TuiProps & { children?: unknown };
-type TextInstance = { kind: "text"; value: string; parent: TuiElement | null };
 
 function propsFromRaw(raw: Props): TuiProps {
   const { children: _, ...rest } = raw;
@@ -33,43 +33,43 @@ export const hostConfig = {
     return createElement(type, propsFromRaw(props));
   },
 
-  createTextInstance(text: string): TextInstance {
+  createTextInstance(text: string): TuiTextNode {
     return createTextNode(text);
   },
 
-  appendInitialChild(parent: TuiElement, child: TuiElement | TextInstance) {
-    appendChild(parent, child as TuiNode);
+  appendInitialChild(parent: TuiElement, child: TuiNode) {
+    appendChild(parent, child);
   },
 
-  appendChild(parent: TuiElement, child: TuiElement | TextInstance) {
-    appendChild(parent, child as TuiNode);
+  appendChild(parent: TuiElement, child: TuiNode) {
+    appendChild(parent, child);
   },
 
-  appendChildToContainer(container: TuiElement, child: TuiElement | TextInstance) {
-    appendChild(container, child as TuiNode);
+  appendChildToContainer(container: TuiElement, child: TuiNode) {
+    appendChild(container, child);
   },
 
-  removeChild(parent: TuiElement, child: TuiElement | TextInstance) {
-    removeChild(parent, child as TuiNode);
+  removeChild(parent: TuiElement, child: TuiNode) {
+    removeChild(parent, child);
   },
 
-  removeChildFromContainer(container: TuiElement, child: TuiElement | TextInstance) {
-    removeChild(container, child as TuiNode);
+  removeChildFromContainer(container: TuiElement, child: TuiNode) {
+    removeChild(container, child);
   },
 
-  insertBefore(parent: TuiElement, child: TuiElement | TextInstance, before: TuiElement | TextInstance) {
-    insertBefore(parent, child as TuiNode, before as TuiNode);
+  insertBefore(parent: TuiElement, child: TuiNode, before: TuiNode) {
+    insertBefore(parent, child, before);
   },
 
-  insertInContainerBefore(container: TuiElement, child: TuiElement | TextInstance, before: TuiElement | TextInstance) {
-    insertBefore(container, child as TuiNode, before as TuiNode);
+  insertInContainerBefore(container: TuiElement, child: TuiNode, before: TuiNode) {
+    insertBefore(container, child, before);
   },
 
   commitUpdate(instance: TuiElement, _type: TuiNodeType, _oldProps: Props, newProps: Props) {
     instance.props = propsFromRaw(newProps);
   },
 
-  commitTextUpdate(textInstance: TextInstance, _oldText: string, newText: string) {
+  commitTextUpdate(textInstance: TuiTextNode, _oldText: string, newText: string) {
     textInstance.value = newText;
   },
 
@@ -107,20 +107,20 @@ export const hostConfig = {
 
   scheduleTimeout: setTimeout,
   cancelTimeout: clearTimeout,
-  noTimeout: -1 as const,
+  noTimeout: -1,
   isPrimaryRenderer: true,
   warnsIfNotActing: false,
   supportsMicrotasks: true,
   scheduleMicrotask: queueMicrotask,
 
-  NotPendingTransition: null as never,
+  NotPendingTransition: null,
   HostTransitionContext: {
     $$typeof: Symbol.for("react.context"),
-    _currentValue: null as never,
-    _currentValue2: null as never,
+    _currentValue: null,
+    _currentValue2: null,
     _threadCount: 0,
-    Consumer: null as never,
-    Provider: null as never,
+    Consumer: null,
+    Provider: null,
   },
 
   setCurrentUpdatePriority() {},

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -1,0 +1,5 @@
+export { Box, Text, Static } from "./components";
+export { useApp, useInput } from "./hooks";
+export { render } from "./render";
+export { renderToString } from "./render-to-string";
+export type { KeyEvent } from "./context";

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -1,5 +1,5 @@
-export { Box, Text, Static } from "./components";
+export { Box, Static, Text } from "./components";
+export type { KeyEvent } from "./context";
 export { useApp, useInput } from "./hooks";
 export { render } from "./render";
 export { renderToString } from "./render-to-string";
-export type { KeyEvent } from "./context";

--- a/src/tui/input.test.ts
+++ b/src/tui/input.test.ts
@@ -15,18 +15,21 @@ describe("parseKeyInput", () => {
   });
 
   test("enter", () => {
-    const { key } = parse("\r");
+    const { input, key } = parse("\r");
     expect(key.return).toBe(true);
+    expect(input).toBe("");
   });
 
   test("tab", () => {
-    const { key } = parse("\t");
+    const { input, key } = parse("\t");
     expect(key.tab).toBe(true);
+    expect(input).toBe("");
   });
 
   test("backspace", () => {
-    const { key } = parse("\x7f");
+    const { input, key } = parse("\x7f");
     expect(key.backspace).toBe(true);
+    expect(input).toBe("");
   });
 
   test("escape", () => {
@@ -42,34 +45,46 @@ describe("parseKeyInput", () => {
   });
 
   test("arrow up", () => {
-    const { key } = parse("\x1b[A");
+    const { input, key } = parse("\x1b[A");
     expect(key.upArrow).toBe(true);
+    expect(input).toBe("");
   });
 
   test("arrow down", () => {
-    const { key } = parse("\x1b[B");
+    const { input, key } = parse("\x1b[B");
     expect(key.downArrow).toBe(true);
+    expect(input).toBe("");
   });
 
   test("shift+tab", () => {
-    const { key } = parse("\x1b[Z");
+    const { input, key } = parse("\x1b[Z");
     expect(key.tab).toBe(true);
     expect(key.shift).toBe(true);
+    expect(input).toBe("");
   });
 
   test("delete key", () => {
-    const { key } = parse("\x1b[3~");
+    const { input, key } = parse("\x1b[3~");
     expect(key.delete).toBe(true);
+    expect(input).toBe("");
   });
 
   test("home key", () => {
-    const { key } = parse("\x1b[H");
+    const { input, key } = parse("\x1b[H");
     expect(key.home).toBe(true);
+    expect(input).toBe("");
   });
 
   test("end key", () => {
-    const { key } = parse("\x1b[F");
+    const { input, key } = parse("\x1b[F");
     expect(key.end).toBe(true);
+    expect(input).toBe("");
+  });
+
+  test("SS3 home/end", () => {
+    expect(parse("\x1bOH").key.home).toBe(true);
+    expect(parse("\x1bOF").key.end).toBe(true);
+    expect(parse("\x1bOH").input).toBe("");
   });
 
   describe("kitty keyboard protocol", () => {
@@ -103,29 +118,81 @@ describe("parseKeyInput", () => {
 
   describe("modifier arrows", () => {
     test("shift+up", () => {
-      const { key } = parse("\x1b[1;2A");
+      const { input, key } = parse("\x1b[1;2A");
       expect(key.upArrow).toBe(true);
+      expect(key.shift).toBe(true);
+      expect(input).toBe("");
+    });
+
+    test("alt+right (word nav)", () => {
+      const { input, key } = parse("\x1b[1;3C");
+      expect(key.rightArrow).toBe(true);
+      expect(key.meta).toBe(true);
+      expect(input).toBe("");
+    });
+
+    test("ctrl+left (word nav)", () => {
+      const { input, key } = parse("\x1b[1;5D");
+      expect(key.leftArrow).toBe(true);
+      expect(key.ctrl).toBe(true);
+      expect(input).toBe("");
+    });
+
+    test("super+left (Cmd+arrow, line nav)", () => {
+      const { input, key } = parse("\x1b[1;9D");
+      expect(key.leftArrow).toBe(true);
+      expect(key.super).toBe(true);
+      expect(input).toBe("");
+    });
+
+    test("super+right (Cmd+arrow, line nav)", () => {
+      const { input, key } = parse("\x1b[1;9C");
+      expect(key.rightArrow).toBe(true);
+      expect(key.super).toBe(true);
+      expect(input).toBe("");
+    });
+
+    test("super+shift+left (Cmd+Shift+arrow)", () => {
+      const { key } = parse("\x1b[1;10D");
+      expect(key.leftArrow).toBe(true);
+      expect(key.super).toBe(true);
       expect(key.shift).toBe(true);
     });
 
-    test("alt+right", () => {
-      const { key } = parse("\x1b[1;3C");
-      expect(key.rightArrow).toBe(true);
-      expect(key.meta).toBe(true);
-    });
-
-    test("ctrl+left", () => {
-      const { key } = parse("\x1b[1;5D");
-      expect(key.leftArrow).toBe(true);
-      expect(key.ctrl).toBe(true);
+    test("super+home", () => {
+      const { key } = parse("\x1b[1;9H");
+      expect(key.home).toBe(true);
+      expect(key.super).toBe(true);
     });
   });
 
   describe("meta prefix", () => {
     test("alt+backspace", () => {
-      const { key } = parse("\x1b\x7f");
+      const { input, key } = parse("\x1b\x7f");
       expect(key.meta).toBe(true);
       expect(key.backspace).toBe(true);
+      expect(input).toBe("");
+    });
+
+    test("alt+b (word left)", () => {
+      const { input, key } = parse("\x1bb");
+      expect(key.meta).toBe(true);
+      expect(input).toBe("b");
+    });
+
+    test("alt+f (word right)", () => {
+      const { input, key } = parse("\x1bf");
+      expect(key.meta).toBe(true);
+      expect(input).toBe("f");
+    });
+  });
+
+  describe("CSI input field is empty", () => {
+    test("parsed CSI sequences yield empty input", () => {
+      expect(parse("\x1b[A").input).toBe("");
+      expect(parse("\x1b[1;5D").input).toBe("");
+      expect(parse("\x1b[3~").input).toBe("");
+      expect(parse("\x1b[1;9C").input).toBe("");
     });
   });
 });

--- a/src/tui/input.test.ts
+++ b/src/tui/input.test.ts
@@ -195,4 +195,30 @@ describe("parseKeyInput", () => {
       expect(parse("\x1b[1;9C").input).toBe("");
     });
   });
+
+  describe("multi-sequence chunks", () => {
+    test("ctrl+u followed by left arrow in one chunk", () => {
+      const results = parseKeyInput("\x15\x1b[D");
+      expect(results).toHaveLength(2);
+      expect(results[0]!.key.ctrl).toBe(true);
+      expect(results[0]!.input).toBe("u");
+      expect(results[1]!.key.leftArrow).toBe(true);
+      expect(results[1]!.input).toBe("");
+    });
+
+    test("multiple plain characters in one chunk", () => {
+      const results = parseKeyInput("abc");
+      expect(results).toHaveLength(3);
+      expect(results[0]!.input).toBe("a");
+      expect(results[1]!.input).toBe("b");
+      expect(results[2]!.input).toBe("c");
+    });
+
+    test("escape sequence followed by regular char", () => {
+      const results = parseKeyInput("\x1b[Ax");
+      expect(results).toHaveLength(2);
+      expect(results[0]!.key.upArrow).toBe(true);
+      expect(results[1]!.input).toBe("x");
+    });
+  });
 });

--- a/src/tui/input.test.ts
+++ b/src/tui/input.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import { parseKeyInput } from "./input";
+
+function parse(data: string) {
+  const results = parseKeyInput(data);
+  return results[0] ?? { input: "", key: {} };
+}
+
+describe("parseKeyInput", () => {
+  test("regular character", () => {
+    const { input, key } = parse("a");
+    expect(input).toBe("a");
+    expect(key.ctrl).toBe(false);
+    expect(key.meta).toBe(false);
+  });
+
+  test("enter", () => {
+    const { key } = parse("\r");
+    expect(key.return).toBe(true);
+  });
+
+  test("tab", () => {
+    const { key } = parse("\t");
+    expect(key.tab).toBe(true);
+  });
+
+  test("backspace", () => {
+    const { key } = parse("\x7f");
+    expect(key.backspace).toBe(true);
+  });
+
+  test("escape", () => {
+    const { input, key } = parse("\x1b");
+    expect(key.escape).toBe(true);
+    expect(input).toBe("");
+  });
+
+  test("ctrl+c", () => {
+    const { input, key } = parse("\x03");
+    expect(key.ctrl).toBe(true);
+    expect(input).toBe("c");
+  });
+
+  test("arrow up", () => {
+    const { key } = parse("\x1b[A");
+    expect(key.upArrow).toBe(true);
+  });
+
+  test("arrow down", () => {
+    const { key } = parse("\x1b[B");
+    expect(key.downArrow).toBe(true);
+  });
+
+  test("shift+tab", () => {
+    const { key } = parse("\x1b[Z");
+    expect(key.tab).toBe(true);
+    expect(key.shift).toBe(true);
+  });
+
+  test("delete key", () => {
+    const { key } = parse("\x1b[3~");
+    expect(key.delete).toBe(true);
+  });
+
+  test("home key", () => {
+    const { key } = parse("\x1b[H");
+    expect(key.home).toBe(true);
+  });
+
+  test("end key", () => {
+    const { key } = parse("\x1b[F");
+    expect(key.end).toBe(true);
+  });
+
+  describe("kitty keyboard protocol", () => {
+    test("escape via kitty", () => {
+      const { key } = parse("\x1b[27u");
+      expect(key.escape).toBe(true);
+    });
+
+    test("enter via kitty", () => {
+      const { key } = parse("\x1b[13u");
+      expect(key.return).toBe(true);
+    });
+
+    test("ctrl+a via kitty", () => {
+      const { input, key } = parse("\x1b[97;5u");
+      expect(key.ctrl).toBe(true);
+      expect(input).toBe("a");
+    });
+
+    test("shift+enter via kitty", () => {
+      const { key } = parse("\x1b[13;2u");
+      expect(key.return).toBe(true);
+      expect(key.shift).toBe(true);
+    });
+
+    test("regular char via kitty", () => {
+      const { input } = parse("\x1b[120u");
+      expect(input).toBe("x");
+    });
+  });
+
+  describe("modifier arrows", () => {
+    test("shift+up", () => {
+      const { key } = parse("\x1b[1;2A");
+      expect(key.upArrow).toBe(true);
+      expect(key.shift).toBe(true);
+    });
+
+    test("alt+right", () => {
+      const { key } = parse("\x1b[1;3C");
+      expect(key.rightArrow).toBe(true);
+      expect(key.meta).toBe(true);
+    });
+
+    test("ctrl+left", () => {
+      const { key } = parse("\x1b[1;5D");
+      expect(key.leftArrow).toBe(true);
+      expect(key.ctrl).toBe(true);
+    });
+  });
+
+  describe("meta prefix", () => {
+    test("alt+backspace", () => {
+      const { key } = parse("\x1b\x7f");
+      expect(key.meta).toBe(true);
+      expect(key.backspace).toBe(true);
+    });
+  });
+});

--- a/src/tui/input.ts
+++ b/src/tui/input.ts
@@ -1,0 +1,205 @@
+import type { InputHandler, KeyEvent } from "./context";
+
+const ESCAPE = "\x1b";
+
+function emptyKey(): KeyEvent {
+  return {
+    return: false,
+    tab: false,
+    shift: false,
+    ctrl: false,
+    meta: false,
+    escape: false,
+    upArrow: false,
+    downArrow: false,
+    leftArrow: false,
+    rightArrow: false,
+    home: false,
+    end: false,
+    backspace: false,
+    delete: false,
+  };
+}
+
+/** Parse raw stdin data into (input, key) pairs compatible with Ink's useInput. */
+export function parseKeyInput(data: Buffer | string): Array<{ input: string; key: KeyEvent }> {
+  const raw = typeof data === "string" ? data : data.toString("utf8");
+  const results: Array<{ input: string; key: KeyEvent }> = [];
+
+  // CSI sequences: ESC [ ... final_byte
+  if (raw.startsWith(`${ESCAPE}[`)) {
+    const key = emptyKey();
+    const seq = raw.slice(2);
+
+    // Arrow keys with modifiers: ESC [ 1 ; <mod> <A-D>
+    const arrowModMatch = seq.match(/^1;(\d+)([A-D])$/);
+    if (arrowModMatch) {
+      const mod = Number.parseInt(arrowModMatch[1] ?? "1", 10);
+      if (mod >= 2) key.shift = (mod - 1 & 1) !== 0;
+      if (mod >= 2) key.meta = (mod - 1 & 2) !== 0;
+      if (mod >= 2) key.ctrl = (mod - 1 & 4) !== 0;
+      const arrow = arrowModMatch[2];
+      if (arrow === "A") key.upArrow = true;
+      else if (arrow === "B") key.downArrow = true;
+      else if (arrow === "C") key.rightArrow = true;
+      else if (arrow === "D") key.leftArrow = true;
+      results.push({ input: raw, key });
+      return results;
+    }
+
+    // Home/End with modifiers: ESC [ 1 ; <mod> <H|F>
+    const homeEndModMatch = seq.match(/^1;(\d+)([HF])$/);
+    if (homeEndModMatch) {
+      const mod = Number.parseInt(homeEndModMatch[1] ?? "1", 10);
+      if (mod >= 2) key.shift = (mod - 1 & 1) !== 0;
+      if (mod >= 2) key.meta = (mod - 1 & 2) !== 0;
+      if (mod >= 2) key.ctrl = (mod - 1 & 4) !== 0;
+      if (homeEndModMatch[2] === "H") key.home = true;
+      else key.end = true;
+      results.push({ input: raw, key });
+      return results;
+    }
+
+    // Simple arrows
+    if (seq === "A") {
+      key.upArrow = true;
+      results.push({ input: raw, key });
+      return results;
+    }
+    if (seq === "B") {
+      key.downArrow = true;
+      results.push({ input: raw, key });
+      return results;
+    }
+    if (seq === "C") {
+      key.rightArrow = true;
+      results.push({ input: raw, key });
+      return results;
+    }
+    if (seq === "D") {
+      key.leftArrow = true;
+      results.push({ input: raw, key });
+      return results;
+    }
+
+    // Home/End
+    if (seq === "H" || seq === "1~" || seq === "7~") {
+      key.home = true;
+      results.push({ input: raw, key });
+      return results;
+    }
+    if (seq === "F" || seq === "4~" || seq === "8~") {
+      key.end = true;
+      results.push({ input: raw, key });
+      return results;
+    }
+
+    // Delete key: ESC [ 3 ~
+    if (seq === "3~") {
+      key.delete = true;
+      results.push({ input: raw, key });
+      return results;
+    }
+
+    // Shift+Tab: ESC [ Z
+    if (seq === "Z") {
+      key.tab = true;
+      key.shift = true;
+      results.push({ input: raw, key });
+      return results;
+    }
+
+    // Pass through other CSI sequences as-is
+    results.push({ input: raw, key });
+    return results;
+  }
+
+  // SS3 sequences: ESC O <letter>
+  if (raw.startsWith(`${ESCAPE}O`)) {
+    const key = emptyKey();
+    const letter = raw[2];
+    if (letter === "H") key.home = true;
+    else if (letter === "F") key.end = true;
+    else if (letter === "A") key.upArrow = true;
+    else if (letter === "B") key.downArrow = true;
+    else if (letter === "C") key.rightArrow = true;
+    else if (letter === "D") key.leftArrow = true;
+    results.push({ input: raw, key });
+    return results;
+  }
+
+  // Meta prefix: ESC + char (Alt+key)
+  if (raw.length >= 2 && raw[0] === ESCAPE && raw[1] !== "[" && raw[1] !== "O") {
+    const key = emptyKey();
+    key.meta = true;
+    const ch = raw.slice(1);
+    if (ch === "\x7f") {
+      key.backspace = true;
+      key.meta = true;
+    } else if (ch === "\x08") {
+      key.backspace = true;
+      key.meta = true;
+    }
+    results.push({ input: raw, key });
+    return results;
+  }
+
+  // Standalone escape
+  if (raw === ESCAPE) {
+    const key = emptyKey();
+    key.escape = true;
+    results.push({ input: raw, key });
+    return results;
+  }
+
+  // Control characters
+  if (raw.length === 1) {
+    const code = raw.charCodeAt(0);
+    const key = emptyKey();
+
+    if (code === 0x0d || code === 0x0a) {
+      key.return = true;
+      results.push({ input: raw, key });
+      return results;
+    }
+    if (code === 0x09) {
+      key.tab = true;
+      results.push({ input: raw, key });
+      return results;
+    }
+    if (code === 0x7f || code === 0x08) {
+      key.backspace = true;
+      results.push({ input: raw, key });
+      return results;
+    }
+    if (code >= 1 && code <= 26) {
+      key.ctrl = true;
+      const ch = String.fromCharCode(code + 96);
+      results.push({ input: ch, key });
+      return results;
+    }
+  }
+
+  // Regular text input
+  const key = emptyKey();
+  results.push({ input: raw, key });
+  return results;
+}
+
+export function createInputDispatcher(): {
+  handlers: Set<{ handler: InputHandler; isActive: boolean }>;
+  dispatch: (data: Buffer | string) => void;
+} {
+  const handlers = new Set<{ handler: InputHandler; isActive: boolean }>();
+  return {
+    handlers,
+    dispatch(data: Buffer | string) {
+      const events = parseKeyInput(data);
+      for (const { input, key } of events) {
+        for (const reg of handlers) {
+          if (reg.isActive) reg.handler(input, key);
+        }
+      }
+    },
+  };
+}

--- a/src/tui/input.ts
+++ b/src/tui/input.ts
@@ -84,176 +84,183 @@ function parseKittySequence(seq: string, key: KeyEvent): { input: string; key: K
   }
 }
 
-export function parseKeyInput(data: Buffer | string): Array<{ input: string; key: KeyEvent }> {
-  const raw = typeof data === "string" ? data : data.toString("utf8");
-  const results: Array<{ input: string; key: KeyEvent }> = [];
+/**
+ * Find the end of a CSI sequence starting at `offset` (pointing at ESC).
+ * CSI = ESC [ <params> <final byte>. Final byte is 0x40–0x7E.
+ * Returns the index past the final byte, or -1 if not a valid CSI.
+ */
+function csiEnd(raw: string, offset: number): number {
+  if (offset + 1 >= raw.length || raw[offset + 1] !== "[") return -1;
+  let i = offset + 2;
+  while (i < raw.length) {
+    const code = raw.charCodeAt(i);
+    if (code >= 0x40 && code <= 0x7e) return i + 1;
+    i++;
+  }
+  return -1;
+}
 
-  if (raw.startsWith(`${ESCAPE}[`)) {
-    const key = emptyKey();
-    const seq = raw.slice(2);
+/**
+ * Parse a single key event starting at `offset` in `raw`.
+ * Returns the parsed event and the number of bytes consumed.
+ */
+function parseSingle(raw: string, offset: number): { event: { input: string; key: KeyEvent }; consumed: number } {
+  const ch0 = raw[offset]!;
+  const code0 = raw.charCodeAt(offset);
 
-    // Kitty keyboard protocol: CSI <number> ; <modifier> u
-    const kittyResult = parseKittySequence(seq, key);
-    if (kittyResult) {
-      results.push(kittyResult);
-      return results;
-    }
+  // CSI sequences: ESC [
+  if (ch0 === ESCAPE && offset + 1 < raw.length && raw[offset + 1] === "[") {
+    const end = csiEnd(raw, offset);
+    if (end > 0) {
+      const seq = raw.slice(offset + 2, end);
+      const key = emptyKey();
 
-    // Delete key with modifiers: CSI 3 ; <mod> ~
-    const deleteModMatch = seq.match(/^3;(\d+)~$/);
-    if (deleteModMatch) {
-      const mod = Number.parseInt(deleteModMatch[1] ?? "1", 10);
-      applyModifiers(key, mod);
-      key.delete = true;
-      results.push({ input: "", key });
-      return results;
-    }
+      const kittyResult = parseKittySequence(seq, key);
+      if (kittyResult) return { event: kittyResult, consumed: end - offset };
 
-    // Arrow keys with modifiers: CSI 1 ; <mod> <A-D>
-    const arrowModMatch = seq.match(/^1;(\d+)([A-D])$/);
-    if (arrowModMatch) {
-      const mod = Number.parseInt(arrowModMatch[1] ?? "1", 10);
-      applyModifiers(key, mod);
-      const arrow = arrowModMatch[2];
-      if (arrow === "A") key.upArrow = true;
-      else if (arrow === "B") key.downArrow = true;
-      else if (arrow === "C") key.rightArrow = true;
-      else if (arrow === "D") key.leftArrow = true;
-      results.push({ input: "", key });
-      return results;
-    }
+      // Delete key with modifiers: CSI 3 ; <mod> ~
+      const deleteModMatch = seq.match(/^3;(\d+)~$/);
+      if (deleteModMatch) {
+        const mod = Number.parseInt(deleteModMatch[1] ?? "1", 10);
+        applyModifiers(key, mod);
+        key.delete = true;
+        return { event: { input: "", key }, consumed: end - offset };
+      }
 
-    // Home/End with modifiers: CSI 1 ; <mod> <H|F>
-    const homeEndModMatch = seq.match(/^1;(\d+)([HF])$/);
-    if (homeEndModMatch) {
-      const mod = Number.parseInt(homeEndModMatch[1] ?? "1", 10);
-      applyModifiers(key, mod);
-      if (homeEndModMatch[2] === "H") key.home = true;
-      else key.end = true;
-      results.push({ input: "", key });
-      return results;
-    }
+      // Arrow keys with modifiers: CSI 1 ; <mod> <A-D>
+      const arrowModMatch = seq.match(/^1;(\d+)([A-D])$/);
+      if (arrowModMatch) {
+        const mod = Number.parseInt(arrowModMatch[1] ?? "1", 10);
+        applyModifiers(key, mod);
+        const arrow = arrowModMatch[2];
+        if (arrow === "A") key.upArrow = true;
+        else if (arrow === "B") key.downArrow = true;
+        else if (arrow === "C") key.rightArrow = true;
+        else if (arrow === "D") key.leftArrow = true;
+        return { event: { input: "", key }, consumed: end - offset };
+      }
 
-    // Simple arrows
-    if (seq === "A") {
-      key.upArrow = true;
-      results.push({ input: "", key });
-      return results;
-    }
-    if (seq === "B") {
-      key.downArrow = true;
-      results.push({ input: "", key });
-      return results;
-    }
-    if (seq === "C") {
-      key.rightArrow = true;
-      results.push({ input: "", key });
-      return results;
-    }
-    if (seq === "D") {
-      key.leftArrow = true;
-      results.push({ input: "", key });
-      return results;
-    }
+      // Home/End with modifiers: CSI 1 ; <mod> <H|F>
+      const homeEndModMatch = seq.match(/^1;(\d+)([HF])$/);
+      if (homeEndModMatch) {
+        const mod = Number.parseInt(homeEndModMatch[1] ?? "1", 10);
+        applyModifiers(key, mod);
+        if (homeEndModMatch[2] === "H") key.home = true;
+        else key.end = true;
+        return { event: { input: "", key }, consumed: end - offset };
+      }
 
-    // Home/End
-    if (seq === "H" || seq === "1~" || seq === "7~") {
-      key.home = true;
-      results.push({ input: "", key });
-      return results;
-    }
-    if (seq === "F" || seq === "4~" || seq === "8~") {
-      key.end = true;
-      results.push({ input: "", key });
-      return results;
-    }
+      // Simple arrows
+      if (seq === "A") {
+        key.upArrow = true;
+        return { event: { input: "", key }, consumed: end - offset };
+      }
+      if (seq === "B") {
+        key.downArrow = true;
+        return { event: { input: "", key }, consumed: end - offset };
+      }
+      if (seq === "C") {
+        key.rightArrow = true;
+        return { event: { input: "", key }, consumed: end - offset };
+      }
+      if (seq === "D") {
+        key.leftArrow = true;
+        return { event: { input: "", key }, consumed: end - offset };
+      }
 
-    // Delete key: CSI 3 ~
-    if (seq === "3~") {
-      key.delete = true;
-      results.push({ input: "", key });
-      return results;
-    }
+      // Home/End
+      if (seq === "H" || seq === "1~" || seq === "7~") {
+        key.home = true;
+        return { event: { input: "", key }, consumed: end - offset };
+      }
+      if (seq === "F" || seq === "4~" || seq === "8~") {
+        key.end = true;
+        return { event: { input: "", key }, consumed: end - offset };
+      }
 
-    // Shift+Tab: CSI Z
-    if (seq === "Z") {
-      key.tab = true;
-      key.shift = true;
-      results.push({ input: "", key });
-      return results;
-    }
+      // Delete key: CSI 3 ~
+      if (seq === "3~") {
+        key.delete = true;
+        return { event: { input: "", key }, consumed: end - offset };
+      }
 
-    // Pass through other CSI sequences
-    results.push({ input: "", key });
-    return results;
+      // Shift+Tab: CSI Z
+      if (seq === "Z") {
+        key.tab = true;
+        key.shift = true;
+        return { event: { input: "", key }, consumed: end - offset };
+      }
+
+      // Unknown CSI — consume but noop
+      return { event: { input: "", key }, consumed: end - offset };
+    }
   }
 
   // SS3 sequences: ESC O <letter>
-  if (raw.startsWith(`${ESCAPE}O`)) {
+  if (ch0 === ESCAPE && offset + 2 < raw.length && raw[offset + 1] === "O") {
     const key = emptyKey();
-    const letter = raw[2];
+    const letter = raw[offset + 2];
     if (letter === "H") key.home = true;
     else if (letter === "F") key.end = true;
     else if (letter === "A") key.upArrow = true;
     else if (letter === "B") key.downArrow = true;
     else if (letter === "C") key.rightArrow = true;
     else if (letter === "D") key.leftArrow = true;
-    results.push({ input: "", key });
-    return results;
+    return { event: { input: "", key }, consumed: 3 };
   }
 
   // Meta prefix: ESC + char (Alt+key)
-  if (raw.length >= 2 && raw[0] === ESCAPE && raw[1] !== "[" && raw[1] !== "O") {
+  if (ch0 === ESCAPE && offset + 1 < raw.length && raw[offset + 1] !== "[" && raw[offset + 1] !== "O") {
     const key = emptyKey();
     key.meta = true;
-    const ch = raw.slice(1);
+    const ch = raw[offset + 1]!;
     if (ch === Char.DEL || ch === Char.BS) {
       key.backspace = true;
-      results.push({ input: "", key });
-    } else {
-      results.push({ input: ch, key });
+      return { event: { input: "", key }, consumed: 2 };
     }
-    return results;
+    return { event: { input: ch, key }, consumed: 2 };
   }
 
   // Standalone escape
-  if (raw === ESCAPE) {
+  if (ch0 === ESCAPE) {
     const key = emptyKey();
     key.escape = true;
-    results.push({ input: "", key });
-    return results;
+    return { event: { input: "", key }, consumed: 1 };
   }
 
   // Control characters
-  if (raw.length === 1) {
-    const code = raw.charCodeAt(0);
-    const key = emptyKey();
+  const key = emptyKey();
 
-    if (code === Codepoint.CR || code === Codepoint.LF) {
-      key.return = true;
-      results.push({ input: "", key });
-      return results;
-    }
-    if (code === Codepoint.TAB) {
-      key.tab = true;
-      results.push({ input: "", key });
-      return results;
-    }
-    if (code === Codepoint.DEL || code === Codepoint.BS) {
-      key.backspace = true;
-      results.push({ input: "", key });
-      return results;
-    }
-    if (code >= Codepoint.CTRL_A && code <= Codepoint.CTRL_Z) {
-      key.ctrl = true;
-      results.push({ input: String.fromCharCode(code + Codepoint.CTRL_OFFSET), key });
-      return results;
-    }
+  if (code0 === Codepoint.CR || code0 === Codepoint.LF) {
+    key.return = true;
+    return { event: { input: "", key }, consumed: 1 };
+  }
+  if (code0 === Codepoint.TAB) {
+    key.tab = true;
+    return { event: { input: "", key }, consumed: 1 };
+  }
+  if (code0 === Codepoint.DEL || code0 === Codepoint.BS) {
+    key.backspace = true;
+    return { event: { input: "", key }, consumed: 1 };
+  }
+  if (code0 >= Codepoint.CTRL_A && code0 <= Codepoint.CTRL_Z) {
+    key.ctrl = true;
+    return { event: { input: String.fromCharCode(code0 + Codepoint.CTRL_OFFSET), key }, consumed: 1 };
   }
 
-  // Regular text input
-  const key = emptyKey();
-  results.push({ input: raw, key });
+  // Regular character
+  return { event: { input: ch0, key }, consumed: 1 };
+}
+
+export function parseKeyInput(data: Buffer | string): Array<{ input: string; key: KeyEvent }> {
+  const raw = typeof data === "string" ? data : data.toString("utf8");
+  const results: Array<{ input: string; key: KeyEvent }> = [];
+  let offset = 0;
+  while (offset < raw.length) {
+    const { event, consumed } = parseSingle(raw, offset);
+    results.push(event);
+    offset += consumed;
+  }
   return results;
 }
 

--- a/src/tui/input.ts
+++ b/src/tui/input.ts
@@ -9,6 +9,7 @@ function emptyKey(): KeyEvent {
     shift: false,
     ctrl: false,
     meta: false,
+    super: false,
     escape: false,
     upArrow: false,
     downArrow: false,
@@ -23,9 +24,11 @@ function emptyKey(): KeyEvent {
 
 function applyModifiers(key: KeyEvent, mod: number): void {
   if (mod >= 2) {
-    key.shift = ((mod - 1) & 1) !== 0;
-    key.meta = ((mod - 1) & 2) !== 0;
-    key.ctrl = ((mod - 1) & 4) !== 0;
+    const bits = mod - 1;
+    key.shift = (bits & 1) !== 0;
+    key.meta = (bits & 2) !== 0;
+    key.ctrl = (bits & 4) !== 0;
+    key.super = (bits & 8) !== 0;
   }
 }
 
@@ -54,9 +57,6 @@ function parseKittySequence(seq: string, key: KeyEvent): { input: string; key: K
     default: {
       if (codepoint >= 32) {
         const ch = String.fromCodePoint(codepoint);
-        if (key.ctrl && codepoint >= 97 && codepoint <= 122) {
-          return { input: ch, key };
-        }
         return { input: ch, key };
       }
       return { input: "", key };
@@ -85,7 +85,7 @@ export function parseKeyInput(data: Buffer | string): Array<{ input: string; key
       const mod = Number.parseInt(deleteModMatch[1] ?? "1", 10);
       applyModifiers(key, mod);
       key.delete = true;
-      results.push({ input: raw, key });
+      results.push({ input: "", key });
       return results;
     }
 
@@ -99,7 +99,7 @@ export function parseKeyInput(data: Buffer | string): Array<{ input: string; key
       else if (arrow === "B") key.downArrow = true;
       else if (arrow === "C") key.rightArrow = true;
       else if (arrow === "D") key.leftArrow = true;
-      results.push({ input: raw, key });
+      results.push({ input: "", key });
       return results;
     }
 
@@ -110,48 +110,48 @@ export function parseKeyInput(data: Buffer | string): Array<{ input: string; key
       applyModifiers(key, mod);
       if (homeEndModMatch[2] === "H") key.home = true;
       else key.end = true;
-      results.push({ input: raw, key });
+      results.push({ input: "", key });
       return results;
     }
 
     // Simple arrows
     if (seq === "A") {
       key.upArrow = true;
-      results.push({ input: raw, key });
+      results.push({ input: "", key });
       return results;
     }
     if (seq === "B") {
       key.downArrow = true;
-      results.push({ input: raw, key });
+      results.push({ input: "", key });
       return results;
     }
     if (seq === "C") {
       key.rightArrow = true;
-      results.push({ input: raw, key });
+      results.push({ input: "", key });
       return results;
     }
     if (seq === "D") {
       key.leftArrow = true;
-      results.push({ input: raw, key });
+      results.push({ input: "", key });
       return results;
     }
 
     // Home/End
     if (seq === "H" || seq === "1~" || seq === "7~") {
       key.home = true;
-      results.push({ input: raw, key });
+      results.push({ input: "", key });
       return results;
     }
     if (seq === "F" || seq === "4~" || seq === "8~") {
       key.end = true;
-      results.push({ input: raw, key });
+      results.push({ input: "", key });
       return results;
     }
 
     // Delete key: CSI 3 ~
     if (seq === "3~") {
       key.delete = true;
-      results.push({ input: raw, key });
+      results.push({ input: "", key });
       return results;
     }
 
@@ -159,12 +159,12 @@ export function parseKeyInput(data: Buffer | string): Array<{ input: string; key
     if (seq === "Z") {
       key.tab = true;
       key.shift = true;
-      results.push({ input: raw, key });
+      results.push({ input: "", key });
       return results;
     }
 
     // Pass through other CSI sequences
-    results.push({ input: raw, key });
+    results.push({ input: "", key });
     return results;
   }
 
@@ -178,7 +178,7 @@ export function parseKeyInput(data: Buffer | string): Array<{ input: string; key
     else if (letter === "B") key.downArrow = true;
     else if (letter === "C") key.rightArrow = true;
     else if (letter === "D") key.leftArrow = true;
-    results.push({ input: raw, key });
+    results.push({ input: "", key });
     return results;
   }
 
@@ -189,8 +189,10 @@ export function parseKeyInput(data: Buffer | string): Array<{ input: string; key
     const ch = raw.slice(1);
     if (ch === "\x7f" || ch === "\x08") {
       key.backspace = true;
+      results.push({ input: "", key });
+    } else {
+      results.push({ input: ch, key });
     }
-    results.push({ input: raw, key });
     return results;
   }
 
@@ -209,17 +211,17 @@ export function parseKeyInput(data: Buffer | string): Array<{ input: string; key
 
     if (code === 0x0d || code === 0x0a) {
       key.return = true;
-      results.push({ input: raw, key });
+      results.push({ input: "", key });
       return results;
     }
     if (code === 0x09) {
       key.tab = true;
-      results.push({ input: raw, key });
+      results.push({ input: "", key });
       return results;
     }
     if (code === 0x7f || code === 0x08) {
       key.backspace = true;
-      results.push({ input: raw, key });
+      results.push({ input: "", key });
       return results;
     }
     if (code >= 1 && code <= 26) {

--- a/src/tui/input.ts
+++ b/src/tui/input.ts
@@ -21,23 +21,79 @@ function emptyKey(): KeyEvent {
   };
 }
 
-/** Parse raw stdin data into (input, key) pairs compatible with Ink's useInput. */
+function applyModifiers(key: KeyEvent, mod: number): void {
+  if (mod >= 2) {
+    key.shift = ((mod - 1) & 1) !== 0;
+    key.meta = ((mod - 1) & 2) !== 0;
+    key.ctrl = ((mod - 1) & 4) !== 0;
+  }
+}
+
+/** Kitty keyboard protocol: CSI <codepoint> ; <modifiers> u */
+function parseKittySequence(seq: string, key: KeyEvent): { input: string; key: KeyEvent } | null {
+  const match = seq.match(/^(\d+)(?:;(\d+))?u$/);
+  if (!match) return null;
+
+  const codepoint = Number.parseInt(match[1] ?? "0", 10);
+  const mod = Number.parseInt(match[2] ?? "1", 10);
+  applyModifiers(key, mod);
+
+  switch (codepoint) {
+    case 27:
+      key.escape = true;
+      return { input: "", key };
+    case 13:
+      key.return = true;
+      return { input: "", key };
+    case 9:
+      key.tab = true;
+      return { input: "", key };
+    case 127:
+      key.backspace = true;
+      return { input: "", key };
+    default: {
+      if (codepoint >= 32) {
+        const ch = String.fromCodePoint(codepoint);
+        if (key.ctrl && codepoint >= 97 && codepoint <= 122) {
+          return { input: ch, key };
+        }
+        return { input: ch, key };
+      }
+      return { input: "", key };
+    }
+  }
+}
+
 export function parseKeyInput(data: Buffer | string): Array<{ input: string; key: KeyEvent }> {
   const raw = typeof data === "string" ? data : data.toString("utf8");
   const results: Array<{ input: string; key: KeyEvent }> = [];
 
-  // CSI sequences: ESC [ ... final_byte
   if (raw.startsWith(`${ESCAPE}[`)) {
     const key = emptyKey();
     const seq = raw.slice(2);
 
-    // Arrow keys with modifiers: ESC [ 1 ; <mod> <A-D>
+    // Kitty keyboard protocol: CSI <number> ; <modifier> u
+    const kittyResult = parseKittySequence(seq, key);
+    if (kittyResult) {
+      results.push(kittyResult);
+      return results;
+    }
+
+    // Delete key with modifiers: CSI 3 ; <mod> ~
+    const deleteModMatch = seq.match(/^3;(\d+)~$/);
+    if (deleteModMatch) {
+      const mod = Number.parseInt(deleteModMatch[1] ?? "1", 10);
+      applyModifiers(key, mod);
+      key.delete = true;
+      results.push({ input: raw, key });
+      return results;
+    }
+
+    // Arrow keys with modifiers: CSI 1 ; <mod> <A-D>
     const arrowModMatch = seq.match(/^1;(\d+)([A-D])$/);
     if (arrowModMatch) {
       const mod = Number.parseInt(arrowModMatch[1] ?? "1", 10);
-      if (mod >= 2) key.shift = ((mod - 1) & 1) !== 0;
-      if (mod >= 2) key.meta = ((mod - 1) & 2) !== 0;
-      if (mod >= 2) key.ctrl = ((mod - 1) & 4) !== 0;
+      applyModifiers(key, mod);
       const arrow = arrowModMatch[2];
       if (arrow === "A") key.upArrow = true;
       else if (arrow === "B") key.downArrow = true;
@@ -47,13 +103,11 @@ export function parseKeyInput(data: Buffer | string): Array<{ input: string; key
       return results;
     }
 
-    // Home/End with modifiers: ESC [ 1 ; <mod> <H|F>
+    // Home/End with modifiers: CSI 1 ; <mod> <H|F>
     const homeEndModMatch = seq.match(/^1;(\d+)([HF])$/);
     if (homeEndModMatch) {
       const mod = Number.parseInt(homeEndModMatch[1] ?? "1", 10);
-      if (mod >= 2) key.shift = ((mod - 1) & 1) !== 0;
-      if (mod >= 2) key.meta = ((mod - 1) & 2) !== 0;
-      if (mod >= 2) key.ctrl = ((mod - 1) & 4) !== 0;
+      applyModifiers(key, mod);
       if (homeEndModMatch[2] === "H") key.home = true;
       else key.end = true;
       results.push({ input: raw, key });
@@ -94,14 +148,14 @@ export function parseKeyInput(data: Buffer | string): Array<{ input: string; key
       return results;
     }
 
-    // Delete key: ESC [ 3 ~
+    // Delete key: CSI 3 ~
     if (seq === "3~") {
       key.delete = true;
       results.push({ input: raw, key });
       return results;
     }
 
-    // Shift+Tab: ESC [ Z
+    // Shift+Tab: CSI Z
     if (seq === "Z") {
       key.tab = true;
       key.shift = true;
@@ -109,7 +163,7 @@ export function parseKeyInput(data: Buffer | string): Array<{ input: string; key
       return results;
     }
 
-    // Pass through other CSI sequences as-is
+    // Pass through other CSI sequences
     results.push({ input: raw, key });
     return results;
   }
@@ -133,12 +187,8 @@ export function parseKeyInput(data: Buffer | string): Array<{ input: string; key
     const key = emptyKey();
     key.meta = true;
     const ch = raw.slice(1);
-    if (ch === "\x7f") {
+    if (ch === "\x7f" || ch === "\x08") {
       key.backspace = true;
-      key.meta = true;
-    } else if (ch === "\x08") {
-      key.backspace = true;
-      key.meta = true;
     }
     results.push({ input: raw, key });
     return results;
@@ -148,7 +198,7 @@ export function parseKeyInput(data: Buffer | string): Array<{ input: string; key
   if (raw === ESCAPE) {
     const key = emptyKey();
     key.escape = true;
-    results.push({ input: raw, key });
+    results.push({ input: "", key });
     return results;
   }
 
@@ -174,8 +224,7 @@ export function parseKeyInput(data: Buffer | string): Array<{ input: string; key
     }
     if (code >= 1 && code <= 26) {
       key.ctrl = true;
-      const ch = String.fromCharCode(code + 96);
-      results.push({ input: ch, key });
+      results.push({ input: String.fromCharCode(code + 96), key });
       return results;
     }
   }

--- a/src/tui/input.ts
+++ b/src/tui/input.ts
@@ -1,5 +1,25 @@
 import type { InputHandler, KeyEvent } from "./context";
 
+/** ASCII control codepoints used in terminal input. */
+const Codepoint = {
+  ESC: 0x1b,
+  CR: 0x0d,
+  LF: 0x0a,
+  TAB: 0x09,
+  BS: 0x08,
+  DEL: 0x7f,
+  SPACE: 0x20,
+  CTRL_A: 1,
+  CTRL_Z: 26,
+  CTRL_OFFSET: 96,
+} as const;
+
+/** String forms of control chars used in string comparisons. */
+const Char = {
+  DEL: "\x7f",
+  BS: "\x08",
+} as const;
+
 const ESCAPE = "\x1b";
 
 function emptyKey(): KeyEvent {
@@ -42,20 +62,20 @@ function parseKittySequence(seq: string, key: KeyEvent): { input: string; key: K
   applyModifiers(key, mod);
 
   switch (codepoint) {
-    case 27:
+    case Codepoint.ESC:
       key.escape = true;
       return { input: "", key };
-    case 13:
+    case Codepoint.CR:
       key.return = true;
       return { input: "", key };
-    case 9:
+    case Codepoint.TAB:
       key.tab = true;
       return { input: "", key };
-    case 127:
+    case Codepoint.DEL:
       key.backspace = true;
       return { input: "", key };
     default: {
-      if (codepoint >= 32) {
+      if (codepoint >= Codepoint.SPACE) {
         const ch = String.fromCodePoint(codepoint);
         return { input: ch, key };
       }
@@ -187,7 +207,7 @@ export function parseKeyInput(data: Buffer | string): Array<{ input: string; key
     const key = emptyKey();
     key.meta = true;
     const ch = raw.slice(1);
-    if (ch === "\x7f" || ch === "\x08") {
+    if (ch === Char.DEL || ch === Char.BS) {
       key.backspace = true;
       results.push({ input: "", key });
     } else {
@@ -209,24 +229,24 @@ export function parseKeyInput(data: Buffer | string): Array<{ input: string; key
     const code = raw.charCodeAt(0);
     const key = emptyKey();
 
-    if (code === 0x0d || code === 0x0a) {
+    if (code === Codepoint.CR || code === Codepoint.LF) {
       key.return = true;
       results.push({ input: "", key });
       return results;
     }
-    if (code === 0x09) {
+    if (code === Codepoint.TAB) {
       key.tab = true;
       results.push({ input: "", key });
       return results;
     }
-    if (code === 0x7f || code === 0x08) {
+    if (code === Codepoint.DEL || code === Codepoint.BS) {
       key.backspace = true;
       results.push({ input: "", key });
       return results;
     }
-    if (code >= 1 && code <= 26) {
+    if (code >= Codepoint.CTRL_A && code <= Codepoint.CTRL_Z) {
       key.ctrl = true;
-      results.push({ input: String.fromCharCode(code + 96), key });
+      results.push({ input: String.fromCharCode(code + Codepoint.CTRL_OFFSET), key });
       return results;
     }
   }

--- a/src/tui/input.ts
+++ b/src/tui/input.ts
@@ -35,9 +35,9 @@ export function parseKeyInput(data: Buffer | string): Array<{ input: string; key
     const arrowModMatch = seq.match(/^1;(\d+)([A-D])$/);
     if (arrowModMatch) {
       const mod = Number.parseInt(arrowModMatch[1] ?? "1", 10);
-      if (mod >= 2) key.shift = (mod - 1 & 1) !== 0;
-      if (mod >= 2) key.meta = (mod - 1 & 2) !== 0;
-      if (mod >= 2) key.ctrl = (mod - 1 & 4) !== 0;
+      if (mod >= 2) key.shift = ((mod - 1) & 1) !== 0;
+      if (mod >= 2) key.meta = ((mod - 1) & 2) !== 0;
+      if (mod >= 2) key.ctrl = ((mod - 1) & 4) !== 0;
       const arrow = arrowModMatch[2];
       if (arrow === "A") key.upArrow = true;
       else if (arrow === "B") key.downArrow = true;
@@ -51,9 +51,9 @@ export function parseKeyInput(data: Buffer | string): Array<{ input: string; key
     const homeEndModMatch = seq.match(/^1;(\d+)([HF])$/);
     if (homeEndModMatch) {
       const mod = Number.parseInt(homeEndModMatch[1] ?? "1", 10);
-      if (mod >= 2) key.shift = (mod - 1 & 1) !== 0;
-      if (mod >= 2) key.meta = (mod - 1 & 2) !== 0;
-      if (mod >= 2) key.ctrl = (mod - 1 & 4) !== 0;
+      if (mod >= 2) key.shift = ((mod - 1) & 1) !== 0;
+      if (mod >= 2) key.meta = ((mod - 1) & 2) !== 0;
+      if (mod >= 2) key.ctrl = ((mod - 1) & 4) !== 0;
       if (homeEndModMatch[2] === "H") key.home = true;
       else key.end = true;
       results.push({ input: raw, key });

--- a/src/tui/input.ts
+++ b/src/tui/input.ts
@@ -22,7 +22,7 @@ const Char = {
 
 const ESCAPE = "\x1b";
 
-function emptyKey(): KeyEvent {
+export function emptyKey(): KeyEvent {
   return {
     return: false,
     tab: false,

--- a/src/tui/input.ts
+++ b/src/tui/input.ts
@@ -89,10 +89,13 @@ function parseKittySequence(seq: string, key: KeyEvent): { input: string; key: K
  * CSI = ESC [ <params> <final byte>. Final byte is 0x40–0x7E.
  * Returns the index past the final byte, or -1 if not a valid CSI.
  */
+const MAX_CSI_LENGTH = 64;
+
 function csiEnd(raw: string, offset: number): number {
   if (offset + 1 >= raw.length || raw[offset + 1] !== "[") return -1;
   let i = offset + 2;
   while (i < raw.length) {
+    if (i - offset > MAX_CSI_LENGTH) return -1;
     const code = raw.charCodeAt(i);
     if (code >= 0x40 && code <= 0x7e) return i + 1;
     i++;

--- a/src/tui/jsx.d.ts
+++ b/src/tui/jsx.d.ts
@@ -1,0 +1,13 @@
+import type { TuiProps } from "./dom";
+
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      "tui-root": TuiProps & { children?: React.ReactNode };
+      "tui-box": TuiProps & { children?: React.ReactNode };
+      "tui-text": TuiProps & { children?: React.ReactNode };
+      "tui-static": TuiProps & { children?: React.ReactNode };
+      "tui-virtual": TuiProps & { children?: React.ReactNode };
+    }
+  }
+}

--- a/src/tui/jsx.d.ts
+++ b/src/tui/jsx.d.ts
@@ -1,7 +1,7 @@
-import type { ReactNode } from "react";
+import type { Key, ReactNode } from "react";
 import type { TuiProps } from "./dom";
 
-type TuiElementProps = TuiProps & { children?: ReactNode };
+type TuiElementProps = TuiProps & { children?: ReactNode; key?: Key };
 
 declare module "react" {
   namespace JSX {

--- a/src/tui/jsx.d.ts
+++ b/src/tui/jsx.d.ts
@@ -1,13 +1,16 @@
+import type { ReactNode } from "react";
 import type { TuiProps } from "./dom";
 
-declare global {
+type TuiElementProps = TuiProps & { children?: ReactNode };
+
+declare module "react" {
   namespace JSX {
     interface IntrinsicElements {
-      "tui-root": TuiProps & { children?: React.ReactNode };
-      "tui-box": TuiProps & { children?: React.ReactNode };
-      "tui-text": TuiProps & { children?: React.ReactNode };
-      "tui-static": TuiProps & { children?: React.ReactNode };
-      "tui-virtual": TuiProps & { children?: React.ReactNode };
+      "tui-root": TuiElementProps;
+      "tui-box": TuiElementProps;
+      "tui-text": TuiElementProps;
+      "tui-static": TuiElementProps;
+      "tui-virtual": TuiElementProps;
     }
   }
 }

--- a/src/tui/reconciler.ts
+++ b/src/tui/reconciler.ts
@@ -1,0 +1,4 @@
+import ReactReconciler from "react-reconciler";
+import { hostConfig } from "./host-config";
+
+export const reconciler = ReactReconciler(hostConfig);

--- a/src/tui/reconciler.ts
+++ b/src/tui/reconciler.ts
@@ -1,4 +1,30 @@
+import type { ReactNode } from "react";
 import ReactReconciler from "react-reconciler";
+import type { TuiElement } from "./dom";
 import { hostConfig } from "./host-config";
 
-export const reconciler = ReactReconciler(hostConfig);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- react-reconciler types don't match runtime
+const baseReconciler = ReactReconciler(hostConfig as any);
+
+type OpaqueRoot = ReturnType<typeof baseReconciler.createContainer>;
+
+interface TuiReconciler {
+  createContainer: typeof baseReconciler.createContainer;
+  updateContainer(
+    element: ReactNode,
+    container: OpaqueRoot,
+    parentComponent: null,
+    callback: (() => void) | null,
+  ): void;
+  updateContainerSync(
+    element: ReactNode,
+    container: OpaqueRoot,
+    parentComponent: null,
+    callback: (() => void) | null,
+  ): void;
+  flushSyncWork(): void;
+  flushPassiveEffects(): boolean;
+  getPublicRootInstance(container: OpaqueRoot): TuiElement | null;
+}
+
+export const reconciler: TuiReconciler = baseReconciler as TuiReconciler;

--- a/src/tui/reconciler.ts
+++ b/src/tui/reconciler.ts
@@ -3,7 +3,7 @@ import ReactReconciler from "react-reconciler";
 import type { TuiElement } from "./dom";
 import { hostConfig } from "./host-config";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- react-reconciler types don't match runtime
+// biome-ignore lint/suspicious/noExplicitAny: react-reconciler types don't match runtime
 const baseReconciler = ReactReconciler(hostConfig as any);
 
 type OpaqueRoot = ReturnType<typeof baseReconciler.createContainer>;

--- a/src/tui/render-to-string.ts
+++ b/src/tui/render-to-string.ts
@@ -1,0 +1,18 @@
+import type { ReactNode } from "react";
+import { createElement } from "./dom";
+import { reconciler } from "./reconciler";
+import { serialize } from "./serialize";
+
+export function renderToString(node: ReactNode, options?: { columns?: number }): string {
+  const root = createElement("tui-root", {});
+  const container = reconciler.createContainer(
+    root, 0, null, false, null, "",
+    (error: Error) => { throw error; },
+    () => {},
+    () => {},
+    () => {},
+  );
+  reconciler.updateContainer(node, container, null, () => {});
+  reconciler.flushSync(() => {});
+  return serialize(root, options?.columns);
+}

--- a/src/tui/render-to-string.ts
+++ b/src/tui/render-to-string.ts
@@ -6,13 +6,20 @@ import { serialize } from "./serialize";
 export function renderToString(node: ReactNode, options?: { columns?: number }): string {
   const root = createElement("tui-root", {});
   const container = reconciler.createContainer(
-    root, 0, null, false, null, "",
-    (error: Error) => { throw error; },
+    root,
+    0,
+    null,
+    false,
+    null,
+    "",
+    (error: Error) => {
+      throw error;
+    },
     () => {},
     () => {},
     () => {},
   );
-  reconciler.updateContainer(node, container, null, () => {});
-  reconciler.flushSync(() => {});
+  reconciler.updateContainerSync(node, container, null, () => {});
+  reconciler.flushSyncWork();
   return serialize(root, options?.columns);
 }

--- a/src/tui/render-to-string.ts
+++ b/src/tui/render-to-string.ts
@@ -3,7 +3,7 @@ import { createElement } from "./dom";
 import { reconciler } from "./reconciler";
 import { serialize } from "./serialize";
 
-export function renderToString(node: ReactNode, options?: { columns?: number }): string {
+export function renderToString(node: ReactNode): string {
   const root = createElement("tui-root", {});
   const container = reconciler.createContainer(
     root,
@@ -21,5 +21,5 @@ export function renderToString(node: ReactNode, options?: { columns?: number }):
   );
   reconciler.updateContainerSync(node, container, null, () => {});
   reconciler.flushSyncWork();
-  return serialize(root, options?.columns);
+  return serialize(root);
 }

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -181,6 +181,9 @@ export function render(node: ReactNode): RenderInstance {
 
   function cleanup() {
     setOnCommit(null);
+    process.removeListener("SIGINT", onSignal);
+    process.removeListener("SIGTERM", onSignal);
+    process.removeListener("exit", onExit);
     if (stdin.isTTY) {
       stdin.removeListener("data", onStdinData);
       stdin.setRawMode(false);
@@ -193,6 +196,24 @@ export function render(node: ReactNode): RenderInstance {
     }
     reconciler.updateContainer(null, container, null, () => {});
   }
+
+  function onSignal() {
+    exit();
+    process.exit();
+  }
+  function onExit() {
+    if (exited) return;
+    // Synchronous cleanup on exit — restore terminal state.
+    if (stdout.isTTY) {
+      stdout.write(kitty.disable);
+      stdout.write(ansi.cursorShow);
+      stdout.write("\n");
+    }
+  }
+
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
+  process.on("exit", onExit);
 
   return {
     waitUntilExit: () => exitPromise,

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1,0 +1,135 @@
+import type { ReactNode } from "react";
+import { createElement as reactCreateElement } from "react";
+import { AppContext, type InputContextValue, InputContext, type InputRegistration } from "./context";
+import { createElement } from "./dom";
+import { setOnCommit } from "./host-config";
+import { createInputDispatcher } from "./input";
+import { reconciler } from "./reconciler";
+import { serialize } from "./serialize";
+import { ansi, kitty } from "./styles";
+
+type KittyKeyboardOptions = {
+  mode?: "enabled" | "disabled";
+  flags?: string[];
+};
+
+type RenderOptions = {
+  exitOnCtrlC?: boolean;
+  kittyKeyboard?: KittyKeyboardOptions;
+};
+
+type RenderInstance = {
+  waitUntilExit: () => Promise<void>;
+  unmount: () => void;
+};
+
+export function render(node: ReactNode, options?: RenderOptions): RenderInstance {
+  const root = createElement("tui-root", {});
+  const stdout = process.stdout;
+  const stdin = process.stdin;
+  let lastOutput = "";
+  let lastLineCount = 0;
+  let exitResolve: (() => void) | null = null;
+  const exitPromise = new Promise<void>((resolve) => {
+    exitResolve = resolve;
+  });
+  let exited = false;
+
+  const exit = () => {
+    if (exited) return;
+    exited = true;
+    cleanup();
+    exitResolve?.();
+  };
+
+  const dispatcher = createInputDispatcher();
+
+  const inputContextValue: InputContextValue = {
+    register(reg: InputRegistration) {
+      const entry = { handler: reg.handler, isActive: reg.isActive };
+      dispatcher.handlers.add(entry);
+      return () => {
+        dispatcher.handlers.delete(entry);
+      };
+    },
+  };
+
+  const onStdinData = (data: Buffer | string) => {
+    if (options?.exitOnCtrlC !== false) {
+      const raw = typeof data === "string" ? data : data.toString("utf8");
+      if (raw === "\x03") {
+        exit();
+        return;
+      }
+    }
+    dispatcher.dispatch(data);
+  };
+
+  if (stdin.isTTY) {
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.on("data", onStdinData);
+  }
+
+  const kittyFlags = options?.kittyKeyboard?.mode === "enabled" ? 1 : 0;
+  if (kittyFlags > 0) {
+    stdout.write(kitty.enable(kittyFlags));
+  }
+
+  stdout.write(ansi.cursorHide);
+
+  function commitRender() {
+    if (exited) return;
+    const output = serialize(root);
+    if (output === lastOutput) return;
+
+    if (lastLineCount > 0) {
+      stdout.write(ansi.cursorUp(lastLineCount));
+    }
+    stdout.write(`\r${ansi.eraseDown}`);
+    stdout.write(output);
+
+    lastOutput = output;
+    lastLineCount = output.split("\n").length - 1;
+  }
+
+  setOnCommit(commitRender);
+
+  const container = reconciler.createContainer(
+    root, 0, null, false, null, "",
+    (error: Error) => { console.error(error); },
+    () => {},
+    () => {},
+    () => {},
+  );
+
+  const wrappedNode = reactCreateElement(
+    AppContext.Provider,
+    { value: { exit } },
+    reactCreateElement(InputContext.Provider, { value: inputContextValue }, node),
+  );
+
+  reconciler.updateContainer(wrappedNode, container, null, () => {});
+
+  function cleanup() {
+    setOnCommit(null);
+    if (stdin.isTTY) {
+      stdin.removeListener("data", onStdinData);
+      stdin.setRawMode(false);
+      stdin.pause();
+    }
+    if (kittyFlags > 0) {
+      stdout.write(kitty.disable);
+    }
+    stdout.write(ansi.cursorShow);
+    stdout.write("\n");
+    reconciler.updateContainer(null, container, null, () => {});
+  }
+
+  return {
+    waitUntilExit: () => exitPromise,
+    unmount() {
+      exit();
+    },
+  };
+}

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -72,21 +72,24 @@ export function render(node: ReactNode, options?: RenderOptions): RenderInstance
   }
 
   const kittyFlags = options?.kittyKeyboard?.mode === "enabled" ? 1 : 0;
-  if (kittyFlags > 0) {
-    stdout.write(kitty.enable(kittyFlags));
+  if (stdout.isTTY) {
+    if (kittyFlags > 0) {
+      stdout.write(kitty.enable(kittyFlags));
+    }
+    stdout.write(ansi.cursorHide);
   }
-
-  stdout.write(ansi.cursorHide);
 
   function commitRender() {
     if (exited) return;
     const output = serialize(root);
     if (output === lastOutput) return;
 
-    if (lastLineCount > 0) {
-      stdout.write(ansi.cursorUp(lastLineCount));
+    if (stdout.isTTY) {
+      if (lastLineCount > 0) {
+        stdout.write(ansi.cursorUp(lastLineCount));
+      }
+      stdout.write(`\r${ansi.eraseDown}`);
     }
-    stdout.write(`\r${ansi.eraseDown}`);
     stdout.write(output);
 
     lastOutput = output;
@@ -125,11 +128,13 @@ export function render(node: ReactNode, options?: RenderOptions): RenderInstance
       stdin.setRawMode(false);
       stdin.pause();
     }
-    if (kittyFlags > 0) {
-      stdout.write(kitty.disable);
+    if (stdout.isTTY) {
+      if (kittyFlags > 0) {
+        stdout.write(kitty.disable);
+      }
+      stdout.write(ansi.cursorShow);
+      stdout.write("\n");
     }
-    stdout.write(ansi.cursorShow);
-    stdout.write("\n");
     reconciler.updateContainer(null, container, null, () => {});
   }
 

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -32,11 +32,10 @@ export function render(node: ReactNode): RenderInstance {
   let lastActive = "";
   let lastActiveLineCount = 0;
   let flushedStaticCount = 0;
-  // Content that has scrolled into the terminal's scrollback buffer and can no
-  // longer be erased. During streaming the active region can grow beyond the
-  // terminal height; the overflow is written once and tracked here so we never
-  // attempt to rewrite it.
-  let frozenPrefix = "";
+  // Number of logical lines (split by \n) frozen into scrollback. When the
+  // active region overflows the terminal, top lines are written once and we
+  // only re-render the bottom portion that fits on screen.
+  let frozenLineCount = 0;
   let exitResolve: (() => void) | null = null;
   const exitPromise = new Promise<void>((resolve) => {
     exitResolve = resolve;
@@ -105,7 +104,7 @@ export function render(node: ReactNode): RenderInstance {
         buf += `${staticItems[i]}\n`;
       }
       flushedStaticCount = staticItems.length;
-      frozenPrefix = "";
+      frozenLineCount = 0;
       stdout.write(buf + active);
       lastActive = active;
       lastActiveLineCount = Math.min(countRows(active), maxLiveRows);
@@ -115,14 +114,15 @@ export function render(node: ReactNode): RenderInstance {
     // Only re-render the active region if it changed.
     if (active === lastActive) return;
 
-    // If the frozen prefix no longer matches, reset it (e.g. after graduation).
-    if (frozenPrefix.length > 0 && !active.startsWith(frozenPrefix)) {
-      frozenPrefix = "";
+    const allLines = active.split("\n");
+
+    // If content shrank (e.g. graduation removed rows), reset frozen state.
+    if (allLines.length < frozenLineCount) {
+      frozenLineCount = 0;
     }
 
     // Determine the live (on-screen, erasable) portion of the active output.
-    const livePart = active.slice(frozenPrefix.length);
-    const liveLines = livePart.split("\n");
+    const liveLines = allLines.slice(frozenLineCount);
 
     // Count physical rows from the bottom to find what fits on screen.
     let physRows = 0;
@@ -138,15 +138,15 @@ export function render(node: ReactNode): RenderInstance {
 
     if (splitIdx === 0) {
       // Everything fits on screen — normal erase + rewrite.
-      stdout.write(eraseSequence() + livePart);
+      stdout.write(eraseSequence() + liveLines.join("\n"));
       lastActiveLineCount = physRows > 0 ? physRows - 1 : 0;
     } else {
-      // Overflow: freeze lines that won't fit, write them once to scrollback.
-      const toFreeze = liveLines.slice(0, splitIdx);
+      // Overflow: skip lines that don't fit rather than writing them to
+      // scrollback (which caused duplication when the user scrolled).
+      // They'll reappear once they graduate to a static item.
       const onScreen = liveLines.slice(splitIdx);
-      const freezeStr = `${toFreeze.join("\n")}\n`;
-      frozenPrefix += freezeStr;
-      stdout.write(eraseSequence() + freezeStr + onScreen.join("\n"));
+      frozenLineCount += splitIdx;
+      stdout.write(eraseSequence() + onScreen.join("\n"));
       lastActiveLineCount = physRows > 0 ? physRows - 1 : 0;
     }
 

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -5,8 +5,20 @@ import { createElement } from "./dom";
 import { setOnCommit } from "./host-config";
 import { createInputDispatcher } from "./input";
 import { reconciler } from "./reconciler";
-import { serialize } from "./serialize";
+import { serializeSplit, stripAnsiLength } from "./serialize";
 import { ansi, kitty } from "./styles";
+
+/** Count physical terminal rows, accounting for line wrapping. */
+function physicalRowCount(output: string, columns: number): number {
+  const lines = output.split("\n");
+  let rows = 0;
+  for (const line of lines) {
+    const visible = stripAnsiLength(line);
+    rows += visible === 0 ? 1 : Math.ceil(visible / columns);
+  }
+  // Subtract 1: cursor stays on the last row, we only need to move up to the first.
+  return rows - 1;
+}
 
 type RenderInstance = {
   waitUntilExit: () => Promise<void>;
@@ -17,8 +29,14 @@ export function render(node: ReactNode): RenderInstance {
   const root = createElement("tui-root", {});
   const stdout = process.stdout;
   const stdin = process.stdin;
-  let lastOutput = "";
-  let lastLineCount = 0;
+  let lastActive = "";
+  let lastActiveLineCount = 0;
+  let flushedStaticCount = 0;
+  // Content that has scrolled into the terminal's scrollback buffer and can no
+  // longer be erased. During streaming the active region can grow beyond the
+  // terminal height; the overflow is written once and tracked here so we never
+  // attempt to rewrite it.
+  let frozenPrefix = "";
   let exitResolve: (() => void) | null = null;
   const exitPromise = new Promise<void>((resolve) => {
     exitResolve = resolve;
@@ -59,21 +77,80 @@ export function render(node: ReactNode): RenderInstance {
     stdout.write(ansi.cursorHide);
   }
 
+  function countRows(output: string): number {
+    const cols = stdout.columns ?? 120;
+    return physicalRowCount(output, cols);
+  }
+
+  function eraseSequence(): string {
+    if (!stdout.isTTY || lastActiveLineCount <= 0) return "";
+    return `${ansi.cursorUp(lastActiveLineCount)}\r${ansi.eraseDown}`;
+  }
+
+  function linePhysRows(line: string, cols: number): number {
+    const visible = stripAnsiLength(line);
+    return visible === 0 ? 1 : Math.ceil(visible / cols);
+  }
+
   function commitRender() {
     if (exited) return;
-    const output = serialize(root);
-    if (output === lastOutput) return;
+    const { staticItems, active } = serializeSplit(root);
+    const cols = stdout.columns ?? 120;
+    const maxLiveRows = (stdout.rows ?? 24) - 1;
 
-    if (stdout.isTTY) {
-      if (lastLineCount > 0) {
-        stdout.write(ansi.cursorUp(lastLineCount));
+    // Flush any new static items (write-once scrollback).
+    if (staticItems.length > flushedStaticCount) {
+      let buf = eraseSequence();
+      for (let i = flushedStaticCount; i < staticItems.length; i++) {
+        buf += `${staticItems[i]}\n`;
       }
-      stdout.write(`\r${ansi.eraseDown}`);
+      flushedStaticCount = staticItems.length;
+      frozenPrefix = "";
+      stdout.write(buf + active);
+      lastActive = active;
+      lastActiveLineCount = Math.min(countRows(active), maxLiveRows);
+      return;
     }
-    stdout.write(output);
 
-    lastOutput = output;
-    lastLineCount = output.split("\n").length - 1;
+    // Only re-render the active region if it changed.
+    if (active === lastActive) return;
+
+    // If the frozen prefix no longer matches, reset it (e.g. after graduation).
+    if (frozenPrefix.length > 0 && !active.startsWith(frozenPrefix)) {
+      frozenPrefix = "";
+    }
+
+    // Determine the live (on-screen, erasable) portion of the active output.
+    const livePart = active.slice(frozenPrefix.length);
+    const liveLines = livePart.split("\n");
+
+    // Count physical rows from the bottom to find what fits on screen.
+    let physRows = 0;
+    let splitIdx = 0;
+    for (let i = liveLines.length - 1; i >= 0; i--) {
+      const rows = linePhysRows(liveLines[i]!, cols);
+      if (physRows + rows > maxLiveRows) {
+        splitIdx = i + 1;
+        break;
+      }
+      physRows += rows;
+    }
+
+    if (splitIdx === 0) {
+      // Everything fits on screen — normal erase + rewrite.
+      stdout.write(eraseSequence() + livePart);
+      lastActiveLineCount = physRows > 0 ? physRows - 1 : 0;
+    } else {
+      // Overflow: freeze lines that won't fit, write them once to scrollback.
+      const toFreeze = liveLines.slice(0, splitIdx);
+      const onScreen = liveLines.slice(splitIdx);
+      const freezeStr = `${toFreeze.join("\n")}\n`;
+      frozenPrefix += freezeStr;
+      stdout.write(eraseSequence() + freezeStr + onScreen.join("\n"));
+      lastActiveLineCount = physRows > 0 ? physRows - 1 : 0;
+    }
+
+    lastActive = active;
   }
 
   setOnCommit(commitRender);

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { createElement as reactCreateElement } from "react";
-import { AppContext, type InputContextValue, InputContext, type InputRegistration } from "./context";
+import { AppContext, InputContext, type InputContextValue, type InputRegistration } from "./context";
 import { createElement } from "./dom";
 import { setOnCommit } from "./host-config";
 import { createInputDispatcher } from "./input";
@@ -96,8 +96,15 @@ export function render(node: ReactNode, options?: RenderOptions): RenderInstance
   setOnCommit(commitRender);
 
   const container = reconciler.createContainer(
-    root, 0, null, false, null, "",
-    (error: Error) => { console.error(error); },
+    root,
+    0,
+    null,
+    false,
+    null,
+    "",
+    (error: Error) => {
+      console.error(error);
+    },
     () => {},
     () => {},
     () => {},

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -8,22 +8,12 @@ import { reconciler } from "./reconciler";
 import { serialize } from "./serialize";
 import { ansi, kitty } from "./styles";
 
-type KittyKeyboardOptions = {
-  mode?: "enabled" | "disabled";
-  flags?: string[];
-};
-
-type RenderOptions = {
-  exitOnCtrlC?: boolean;
-  kittyKeyboard?: KittyKeyboardOptions;
-};
-
 type RenderInstance = {
   waitUntilExit: () => Promise<void>;
   unmount: () => void;
 };
 
-export function render(node: ReactNode, options?: RenderOptions): RenderInstance {
+export function render(node: ReactNode): RenderInstance {
   const root = createElement("tui-root", {});
   const stdout = process.stdout;
   const stdin = process.stdin;
@@ -55,13 +45,6 @@ export function render(node: ReactNode, options?: RenderOptions): RenderInstance
   };
 
   const onStdinData = (data: Buffer | string) => {
-    if (options?.exitOnCtrlC !== false) {
-      const raw = typeof data === "string" ? data : data.toString("utf8");
-      if (raw === "\x03") {
-        exit();
-        return;
-      }
-    }
     dispatcher.dispatch(data);
   };
 
@@ -71,11 +54,8 @@ export function render(node: ReactNode, options?: RenderOptions): RenderInstance
     stdin.on("data", onStdinData);
   }
 
-  const kittyFlags = options?.kittyKeyboard?.mode === "enabled" ? 1 : 0;
   if (stdout.isTTY) {
-    if (kittyFlags > 0) {
-      stdout.write(kitty.enable(kittyFlags));
-    }
+    stdout.write(kitty.enable(1));
     stdout.write(ansi.cursorHide);
   }
 
@@ -129,9 +109,7 @@ export function render(node: ReactNode, options?: RenderOptions): RenderInstance
       stdin.pause();
     }
     if (stdout.isTTY) {
-      if (kittyFlags > 0) {
-        stdout.write(kitty.disable);
-      }
+      stdout.write(kitty.disable);
       stdout.write(ansi.cursorShow);
       stdout.write("\n");
     }

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -141,12 +141,13 @@ export function render(node: ReactNode): RenderInstance {
       stdout.write(eraseSequence() + liveLines.join("\n"));
       lastActiveLineCount = physRows > 0 ? physRows - 1 : 0;
     } else {
-      // Overflow: skip lines that don't fit rather than writing them to
-      // scrollback (which caused duplication when the user scrolled).
-      // They'll reappear once they graduate to a static item.
+      // Overflow: flush top lines to scrollback (they are stable during
+      // streaming — content is append-only), then re-render only the
+      // bottom portion that fits on screen.
+      const overflow = liveLines.slice(0, splitIdx);
       const onScreen = liveLines.slice(splitIdx);
       frozenLineCount += splitIdx;
-      stdout.write(eraseSequence() + onScreen.join("\n"));
+      stdout.write(eraseSequence() + overflow.join("\n") + "\n" + onScreen.join("\n"));
       lastActiveLineCount = physRows > 0 ? physRows - 1 : 0;
     }
 

--- a/src/tui/serialize.test.tsx
+++ b/src/tui/serialize.test.tsx
@@ -161,4 +161,22 @@ describe("serialize", () => {
       expect(renderPlain(<Text dimColor>hi</Text>)).toBe("hi");
     });
   });
+
+  describe("text sanitization", () => {
+    test("strips ESC byte from escape sequences", () => {
+      expect(renderPlain(<Text>{"\x1b[2Jhello"}</Text>)).toBe("[2Jhello");
+    });
+
+    test("strips ESC byte from OSC sequences", () => {
+      expect(renderPlain(<Text>{"\x1b]0;evil title\x07world"}</Text>)).toBe("]0;evil titleworld");
+    });
+
+    test("preserves newlines and tabs", () => {
+      expect(renderPlain(<Text>{"a\nb\tc"}</Text>)).toBe("a\nb\tc");
+    });
+
+    test("strips other C0 control chars", () => {
+      expect(renderPlain(<Text>{"a\x00b\x01c\x7f"}</Text>)).toBe("abc\x7f");
+    });
+  });
 });

--- a/src/tui/serialize.test.tsx
+++ b/src/tui/serialize.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { renderPlain } from "../tui-test-utils";
 import { Box, Text } from "./components";
 import { renderToString } from "./render-to-string";
+import { stripAnsiLength } from "./serialize";
 
 describe("serialize", () => {
   describe("text", () => {
@@ -159,6 +160,24 @@ describe("serialize", () => {
       expect(renderPlain(<Text bold>hi</Text>)).toBe("hi");
       expect(renderPlain(<Text color="red">hi</Text>)).toBe("hi");
       expect(renderPlain(<Text dimColor>hi</Text>)).toBe("hi");
+    });
+  });
+
+  describe("stripAnsiLength", () => {
+    test("counts visible characters ignoring CSI sequences", () => {
+      expect(stripAnsiLength("\x1b[1mhello\x1b[0m")).toBe(5);
+    });
+
+    test("counts visible characters ignoring OSC sequences (BEL terminated)", () => {
+      expect(stripAnsiLength("\x1b]0;title\x07hello")).toBe(5);
+    });
+
+    test("counts visible characters ignoring OSC sequences (ST terminated)", () => {
+      expect(stripAnsiLength("\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\")).toBe(4);
+    });
+
+    test("handles plain text", () => {
+      expect(stripAnsiLength("hello world")).toBe(11);
     });
   });
 

--- a/src/tui/serialize.test.tsx
+++ b/src/tui/serialize.test.tsx
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+import { renderPlain } from "../tui-test-utils";
+import { Box, Text } from "./components";
+import { renderToString } from "./render-to-string";
+
+describe("serialize", () => {
+  describe("text", () => {
+    test("renders plain text", () => {
+      expect(renderPlain(<Text>hello</Text>)).toBe("hello");
+    });
+
+    test("renders nested text", () => {
+      expect(
+        renderPlain(
+          <Text>
+            hello <Text bold>world</Text>
+          </Text>,
+        ),
+      ).toBe("hello world");
+    });
+
+    test("renders empty text as empty string", () => {
+      expect(renderPlain(<Text>{""}</Text>)).toBe("");
+    });
+  });
+
+  describe("box column", () => {
+    test("renders children as lines", () => {
+      expect(
+        renderPlain(
+          <Box flexDirection="column">
+            <Text>line 1</Text>
+            <Text>line 2</Text>
+          </Box>,
+        ),
+      ).toBe("line 1\nline 2");
+    });
+
+    test("pads lines to width", () => {
+      expect(
+        renderPlain(
+          <Box flexDirection="column" width={10}>
+            <Text>hi</Text>
+          </Box>,
+        ),
+      ).toBe("hi");
+    });
+  });
+
+  describe("box row", () => {
+    test("concatenates children horizontally", () => {
+      expect(
+        renderPlain(
+          <Box>
+            <Text>hello </Text>
+            <Text>world</Text>
+          </Box>,
+        ),
+      ).toBe("hello world");
+    });
+  });
+
+  describe("justifyContent", () => {
+    test("space-between distributes gap", () => {
+      const out = renderPlain(
+        <Box justifyContent="space-between" width={20}>
+          <Text>a</Text>
+          <Text>b</Text>
+        </Box>,
+      );
+      expect(out).toBe("a                  b");
+    });
+
+    test("space-between with three children", () => {
+      const out = renderPlain(
+        <Box justifyContent="space-between" width={21}>
+          <Text>a</Text>
+          <Text>b</Text>
+          <Text>c</Text>
+        </Box>,
+      );
+      expect(out).toBe("a         b         c");
+    });
+
+    test("flex-end right-aligns content", () => {
+      const out = renderPlain(
+        <Box justifyContent="flex-end" width={20}>
+          <Text>end</Text>
+        </Box>,
+      );
+      expect(out).toBe("                 end");
+    });
+  });
+
+  describe("flexWrap", () => {
+    test("nowrap keeps children on one line", () => {
+      const out = renderPlain(
+        <Box width={10}>
+          <Text>hello</Text>
+          <Text>world</Text>
+        </Box>,
+      );
+      expect(out).toBe("helloworld");
+    });
+
+    test("wrap stacks children when they overflow", () => {
+      const out = renderPlain(
+        <Box flexWrap="wrap" width={10}>
+          <Text>hello</Text>
+          <Text>world!</Text>
+        </Box>,
+      );
+      expect(out).toBe("hello\nworld!");
+    });
+
+    test("wrap keeps row when children fit", () => {
+      const out = renderPlain(
+        <Box flexWrap="wrap" width={20}>
+          <Text>hello</Text>
+          <Text>world</Text>
+        </Box>,
+      );
+      expect(out).toBe("helloworld");
+    });
+  });
+
+  describe("styles", () => {
+    test("renderToString includes ANSI codes", () => {
+      const raw = renderToString(<Text bold>hi</Text>);
+      expect(raw).toContain("\x1b[1m");
+      expect(raw).toContain("hi");
+      expect(raw).toContain("\x1b[0m");
+    });
+
+    test("renderPlain strips ANSI codes", () => {
+      expect(renderPlain(<Text bold>hi</Text>)).toBe("hi");
+      expect(renderPlain(<Text color="red">hi</Text>)).toBe("hi");
+      expect(renderPlain(<Text dimColor>hi</Text>)).toBe("hi");
+    });
+  });
+});

--- a/src/tui/serialize.test.tsx
+++ b/src/tui/serialize.test.tsx
@@ -122,6 +122,29 @@ describe("serialize", () => {
       );
       expect(out).toBe("helloworld");
     });
+
+    test("wrap with space-between groups children into rows", () => {
+      const out = renderPlain(
+        <Box flexWrap="wrap" justifyContent="space-between" width={20}>
+          <Text>left</Text>
+          <Text>middle</Text>
+          <Text>right</Text>
+        </Box>,
+      );
+      // "left" (4) + "middle" (6) + "right" (5) = 15, fits in 20
+      expect(out).toBe("left   middle  right");
+    });
+
+    test("wrap with space-between wraps when too wide", () => {
+      const out = renderPlain(
+        <Box flexWrap="wrap" justifyContent="space-between" width={15}>
+          <Text>hello world</Text>
+          <Text>overflow!</Text>
+        </Box>,
+      );
+      // "hello world" (11) + "overflow!" (9) = 20 > 15, wraps
+      expect(out).toBe("hello world\noverflow!");
+    });
   });
 
   describe("styles", () => {

--- a/src/tui/serialize.ts
+++ b/src/tui/serialize.ts
@@ -36,7 +36,7 @@ function mergeStyle(parent: StyleStack, props: TuiProps): StyleStack {
   };
 }
 
-function stripAnsiLength(value: string): number {
+export function stripAnsiLength(value: string): number {
   let length = 0;
   let i = 0;
   while (i < value.length) {
@@ -66,7 +66,13 @@ function padLine(line: string, width: number): string {
   return line;
 }
 
-function serializeNode(node: TuiNode, inherited: StyleStack): string {
+/**
+ * Serialize a node to string. When `staticAcc` is provided, `tui-static`
+ * children are collected into it instead of rendered inline — this lets
+ * the render loop flush them once to scrollback and only re-render the
+ * active (non-static) portion of the tree.
+ */
+function serializeNode(node: TuiNode, inherited: StyleStack, staticAcc?: string[]): string {
   if (node.kind === "text") {
     if (node.value.length === 0) return "";
     if (hasStyle(inherited)) {
@@ -78,12 +84,24 @@ function serializeNode(node: TuiNode, inherited: StyleStack): string {
   const el = node;
 
   if (el.type === "tui-virtual") {
-    return el.children.map((child) => serializeNode(child, inherited)).join("");
+    return el.children.map((child) => serializeNode(child, inherited, staticAcc)).join("");
   }
 
   if (el.type === "tui-text") {
     const style = mergeStyle(inherited, el.props);
-    return el.children.map((child) => serializeNode(child, style)).join("");
+    return el.children.map((child) => serializeNode(child, style, staticAcc)).join("");
+  }
+
+  if (el.type === "tui-static") {
+    if (staticAcc) {
+      // Collect each virtual child separately for incremental flushing.
+      for (const child of el.children) {
+        staticAcc.push(serializeNode(child, inherited));
+      }
+      return "";
+    }
+    // No accumulator — render inline (used by serialize / renderToString).
+    return el.children.map((child) => serializeNode(child, inherited)).join("\n");
   }
 
   if (el.type === "tui-box") {
@@ -91,7 +109,7 @@ function serializeNode(node: TuiNode, inherited: StyleStack): string {
     const isColumn = el.props.flexDirection === "column";
 
     if (isColumn) {
-      const parts = el.children.map((child) => serializeNode(child, style));
+      const parts = el.children.map((child) => serializeNode(child, style, staticAcc)).filter((p) => p.length > 0);
       let joined = parts.join("\n");
       if (el.props.width !== undefined) {
         const w = el.props.width;
@@ -104,7 +122,7 @@ function serializeNode(node: TuiNode, inherited: StyleStack): string {
     }
 
     // Row direction: concatenate children horizontally.
-    const childOutputs = el.children.map((child) => serializeNode(child, style));
+    const childOutputs = el.children.map((child) => serializeNode(child, style, staticAcc));
     const boxWidth = el.props.width;
     const justify = el.props.justifyContent;
     const wrap = el.props.flexWrap === "wrap";
@@ -135,8 +153,11 @@ function serializeNode(node: TuiNode, inherited: StyleStack): string {
     return joinRow(childOutputs, boxWidth);
   }
 
-  // Root or static — render children as column
-  return el.children.map((child) => serializeNode(child, inherited)).join("\n");
+  // Root — render children as column
+  return el.children
+    .map((child) => serializeNode(child, inherited, staticAcc))
+    .filter((p) => p.length > 0)
+    .join("\n");
 }
 
 /** Join children with space distributed evenly between them. */
@@ -210,4 +231,17 @@ function joinRow(childOutputs: string[], boxWidth?: number): string {
 export function serialize(root: TuiElement): string {
   const emptyStyle: StyleStack = {};
   return serializeNode(root, emptyStyle);
+}
+
+/**
+ * Split root into static (write-once scrollback) and active (re-rendered) regions.
+ * Walks the full tree — `tui-static` elements at any depth are collected into
+ * `staticItems` instead of rendered inline, so the render loop can flush them
+ * once to scrollback and only re-draw the active portion each frame.
+ */
+export function serializeSplit(root: TuiElement): { staticItems: string[]; active: string } {
+  const emptyStyle: StyleStack = {};
+  const staticItems: string[] = [];
+  const active = serializeNode(root, emptyStyle, staticItems);
+  return { staticItems, active };
 }

--- a/src/tui/serialize.ts
+++ b/src/tui/serialize.ts
@@ -36,51 +36,6 @@ function mergeStyle(parent: StyleStack, props: TuiProps): StyleStack {
   };
 }
 
-function serializeNode(node: TuiNode, inherited: StyleStack): string {
-  if (node.kind === "text") {
-    if (node.value.length === 0) return "";
-    if (hasStyle(inherited)) {
-      return `${openStyle(inherited)}${node.value}${ansi.reset}`;
-    }
-    return node.value;
-  }
-
-  const el = node as TuiElement;
-
-  if (el.type === "tui-virtual") {
-    return el.children.map((child) => serializeNode(child, inherited)).join("");
-  }
-
-  if (el.type === "tui-text") {
-    const style = mergeStyle(inherited, el.props);
-    const content = el.children.map((child) => serializeNode(child, style)).join("");
-    return content;
-  }
-
-  if (el.type === "tui-box") {
-    const style = mergeStyle(inherited, el.props);
-    const isColumn = el.props.flexDirection === "column";
-    const parts = el.children.map((child) => serializeNode(child, style));
-    let joined = isColumn ? parts.join("\n") : parts.join("");
-
-    if (el.props.width !== undefined) {
-      const width = el.props.width;
-      const lines = joined.split("\n");
-      joined = lines
-        .map((line) => {
-          const visible = stripAnsiLength(line);
-          if (visible < width) return line + " ".repeat(width - visible);
-          return line;
-        })
-        .join("\n");
-    }
-    return joined;
-  }
-
-  // Root or static — just render children as column
-  return el.children.map((child) => serializeNode(child, inherited)).join("\n");
-}
-
 function stripAnsiLength(value: string): number {
   let length = 0;
   let inEscape = false;
@@ -96,6 +51,107 @@ function stripAnsiLength(value: string): number {
     length++;
   }
   return length;
+}
+
+function padLine(line: string, width: number): string {
+  const visible = stripAnsiLength(line);
+  if (visible < width) return line + " ".repeat(width - visible);
+  return line;
+}
+
+function serializeNode(node: TuiNode, inherited: StyleStack): string {
+  if (node.kind === "text") {
+    if (node.value.length === 0) return "";
+    if (hasStyle(inherited)) {
+      return `${openStyle(inherited)}${node.value}${ansi.reset}`;
+    }
+    return node.value;
+  }
+
+  const el = node;
+
+  if (el.type === "tui-virtual") {
+    return el.children.map((child) => serializeNode(child, inherited)).join("");
+  }
+
+  if (el.type === "tui-text") {
+    const style = mergeStyle(inherited, el.props);
+    return el.children.map((child) => serializeNode(child, style)).join("");
+  }
+
+  if (el.type === "tui-box") {
+    const style = mergeStyle(inherited, el.props);
+    const isColumn = el.props.flexDirection === "column";
+
+    if (isColumn) {
+      const parts = el.children.map((child) => serializeNode(child, style));
+      let joined = parts.join("\n");
+      if (el.props.width !== undefined) {
+        const w = el.props.width;
+        joined = joined
+          .split("\n")
+          .map((line) => padLine(line, w))
+          .join("\n");
+      }
+      return joined;
+    }
+
+    // Row direction: concatenate children horizontally.
+    // For multiline children, subsequent lines must be padded to align
+    // with the child's horizontal start position.
+    const childOutputs = el.children.map((child) => serializeNode(child, style));
+    return joinRow(childOutputs, el.props.width);
+  }
+
+  // Root or static — render children as column
+  return el.children.map((child) => serializeNode(child, inherited)).join("\n");
+}
+
+/** Join child outputs horizontally, handling multiline content. */
+function joinRow(childOutputs: string[], boxWidth?: number): string {
+  // Determine which children have multiline content
+  const childLines = childOutputs.map((output) => output.split("\n"));
+  const maxLines = Math.max(1, ...childLines.map((lines) => lines.length));
+
+  if (maxLines === 1) {
+    let result = childOutputs.join("");
+    if (boxWidth !== undefined) {
+      result = padLine(result, boxWidth);
+    }
+    return result;
+  }
+
+  // Multiline: for each output line index, build the row by padding
+  // earlier children to their visible width so later children align.
+  const resultLines: string[] = [];
+  for (let lineIdx = 0; lineIdx < maxLines; lineIdx++) {
+    let row = "";
+    for (let childIdx = 0; childIdx < childLines.length; childIdx++) {
+      const lines = childLines[childIdx] ?? [];
+      const line = lines[lineIdx] ?? "";
+
+      if (lineIdx === 0 || childIdx === childLines.length - 1) {
+        // First line or last child: just append
+        row += line;
+      } else {
+        // Non-first line, non-last child: pad earlier children to
+        // their first-line visible width for alignment
+        const firstLine = lines[0] ?? "";
+        const firstLineWidth = stripAnsiLength(firstLine);
+        row += padLine(line, firstLineWidth);
+      }
+    }
+    resultLines.push(row);
+  }
+
+  let result = resultLines.join("\n");
+  if (boxWidth !== undefined) {
+    result = result
+      .split("\n")
+      .map((line) => padLine(line, boxWidth))
+      .join("\n");
+  }
+  return result;
 }
 
 export function serialize(root: TuiElement, _columns?: number): string {

--- a/src/tui/serialize.ts
+++ b/src/tui/serialize.ts
@@ -1,0 +1,104 @@
+import type { TuiElement, TuiNode, TuiProps } from "./dom";
+import { ansi, colorToBg, colorToFg } from "./styles";
+
+interface StyleStack {
+  color?: string;
+  dimColor?: boolean;
+  backgroundColor?: string;
+  bold?: boolean;
+  underline?: boolean;
+  inverse?: boolean;
+}
+
+function openStyle(style: StyleStack): string {
+  let out = "";
+  if (style.bold) out += ansi.bold;
+  if (style.dimColor) out += ansi.dim;
+  if (style.underline) out += ansi.underline;
+  if (style.inverse) out += ansi.inverse;
+  if (style.color) out += colorToFg(style.color);
+  if (style.backgroundColor) out += colorToBg(style.backgroundColor);
+  return out;
+}
+
+function hasStyle(style: StyleStack): boolean {
+  return !!(style.color || style.dimColor || style.backgroundColor || style.bold || style.underline || style.inverse);
+}
+
+function mergeStyle(parent: StyleStack, props: TuiProps): StyleStack {
+  return {
+    color: props.color ?? parent.color,
+    dimColor: props.dimColor ?? parent.dimColor,
+    backgroundColor: props.backgroundColor ?? parent.backgroundColor,
+    bold: props.bold ?? parent.bold,
+    underline: props.underline ?? parent.underline,
+    inverse: props.inverse ?? parent.inverse,
+  };
+}
+
+function serializeNode(node: TuiNode, inherited: StyleStack): string {
+  if (node.kind === "text") {
+    if (node.value.length === 0) return "";
+    if (hasStyle(inherited)) {
+      return `${openStyle(inherited)}${node.value}${ansi.reset}`;
+    }
+    return node.value;
+  }
+
+  const el = node as TuiElement;
+
+  if (el.type === "tui-virtual") {
+    return el.children.map((child) => serializeNode(child, inherited)).join("");
+  }
+
+  if (el.type === "tui-text") {
+    const style = mergeStyle(inherited, el.props);
+    const content = el.children.map((child) => serializeNode(child, style)).join("");
+    return content;
+  }
+
+  if (el.type === "tui-box") {
+    const style = mergeStyle(inherited, el.props);
+    const isColumn = el.props.flexDirection === "column";
+    const parts = el.children.map((child) => serializeNode(child, style));
+    let joined = isColumn ? parts.join("\n") : parts.join("");
+
+    if (el.props.width !== undefined) {
+      const width = el.props.width;
+      const lines = joined.split("\n");
+      joined = lines
+        .map((line) => {
+          const visible = stripAnsiLength(line);
+          if (visible < width) return line + " ".repeat(width - visible);
+          return line;
+        })
+        .join("\n");
+    }
+    return joined;
+  }
+
+  // Root or static — just render children as column
+  return el.children.map((child) => serializeNode(child, inherited)).join("\n");
+}
+
+function stripAnsiLength(value: string): number {
+  let length = 0;
+  let inEscape = false;
+  for (let i = 0; i < value.length; i++) {
+    if (value[i] === "\x1b") {
+      inEscape = true;
+      continue;
+    }
+    if (inEscape) {
+      if (value[i] === "m") inEscape = false;
+      continue;
+    }
+    length++;
+  }
+  return length;
+}
+
+export function serialize(root: TuiElement, _columns?: number): string {
+  const emptyStyle: StyleStack = {};
+  return serializeNode(root, emptyStyle);
+}

--- a/src/tui/serialize.ts
+++ b/src/tui/serialize.ts
@@ -104,14 +104,64 @@ function serializeNode(node: TuiNode, inherited: StyleStack): string {
     }
 
     // Row direction: concatenate children horizontally.
-    // For multiline children, subsequent lines must be padded to align
-    // with the child's horizontal start position.
     const childOutputs = el.children.map((child) => serializeNode(child, style));
-    return joinRow(childOutputs, el.props.width);
+    const boxWidth = el.props.width;
+    const justify = el.props.justifyContent;
+    const wrap = el.props.flexWrap === "wrap";
+
+    if (wrap && boxWidth !== undefined) {
+      const totalWidth = childOutputs.reduce((sum, o) => sum + stripAnsiLength(o.split("\n")[0] ?? ""), 0);
+      if (totalWidth > boxWidth) {
+        let joined = childOutputs.join("\n");
+        joined = joined
+          .split("\n")
+          .map((line) => padLine(line, boxWidth))
+          .join("\n");
+        return joined;
+      }
+    }
+
+    if (justify === "space-between" && boxWidth !== undefined && childOutputs.length >= 2) {
+      return joinRowSpaceBetween(childOutputs, boxWidth);
+    }
+
+    if (justify === "flex-end" && boxWidth !== undefined) {
+      const content = childOutputs.join("");
+      const visible = stripAnsiLength(content);
+      if (visible < boxWidth) return " ".repeat(boxWidth - visible) + content;
+      return content;
+    }
+
+    return joinRow(childOutputs, boxWidth);
   }
 
   // Root or static — render children as column
   return el.children.map((child) => serializeNode(child, inherited)).join("\n");
+}
+
+/** Join children with space distributed evenly between them. */
+function joinRowSpaceBetween(childOutputs: string[], boxWidth: number): string {
+  const visibleWidths = childOutputs.map((o) => stripAnsiLength(o.split("\n")[0] ?? ""));
+  const totalContent = visibleWidths.reduce((a, b) => a + b, 0);
+  const totalGap = Math.max(0, boxWidth - totalContent);
+  const gaps = childOutputs.length - 1;
+
+  if (gaps <= 0) {
+    return padLine(childOutputs[0] ?? "", boxWidth);
+  }
+
+  const baseGap = Math.floor(totalGap / gaps);
+  let extraGaps = totalGap - baseGap * gaps;
+  let result = "";
+  for (let i = 0; i < childOutputs.length; i++) {
+    result += childOutputs[i];
+    if (i < childOutputs.length - 1) {
+      const extra = extraGaps > 0 ? 1 : 0;
+      extraGaps -= extra;
+      result += " ".repeat(baseGap + extra);
+    }
+  }
+  return result;
 }
 
 /** Join child outputs horizontally, handling multiline content. */

--- a/src/tui/serialize.ts
+++ b/src/tui/serialize.ts
@@ -10,6 +10,18 @@ interface StyleStack {
   inverse?: boolean;
 }
 
+/** Strip C0 control chars and ESC from text to prevent terminal escape injection. */
+function sanitizeText(text: string): string {
+  let out = "";
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (code === 0x1b) continue;
+    if (code < 0x20 && code !== 0x0a && code !== 0x09) continue;
+    out += text[i];
+  }
+  return out;
+}
+
 function openStyle(style: StyleStack): string {
   let out = "";
   if (style.bold) out += ansi.bold;
@@ -74,11 +86,12 @@ function padLine(line: string, width: number): string {
  */
 function serializeNode(node: TuiNode, inherited: StyleStack, staticAcc?: string[]): string {
   if (node.kind === "text") {
-    if (node.value.length === 0) return "";
+    const text = sanitizeText(node.value);
+    if (text.length === 0) return "";
     if (hasStyle(inherited)) {
-      return `${openStyle(inherited)}${node.value}${ansi.reset}`;
+      return `${openStyle(inherited)}${text}${ansi.reset}`;
     }
-    return node.value;
+    return text;
   }
 
   const el = node;

--- a/src/tui/serialize.ts
+++ b/src/tui/serialize.ts
@@ -128,14 +128,29 @@ function serializeNode(node: TuiNode, inherited: StyleStack, staticAcc?: string[
     const wrap = el.props.flexWrap === "wrap";
 
     if (wrap && boxWidth !== undefined) {
-      const totalWidth = childOutputs.reduce((sum, o) => sum + stripAnsiLength(o.split("\n")[0] ?? ""), 0);
+      const childWidths = childOutputs.map((o) => stripAnsiLength(o.split("\n")[0] ?? ""));
+      const totalWidth = childWidths.reduce((a, b) => a + b, 0);
       if (totalWidth > boxWidth) {
-        let joined = childOutputs.join("\n");
-        joined = joined
-          .split("\n")
-          .map((line) => padLine(line, boxWidth))
-          .join("\n");
-        return joined;
+        // Group children into rows that fit within boxWidth.
+        const rows: string[][] = [[]];
+        let rowWidth = 0;
+        for (let i = 0; i < childOutputs.length; i++) {
+          const w = childWidths[i]!;
+          if (rows[rows.length - 1]!.length > 0 && rowWidth + w > boxWidth) {
+            rows.push([]);
+            rowWidth = 0;
+          }
+          rows[rows.length - 1]!.push(childOutputs[i]!);
+          rowWidth += w;
+        }
+        // Apply justifyContent to each row, fall back to joinRow for single-item rows.
+        const renderedRows = rows.map((row) => {
+          if (justify === "space-between" && row.length >= 2) {
+            return joinRowSpaceBetween(row, boxWidth);
+          }
+          return joinRow(row, boxWidth);
+        });
+        return renderedRows.join("\n");
       }
     }
 

--- a/src/tui/serialize.ts
+++ b/src/tui/serialize.ts
@@ -55,11 +55,26 @@ export function stripAnsiLength(value: string): number {
     if (value[i] === "\x1b") {
       i++;
       if (i < value.length && value[i] === "[") {
+        // CSI sequence: ESC [ <params> <final byte 0x40-0x7E>
         i++;
         while (i < value.length) {
           const code = value.charCodeAt(i);
           i++;
           if (code >= 0x40 && code <= 0x7e) break;
+        }
+      } else if (i < value.length && value[i] === "]") {
+        // OSC sequence: ESC ] ... (BEL | ESC \)
+        i++;
+        while (i < value.length) {
+          if (value[i] === "\x07") {
+            i++;
+            break;
+          }
+          if (value[i] === "\x1b" && i + 1 < value.length && value[i + 1] === "\\") {
+            i += 2;
+            break;
+          }
+          i++;
         }
       } else if (i < value.length) {
         i++;

--- a/src/tui/serialize.ts
+++ b/src/tui/serialize.ts
@@ -48,35 +48,32 @@ function mergeStyle(parent: StyleStack, props: TuiProps): StyleStack {
   };
 }
 
-/** Advance past an escape sequence starting after the ESC byte at `value[start]`. */
-function skipEscapeSequence(value: string, start: number): number {
-  let i = start;
-  if (i < value.length && value[i] === "[") {
-    // CSI: ESC [ <params> <final byte 0x40-0x7E>
+/** Skip CSI: ESC [ <params> <final byte 0x40-0x7E>. `i` points past `[`. */
+function skipCsi(value: string, i: number): number {
+  while (i < value.length) {
+    const code = value.charCodeAt(i);
     i++;
-    while (i < value.length) {
-      const code = value.charCodeAt(i);
-      i++;
-      if (code >= 0x40 && code <= 0x7e) break;
-    }
-  } else if (i < value.length && value[i] === "]") {
-    // OSC: ESC ] ... (BEL | ESC \)
-    i++;
-    while (i < value.length) {
-      if (value[i] === "\x07") {
-        i++;
-        break;
-      }
-      if (value[i] === "\x1b" && i + 1 < value.length && value[i + 1] === "\\") {
-        i += 2;
-        break;
-      }
-      i++;
-    }
-  } else if (i < value.length) {
+    if (code >= 0x40 && code <= 0x7e) return i;
+  }
+  return i;
+}
+
+/** Skip OSC: ESC ] ... terminated by BEL or ST (ESC \). `i` points past `]`. */
+function skipOsc(value: string, i: number): number {
+  while (i < value.length) {
+    if (value[i] === "\x07") return i + 1;
+    if (value[i] === "\x1b" && value[i + 1] === "\\") return i + 2;
     i++;
   }
   return i;
+}
+
+/** Advance past an escape sequence. `start` points to the byte after ESC. */
+function skipEscapeSequence(value: string, start: number): number {
+  const ch = value[start];
+  if (ch === "[") return skipCsi(value, start + 1);
+  if (ch === "]") return skipOsc(value, start + 1);
+  return start < value.length ? start + 1 : start;
 }
 
 export function stripAnsiLength(value: string): number {

--- a/src/tui/serialize.ts
+++ b/src/tui/serialize.ts
@@ -48,43 +48,63 @@ function mergeStyle(parent: StyleStack, props: TuiProps): StyleStack {
   };
 }
 
+/** Advance past an escape sequence starting after the ESC byte at `value[start]`. */
+function skipEscapeSequence(value: string, start: number): number {
+  let i = start;
+  if (i < value.length && value[i] === "[") {
+    // CSI: ESC [ <params> <final byte 0x40-0x7E>
+    i++;
+    while (i < value.length) {
+      const code = value.charCodeAt(i);
+      i++;
+      if (code >= 0x40 && code <= 0x7e) break;
+    }
+  } else if (i < value.length && value[i] === "]") {
+    // OSC: ESC ] ... (BEL | ESC \)
+    i++;
+    while (i < value.length) {
+      if (value[i] === "\x07") {
+        i++;
+        break;
+      }
+      if (value[i] === "\x1b" && i + 1 < value.length && value[i + 1] === "\\") {
+        i += 2;
+        break;
+      }
+      i++;
+    }
+  } else if (i < value.length) {
+    i++;
+  }
+  return i;
+}
+
 export function stripAnsiLength(value: string): number {
   let length = 0;
   let i = 0;
   while (i < value.length) {
     if (value[i] === "\x1b") {
-      i++;
-      if (i < value.length && value[i] === "[") {
-        // CSI sequence: ESC [ <params> <final byte 0x40-0x7E>
-        i++;
-        while (i < value.length) {
-          const code = value.charCodeAt(i);
-          i++;
-          if (code >= 0x40 && code <= 0x7e) break;
-        }
-      } else if (i < value.length && value[i] === "]") {
-        // OSC sequence: ESC ] ... (BEL | ESC \)
-        i++;
-        while (i < value.length) {
-          if (value[i] === "\x07") {
-            i++;
-            break;
-          }
-          if (value[i] === "\x1b" && i + 1 < value.length && value[i + 1] === "\\") {
-            i += 2;
-            break;
-          }
-          i++;
-        }
-      } else if (i < value.length) {
-        i++;
-      }
+      i = skipEscapeSequence(value, i + 1);
       continue;
     }
     length++;
     i++;
   }
   return length;
+}
+
+export function stripAnsi(value: string): string {
+  let out = "";
+  let i = 0;
+  while (i < value.length) {
+    if (value[i] === "\x1b") {
+      i = skipEscapeSequence(value, i + 1);
+      continue;
+    }
+    out += value[i];
+    i++;
+  }
+  return out;
 }
 
 function padLine(line: string, width: number): string {

--- a/src/tui/serialize.ts
+++ b/src/tui/serialize.ts
@@ -38,17 +38,24 @@ function mergeStyle(parent: StyleStack, props: TuiProps): StyleStack {
 
 function stripAnsiLength(value: string): number {
   let length = 0;
-  let inEscape = false;
-  for (let i = 0; i < value.length; i++) {
+  let i = 0;
+  while (i < value.length) {
     if (value[i] === "\x1b") {
-      inEscape = true;
-      continue;
-    }
-    if (inEscape) {
-      if (value[i] === "m") inEscape = false;
+      i++;
+      if (i < value.length && value[i] === "[") {
+        i++;
+        while (i < value.length) {
+          const code = value.charCodeAt(i);
+          i++;
+          if (code >= 0x40 && code <= 0x7e) break;
+        }
+      } else if (i < value.length) {
+        i++;
+      }
       continue;
     }
     length++;
+    i++;
   }
   return length;
 }
@@ -121,8 +128,9 @@ function joinRow(childOutputs: string[], boxWidth?: number): string {
     return result;
   }
 
-  // Multiline: for each output line index, build the row by padding
-  // earlier children to their visible width so later children align.
+  // Compute the max visible width for each child across all its lines.
+  const childWidths = childLines.map((lines) => Math.max(0, ...lines.map((line) => stripAnsiLength(line))));
+
   const resultLines: string[] = [];
   for (let lineIdx = 0; lineIdx < maxLines; lineIdx++) {
     let row = "";
@@ -130,15 +138,10 @@ function joinRow(childOutputs: string[], boxWidth?: number): string {
       const lines = childLines[childIdx] ?? [];
       const line = lines[lineIdx] ?? "";
 
-      if (lineIdx === 0 || childIdx === childLines.length - 1) {
-        // First line or last child: just append
+      if (childIdx === childLines.length - 1) {
         row += line;
       } else {
-        // Non-first line, non-last child: pad earlier children to
-        // their first-line visible width for alignment
-        const firstLine = lines[0] ?? "";
-        const firstLineWidth = stripAnsiLength(firstLine);
-        row += padLine(line, firstLineWidth);
+        row += padLine(line, childWidths[childIdx] ?? 0);
       }
     }
     resultLines.push(row);
@@ -154,7 +157,7 @@ function joinRow(childOutputs: string[], boxWidth?: number): string {
   return result;
 }
 
-export function serialize(root: TuiElement, _columns?: number): string {
+export function serialize(root: TuiElement): string {
   const emptyStyle: StyleStack = {};
   return serializeNode(root, emptyStyle);
 }

--- a/src/tui/styles.test.ts
+++ b/src/tui/styles.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { colorToBg, colorToFg } from "./styles";
+
+describe("colorToFg", () => {
+  test("named color", () => {
+    expect(colorToFg("red")).toBe("\x1b[31m");
+  });
+
+  test("bright named color", () => {
+    expect(colorToFg("redBright")).toBe("\x1b[91m");
+  });
+
+  test("case-insensitive fallback", () => {
+    expect(colorToFg("Red")).toBe("\x1b[31m");
+  });
+
+  test("hex 6-digit", () => {
+    expect(colorToFg("#ff8800")).toBe("\x1b[38;2;255;136;0m");
+  });
+
+  test("hex 3-digit shorthand", () => {
+    expect(colorToFg("#f80")).toBe("\x1b[38;2;255;136;0m");
+  });
+
+  test("unknown color returns empty string", () => {
+    expect(colorToFg("nope")).toBe("");
+  });
+
+  test("invalid hex returns empty string", () => {
+    expect(colorToFg("#xyz")).toBe("");
+  });
+});
+
+describe("colorToBg", () => {
+  test("named color", () => {
+    expect(colorToBg("blue")).toBe("\x1b[44m");
+  });
+
+  test("bright named color", () => {
+    expect(colorToBg("whiteBright")).toBe("\x1b[107m");
+  });
+
+  test("hex color", () => {
+    expect(colorToBg("#000000")).toBe("\x1b[48;2;0;0;0m");
+  });
+});

--- a/src/tui/styles.ts
+++ b/src/tui/styles.ts
@@ -1,0 +1,103 @@
+const ESC = "\x1b[";
+
+export const ansi = {
+  reset: `${ESC}0m`,
+  bold: `${ESC}1m`,
+  dim: `${ESC}2m`,
+  underline: `${ESC}4m`,
+  inverse: `${ESC}7m`,
+
+  fg256(code: number): string {
+    return `${ESC}38;5;${code}m`;
+  },
+  bg256(code: number): string {
+    return `${ESC}48;5;${code}m`;
+  },
+  fgRgb(r: number, g: number, b: number): string {
+    return `${ESC}38;2;${r};${g};${b}m`;
+  },
+  bgRgb(r: number, g: number, b: number): string {
+    return `${ESC}48;2;${r};${g};${b}m`;
+  },
+
+  cursorHide: `${ESC}?25l`,
+  cursorShow: `${ESC}?25h`,
+  eraseDown: `${ESC}J`,
+  eraseLine: `${ESC}2K`,
+  cursorTo(row: number, col: number): string {
+    return `${ESC}${row + 1};${col + 1}H`;
+  },
+  cursorUp(n: number): string {
+    return n > 0 ? `${ESC}${n}A` : "";
+  },
+  cursorSavePosition: "\x1b7",
+  cursorRestorePosition: "\x1b8",
+} as const;
+
+export const kitty = {
+  enable(flags: number): string {
+    return `${ESC}>${flags}u`;
+  },
+  disable: `${ESC}<u`,
+} as const;
+
+const NAMED_COLORS: Record<string, number> = {
+  black: 0,
+  red: 1,
+  green: 2,
+  yellow: 3,
+  blue: 4,
+  magenta: 5,
+  cyan: 6,
+  white: 7,
+  gray: 8,
+  grey: 8,
+  blackBright: 8,
+  redBright: 9,
+  greenBright: 10,
+  yellowBright: 11,
+  blueBright: 12,
+  magentaBright: 13,
+  cyanBright: 14,
+  whiteBright: 15,
+};
+
+function parseHex(hex: string): [number, number, number] | null {
+  if (!hex.startsWith("#")) return null;
+  const h = hex.slice(1);
+  if (h.length === 3) {
+    const r = Number.parseInt(`${h[0]}${h[0]}`, 16);
+    const g = Number.parseInt(`${h[1]}${h[1]}`, 16);
+    const b = Number.parseInt(`${h[2]}${h[2]}`, 16);
+    if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+    return [r, g, b];
+  }
+  if (h.length === 6) {
+    const r = Number.parseInt(h.slice(0, 2), 16);
+    const g = Number.parseInt(h.slice(2, 4), 16);
+    const b = Number.parseInt(h.slice(4, 6), 16);
+    if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return null;
+    return [r, g, b];
+  }
+  return null;
+}
+
+export function colorToFg(color: string): string {
+  const named = NAMED_COLORS[color];
+  if (named !== undefined) {
+    return named < 8 ? `${ESC}${30 + named}m` : `${ESC}${90 + named - 8}m`;
+  }
+  const hex = parseHex(color);
+  if (hex) return ansi.fgRgb(hex[0], hex[1], hex[2]);
+  return "";
+}
+
+export function colorToBg(color: string): string {
+  const named = NAMED_COLORS[color];
+  if (named !== undefined) {
+    return named < 8 ? `${ESC}${40 + named}m` : `${ESC}${100 + named - 8}m`;
+  }
+  const hex = parseHex(color);
+  if (hex) return ansi.bgRgb(hex[0], hex[1], hex[2]);
+  return "";
+}

--- a/src/tui/styles.ts
+++ b/src/tui/styles.ts
@@ -83,7 +83,7 @@ function parseHex(hex: string): [number, number, number] | null {
 }
 
 export function colorToFg(color: string): string {
-  const named = NAMED_COLORS[color];
+  const named = NAMED_COLORS[color] ?? NAMED_COLORS[color.toLowerCase()];
   if (named !== undefined) {
     return named < 8 ? `${ESC}${30 + named}m` : `${ESC}${90 + named - 8}m`;
   }
@@ -93,7 +93,7 @@ export function colorToFg(color: string): string {
 }
 
 export function colorToBg(color: string): string {
-  const named = NAMED_COLORS[color];
+  const named = NAMED_COLORS[color] ?? NAMED_COLORS[color.toLowerCase()];
   if (named !== undefined) {
     return named < 8 ? `${ESC}${40 + named}m` : `${ESC}${100 + named - 8}m`;
   }


### PR DESCRIPTION
Replaces Ink with a custom React reconciler for terminal rendering. The main driver was broken rendering — duplicated lines, jumping output, and broken scrollback even when using Ink's `Static` component correctly. But the real reason to commit to a custom renderer was owning the input model: input behavior is core product behavior for a terminal-first tool, and Ink's incomplete modifier reporting forced duplicate escape sequence parsing in the application layer.

## Changes
- Custom React terminal renderer (`src/tui/`) with virtual DOM, flex layout, and static/active split
- Centralized input pipeline: legacy escape sequences and Kitty keyboard protocol in one parser
- Prompt keymap rewritten to use `KeyEvent` flags — all raw escape matching removed
- `super` (Cmd) modifier support, multi-sequence stdin chunk parsing, named codepoints
- Overflow lines flush to scrollback during streaming instead of being dropped
- History navigation works while assistant is generating
- Layout components replace manual string padding and `formatShortcutRows()`
- Docs: TUI renderer docs, product persona update, `--force-with-lease` rule