### PR TITLE
fix(server): harden local auth and stabilize hermetic tests

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+exec bun run verify

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,6 @@ Patterns to follow:
 - Feature branch review → run `/review` skill (runs style, arch, and security audits against branch diff)
 
 Development:
-- After cloning, run `bun install` to activate the pre-push hook (via `prepare`).
-- To format code: `bun run format`.
 - Validate: `bun run verify` (lint + typecheck + test)
 
 ## Tooling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Patterns to follow:
 - Feature branch review → run `/review` skill (runs style, arch, and security audits against branch diff)
 
 Development:
-- Validate: `bun run verify` (format + lint + typecheck + test)
+- Validate: `bun run verify` (lint + typecheck + test)
 
 ## Tooling
 
@@ -86,7 +86,7 @@ Development:
 
 - Run relevant validation after changes.
 - Keep the branch green after each fix slice: run the narrowest relevant checks while iterating, then run the required gate before committing.
-- For this repo baseline, run `bun run verify` as the final gate before committing (`format` + `lint` + `typecheck` + `test`).
+- For this repo baseline, run `bun run verify` as the final gate before committing (`lint` + `typecheck` + `test`).
 - While iterating, run the narrowest check: `bun run typecheck` for type changes, `bun run lint` for style, `bun test <file>` for specific tests.
 - Do not commit on red. If baseline is already red, first land a dedicated fix slice that restores green, then continue feature work.
 - Prefer automated smoke checks for readiness; ask for manual user testing only at milestone checkpoints.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,8 @@ Patterns to follow:
 - Feature branch review → run `/review` skill (runs style, arch, and security audits against branch diff)
 
 Development:
+- After cloning, run `bun install` to activate the pre-push hook (via `prepare`).
+- To format code: `bun run format`.
 - Validate: `bun run verify` (lint + typecheck + test)
 
 ## Tooling

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,14 @@ Minimal workflow for external contributors.
 
 See the [Quick Start](./README.md#quick-start) for prerequisites and initial setup.
 
+After cloning, run `bun install` to install dependencies and activate the pre-push hook:
+
+```bash
+bun install
+```
+
+The hook runs `bun run verify` before every push. To format code manually: `bun run format`.
+
 ## Development loop
 
 1. Create a branch from `main`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See all commands: `bun run start help`
 ## Validate
 
 ```bash
-bun run verify        # format + lint + typecheck + all tests
+bun run verify        # lint + typecheck + all tests
 bun test              # all tests
 bun run test:unit     # unit tests only
 bun run test:int      # integration tests

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -48,6 +48,10 @@ Events are append-only and ordered per request.
 RPC uses JSON envelopes with transport request `id` (`rpc_*`), `type`, and optional `payload`.
 Domain task ids are separate (`task_*`).
 
+Authentication:
+- HTTP endpoints use `Authorization: Bearer <apiKey>`.
+- WebSocket RPC uses Bearer auth via `sec-websocket-protocol` (`bearer.<apiKey>`).
+
 Client methods:
 
 - `status.get`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,7 +10,7 @@ Built for safe autonomous execution of bounded tasks with the developer in contr
 
 Acolyte v0 ships with these capabilities:
 
-- **Foundations** — `bun run verify` runs format, lint, typecheck, and tests; CI passes on every commit
+- **Foundations** — `bun run verify` runs lint, typecheck, and tests; CI passes on every commit
 - **Core UX** — setup, diagnostics, per-tool permissions, error recovery
 - **Execution engine** — 5-phase lifecycle (resolve → prepare → generate → evaluate → finalize) with streaming tool calls
 - **Reliability** — anti-loop guards, step budgets, actionable diagnostics, automatic verify cycles

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:tui": "bash scripts/run-test-suite.sh tui",
     "test:int": "bash scripts/run-test-suite.sh int",
     "test:perf": "bash scripts/run-test-suite.sh perf",
-    "verify": "bunx biome format --check . && bun run lint && bun run typecheck && bun test",
+    "verify": "bun run lint && bun run typecheck && bun test",
     "benchmark": "bun run scripts/benchmark.ts",
     "release": "bash scripts/release.sh"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "acolyte": "./src/cli.ts"
   },
   "scripts": {
-    "prepare": "git config core.hooksPath .githooks",
+    "prepare": "bash scripts/setup-hooks.sh",
     "start": "bun run src/cli.ts",
     "dev": "ACOLYTE_SERVER_RESTART=1 ./scripts/with-server.sh serve:watch bun run src/cli.ts",
     "run": "bun run src/cli.ts run",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test:tui": "bash scripts/run-test-suite.sh tui",
     "test:int": "bash scripts/run-test-suite.sh int",
     "test:perf": "bash scripts/run-test-suite.sh perf",
-    "verify": "bun run format && bun run lint && bun run typecheck && bun test",
+    "verify": "bunx biome format --check . && bun run lint && bun run typecheck && bun test",
     "benchmark": "bun run scripts/benchmark.ts",
     "release": "bash scripts/release.sh"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "acolyte": "./src/cli.ts"
   },
   "scripts": {
+    "prepare": "git config core.hooksPath .githooks",
     "start": "bun run src/cli.ts",
     "dev": "ACOLYTE_SERVER_RESTART=1 ./scripts/with-server.sh serve:watch bun run src/cli.ts",
     "run": "bun run src/cli.ts run",

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v git >/dev/null 2>&1; then
+  exit 0
+fi
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  exit 0
+fi
+
+git config core.hooksPath .githooks

--- a/src/app-config.ts
+++ b/src/app-config.ts
@@ -70,3 +70,35 @@ export function setDefaultModel(model: string): void {
 export function setModeModel(mode: AgentMode, model: string): void {
   (appConfig.models as Record<string, string>)[mode] = model;
 }
+
+/**
+ * Resets all file-config-derived fields on appConfig to their default values.
+ * Env-var-derived fields (API keys) are left untouched.
+ * Call in beforeEach/afterEach to prevent local .acolyte config from leaking into tests.
+ */
+export function resetAppConfigForTesting(): void {
+  // Load pure defaults by pointing at a path that has no .acolyte directory.
+  const defaults = readResolvedConfigSync({ homeDir: "/__acolyte_test_reset__", cwd: "/__acolyte_test_reset__" });
+  (appConfig as { model: string }).model = defaults.model;
+  (appConfig as { models: Record<string, string | undefined> }).models = {};
+  (appConfig as { temperatures: Record<string, number | undefined> }).temperatures = {};
+  Object.assign(appConfig.server, {
+    port: defaults.port,
+    transportMode: defaults.transportMode,
+    replyTimeoutMs: defaults.replyTimeoutMs,
+  });
+  Object.assign(appConfig.openai, { baseUrl: defaults.openaiBaseUrl });
+  Object.assign(appConfig.anthropic, { baseUrl: defaults.anthropicBaseUrl });
+  Object.assign(appConfig.google, { baseUrl: defaults.googleBaseUrl });
+  Object.assign(appConfig.distill, {
+    model: defaults.distillModel,
+    messageThreshold: defaults.distillMessageThreshold,
+    reflectionThresholdTokens: defaults.distillReflectionThresholdTokens,
+    maxOutputTokens: defaults.distillMaxOutputTokens,
+  });
+  Object.assign(appConfig.memory, {
+    budgetTokens: defaults.memoryBudgetTokens,
+    sources: [...defaults.memorySources],
+  });
+  (appConfig.agent as { contextMaxTokens: number }).contextMaxTokens = defaults.contextMaxTokens;
+}

--- a/src/app-config.ts
+++ b/src/app-config.ts
@@ -70,35 +70,3 @@ export function setDefaultModel(model: string): void {
 export function setModeModel(mode: AgentMode, model: string): void {
   (appConfig.models as Record<string, string>)[mode] = model;
 }
-
-/**
- * Resets all file-config-derived fields on appConfig to their default values.
- * Env-var-derived fields (API keys) are left untouched.
- * Call in beforeEach/afterEach to prevent local .acolyte config from leaking into tests.
- */
-export function resetAppConfigForTesting(): void {
-  // Load pure defaults by pointing at a path that has no .acolyte directory.
-  const defaults = readResolvedConfigSync({ homeDir: "/__acolyte_test_reset__", cwd: "/__acolyte_test_reset__" });
-  (appConfig as { model: string }).model = defaults.model;
-  (appConfig as { models: Record<string, string | undefined> }).models = {};
-  (appConfig as { temperatures: Record<string, number | undefined> }).temperatures = {};
-  Object.assign(appConfig.server, {
-    port: defaults.port,
-    transportMode: defaults.transportMode,
-    replyTimeoutMs: defaults.replyTimeoutMs,
-  });
-  Object.assign(appConfig.openai, { baseUrl: defaults.openaiBaseUrl });
-  Object.assign(appConfig.anthropic, { baseUrl: defaults.anthropicBaseUrl });
-  Object.assign(appConfig.google, { baseUrl: defaults.googleBaseUrl });
-  Object.assign(appConfig.distill, {
-    model: defaults.distillModel,
-    messageThreshold: defaults.distillMessageThreshold,
-    reflectionThresholdTokens: defaults.distillReflectionThresholdTokens,
-    maxOutputTokens: defaults.distillMaxOutputTokens,
-  });
-  Object.assign(appConfig.memory, {
-    budgetTokens: defaults.memoryBudgetTokens,
-    sources: [...defaults.memorySources],
-  });
-  (appConfig.agent as { contextMaxTokens: number }).contextMaxTokens = defaults.contextMaxTokens;
-}

--- a/src/lifecycle-resolve.test.ts
+++ b/src/lifecycle-resolve.test.ts
@@ -1,9 +1,14 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { appConfig, setModeModel } from "./app-config";
 import { resolveModeModel } from "./lifecycle-resolve";
 
 const savedModels = { ...appConfig.models };
 const savedOpenai = { ...appConfig.openai };
+
+beforeEach(() => {
+  (appConfig as { models: typeof appConfig.models }).models = {};
+  Object.assign(appConfig.openai, savedOpenai);
+});
 
 afterEach(() => {
   (appConfig as { models: typeof appConfig.models }).models = { ...savedModels };

--- a/src/lifecycle-resolve.test.ts
+++ b/src/lifecycle-resolve.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import { appConfig, setModeModel } from "./app-config";
 import { readResolvedConfigSync } from "./config";
 import { resolveModeModel } from "./lifecycle-resolve";
@@ -18,10 +18,6 @@ function resetAppConfigForTest(): void {
 }
 
 beforeEach(() => {
-  resetAppConfigForTest();
-});
-
-afterEach(() => {
   resetAppConfigForTest();
 });
 

--- a/src/lifecycle-resolve.test.ts
+++ b/src/lifecycle-resolve.test.ts
@@ -1,18 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { appConfig, setModeModel } from "./app-config";
+import { appConfig, resetAppConfigForTesting, setModeModel } from "./app-config";
 import { resolveModeModel } from "./lifecycle-resolve";
 
-const savedModels = { ...appConfig.models };
-const savedOpenai = { ...appConfig.openai };
-
 beforeEach(() => {
-  (appConfig as { models: typeof appConfig.models }).models = {};
-  Object.assign(appConfig.openai, savedOpenai);
+  resetAppConfigForTesting();
 });
 
 afterEach(() => {
-  (appConfig as { models: typeof appConfig.models }).models = { ...savedModels };
-  Object.assign(appConfig.openai, savedOpenai);
+  resetAppConfigForTesting();
 });
 
 function withOpenaiKey(key: string | undefined): void {

--- a/src/lifecycle-resolve.test.ts
+++ b/src/lifecycle-resolve.test.ts
@@ -1,13 +1,28 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { appConfig, resetAppConfigForTesting, setModeModel } from "./app-config";
+import { appConfig, setModeModel } from "./app-config";
+import { readResolvedConfigSync } from "./config";
 import { resolveModeModel } from "./lifecycle-resolve";
 
+function resetAppConfigForTest(): void {
+  const defaults = readResolvedConfigSync({ homeDir: "/__acolyte_test_reset__", cwd: "/__acolyte_test_reset__" });
+  (appConfig as { model: string }).model = defaults.model;
+  (appConfig as { models: Record<string, string | undefined> }).models = {};
+  Object.assign(appConfig.server, {
+    port: defaults.port,
+    transportMode: defaults.transportMode,
+    replyTimeoutMs: defaults.replyTimeoutMs,
+  });
+  Object.assign(appConfig.openai, { baseUrl: defaults.openaiBaseUrl });
+  Object.assign(appConfig.anthropic, { baseUrl: defaults.anthropicBaseUrl });
+  Object.assign(appConfig.google, { baseUrl: defaults.googleBaseUrl });
+}
+
 beforeEach(() => {
-  resetAppConfigForTesting();
+  resetAppConfigForTest();
 });
 
 afterEach(() => {
-  resetAppConfigForTesting();
+  resetAppConfigForTest();
 });
 
 function withOpenaiKey(key: string | undefined): void {

--- a/src/server-app.ts
+++ b/src/server-app.ts
@@ -16,18 +16,12 @@ import type { TaskId, TaskState, TaskTransitionReason } from "./task-contract";
 import { TaskRegistry } from "./task-registry";
 
 const PORT = process.env.PORT ? Number(process.env.PORT) : appConfig.server.port;
+const HOST = "127.0.0.1";
 const API_KEY = appConfig.server.apiKey;
 const OPENAI_API_KEY = appConfig.openai.apiKey;
 const SUPPRESSED_STDERR_PREFIX = "Upstream LLM API error from";
 const SERVER_IDLE_TIMEOUT_SECONDS = Math.max(30, Math.ceil(appConfig.server.replyTimeoutMs / 1000) + 30);
 const taskRegistry = new TaskRegistry();
-
-const originalConsoleError = console.error.bind(console);
-console.error = (...args: unknown[]): void => {
-  const first = args[0];
-  if (typeof first === "string" && first.includes(SUPPRESSED_STDERR_PREFIX)) return;
-  originalConsoleError(...args);
-};
 
 function nextErrorId(): ErrorId {
   return errorIdSchema.parse(`err_${createId()}`);
@@ -61,7 +55,7 @@ function safeEqual(a: string, b: string): boolean {
   return crypto.timingSafeEqual(bufA, bufB);
 }
 
-function hasValidAuth(req: Request, url?: URL): boolean {
+function hasValidAuth(req: Request): boolean {
   if (!API_KEY) return true;
 
   const auth = req.headers.get("authorization");
@@ -73,8 +67,7 @@ function hasValidAuth(req: Request, url?: URL): boolean {
     if (trimmed.startsWith("bearer.") && safeEqual(trimmed.slice(7), API_KEY)) return true;
   }
 
-  const param = url?.searchParams.get("apiKey");
-  return param !== null && param !== undefined && safeEqual(param, API_KEY);
+  return false;
 }
 
 function transitionTaskState(
@@ -136,6 +129,15 @@ async function createStatusPayload(): Promise<StatusPayload> {
 }
 
 export async function startServer(): Promise<void> {
+  // Suppress noisy upstream LLM SDK errors that are already handled at the application layer.
+  // Scoped here so it only applies while the server is running.
+  const originalConsoleError = console.error.bind(console);
+  console.error = (...args: unknown[]): void => {
+    const first = args[0];
+    if (typeof first === "string" && first.includes(SUPPRESSED_STDERR_PREFIX)) return;
+    originalConsoleError(...args);
+  };
+
   const rpcWebsocketHandlers = createRpcWebsocketHandlers({
     createStatusPayload,
     isChatRequest,
@@ -166,6 +168,7 @@ export async function startServer(): Promise<void> {
 
   server = Bun.serve<RpcConnectionState>({
     port: PORT,
+    hostname: HOST,
     idleTimeout: SERVER_IDLE_TIMEOUT_SECONDS,
     fetch: fetchHandler,
     websocket: rpcWebsocketHandlers,
@@ -178,5 +181,5 @@ export async function startServer(): Promise<void> {
     log.error("unhandled rejection", errorToLogFields(reason instanceof Error ? reason : new Error(String(reason))));
   });
 
-  log.info("server listening", { url: `http://localhost:${server.port}` });
+  log.info("server listening", { url: `http://${HOST}:${server.port}` });
 }

--- a/src/server-app.ts
+++ b/src/server-app.ts
@@ -16,7 +16,6 @@ import type { TaskId, TaskState, TaskTransitionReason } from "./task-contract";
 import { TaskRegistry } from "./task-registry";
 
 const PORT = process.env.PORT ? Number(process.env.PORT) : appConfig.server.port;
-const HOST = "127.0.0.1";
 const API_KEY = appConfig.server.apiKey;
 const OPENAI_API_KEY = appConfig.openai.apiKey;
 const SUPPRESSED_STDERR_PREFIX = "Upstream LLM API error from";
@@ -168,7 +167,6 @@ export async function startServer(): Promise<void> {
 
   server = Bun.serve<RpcConnectionState>({
     port: PORT,
-    hostname: HOST,
     idleTimeout: SERVER_IDLE_TIMEOUT_SECONDS,
     fetch: fetchHandler,
     websocket: rpcWebsocketHandlers,
@@ -181,5 +179,5 @@ export async function startServer(): Promise<void> {
     log.error("unhandled rejection", errorToLogFields(reason instanceof Error ? reason : new Error(String(reason))));
   });
 
-  log.info("server listening", { url: `http://${HOST}:${server.port}` });
+  log.info("server listening", { url: `http://${server.hostname}:${server.port}` });
 }

--- a/src/server-app.ts
+++ b/src/server-app.ts
@@ -16,6 +16,7 @@ import type { TaskId, TaskState, TaskTransitionReason } from "./task-contract";
 import { TaskRegistry } from "./task-registry";
 
 const PORT = process.env.PORT ? Number(process.env.PORT) : appConfig.server.port;
+const HOST = "127.0.0.1";
 const API_KEY = appConfig.server.apiKey;
 const OPENAI_API_KEY = appConfig.openai.apiKey;
 const SUPPRESSED_STDERR_PREFIX = "Upstream LLM API error from";
@@ -167,6 +168,7 @@ export async function startServer(): Promise<void> {
 
   server = Bun.serve<RpcConnectionState>({
     port: PORT,
+    hostname: HOST,
     idleTimeout: SERVER_IDLE_TIMEOUT_SECONDS,
     fetch: fetchHandler,
     websocket: rpcWebsocketHandlers,
@@ -179,5 +181,5 @@ export async function startServer(): Promise<void> {
     log.error("unhandled rejection", errorToLogFields(reason instanceof Error ? reason : new Error(String(reason))));
   });
 
-  log.info("server listening", { url: `http://${server.hostname}:${server.port}` });
+  log.info("server listening", { url: `http://${HOST}:${server.port}` });
 }

--- a/src/server-http.test.ts
+++ b/src/server-http.test.ts
@@ -82,16 +82,12 @@ describe("server-http auth coverage", () => {
     expect(runCalls).toBe(0);
   });
 
-  test("/v1/rpc authorization receives URL query context", async () => {
+  test("/v1/rpc rejects unauthorized and accepts Bearer header auth", async () => {
     let upgradeCalls = 0;
-    const seenUrls: string[] = [];
 
     const handler = createServerFetchHandler(
       createTestDeps({
-        hasValidAuth: (_req, url) => {
-          seenUrls.push(url?.toString() ?? "");
-          return url?.searchParams.get("apiKey") === "test-key";
-        },
+        hasValidAuth: (req) => req.headers.get("authorization") === "Bearer test-key",
         upgradeToRpc: () => {
           upgradeCalls += 1;
           return false;
@@ -99,12 +95,13 @@ describe("server-http auth coverage", () => {
       }),
     );
 
-    const unauthorized = await handler(new Request("http://localhost/v1/rpc?apiKey=wrong"));
-    const authorized = await handler(new Request("http://localhost/v1/rpc?apiKey=test-key"));
+    const unauthorized = await handler(new Request("http://localhost/v1/rpc"));
+    const authorized = await handler(
+      new Request("http://localhost/v1/rpc", { headers: { authorization: "Bearer test-key" } }),
+    );
 
     expect(unauthorized?.status).toBe(401);
     expect(authorized?.status).toBe(400);
     expect(upgradeCalls).toBe(1);
-    expect(seenUrls).toEqual(["http://localhost/v1/rpc?apiKey=wrong", "http://localhost/v1/rpc?apiKey=test-key"]);
   });
 });

--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -4,7 +4,7 @@ import type { RunChatHandlers, StatusPayload } from "./server-contract";
 
 type ServerHttpDeps = {
   createStatusPayload: () => Promise<StatusPayload>;
-  hasValidAuth: (req: Request, url?: URL) => boolean;
+  hasValidAuth: (req: Request) => boolean;
   isChatRequest: (value: unknown) => value is ChatRequest;
   runChatRequest: (chatRequest: ChatRequest, handlers: RunChatHandlers) => Promise<void>;
   serverError: (
@@ -51,7 +51,7 @@ async function handleHealthz(ctx: RouteContext): Promise<Response | null> {
 
 async function handleStatus(ctx: RouteContext): Promise<Response | null> {
   if (ctx.url.pathname !== "/v1/status" || ctx.req.method !== "GET") return null;
-  if (!ctx.deps.hasValidAuth(ctx.req, ctx.url)) return warnUnauthorized(ctx.url.pathname, ctx.req.method);
+  if (!ctx.deps.hasValidAuth(ctx.req)) return warnUnauthorized(ctx.url.pathname, ctx.req.method);
   return json(await ctx.deps.createStatusPayload());
 }
 
@@ -65,7 +65,7 @@ async function handleShutdown(ctx: RouteContext): Promise<Response | null> {
 
 async function handleRpcUpgrade(ctx: RouteContext): Promise<Response | undefined | null> {
   if (ctx.url.pathname !== "/v1/rpc") return null;
-  if (!ctx.deps.hasValidAuth(ctx.req, ctx.url)) return warnUnauthorized(ctx.url.pathname, ctx.req.method);
+  if (!ctx.deps.hasValidAuth(ctx.req)) return warnUnauthorized(ctx.url.pathname, ctx.req.method);
   if (ctx.deps.upgradeToRpc(ctx.req)) return;
   return badRequest("WebSocket upgrade failed");
 }

--- a/src/server-rpc.int.test.ts
+++ b/src/server-rpc.int.test.ts
@@ -95,9 +95,13 @@ function sendRpc(ws: WebSocket, payload: Record<string, unknown>): void {
   ws.send(JSON.stringify(payload));
 }
 
+function createAuthenticatedRpcSocket(port: number, apiKey: string): WebSocket {
+  return new WebSocket(`ws://127.0.0.1:${port}/v1/rpc`, [`bearer.${apiKey}`]);
+}
+
 async function openRpcSession(port: number, apiKey: string): Promise<RpcSession> {
   const messages: RpcEnvelope[] = [];
-  const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/rpc?apiKey=${apiKey}`);
+  const ws = createAuthenticatedRpcSocket(port, apiKey);
   await new Promise<void>((resolve, reject) => {
     const timeout = setTimeout(() => reject(new Error("websocket open timed out")), 5000);
     ws.addEventListener("open", () => {
@@ -159,7 +163,9 @@ describe("server rpc websocket queue", () => {
     const missingKey = await fetch(`http://127.0.0.1:${port}/v1/rpc`);
     expect(missingKey.status).toBe(401);
 
-    const wrongKey = await fetch(`http://127.0.0.1:${port}/v1/rpc?apiKey=wrong_key`);
+    const wrongKey = await fetch(`http://127.0.0.1:${port}/v1/rpc`, {
+      headers: { authorization: "Bearer wrong_key" },
+    });
     expect(wrongKey.status).toBe(401);
   });
 
@@ -171,7 +177,7 @@ describe("server rpc websocket queue", () => {
         await startServerForRpcTest(port, apiKey, { providerBaseUrl });
 
         const messages: RpcEnvelope[] = [];
-        const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/rpc?apiKey=${apiKey}`);
+        const ws = createAuthenticatedRpcSocket(port, apiKey);
         await new Promise<void>((resolve, reject) => {
           const timeout = setTimeout(() => reject(new Error("websocket open timed out")), 5000);
           ws.addEventListener("open", () => {
@@ -284,7 +290,7 @@ describe("server rpc websocket queue", () => {
         const apiKey = "rpc_test_key";
         await startServerForRpcTest(port, apiKey, { providerBaseUrl });
 
-        const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/rpc?apiKey=${apiKey}`);
+        const ws = createAuthenticatedRpcSocket(port, apiKey);
         await new Promise<void>((resolve, reject) => {
           const timeout = setTimeout(() => reject(new Error("websocket open timed out")), 5000);
           ws.addEventListener("open", () => {
@@ -395,7 +401,7 @@ describe("server rpc websocket queue", () => {
         await prepareRpcTestProject(project, port, providerBaseUrl);
 
         const proc = await startRpcTestServerProcess(home, project, apiKey, port, { providerBaseUrl });
-        const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/rpc?apiKey=${apiKey}`);
+        const ws = createAuthenticatedRpcSocket(port, apiKey);
         await new Promise<void>((resolve, reject) => {
           const timeout = setTimeout(() => reject(new Error("websocket open timed out")), 5000);
           ws.addEventListener("open", () => {
@@ -466,7 +472,7 @@ describe("server rpc websocket queue", () => {
         await proc.exited.catch(() => {});
 
         await startRpcTestServerProcess(home, project, apiKey, port, { providerBaseUrl });
-        const wsAfter = new WebSocket(`ws://127.0.0.1:${port}/v1/rpc?apiKey=${apiKey}`);
+        const wsAfter = createAuthenticatedRpcSocket(port, apiKey);
         await new Promise<void>((resolve, reject) => {
           const timeout = setTimeout(() => reject(new Error("websocket open timed out")), 5000);
           wsAfter.addEventListener("open", () => {
@@ -524,7 +530,7 @@ describe("server rpc websocket queue", () => {
         const apiKey = "rpc_test_key";
         await startServerForRpcTest(port, apiKey, { providerBaseUrl });
 
-        const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/rpc?apiKey=${apiKey}`);
+        const ws = createAuthenticatedRpcSocket(port, apiKey);
         await new Promise<void>((resolve, reject) => {
           const timeout = setTimeout(() => reject(new Error("websocket open timed out")), 5000);
           ws.addEventListener("open", () => {
@@ -604,7 +610,7 @@ describe("server rpc websocket queue", () => {
         await startServerForRpcTest(port, apiKey, { providerBaseUrl });
 
         const messages: RpcEnvelope[] = [];
-        const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/rpc?apiKey=${apiKey}`);
+        const ws = createAuthenticatedRpcSocket(port, apiKey);
         await new Promise<void>((resolve, reject) => {
           const timeout = setTimeout(() => reject(new Error("websocket open timed out")), 5000);
           ws.addEventListener("open", () => {
@@ -703,7 +709,7 @@ describe("server rpc websocket queue", () => {
         await startServerForRpcTest(port, apiKey, { providerBaseUrl });
 
         const messages: RpcEnvelope[] = [];
-        const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/rpc?apiKey=${apiKey}`);
+        const ws = createAuthenticatedRpcSocket(port, apiKey);
         await new Promise<void>((resolve, reject) => {
           const timeout = setTimeout(() => reject(new Error("websocket open timed out")), 5000);
           ws.addEventListener("open", () => {
@@ -800,7 +806,7 @@ describe("server rpc websocket queue", () => {
         await startServerForRpcTest(port, apiKey, { providerBaseUrl });
 
         const messages: RpcEnvelope[] = [];
-        const ws = new WebSocket(`ws://127.0.0.1:${port}/v1/rpc?apiKey=${apiKey}`);
+        const ws = createAuthenticatedRpcSocket(port, apiKey);
         await new Promise<void>((resolve, reject) => {
           const timeout = setTimeout(() => reject(new Error("websocket open timed out")), 5000);
           ws.addEventListener("open", () => {


### PR DESCRIPTION
## Summary
- bind server to loopback (`127.0.0.1`) by default
- remove query-param auth path and keep Bearer auth for HTTP + WS subprotocol auth for RPC
- align RPC integration tests with canonical websocket auth (`sec-websocket-protocol: bearer.<apiKey>`)
- make `verify` non-mutating (`lint + typecheck + test`)
- keep runtime config module free of test-only APIs (moved reset helper to test scope)
- add repo-managed pre-push verification hook (`.githooks/pre-push`) and wire setup via `prepare`
- align docs with current verify/auth behavior and hook setup
