### PR TITLE
refactor(lifecycle): improve lifecycle feedback loop

### DIFF
--- a/.agents/skills/arch-audit/SKILL.md
+++ b/.agents/skills/arch-audit/SKILL.md
@@ -34,6 +34,9 @@ Other areas:
 - error-model consistency (`AppError`/coded errors, stable searchable codes, clear UX messages)
 - file cohesion and split hygiene (flag oversized/multi-responsibility files; prefer small focused modules)
 - SRP violations: functions/modules that mix concerns (e.g. persistence + display, mutation + rendering)
+- pass-through layers that add no policy, invariants, or boundary value
+- extension seams or abstractions with no current product use
+- changes that require touching too many unrelated modules for one feature
 
 ## References
 

--- a/.agents/skills/style-audit/SKILL.md
+++ b/.agents/skills/style-audit/SKILL.md
@@ -14,6 +14,7 @@ Focus on:
 - factory naming consistency (`create*` for factory functions; avoid `build*`/`make*` for factories)
 - switch exhaustiveness (`default` + `unreachable` when applicable)
 - assert patterns (`invariant` for impossible states vs user-facing errors)
+- state modeling clarity: prefer explicit status/state fields over ambiguous boolean flags when values represent lifecycle or workflow phases
 - table-driven/rule-driven structure where the codebase already uses it
 - dispatch shape: prefer data-driven lookups/tables over long control-flow chains where behavior is mapping-like
 - control flow shape: prefer guard clauses and early returns over nested `if/else` chains
@@ -60,4 +61,5 @@ Then inspect relevant files for the feature under review.
 - Enforcing generic style-guide dogma over local conventions.
 - Broad rewrites over minimal diffs.
 - Speculative abstractions.
+- Boolean flags that hide richer state transitions better modeled as explicit status enums/unions.
 - Message-text parsing as primary control flow when a typed contract can be enforced.

--- a/.agents/skills/style-audit/SKILL.md
+++ b/.agents/skills/style-audit/SKILL.md
@@ -23,6 +23,7 @@ Focus on:
 - error classification consistency: prefer structured `kind` contracts over message regex heuristics
 - module layout consistency (flat `src/`, `*-contract`, `*-http`, `*-rpc`, no unnecessary re-export layers)
 - export shape consistency: prefer direct `export const` declarations over local alias + `export { ... }` wrappers
+- import clarity: avoid aliasing imports unless it resolves a real collision or boundary distinction
 
 ## References
 

--- a/.agents/skills/style-audit/SKILL.md
+++ b/.agents/skills/style-audit/SKILL.md
@@ -24,6 +24,9 @@ Focus on:
 - module layout consistency (flat `src/`, `*-contract`, `*-http`, `*-rpc`, no unnecessary re-export layers)
 - export shape consistency: prefer direct `export const` declarations over local alias + `export { ... }` wrappers
 - import clarity: avoid aliasing imports unless it resolves a real collision or boundary distinction
+- helper signatures that should become a clearer contract object
+- repeated argument/field groups that want one named type or helper
+- raw strings/flags/codes that should become small typed values or schema-backed unions
 
 ## References
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,6 +83,7 @@ resolve →prepare →generate →evaluate →finalize
 
 - **regeneration:** evaluators may request regeneration, bounded by caps.
 - **lifecycle state:** regeneration uses internal task-scoped pending feedback/verify state; this state is not persisted to session or memory.
+- **host/model boundary:** lifecycle state supports retries with concrete runtime outcomes, while the model remains responsible for deciding how to complete the task.
 - **scheduling:** yield checks happen between lifecycle decisions, never mid-step.
 - **task metrics:** evaluator and summary metrics are scoped by `task_id`.
 - **details:** see [Lifecycle](./lifecycle.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,6 +9,7 @@ Every concept below is modeled as an explicit entity with typed contracts, its o
 - **Sessions** — persistent conversation context with history and state
 - **Tasks** — state-machined units of work with stable IDs and per-task scoping
 - **Lifecycle phases** — resolve, prepare, generate, evaluate, finalize as separate modules
+- **Lifecycle state** — task-scoped internal retry/support state owned by the lifecycle
 - **Modes** — explicit operating behaviors (work, verify) with per-mode model routing
 - **Tools** — typed definitions with categories, permissions, schemas, and output contracts
 - **Guards** — behavioral checks that run before every tool call
@@ -77,10 +78,11 @@ resolve →prepare →generate →evaluate →finalize
 - **resolve:** pick mode and model (sync, not a full phase).
 - **prepare:** build inputs, context, and tools.
 - **generate:** run model + tool calls.
-- **evaluate:** decide accept/retry/regenerate (bounded).
+- **evaluate:** decide accept/retry/regenerate (bounded) and update task-scoped lifecycle state.
 - **finalize:** persist outputs and emit final response.
 
 - **regeneration:** evaluators may request regeneration, bounded by caps.
+- **lifecycle state:** regeneration uses internal task-scoped pending feedback/verify state; this state is not persisted to session or memory.
 - **scheduling:** yield checks happen between lifecycle decisions, never mid-step.
 - **task metrics:** evaluator and summary metrics are scoped by `task_id`.
 - **details:** see [Lifecycle](./lifecycle.md).

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -22,6 +22,8 @@ Naming conventions and core terms used across Acolyte code and docs.
 - **Evaluator**: post-generation rule that accepts or requests regeneration.
 - **Guard**: pre-tool execution rule that may block calls (step budget, file churn, duplicate call, redundant search/find/verify).
 - **Lifecycle Policy**: bounded execution controls for lifecycle behavior (for example, timeouts and regeneration caps).
+- **Lifecycle Feedback**: task-scoped runtime feedback emitted by evaluators or selected guard outcomes and consumed by the next matching lifecycle attempt.
+- **Lifecycle State**: internal task-scoped lifecycle runtime state used to carry feedback, verify outcomes, and repeated-failure streaks between attempts.
 - **Memory Engine**: top-level memory capability that maintains continuity across turns.
 - **Memory Pipeline**: internal staged flow inside the Memory Engine (ingest → normalize → select → inject → commit).
 - **Memory Source**: pluggable provider that contributes memory entries and optional commit behavior (`stored`, `distill_project`, `distill_user`, `distill_session`).
@@ -30,6 +32,7 @@ Naming conventions and core terms used across Acolyte code and docs.
 - **Mode**: explicit operating behavior profile for a request (`work`, `verify`).
 - **Observation**: distill record tier capturing round-level facts.
 - **Provider**: model backend selected by the active model for a request (`openai`, `anthropic`, `gemini`, or `openai-compatible`), not “all configured providers”.
+- **Base Agent Input**: immutable prompt input created during `prepare` and used as the base for each generation attempt.
 - **Record**: persisted entity object stored by a persistence backend.
 - **Reflection**: distill record tier consolidating cross-round facts.
 - **Registry**: composition layer that wires implementations into an agent-facing surface under contracts (for example, tool registry, memory registry).

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -9,7 +9,7 @@ resolve →prepare →generate →evaluate →finalize
 ## Phase contracts
 
 - **resolve**: pick mode and policy from request intent.
-- **prepare**: build agent input, tools, session context, and policy state.
+- **prepare**: build base agent input, tools, session context, and policy state.
 - **generate**: run model + tool loop for one attempt.
 - **evaluate**: apply evaluators; choose `done` or bounded regeneration.
 - **finalize**: emit final response and lifecycle summary events.
@@ -17,8 +17,18 @@ resolve →prepare →generate →evaluate →finalize
 ## Regeneration model
 
 - Evaluators can request regeneration.
+- Regeneration uses task-scoped `lifecycleState` to carry internal feedback and verify outcome between attempts.
+- Generation input is rebuilt from immutable base input plus pending mode-scoped lifecycle feedback.
 - Regeneration is bounded by lifecycle policy caps.
 - Yield checks only occur at safe checkpoints between lifecycle decisions.
+
+## Lifecycle state
+
+- `lifecycleState` is internal, task-scoped runtime state owned by the lifecycle.
+- It currently carries:
+  - `feedback`: pending runtime feedback consumed by the next matching-mode attempt
+  - `verifyOutcome`: structured verifier result used across `keepResult` restore boundaries
+- `lifecycleState` is not persisted to session history or memory sources.
 
 ## Memory integration point
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -29,6 +29,7 @@ resolve →prepare →generate →evaluate →finalize
 - It currently carries:
   - `feedback`: pending runtime feedback consumed by the next matching-mode attempt
   - `verifyOutcome`: structured verifier result used across `keepResult` restore boundaries
+  - `repeatedFailure`: task-scoped failure streak state used to surface one recovery nudge per repeated failure signature
 - Lifecycle may translate selected guard blocks into feedback, so the next attempt can recover with clearer runtime context.
 - `lifecycleState` is not persisted to session history or memory sources.
 - `lifecycleState` supports the model with concrete runtime outcomes; it does not plan tasks or decide how issues should be resolved.

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -28,6 +28,7 @@ resolve →prepare →generate →evaluate →finalize
 - It currently carries:
   - `feedback`: pending runtime feedback consumed by the next matching-mode attempt
   - `verifyOutcome`: structured verifier result used across `keepResult` restore boundaries
+- Guards may also contribute structured feedback when they block a call, so the next attempt can recover with clearer runtime context.
 - `lifecycleState` is not persisted to session history or memory sources.
 - `lifecycleState` supports the model with concrete runtime outcomes; it does not plan tasks or decide how issues should be resolved.
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -29,6 +29,7 @@ resolve →prepare →generate →evaluate →finalize
   - `feedback`: pending runtime feedback consumed by the next matching-mode attempt
   - `verifyOutcome`: structured verifier result used across `keepResult` restore boundaries
 - `lifecycleState` is not persisted to session history or memory sources.
+- `lifecycleState` supports the model with concrete runtime outcomes; it does not plan tasks or decide how issues should be resolved.
 
 ## Memory integration point
 

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -19,6 +19,7 @@ resolve →prepare →generate →evaluate →finalize
 - Evaluators can request regeneration.
 - Regeneration uses task-scoped `lifecycleState` to carry internal feedback and verify outcome between attempts.
 - Generation input is rebuilt from immutable base input plus pending mode-scoped lifecycle feedback.
+- Selected guard blocks may also be translated into lifecycle feedback before the next attempt.
 - Regeneration is bounded by lifecycle policy caps.
 - Yield checks only occur at safe checkpoints between lifecycle decisions.
 
@@ -28,7 +29,7 @@ resolve →prepare →generate →evaluate →finalize
 - It currently carries:
   - `feedback`: pending runtime feedback consumed by the next matching-mode attempt
   - `verifyOutcome`: structured verifier result used across `keepResult` restore boundaries
-- Guards may also contribute structured feedback when they block a call, so the next attempt can recover with clearer runtime context.
+- Lifecycle may translate selected guard blocks into feedback, so the next attempt can recover with clearer runtime context.
 - `lifecycleState` is not persisted to session history or memory sources.
 - `lifecycleState` supports the model with concrete runtime outcomes; it does not plan tasks or decide how issues should be resolved.
 
@@ -43,3 +44,4 @@ resolve →prepare →generate →evaluate →finalize
 - `src/lifecycle.ts`
 - `src/lifecycle-*.ts`
 - `src/lifecycle-evaluators.ts`
+- `src/lifecycle-guard-feedback.ts`

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -95,6 +95,11 @@ export type SavedRegenerationState = {
   currentError: LifecycleError | undefined;
 };
 
+export type VerifyOutcome = {
+  text: string;
+  error?: LifecycleError;
+};
+
 export type LifecycleInput = {
   request: ChatRequest;
   soulPrompt: string;
@@ -133,6 +138,7 @@ export type RunContext = {
   regenerationCount: number;
   regenerationLimitHit: boolean;
   sawEditFileMultiMatchError: boolean;
+  lastVerifyOutcome?: VerifyOutcome;
   currentError?: LifecycleError;
   errorStats: Record<ErrorCategory, number>;
   result?: GenerateResult;

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -100,7 +100,7 @@ export type VerifyOutcome = {
   error?: LifecycleError;
 };
 
-export type FeedbackSource = "guard" | "lint" | "verify" | "multi-match";
+export type FeedbackSource = "guard" | "lint" | "verify" | "multi-match" | "repeated-failure";
 
 export type LifecycleFeedback = {
   source: FeedbackSource;
@@ -172,7 +172,5 @@ type GuardStats = { blocked: number; flagSet: number };
 export function guardStatsFromSession(session: SessionContext): GuardStats {
   return { blocked: session.flags.guardStats?.blocked ?? 0, flagSet: session.flags.guardStats?.flagSet ?? 0 };
 }
-
-export { haveChangesBeenVerified, scopedCallLog as taskScopedCallLog } from "./tool-guards";
 
 export type LifecycleResult = ChatResponse;

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -105,7 +105,9 @@ export type FeedbackSource = "lint" | "verify" | "multi-match";
 export type LifecycleFeedback = {
   source: FeedbackSource;
   mode: AgentMode;
-  content: string;
+  summary: string;
+  details?: string;
+  instruction?: string;
 };
 
 export type LifecycleState = {

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -113,6 +113,11 @@ export type LifecycleFeedback = {
 export type LifecycleState = {
   feedback: LifecycleFeedback[];
   verifyOutcome?: VerifyOutcome;
+  repeatedFailure?: {
+    signature: string;
+    count: number;
+    surfacedCount: number;
+  };
 };
 
 export type LifecycleInput = {

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -86,7 +86,7 @@ export type PhasePrepareInput = {
 export type PhasePrepareResult = {
   session: SessionContext;
   tools: Toolset;
-  agentInput: string;
+  baseAgentInput: string;
   promptUsage: PromptUsage;
 };
 export type GenerateOptions = { cycleLimit?: number; timeoutMs: number };
@@ -98,6 +98,19 @@ export type SavedRegenerationState = {
 export type VerifyOutcome = {
   text: string;
   error?: LifecycleError;
+};
+
+export type FeedbackSource = "lint" | "verify" | "multi-match";
+
+export type LifecycleFeedback = {
+  source: FeedbackSource;
+  mode: AgentMode;
+  content: string;
+};
+
+export type LifecycleState = {
+  feedback: LifecycleFeedback[];
+  verifyOutcome?: VerifyOutcome;
 };
 
 export type LifecycleInput = {
@@ -121,9 +134,10 @@ export type RunContext = {
   readonly initialMode: AgentMode;
   readonly tools: Toolset;
   readonly session: SessionContext;
-  readonly agentInput: string;
+  readonly baseAgentInput: string;
   readonly policy: LifecyclePolicy;
   readonly promptUsage: PromptUsage;
+  lifecycleState: LifecycleState;
   model: string;
   agent: Agent;
   agentForMode: AgentMode;
@@ -138,7 +152,6 @@ export type RunContext = {
   regenerationCount: number;
   regenerationLimitHit: boolean;
   sawEditFileMultiMatchError: boolean;
-  lastVerifyOutcome?: VerifyOutcome;
   currentError?: LifecycleError;
   errorStats: Record<ErrorCategory, number>;
   result?: GenerateResult;

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -100,7 +100,7 @@ export type VerifyOutcome = {
   error?: LifecycleError;
 };
 
-export type FeedbackSource = "lint" | "verify" | "multi-match";
+export type FeedbackSource = "guard" | "lint" | "verify" | "multi-match";
 
 export type LifecycleFeedback = {
   source: FeedbackSource;

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -116,7 +116,7 @@ export type LifecycleState = {
   repeatedFailure?: {
     signature: string;
     count: number;
-    surfacedCount: number;
+    status: "pending" | "surfaced";
   };
 };
 

--- a/src/lifecycle-evaluate.ts
+++ b/src/lifecycle-evaluate.ts
@@ -2,8 +2,8 @@ import { type RecoveryAction, recoveryActionForError as resolveRecoveryAction } 
 import { t } from "./i18n";
 import type { LifecycleInput, RunContext, SavedRegenerationState } from "./lifecycle-contract";
 import {
-  guardRecoveryEvaluator,
   type Evaluator,
+  guardRecoveryEvaluator,
   lintEvaluator,
   multiMatchEditEvaluator,
   repeatedFailureEvaluator,

--- a/src/lifecycle-evaluate.ts
+++ b/src/lifecycle-evaluate.ts
@@ -1,6 +1,6 @@
 import { type RecoveryAction, recoveryActionForError as resolveRecoveryAction } from "./error-handling";
 import { t } from "./i18n";
-import type { LifecycleInput, RunContext, SavedRegenerationState } from "./lifecycle-contract";
+import type { FeedbackSource, LifecycleInput, RunContext, SavedRegenerationState } from "./lifecycle-contract";
 import { type Evaluator, lintEvaluator, multiMatchEditEvaluator, verifyCycle } from "./lifecycle-evaluators";
 import { phaseGenerate, setMode, shouldYieldNow } from "./lifecycle-generate";
 import { defaultLifecyclePolicy, type LifecyclePolicy } from "./lifecycle-policy";
@@ -17,6 +17,10 @@ function snapshotState(ctx: RunContext): SavedRegenerationState {
 function restoreState(ctx: RunContext, saved: SavedRegenerationState): void {
   ctx.result = saved.result;
   ctx.currentError = saved.currentError;
+}
+
+function prepareLifecycleStateForRegeneration(ctx: RunContext, feedbackSource?: FeedbackSource): void {
+  if (feedbackSource === "verify") ctx.lifecycleState.verifyOutcome = undefined;
 }
 
 export function recoveryActionForError(
@@ -86,6 +90,7 @@ export async function phaseEvaluate(ctx: RunContext, shouldYield: LifecycleInput
         regeneration_count: ctx.regenerationCount,
       });
 
+      prepareLifecycleStateForRegeneration(ctx, action.feedback?.source);
       if (action.feedback) ctx.lifecycleState.feedback.push(action.feedback);
 
       await phaseGenerate(ctx, {

--- a/src/lifecycle-evaluate.ts
+++ b/src/lifecycle-evaluate.ts
@@ -1,11 +1,17 @@
 import { type RecoveryAction, recoveryActionForError as resolveRecoveryAction } from "./error-handling";
 import { t } from "./i18n";
 import type { FeedbackSource, LifecycleInput, RunContext, SavedRegenerationState } from "./lifecycle-contract";
-import { type Evaluator, lintEvaluator, multiMatchEditEvaluator, verifyCycle } from "./lifecycle-evaluators";
+import {
+  guardRecoveryEvaluator,
+  type Evaluator,
+  lintEvaluator,
+  multiMatchEditEvaluator,
+  verifyCycle,
+} from "./lifecycle-evaluators";
 import { phaseGenerate, setMode, shouldYieldNow } from "./lifecycle-generate";
 import { defaultLifecyclePolicy, type LifecyclePolicy } from "./lifecycle-policy";
 
-const EVALUATORS: Evaluator[] = [multiMatchEditEvaluator, lintEvaluator, verifyCycle];
+const EVALUATORS: Evaluator[] = [guardRecoveryEvaluator, multiMatchEditEvaluator, lintEvaluator, verifyCycle];
 
 function snapshotState(ctx: RunContext): SavedRegenerationState {
   return {

--- a/src/lifecycle-evaluate.ts
+++ b/src/lifecycle-evaluate.ts
@@ -1,6 +1,6 @@
 import { type RecoveryAction, recoveryActionForError as resolveRecoveryAction } from "./error-handling";
 import { t } from "./i18n";
-import type { FeedbackSource, LifecycleInput, RunContext, SavedRegenerationState } from "./lifecycle-contract";
+import type { LifecycleInput, RunContext, SavedRegenerationState } from "./lifecycle-contract";
 import {
   guardRecoveryEvaluator,
   type Evaluator,
@@ -11,6 +11,7 @@ import {
 } from "./lifecycle-evaluators";
 import { phaseGenerate, setMode, shouldYieldNow } from "./lifecycle-generate";
 import { defaultLifecyclePolicy, type LifecyclePolicy } from "./lifecycle-policy";
+import { clearVerifyOutcomeForFeedback, updateRepeatedFailureState } from "./lifecycle-state";
 
 const EVALUATORS: Evaluator[] = [
   guardRecoveryEvaluator,
@@ -19,31 +20,6 @@ const EVALUATORS: Evaluator[] = [
   verifyCycle,
   repeatedFailureEvaluator,
 ];
-
-function failureSignatureForError(ctx: RunContext): string | undefined {
-  if (!ctx.currentError) return undefined;
-  const code = ctx.currentError.code ?? "unknown";
-  const category = ctx.currentError.category ?? "other";
-  const source = ctx.currentError.source ?? "generate";
-  const tool = ctx.currentError.tool ?? "none";
-  return [category, source, tool, code].join(":");
-}
-
-function updateRepeatedFailureState(ctx: RunContext): void {
-  const signature = failureSignatureForError(ctx);
-  if (!signature) {
-    ctx.lifecycleState.repeatedFailure = undefined;
-    return;
-  }
-
-  const previous = ctx.lifecycleState.repeatedFailure;
-  if (!previous || previous.signature !== signature) {
-    ctx.lifecycleState.repeatedFailure = { signature, count: 1, surfacedCount: 0 };
-    return;
-  }
-
-  ctx.lifecycleState.repeatedFailure = { ...previous, count: previous.count + 1 };
-}
 
 function snapshotState(ctx: RunContext): SavedRegenerationState {
   return {
@@ -55,10 +31,6 @@ function snapshotState(ctx: RunContext): SavedRegenerationState {
 function restoreState(ctx: RunContext, saved: SavedRegenerationState): void {
   ctx.result = saved.result;
   ctx.currentError = saved.currentError;
-}
-
-function prepareLifecycleStateForRegeneration(ctx: RunContext, feedbackSource?: FeedbackSource): void {
-  if (feedbackSource === "verify") ctx.lifecycleState.verifyOutcome = undefined;
 }
 
 export function recoveryActionForError(
@@ -129,7 +101,7 @@ export async function phaseEvaluate(ctx: RunContext, shouldYield: LifecycleInput
         regeneration_count: ctx.regenerationCount,
       });
 
-      prepareLifecycleStateForRegeneration(ctx, action.feedback?.source);
+      clearVerifyOutcomeForFeedback(ctx, action.feedback?.source);
       if (action.feedback) ctx.lifecycleState.feedback.push(action.feedback);
 
       await phaseGenerate(ctx, {

--- a/src/lifecycle-evaluate.ts
+++ b/src/lifecycle-evaluate.ts
@@ -91,6 +91,13 @@ export async function phaseEvaluate(ctx: RunContext, shouldYield: LifecycleInput
       });
       if (shouldYieldNow(ctx, shouldYield)) break;
 
+      if (saved && ctx.mode === "verify") {
+        ctx.lastVerifyOutcome = {
+          text: ctx.result?.text ?? "",
+          error: ctx.currentError,
+        };
+      }
+
       if (saved) restoreState(ctx, saved);
       regenerated = true;
       break;

--- a/src/lifecycle-evaluate.ts
+++ b/src/lifecycle-evaluate.ts
@@ -82,17 +82,20 @@ export async function phaseEvaluate(ctx: RunContext, shouldYield: LifecycleInput
         mode: ctx.mode,
         cycle_limit: action.cycleLimit ?? ctx.policy.initialMaxSteps,
         keep_result: Boolean(action.keepResult),
+        feedback_source: action.feedback?.source ?? null,
         regeneration_count: ctx.regenerationCount,
       });
 
-      await phaseGenerate(ctx, action.prompt, {
+      if (action.feedback) ctx.lifecycleState.feedback.push(action.feedback);
+
+      await phaseGenerate(ctx, {
         cycleLimit: action.cycleLimit ?? ctx.policy.initialMaxSteps,
         timeoutMs: ctx.policy.stepTimeoutMs,
       });
       if (shouldYieldNow(ctx, shouldYield)) break;
 
       if (saved && ctx.mode === "verify") {
-        ctx.lastVerifyOutcome = {
+        ctx.lifecycleState.verifyOutcome = {
           text: ctx.result?.text ?? "",
           error: ctx.currentError,
         };

--- a/src/lifecycle-evaluate.ts
+++ b/src/lifecycle-evaluate.ts
@@ -6,12 +6,44 @@ import {
   type Evaluator,
   lintEvaluator,
   multiMatchEditEvaluator,
+  repeatedFailureEvaluator,
   verifyCycle,
 } from "./lifecycle-evaluators";
 import { phaseGenerate, setMode, shouldYieldNow } from "./lifecycle-generate";
 import { defaultLifecyclePolicy, type LifecyclePolicy } from "./lifecycle-policy";
 
-const EVALUATORS: Evaluator[] = [guardRecoveryEvaluator, multiMatchEditEvaluator, lintEvaluator, verifyCycle];
+const EVALUATORS: Evaluator[] = [
+  guardRecoveryEvaluator,
+  multiMatchEditEvaluator,
+  lintEvaluator,
+  verifyCycle,
+  repeatedFailureEvaluator,
+];
+
+function failureSignatureForError(ctx: RunContext): string | undefined {
+  if (!ctx.currentError) return undefined;
+  const code = ctx.currentError.code ?? "unknown";
+  const category = ctx.currentError.category ?? "other";
+  const source = ctx.currentError.source ?? "generate";
+  const tool = ctx.currentError.tool ?? "none";
+  return [category, source, tool, code].join(":");
+}
+
+function updateRepeatedFailureState(ctx: RunContext): void {
+  const signature = failureSignatureForError(ctx);
+  if (!signature) {
+    ctx.lifecycleState.repeatedFailure = undefined;
+    return;
+  }
+
+  const previous = ctx.lifecycleState.repeatedFailure;
+  if (!previous || previous.signature !== signature) {
+    ctx.lifecycleState.repeatedFailure = { signature, count: 1, surfacedCount: 0 };
+    return;
+  }
+
+  ctx.lifecycleState.repeatedFailure = { ...previous, count: previous.count + 1 };
+}
 
 function snapshotState(ctx: RunContext): SavedRegenerationState {
   return {
@@ -39,6 +71,7 @@ export function recoveryActionForError(
 export async function phaseEvaluate(ctx: RunContext, shouldYield: LifecycleInput["shouldYield"]) {
   while (ctx.result) {
     if (shouldYieldNow(ctx, shouldYield)) break;
+    updateRepeatedFailureState(ctx);
 
     if (
       recoveryActionForError({

--- a/src/lifecycle-evaluators.ts
+++ b/src/lifecycle-evaluators.ts
@@ -5,7 +5,7 @@ import type { LifecycleError, LifecycleEventName, LifecycleFeedback, VerifyOutco
 import type { LifecyclePolicy } from "./lifecycle-policy";
 import { lintFiles } from "./lint-reflection";
 import { extractReadPaths } from "./tool-arg-paths";
-import { haveChangesBeenVerified, type SessionContext, scopedCallLog as taskScopedCallLog } from "./tool-guards";
+import { haveChangesBeenVerified, type SessionContext, scopedCallLog } from "./tool-guards";
 import { WRITE_TOOL_SET, WRITE_TOOLS } from "./tool-registry";
 
 export type EvalAction =
@@ -44,7 +44,7 @@ export type Evaluator = {
 };
 
 function findLastEditFilePath(ctx: EvaluatorContext): string | undefined {
-  const callLog = taskScopedCallLog(ctx.session, ctx.taskId);
+  const callLog = scopedCallLog(ctx.session, ctx.taskId);
   for (let i = callLog.length - 1; i >= 0; i -= 1) {
     const entry = callLog[i];
     if (entry?.toolName !== "edit-file") continue;
@@ -56,7 +56,7 @@ function findLastEditFilePath(ctx: EvaluatorContext): string | undefined {
 
 function writePathsForCurrentTask(ctx: EvaluatorContext): string[] {
   const out = new Set<string>();
-  for (const entry of taskScopedCallLog(ctx.session, ctx.taskId)) {
+  for (const entry of scopedCallLog(ctx.session, ctx.taskId)) {
     if (!WRITE_TOOL_SET.has(entry.toolName)) continue;
     const path = entry.args?.path;
     if (typeof path !== "string") continue;
@@ -69,7 +69,7 @@ function writePathsForCurrentTask(ctx: EvaluatorContext): string[] {
 
 function readPathsForCurrentTask(ctx: EvaluatorContext): string[] {
   const out = new Set<string>();
-  for (const entry of taskScopedCallLog(ctx.session, ctx.taskId)) {
+  for (const entry of scopedCallLog(ctx.session, ctx.taskId)) {
     if (entry.toolName === "read-file") {
       for (const key of extractReadPaths(entry.args)) out.add(key);
       continue;

--- a/src/lifecycle-evaluators.ts
+++ b/src/lifecycle-evaluators.ts
@@ -128,12 +128,9 @@ export const lintEvaluator: Evaluator = {
       feedback: {
         source: "lint",
         mode: "work",
-        content: [
-          "Lint errors detected in files you edited:",
-          result.output,
-          "",
-          "Fix the issues above, then stop.",
-        ].join("\n"),
+        summary: "Lint errors detected in files you edited.",
+        details: result.output,
+        instruction: "Fix the issues above, then stop.",
       },
     };
   },
@@ -153,7 +150,8 @@ export const verifyCycle: Evaluator = {
           feedback: {
             source: "verify",
             mode: "verify",
-            content: scopedVerifyPrompt(ctx),
+            summary: "Run verification for the current task scope.",
+            details: scopedVerifyPrompt(ctx),
           },
           mode: "verify",
           cycleLimit: ctx.policy.verifyMaxSteps,
@@ -172,7 +170,9 @@ export const verifyCycle: Evaluator = {
       feedback: {
         source: "verify",
         mode: "work",
-        content: `Verification found issues:\n${verifyOutcome.text}\n\nFix the issues above, then stop.`,
+        summary: "Verification found issues.",
+        details: verifyOutcome.text,
+        instruction: "Fix the issues above, then stop.",
       },
       mode: "work",
     };
@@ -198,8 +198,8 @@ export const multiMatchEditEvaluator: Evaluator = {
       feedback: {
         source: "multi-match",
         mode: "work",
-        content:
-          "Your previous edit-file call matched multiple locations. " +
+        summary: "Your previous edit-file call matched multiple locations.",
+        instruction:
           "For this task, your next tool call must be edit-code (not edit-file). " +
           (targetPath
             ? `Use path '${targetPath}' for edit-code and do not use '.' or directory paths. `

--- a/src/lifecycle-evaluators.ts
+++ b/src/lifecycle-evaluators.ts
@@ -37,7 +37,11 @@ export type EvaluatorContext = {
   workspace: string | undefined;
   request: { message: string; verifyScope?: VerifyScope };
   sawEditFileMultiMatchError: boolean;
-  lifecycleState: { feedback: LifecycleFeedback[]; verifyOutcome?: VerifyOutcome };
+  lifecycleState: {
+    feedback: LifecycleFeedback[];
+    verifyOutcome?: VerifyOutcome;
+    repeatedFailure?: { signature: string; count: number; surfacedCount: number };
+  };
   currentError?: LifecycleError;
 };
 
@@ -147,6 +151,37 @@ export const guardRecoveryEvaluator: Evaluator = {
     if (!hasPendingFeedback) return { type: "done" };
     ctx.debug("lifecycle.eval.guard_recovery", { mode: ctx.mode, error: ctx.currentError.message });
     return { type: "regenerate" };
+  },
+};
+
+export const repeatedFailureEvaluator: Evaluator = {
+  id: "repeated-failure",
+  evaluate(ctx) {
+    const repeatedFailure = ctx.lifecycleState.repeatedFailure;
+    if (!ctx.result || !ctx.currentError || !repeatedFailure) return { type: "done" };
+    if (ctx.currentError.category === "guard-blocked") return { type: "done" };
+    if (repeatedFailure.count < 2) return { type: "done" };
+    if (repeatedFailure.surfacedCount >= repeatedFailure.count) return { type: "done" };
+
+    repeatedFailure.surfacedCount = repeatedFailure.count;
+    ctx.debug("lifecycle.eval.repeated_failure", {
+      signature: repeatedFailure.signature,
+      count: repeatedFailure.count,
+      code: ctx.currentError.code ?? null,
+      category: ctx.currentError.category ?? null,
+      tool: ctx.currentError.tool ?? null,
+    });
+
+    return {
+      type: "regenerate",
+      feedback: {
+        source: "guard",
+        mode: ctx.mode,
+        summary: "The same runtime failure has repeated.",
+        details: ctx.currentError.message,
+        instruction: "Do not retry the same failing move. Change approach before continuing.",
+      },
+    };
   },
 };
 

--- a/src/lifecycle-evaluators.ts
+++ b/src/lifecycle-evaluators.ts
@@ -5,6 +5,7 @@ import {
   haveChangesBeenVerified,
   type LifecycleError,
   type LifecycleEventName,
+  type VerifyOutcome,
   taskScopedCallLog,
 } from "./lifecycle-contract";
 import type { LifecyclePolicy } from "./lifecycle-policy";
@@ -36,6 +37,7 @@ export type EvaluatorContext = {
   workspace: string | undefined;
   request: { message: string; verifyScope?: VerifyScope };
   sawEditFileMultiMatchError: boolean;
+  lastVerifyOutcome?: VerifyOutcome;
   currentError?: LifecycleError;
 };
 
@@ -155,13 +157,13 @@ export const verifyCycle: Evaluator = {
       return { type: "done" };
     }
 
-    // Verify → Work: return to work only when verify found issues (currentError set).
-    // If verification passed or was never marked, we are done.
-    if (!ctx.currentError) return { type: "done" };
-    ctx.debug("lifecycle.eval.verify_failure", { text_chars: ctx.result.text.length });
+    // Verify → Work: use the verifier's structured outcome, not the restored work-mode result.
+    const verifyOutcome = ctx.lastVerifyOutcome;
+    if (!verifyOutcome?.error) return { type: "done" };
+    ctx.debug("lifecycle.eval.verify_failure", { text_chars: verifyOutcome.text.length });
     return {
       type: "regenerate",
-      prompt: `${ctx.agentInput}\n\nVerification found issues:\n${ctx.result.text}\n\nFix the issues above, then stop.`,
+      prompt: `${ctx.agentInput}\n\nVerification found issues:\n${verifyOutcome.text}\n\nFix the issues above, then stop.`,
       mode: "work",
     };
   },

--- a/src/lifecycle-evaluators.ts
+++ b/src/lifecycle-evaluators.ts
@@ -1,18 +1,11 @@
 import type { AgentMode } from "./agent-contract";
 import { createModeInstructions } from "./agent-instructions";
 import type { VerifyScope } from "./api";
-import {
-  haveChangesBeenVerified,
-  type LifecycleError,
-  type LifecycleEventName,
-  type LifecycleFeedback,
-  taskScopedCallLog,
-  type VerifyOutcome,
-} from "./lifecycle-contract";
+import type { LifecycleError, LifecycleEventName, LifecycleFeedback, VerifyOutcome } from "./lifecycle-contract";
 import type { LifecyclePolicy } from "./lifecycle-policy";
 import { lintFiles } from "./lint-reflection";
 import { extractReadPaths } from "./tool-arg-paths";
-import type { SessionContext } from "./tool-guards";
+import { haveChangesBeenVerified, type SessionContext, scopedCallLog as taskScopedCallLog } from "./tool-guards";
 import { WRITE_TOOL_SET, WRITE_TOOLS } from "./tool-registry";
 
 export type EvalAction =
@@ -175,7 +168,7 @@ export const repeatedFailureEvaluator: Evaluator = {
     return {
       type: "regenerate",
       feedback: {
-        source: "guard",
+        source: "repeated-failure",
         mode: ctx.mode,
         summary: "The same runtime failure has repeated.",
         details: ctx.currentError.message,

--- a/src/lifecycle-evaluators.ts
+++ b/src/lifecycle-evaluators.ts
@@ -40,7 +40,7 @@ export type EvaluatorContext = {
   lifecycleState: {
     feedback: LifecycleFeedback[];
     verifyOutcome?: VerifyOutcome;
-    repeatedFailure?: { signature: string; count: number; surfacedCount: number };
+    repeatedFailure?: { signature: string; count: number; status: "pending" | "surfaced" };
   };
   currentError?: LifecycleError;
 };
@@ -161,9 +161,9 @@ export const repeatedFailureEvaluator: Evaluator = {
     if (!ctx.result || !ctx.currentError || !repeatedFailure) return { type: "done" };
     if (ctx.currentError.category === "guard-blocked") return { type: "done" };
     if (repeatedFailure.count < 2) return { type: "done" };
-    if (repeatedFailure.surfacedCount >= repeatedFailure.count) return { type: "done" };
+    if (repeatedFailure.status === "surfaced") return { type: "done" };
 
-    repeatedFailure.surfacedCount = repeatedFailure.count;
+    repeatedFailure.status = "surfaced";
     ctx.debug("lifecycle.eval.repeated_failure", {
       signature: repeatedFailure.signature,
       count: repeatedFailure.count,

--- a/src/lifecycle-evaluators.ts
+++ b/src/lifecycle-evaluators.ts
@@ -6,8 +6,8 @@ import {
   type LifecycleError,
   type LifecycleEventName,
   type LifecycleFeedback,
-  type VerifyOutcome,
   taskScopedCallLog,
+  type VerifyOutcome,
 } from "./lifecycle-contract";
 import type { LifecyclePolicy } from "./lifecycle-policy";
 import { lintFiles } from "./lint-reflection";

--- a/src/lifecycle-evaluators.ts
+++ b/src/lifecycle-evaluators.ts
@@ -37,7 +37,7 @@ export type EvaluatorContext = {
   workspace: string | undefined;
   request: { message: string; verifyScope?: VerifyScope };
   sawEditFileMultiMatchError: boolean;
-  lifecycleState: { verifyOutcome?: VerifyOutcome };
+  lifecycleState: { feedback: LifecycleFeedback[]; verifyOutcome?: VerifyOutcome };
   currentError?: LifecycleError;
 };
 
@@ -133,6 +133,20 @@ export const lintEvaluator: Evaluator = {
         instruction: "Fix the issues above, then stop.",
       },
     };
+  },
+};
+
+export const guardRecoveryEvaluator: Evaluator = {
+  id: "guard-recovery",
+  evaluate(ctx) {
+    if (!ctx.result) return { type: "done" };
+    if (ctx.currentError?.category !== "guard-blocked") return { type: "done" };
+    const hasPendingFeedback = ctx.lifecycleState.feedback.some(
+      (feedback) => feedback.source === "guard" && feedback.mode === ctx.mode,
+    );
+    if (!hasPendingFeedback) return { type: "done" };
+    ctx.debug("lifecycle.eval.guard_recovery", { mode: ctx.mode, error: ctx.currentError.message });
+    return { type: "regenerate" };
   },
 };
 

--- a/src/lifecycle-evaluators.ts
+++ b/src/lifecycle-evaluators.ts
@@ -5,6 +5,7 @@ import {
   haveChangesBeenVerified,
   type LifecycleError,
   type LifecycleEventName,
+  type LifecycleFeedback,
   type VerifyOutcome,
   taskScopedCallLog,
 } from "./lifecycle-contract";
@@ -18,7 +19,7 @@ export type EvalAction =
   | { type: "done" }
   | {
       type: "regenerate";
-      prompt: string;
+      feedback?: LifecycleFeedback;
       mode?: AgentMode;
       cycleLimit?: number;
       keepResult?: boolean;
@@ -28,7 +29,6 @@ export type EvaluatorContext = {
   result?: { text: string };
   observedTools: Set<string>;
   debug: (event: LifecycleEventName, fields?: Record<string, unknown>) => void;
-  agentInput: string;
   policy: LifecyclePolicy;
   initialMode: AgentMode;
   mode: AgentMode;
@@ -37,7 +37,7 @@ export type EvaluatorContext = {
   workspace: string | undefined;
   request: { message: string; verifyScope?: VerifyScope };
   sawEditFileMultiMatchError: boolean;
-  lastVerifyOutcome?: VerifyOutcome;
+  lifecycleState: { verifyOutcome?: VerifyOutcome };
   currentError?: LifecycleError;
 };
 
@@ -125,14 +125,16 @@ export const lintEvaluator: Evaluator = {
     ctx.debug("lifecycle.eval.lint", { files: paths.length });
     return {
       type: "regenerate",
-      prompt: [
-        ctx.agentInput,
-        "",
-        "Lint errors detected in files you edited:",
-        result.output,
-        "",
-        "If the project has an auto-fix command, run it first. Otherwise fix the errors manually, then stop.",
-      ].join("\n"),
+      feedback: {
+        source: "lint",
+        mode: "work",
+        content: [
+          "Lint errors detected in files you edited:",
+          result.output,
+          "",
+          "Fix the issues above, then stop.",
+        ].join("\n"),
+      },
     };
   },
 };
@@ -148,7 +150,11 @@ export const verifyCycle: Evaluator = {
       if (ctx.initialMode === "work" && usedWriteTools && !haveChangesBeenVerified(ctx.session, ctx.taskId)) {
         return {
           type: "regenerate",
-          prompt: scopedVerifyPrompt(ctx),
+          feedback: {
+            source: "verify",
+            mode: "verify",
+            content: scopedVerifyPrompt(ctx),
+          },
           mode: "verify",
           cycleLimit: ctx.policy.verifyMaxSteps,
           keepResult: true,
@@ -158,12 +164,16 @@ export const verifyCycle: Evaluator = {
     }
 
     // Verify → Work: use the verifier's structured outcome, not the restored work-mode result.
-    const verifyOutcome = ctx.lastVerifyOutcome;
+    const verifyOutcome = ctx.lifecycleState.verifyOutcome;
     if (!verifyOutcome?.error) return { type: "done" };
     ctx.debug("lifecycle.eval.verify_failure", { text_chars: verifyOutcome.text.length });
     return {
       type: "regenerate",
-      prompt: `${ctx.agentInput}\n\nVerification found issues:\n${verifyOutcome.text}\n\nFix the issues above, then stop.`,
+      feedback: {
+        source: "verify",
+        mode: "work",
+        content: `Verification found issues:\n${verifyOutcome.text}\n\nFix the issues above, then stop.`,
+      },
       mode: "work",
     };
   },
@@ -185,15 +195,18 @@ export const multiMatchEditEvaluator: Evaluator = {
     });
     return {
       type: "regenerate",
-      prompt:
-        `${ctx.agentInput}\n\n` +
-        "Your previous edit-file call matched multiple locations. " +
-        "For this task, your next tool call must be edit-code (not edit-file). " +
-        (targetPath
-          ? `Use path '${targetPath}' for edit-code and do not use '.' or directory paths. `
-          : "Use a concrete file path for edit-code and do not use '.' or directory paths. ") +
-        "Do not run additional find/search/read calls unless edit-code fails. " +
-        "After applying edit-code changes, run verify.",
+      feedback: {
+        source: "multi-match",
+        mode: "work",
+        content:
+          "Your previous edit-file call matched multiple locations. " +
+          "For this task, your next tool call must be edit-code (not edit-file). " +
+          (targetPath
+            ? `Use path '${targetPath}' for edit-code and do not use '.' or directory paths. `
+            : "Use a concrete file path for edit-code and do not use '.' or directory paths. ") +
+          "Do not run additional find/search/read calls unless edit-code fails. " +
+          "After applying edit-code changes, run verify.",
+      },
     };
   },
 };

--- a/src/lifecycle-finalize.ts
+++ b/src/lifecycle-finalize.ts
@@ -1,7 +1,8 @@
 import { estimateTokens } from "./agent-input";
 import type { ChatResponse } from "./api";
 import { t } from "./i18n";
-import { guardStatsFromSession, type RunContext, taskScopedCallLog } from "./lifecycle-contract";
+import { guardStatsFromSession, type RunContext } from "./lifecycle-contract";
+import { scopedCallLog as taskScopedCallLog } from "./tool-guards";
 import { DISCOVERY_TOOL_SET, READ_TOOL_SET, SEARCH_TOOL_SET, WRITE_TOOL_SET } from "./tool-registry";
 
 export function phaseFinalize(ctx: RunContext): ChatResponse {

--- a/src/lifecycle-finalize.ts
+++ b/src/lifecycle-finalize.ts
@@ -2,7 +2,7 @@ import { estimateTokens } from "./agent-input";
 import type { ChatResponse } from "./api";
 import { t } from "./i18n";
 import { guardStatsFromSession, type RunContext } from "./lifecycle-contract";
-import { scopedCallLog as taskScopedCallLog } from "./tool-guards";
+import { scopedCallLog } from "./tool-guards";
 import { DISCOVERY_TOOL_SET, READ_TOOL_SET, SEARCH_TOOL_SET, WRITE_TOOL_SET } from "./tool-registry";
 
 export function phaseFinalize(ctx: RunContext): ChatResponse {
@@ -29,7 +29,7 @@ export function phaseFinalize(ctx: RunContext): ChatResponse {
     });
   }
 
-  const callLog = taskScopedCallLog(ctx.session, ctx.taskId);
+  const callLog = scopedCallLog(ctx.session, ctx.taskId);
   const guardStats = guardStatsFromSession(ctx.session);
   const totalToolCalls = callLog.length;
   const readCalls = callLog.filter((entry) => READ_TOOL_SET.has(entry.toolName)).length;

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -14,7 +14,14 @@ import {
   isEditFileMultiMatchSignal,
   parseErrorInfo,
 } from "./error-handling";
-import type { GenerateOptions, GenerateResult, LifecycleFeedback, LifecycleState, RunContext, StreamChunk } from "./lifecycle-contract";
+import type {
+  GenerateOptions,
+  GenerateResult,
+  LifecycleFeedback,
+  LifecycleState,
+  RunContext,
+  StreamChunk,
+} from "./lifecycle-contract";
 import { resolveModeModel } from "./lifecycle-resolve";
 import type { StreamError } from "./stream-error";
 import type { ToolDefinition } from "./tool-contract";

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -139,13 +139,16 @@ function ensureAgentForMode(ctx: RunContext): void {
   });
 }
 
-function renderFeedback(feedback: LifecycleFeedback): string {
-  return `SYSTEM: Lifecycle feedback (${feedback.source}):\n${feedback.content}`;
+export function createLifecycleFeedbackText(feedback: LifecycleFeedback): string {
+  const lines = [`SYSTEM: Lifecycle feedback (${feedback.source}):`, feedback.summary];
+  if (feedback.details) lines.push("", feedback.details);
+  if (feedback.instruction) lines.push("", feedback.instruction);
+  return lines.join("\n");
 }
 
 function createGenerationInputFromFeedback(baseAgentInput: string, activeFeedback: LifecycleFeedback[]): string {
   if (activeFeedback.length === 0) return baseAgentInput;
-  return [baseAgentInput, ...activeFeedback.map(renderFeedback)].join("\n\n");
+  return [baseAgentInput, ...activeFeedback.map(createLifecycleFeedbackText)].join("\n\n");
 }
 
 export function consumeLifecycleFeedback(

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -14,7 +14,7 @@ import {
   isEditFileMultiMatchSignal,
   parseErrorInfo,
 } from "./error-handling";
-import type { GenerateOptions, GenerateResult, RunContext, StreamChunk } from "./lifecycle-contract";
+import type { GenerateOptions, GenerateResult, LifecycleFeedback, LifecycleState, RunContext, StreamChunk } from "./lifecycle-contract";
 import { resolveModeModel } from "./lifecycle-resolve";
 import type { StreamError } from "./stream-error";
 import type { ToolDefinition } from "./tool-contract";
@@ -139,12 +139,40 @@ function ensureAgentForMode(ctx: RunContext): void {
   });
 }
 
-export async function phaseGenerate(ctx: RunContext, prompt: string, opts: GenerateOptions): Promise<void> {
+function renderFeedback(feedback: LifecycleFeedback): string {
+  return `SYSTEM: Lifecycle feedback (${feedback.source}):\n${feedback.content}`;
+}
+
+function createGenerationInputFromFeedback(baseAgentInput: string, activeFeedback: LifecycleFeedback[]): string {
+  if (activeFeedback.length === 0) return baseAgentInput;
+  return [baseAgentInput, ...activeFeedback.map(renderFeedback)].join("\n\n");
+}
+
+export function consumeLifecycleFeedback(
+  state: Pick<LifecycleState, "feedback">,
+  mode: RunContext["mode"],
+): LifecycleFeedback[] {
+  const activeFeedback = state.feedback.filter((feedback) => feedback.mode === mode);
+  if (activeFeedback.length === 0) return [];
+  state.feedback = state.feedback.filter((feedback) => feedback.mode !== mode);
+  return activeFeedback;
+}
+
+export function createGenerationInput(
+  ctx: Pick<RunContext, "baseAgentInput" | "mode"> & { lifecycleState: Pick<LifecycleState, "feedback"> },
+): string {
+  const activeFeedback = ctx.lifecycleState.feedback.filter((feedback) => feedback.mode === ctx.mode);
+  return createGenerationInputFromFeedback(ctx.baseAgentInput, activeFeedback);
+}
+
+export async function phaseGenerate(ctx: RunContext, opts: GenerateOptions): Promise<void> {
   ctx.currentError = undefined;
   ctx.sawEditFileMultiMatchError = false;
   ensureAgentForMode(ctx);
   resetCycleStepCount(ctx.session, opts.cycleLimit);
   ctx.generationAttempt += 1;
+  const activeFeedback = consumeLifecycleFeedback(ctx.lifecycleState, ctx.mode);
+  const prompt = createGenerationInputFromFeedback(ctx.baseAgentInput, activeFeedback);
   ctx.emit({ type: "status", message: `${agentModes[ctx.mode].statusText} (${ctx.model})` });
   ctx.emit({
     type: "usage",

--- a/src/lifecycle-guard-feedback.test.ts
+++ b/src/lifecycle-guard-feedback.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { createLifecycleFeedbackForGuard } from "./lifecycle-guard-feedback";
+import type { GuardEvent } from "./tool-guards";
+
+function createGuardEvent(overrides: Partial<GuardEvent> = {}): GuardEvent {
+  return {
+    guardId: "duplicate-call",
+    toolName: "read-file",
+    action: "blocked",
+    detail: "duplicate-call",
+    ...overrides,
+  };
+}
+
+describe("createLifecycleFeedbackForGuard", () => {
+  test("returns undefined for non-blocking guard events", () => {
+    const feedback = createLifecycleFeedbackForGuard(createGuardEvent({ action: "flag_set" }), "work");
+    expect(feedback).toBeUndefined();
+  });
+
+  test("returns undefined for guard ids that lifecycle does not surface", () => {
+    const feedback = createLifecycleFeedbackForGuard(createGuardEvent({ guardId: "step-budget" }), "work");
+    expect(feedback).toBeUndefined();
+  });
+
+  test("maps duplicate-call to work-scoped lifecycle feedback", () => {
+    const feedback = createLifecycleFeedbackForGuard(createGuardEvent(), "work");
+    expect(feedback).toEqual({
+      source: "guard",
+      mode: "work",
+      summary: "The previous read-file call already used these arguments.",
+      instruction: "Reuse the earlier result or change approach instead of repeating the same call.",
+    });
+  });
+
+  test("maps ping-pong detail into lifecycle feedback details", () => {
+    const feedback = createLifecycleFeedbackForGuard(
+      createGuardEvent({
+        guardId: "ping-pong",
+        toolName: "search-files",
+        detail: "search-files<->find-files",
+      }),
+      "work",
+    );
+    expect(feedback).toEqual({
+      source: "guard",
+      mode: "work",
+      summary: "You are alternating between the same tools without changing strategy.",
+      details: "Recent calls are bouncing between search-files<->find-files.",
+      instruction: "Stop repeating the same pattern. Change approach or change inputs.",
+    });
+  });
+
+  test("forces verify mode for redundant-verify feedback", () => {
+    const feedback = createLifecycleFeedbackForGuard(
+      createGuardEvent({
+        guardId: "redundant-verify",
+        toolName: "run-command",
+        detail: "no-writes-since-last-verify",
+      }),
+      "work",
+    );
+    expect(feedback).toEqual({
+      source: "guard",
+      mode: "verify",
+      summary: "This verify command already ran and no writes happened since then.",
+      instruction: "Do not rerun the same verification command until work mode changes the code.",
+    });
+  });
+});

--- a/src/lifecycle-guard-feedback.ts
+++ b/src/lifecycle-guard-feedback.ts
@@ -1,0 +1,76 @@
+import type { LifecycleFeedback } from "./lifecycle-contract";
+import type { GuardEvent } from "./tool-guards";
+
+type GuardFeedbackFactory = (event: GuardEvent, mode: LifecycleFeedback["mode"]) => LifecycleFeedback;
+
+function createGuardFeedback(
+  mode: LifecycleFeedback["mode"],
+  input: Omit<LifecycleFeedback, "source" | "mode">,
+): LifecycleFeedback {
+  return { source: "guard", mode, ...input };
+}
+
+const guardFeedbackFactories = {
+  "duplicate-call": (event, mode) =>
+    createGuardFeedback(mode, {
+      summary: `The previous ${event.toolName} call already used these arguments.`,
+      instruction: "Reuse the earlier result or change approach instead of repeating the same call.",
+    }),
+  "file-churn": (event, mode) =>
+    createGuardFeedback(mode, {
+      summary:
+        event.toolName === "read-file"
+          ? `You have already revisited "${event.detail ?? "this file"}" multiple times without making progress.`
+          : `You are stuck in a read/edit loop on "${event.detail ?? "this file"}".`,
+      instruction:
+        event.toolName === "read-file"
+          ? "Use the content you already have, edit the file, or move to a different file."
+          : "Use one consolidated edit or change approach instead of making another incremental pass.",
+    }),
+  "ping-pong": (event, mode) =>
+    createGuardFeedback(mode, {
+      summary: "You are alternating between the same tools without changing strategy.",
+      details: event.detail ? `Recent calls are bouncing between ${event.detail}.` : undefined,
+      instruction: "Stop repeating the same pattern. Change approach or change inputs.",
+    }),
+  "stale-result": (event, mode) =>
+    createGuardFeedback(mode, {
+      summary: `${event.toolName} is returning the same result repeatedly.`,
+      instruction: "Do not repeat the same call again. Change inputs or use a different approach.",
+    }),
+  "redundant-search": (event, mode) =>
+    createGuardFeedback(mode, {
+      summary: `A previous ${event.toolName} call already covered this discovery step.`,
+      instruction: "Stop repeating search variants. Read a relevant file directly or conclude from current evidence.",
+    }),
+  "redundant-find": (event, mode) =>
+    createGuardFeedback(mode, {
+      summary: `A previous ${event.toolName} call already covered this discovery step.`,
+      instruction: "Reuse the broader result or read a promising file directly.",
+    }),
+  "redundant-verify": () =>
+    createGuardFeedback("verify", {
+      summary: "This verify command already ran and no writes happened since then.",
+      instruction: "Do not rerun the same verification command until work mode changes the code.",
+    }),
+} satisfies Record<string, GuardFeedbackFactory>;
+
+type SupportedGuardId = keyof typeof guardFeedbackFactories;
+
+function isSupportedGuardId(guardId: string): guardId is SupportedGuardId {
+  return guardId in guardFeedbackFactories;
+}
+
+/**
+ * Lifecycle only surfaces selected guard blocks back to the model.
+ * Most guard events remain internal runtime signals and never become feedback.
+ */
+export function createLifecycleFeedbackForGuard(
+  event: GuardEvent,
+  mode: LifecycleFeedback["mode"],
+): LifecycleFeedback | undefined {
+  if (event.action !== "blocked") return undefined;
+  if (!isSupportedGuardId(event.guardId)) return undefined;
+  const factory = guardFeedbackFactories[event.guardId];
+  return factory(event, mode);
+}

--- a/src/lifecycle-prepare.ts
+++ b/src/lifecycle-prepare.ts
@@ -31,6 +31,7 @@ export function phasePrepare(input: PhasePrepareInput): PhasePrepareResult {
       tool: event.toolName,
       action: event.action,
       detail: event.detail,
+      feedback_summary: event.feedback?.summary ?? null,
     });
   };
   session.toolTimeoutMs = input.policy.toolTimeoutMs;

--- a/src/lifecycle-prepare.ts
+++ b/src/lifecycle-prepare.ts
@@ -31,7 +31,6 @@ export function phasePrepare(input: PhasePrepareInput): PhasePrepareResult {
       tool: event.toolName,
       action: event.action,
       detail: event.detail,
-      feedback_summary: event.feedback?.summary ?? null,
     });
   };
   session.toolTimeoutMs = input.policy.toolTimeoutMs;

--- a/src/lifecycle-prepare.ts
+++ b/src/lifecycle-prepare.ts
@@ -11,7 +11,7 @@ export function phasePrepare(input: PhasePrepareInput): PhasePrepareResult {
   // counted — createAgentInput's returned promptTokens intentionally excludes them.
   const systemPromptTokens = estimateTokens(input.soulPrompt) + INSTRUCTION_OVERHEAD_TOKENS;
   const requestInput = createAgentInput(input.request, { systemPromptTokens });
-  const agentInput = requestInput.input;
+  const baseAgentInput = requestInput.input;
 
   const { tools, session } = toolsForAgent({
     workspace: input.workspace,
@@ -50,5 +50,5 @@ export function phasePrepare(input: PhasePrepareInput): PhasePrepareResult {
     });
   }
 
-  return { session, tools, agentInput, promptUsage: requestInput.usage };
+  return { session, tools, baseAgentInput, promptUsage: requestInput.usage };
 }

--- a/src/lifecycle-state.ts
+++ b/src/lifecycle-state.ts
@@ -13,7 +13,7 @@ export function updateRepeatedFailureState(ctx: RunContext): void {
 
   const previous = ctx.lifecycleState.repeatedFailure;
   if (!previous || previous.signature !== signature) {
-    ctx.lifecycleState.repeatedFailure = { signature, count: 1, surfacedCount: 0 };
+    ctx.lifecycleState.repeatedFailure = { signature, count: 1, status: "pending" };
     return;
   }
 

--- a/src/lifecycle-state.ts
+++ b/src/lifecycle-state.ts
@@ -1,4 +1,5 @@
 import type { RunContext } from "./lifecycle-contract";
+import { scopedCallLog as taskScopedCallLog } from "./tool-guards";
 
 export function clearVerifyOutcomeForFeedback(ctx: RunContext, feedbackSource?: string): void {
   if (feedbackSource === "verify") ctx.lifecycleState.verifyOutcome = undefined;
@@ -26,5 +27,46 @@ function failureSignatureForError(ctx: RunContext): string | undefined {
   const category = ctx.currentError.category ?? "other";
   const source = ctx.currentError.source ?? "generate";
   const tool = ctx.currentError.tool ?? "none";
-  return [category, source, tool, code].join(":");
+  const attempt = failureAttemptDiscriminator(ctx, tool);
+  return [category, source, tool, code, attempt].join(":");
+}
+
+function failureAttemptDiscriminator(ctx: RunContext, toolName: string): string {
+  if (toolName !== "none") {
+    const argsSignature = lastToolArgsSignature(ctx, toolName);
+    if (argsSignature) return `args=${argsSignature}`;
+  }
+
+  const message = normalizeFailureMessage(ctx.currentError?.message);
+  return message ? `message=${message}` : "attempt=unknown";
+}
+
+function lastToolArgsSignature(ctx: RunContext, toolName: string): string | undefined {
+  const calls = taskScopedCallLog(ctx.session, ctx.taskId);
+  for (let index = calls.length - 1; index >= 0; index -= 1) {
+    const entry = calls[index];
+    if (entry?.toolName !== toolName) continue;
+    return JSON.stringify(normalizeArgValue(entry.args));
+  }
+  return undefined;
+}
+
+function normalizeArgValue(value: unknown): unknown {
+  if (typeof value === "string") return normalizeFailureMessage(value);
+  if (Array.isArray(value)) return value.map((entry) => normalizeArgValue(entry));
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>).sort(([left], [right]) =>
+      left.localeCompare(right),
+    );
+    const normalized: Record<string, unknown> = {};
+    for (const [key, entry] of entries) normalized[key] = normalizeArgValue(entry);
+    return normalized;
+  }
+  return value;
+}
+
+function normalizeFailureMessage(message: string | undefined): string | undefined {
+  if (!message) return undefined;
+  const normalized = message.replace(/\s+/g, " ").trim();
+  return normalized.length > 0 ? normalized : undefined;
 }

--- a/src/lifecycle-state.ts
+++ b/src/lifecycle-state.ts
@@ -1,0 +1,30 @@
+import type { RunContext } from "./lifecycle-contract";
+
+export function clearVerifyOutcomeForFeedback(ctx: RunContext, feedbackSource?: string): void {
+  if (feedbackSource === "verify") ctx.lifecycleState.verifyOutcome = undefined;
+}
+
+export function updateRepeatedFailureState(ctx: RunContext): void {
+  const signature = failureSignatureForError(ctx);
+  if (!signature) {
+    ctx.lifecycleState.repeatedFailure = undefined;
+    return;
+  }
+
+  const previous = ctx.lifecycleState.repeatedFailure;
+  if (!previous || previous.signature !== signature) {
+    ctx.lifecycleState.repeatedFailure = { signature, count: 1, surfacedCount: 0 };
+    return;
+  }
+
+  ctx.lifecycleState.repeatedFailure = { ...previous, count: previous.count + 1 };
+}
+
+function failureSignatureForError(ctx: RunContext): string | undefined {
+  if (!ctx.currentError) return undefined;
+  const code = ctx.currentError.code ?? "unknown";
+  const category = ctx.currentError.category ?? "other";
+  const source = ctx.currentError.source ?? "generate";
+  const tool = ctx.currentError.tool ?? "none";
+  return [category, source, tool, code].join(":");
+}

--- a/src/lifecycle-state.ts
+++ b/src/lifecycle-state.ts
@@ -1,5 +1,5 @@
 import type { RunContext } from "./lifecycle-contract";
-import { scopedCallLog as taskScopedCallLog } from "./tool-guards";
+import { scopedCallLog } from "./tool-guards";
 
 export function clearVerifyOutcomeForFeedback(ctx: RunContext, feedbackSource?: string): void {
   if (feedbackSource === "verify") ctx.lifecycleState.verifyOutcome = undefined;
@@ -42,7 +42,7 @@ function failureAttemptDiscriminator(ctx: RunContext, toolName: string): string 
 }
 
 function lastToolArgsSignature(ctx: RunContext, toolName: string): string | undefined {
-  const calls = taskScopedCallLog(ctx.session, ctx.taskId);
+  const calls = scopedCallLog(ctx.session, ctx.taskId);
   for (let index = calls.length - 1; index >= 0; index -= 1) {
     const entry = calls[index];
     if (entry?.toolName !== toolName) continue;

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -4,6 +4,7 @@ import { scheduleMemoryCommit, shouldCommitMemory } from "./lifecycle";
 import type { RunContext } from "./lifecycle-contract";
 import { recoveryActionForError } from "./lifecycle-evaluate";
 import { multiMatchEditEvaluator, verifyCycle } from "./lifecycle-evaluators";
+import { consumeLifecycleFeedback, createGenerationInput } from "./lifecycle-generate";
 import { defaultLifecyclePolicy } from "./lifecycle-policy";
 import { phasePrepare } from "./lifecycle-prepare";
 import { LIFECYCLE_ERROR_CODES, TOOL_ERROR_CODES } from "./tool-error-codes";
@@ -24,7 +25,7 @@ function createMockContext(overrides: Partial<RunContext> = {}): RunContext {
     model: "gpt-5-mini",
     session: createSessionContext(),
     agent: {} as RunContext["agent"],
-    agentInput: "test prompt",
+    baseAgentInput: "test prompt",
     policy: defaultLifecyclePolicy,
     promptUsage: {
       promptTokens: 0,
@@ -34,6 +35,7 @@ function createMockContext(overrides: Partial<RunContext> = {}): RunContext {
       includedHistoryMessages: 0,
       totalHistoryMessages: 0,
     },
+    lifecycleState: { feedback: [], verifyOutcome: undefined },
     observedTools: new Set(),
     modelCallCount: 1,
     promptTokensAccum: 0,
@@ -75,13 +77,13 @@ describe("verifyCycle", () => {
     if (action.type === "regenerate") {
       expect(action.mode).toBe("verify");
       expect(action.keepResult).toBe(true);
-      expect(action.prompt).toContain("Task boundary:");
-      expect(action.prompt).toContain("- src/a.ts");
-      expect(action.prompt).toContain("- src/b.ts");
-      expect(action.prompt).toContain("Allowed supporting reads");
-      expect(action.prompt).toContain("- src/c.ts");
-      expect(action.prompt).toContain("- src/d.ts");
-      expect(action.prompt).not.toContain("- src/old.ts");
+      expect(action.feedback?.content).toContain("Task boundary:");
+      expect(action.feedback?.content).toContain("- src/a.ts");
+      expect(action.feedback?.content).toContain("- src/b.ts");
+      expect(action.feedback?.content).toContain("Allowed supporting reads");
+      expect(action.feedback?.content).toContain("- src/c.ts");
+      expect(action.feedback?.content).toContain("- src/d.ts");
+      expect(action.feedback?.content).not.toContain("- src/old.ts");
     }
   });
 
@@ -93,7 +95,7 @@ describe("verifyCycle", () => {
     });
     const action = verifyCycle.evaluate(ctx);
     expect(action.type).toBe("regenerate");
-    if (action.type === "regenerate") expect(action.prompt).not.toContain("Task boundary:");
+    if (action.type === "regenerate") expect(action.feedback?.content).not.toContain("Task boundary:");
   });
 
   test("uses global verify prompt when request explicitly opts into global scope", () => {
@@ -108,7 +110,7 @@ describe("verifyCycle", () => {
     });
     const action = verifyCycle.evaluate(ctx);
     expect(action.type).toBe("regenerate");
-    if (action.type === "regenerate") expect(action.prompt).not.toContain("Task boundary:");
+    if (action.type === "regenerate") expect(action.feedback?.content).not.toContain("Task boundary:");
   });
 
   test("returns done when verify already ran", () => {
@@ -147,9 +149,12 @@ describe("verifyCycle", () => {
       initialMode: "work",
       session,
       result: { text: "Done.", toolCalls: [] },
-      lastVerifyOutcome: {
-        text: "Error: missing export updatePost in post-store.ts",
-        error: { message: "verify failed: missing export updatePost in post-store.ts" },
+      lifecycleState: {
+        feedback: [],
+        verifyOutcome: {
+          text: "Error: missing export updatePost in post-store.ts",
+          error: { message: "verify failed: missing export updatePost in post-store.ts" },
+        },
       },
       observedTools: new Set(["scan-code"]),
     });
@@ -157,7 +162,7 @@ describe("verifyCycle", () => {
     expect(action.type).toBe("regenerate");
     if (action.type === "regenerate") {
       expect(action.mode).toBe("work");
-      expect(action.prompt).toContain("missing export updatePost");
+      expect(action.feedback?.content).toContain("missing export updatePost");
     }
   });
 
@@ -184,7 +189,7 @@ describe("verifyCycle", () => {
       session,
       currentError: undefined,
       result: { text: "Done.", toolCalls: [] },
-      lastVerifyOutcome: undefined,
+      lifecycleState: { feedback: [], verifyOutcome: undefined },
     });
     expect(verifyCycle.evaluate(ctx).type).toBe("done");
   });
@@ -219,9 +224,9 @@ describe("multiMatchEditEvaluator", () => {
     const action = multiMatchEditEvaluator.evaluate(ctx);
     expect(action.type).toBe("regenerate");
     if (action.type === "regenerate") {
-      expect(action.prompt).toContain("next tool call must be edit-code");
-      expect(action.prompt).toContain("Use path 'src/priority.ts' for edit-code");
-      expect(action.prompt).toContain("do not use '.' or directory paths");
+      expect(action.feedback?.content).toContain("next tool call must be edit-code");
+      expect(action.feedback?.content).toContain("Use path 'src/priority.ts' for edit-code");
+      expect(action.feedback?.content).toContain("do not use '.' or directory paths");
     }
   });
 
@@ -236,7 +241,7 @@ describe("multiMatchEditEvaluator", () => {
     });
     const action = multiMatchEditEvaluator.evaluate(ctx);
     expect(action.type).toBe("regenerate");
-    if (action.type === "regenerate") expect(action.prompt).toContain("Use a concrete file path for edit-code");
+    if (action.type === "regenerate") expect(action.feedback?.content).toContain("Use a concrete file path for edit-code");
   });
 
   test("returns done when edit-code was already used", () => {
@@ -426,5 +431,56 @@ describe("phasePrepare", () => {
     });
     expect(prepared.session.toolTimeoutMs).toBe(1_234);
     expect(prepared.session.flags.consecutiveGuardBlockLimit).toBe(7);
+  });
+});
+
+describe("createGenerationInput", () => {
+  test("returns base input when there is no feedback", () => {
+    const input = createGenerationInput({
+      baseAgentInput: "USER: fix it",
+      mode: "work",
+      lifecycleState: { feedback: [] },
+    });
+    expect(input).toBe("USER: fix it");
+  });
+
+  test("appends only active-mode feedback in order", () => {
+    const input = createGenerationInput({
+      baseAgentInput: "USER: fix it",
+      mode: "work",
+      lifecycleState: {
+        feedback: [
+          { source: "verify", mode: "verify", content: "Task boundary:\n- src/a.ts" },
+          { source: "lint", mode: "work", content: "Lint errors detected" },
+          { source: "multi-match", mode: "work", content: "Use edit-code next" },
+        ],
+      },
+    });
+    expect(input).toContain("USER: fix it");
+    expect(input).toContain("Lifecycle feedback (lint)");
+    expect(input).toContain("Lint errors detected");
+    expect(input).toContain("Lifecycle feedback (multi-match)");
+    expect(input).toContain("Use edit-code next");
+    expect(input).not.toContain("Task boundary:\n- src/a.ts");
+  });
+});
+
+describe("consumeLifecycleFeedback", () => {
+  test("returns and clears pending feedback for the active mode only", () => {
+    const state = {
+      feedback: [
+        { source: "verify" as const, mode: "verify" as const, content: "Task boundary:\n- src/a.ts" },
+        { source: "lint" as const, mode: "work" as const, content: "Lint errors detected" },
+        { source: "multi-match" as const, mode: "work" as const, content: "Use edit-code next" },
+      ],
+    };
+
+    const consumed = consumeLifecycleFeedback(state, "work");
+
+    expect(consumed).toEqual([
+      { source: "lint", mode: "work", content: "Lint errors detected" },
+      { source: "multi-match", mode: "work", content: "Use edit-code next" },
+    ]);
+    expect(state.feedback).toEqual([{ source: "verify", mode: "verify", content: "Task boundary:\n- src/a.ts" }]);
   });
 });

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -3,7 +3,7 @@ import { createErrorStats } from "./error-handling";
 import { scheduleMemoryCommit, shouldCommitMemory } from "./lifecycle";
 import type { RunContext } from "./lifecycle-contract";
 import { recoveryActionForError } from "./lifecycle-evaluate";
-import { guardRecoveryEvaluator, multiMatchEditEvaluator, verifyCycle } from "./lifecycle-evaluators";
+import { guardRecoveryEvaluator, multiMatchEditEvaluator, repeatedFailureEvaluator, verifyCycle } from "./lifecycle-evaluators";
 import { consumeLifecycleFeedback, createGenerationInput, createLifecycleFeedbackText } from "./lifecycle-generate";
 import { defaultLifecyclePolicy } from "./lifecycle-policy";
 import { phasePrepare } from "./lifecycle-prepare";
@@ -35,7 +35,7 @@ function createMockContext(overrides: Partial<RunContext> = {}): RunContext {
       includedHistoryMessages: 0,
       totalHistoryMessages: 0,
     },
-    lifecycleState: { feedback: [], verifyOutcome: undefined },
+    lifecycleState: { feedback: [], verifyOutcome: undefined, repeatedFailure: undefined },
     observedTools: new Set(),
     modelCallCount: 1,
     promptTokensAccum: 0,
@@ -236,6 +236,57 @@ describe("guardRecoveryEvaluator", () => {
     });
 
     expect(guardRecoveryEvaluator.evaluate(ctx)).toEqual({ type: "done" });
+  });
+});
+
+describe("repeatedFailureEvaluator", () => {
+  test("returns regenerate when the same non-guard failure repeats", () => {
+    const ctx = createMockContext({
+      currentError: {
+        message: "run-command failed: command exited with code 1",
+        category: "other",
+        code: "E_COMMAND_FAILED",
+        tool: "run-command",
+        source: "tool-error",
+      },
+      result: { text: "Attempted fix.", toolCalls: [] },
+      lifecycleState: {
+        feedback: [],
+        verifyOutcome: undefined,
+        repeatedFailure: {
+          signature: "other:tool-error:run-command:E_COMMAND_FAILED",
+          count: 2,
+          surfacedCount: 0,
+        },
+      },
+    });
+
+    const action = repeatedFailureEvaluator.evaluate(ctx);
+    expect(action.type).toBe("regenerate");
+    if (action.type === "regenerate") {
+      expect(action.feedback?.summary).toBe("The same runtime failure has repeated.");
+      expect(action.feedback?.details).toContain("command exited with code 1");
+      expect(action.feedback?.instruction).toContain("Change approach");
+    }
+    expect(ctx.lifecycleState.repeatedFailure?.surfacedCount).toBe(2);
+  });
+
+  test("returns done for repeated guard-blocked failures", () => {
+    const ctx = createMockContext({
+      currentError: { message: "Duplicate read-file call detected", category: "guard-blocked" },
+      result: { text: "Attempted read.", toolCalls: [] },
+      lifecycleState: {
+        feedback: [],
+        verifyOutcome: undefined,
+        repeatedFailure: {
+          signature: "guard-blocked:tool-error:none:E_GUARD_BLOCKED",
+          count: 2,
+          surfacedCount: 0,
+        },
+      },
+    });
+
+    expect(repeatedFailureEvaluator.evaluate(ctx)).toEqual({ type: "done" });
   });
 });
 

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -4,7 +4,7 @@ import { scheduleMemoryCommit, shouldCommitMemory } from "./lifecycle";
 import type { RunContext } from "./lifecycle-contract";
 import { recoveryActionForError } from "./lifecycle-evaluate";
 import { multiMatchEditEvaluator, verifyCycle } from "./lifecycle-evaluators";
-import { consumeLifecycleFeedback, createGenerationInput } from "./lifecycle-generate";
+import { consumeLifecycleFeedback, createGenerationInput, createLifecycleFeedbackText } from "./lifecycle-generate";
 import { defaultLifecyclePolicy } from "./lifecycle-policy";
 import { phasePrepare } from "./lifecycle-prepare";
 import { LIFECYCLE_ERROR_CODES, TOOL_ERROR_CODES } from "./tool-error-codes";
@@ -77,13 +77,13 @@ describe("verifyCycle", () => {
     if (action.type === "regenerate") {
       expect(action.mode).toBe("verify");
       expect(action.keepResult).toBe(true);
-      expect(action.feedback?.content).toContain("Task boundary:");
-      expect(action.feedback?.content).toContain("- src/a.ts");
-      expect(action.feedback?.content).toContain("- src/b.ts");
-      expect(action.feedback?.content).toContain("Allowed supporting reads");
-      expect(action.feedback?.content).toContain("- src/c.ts");
-      expect(action.feedback?.content).toContain("- src/d.ts");
-      expect(action.feedback?.content).not.toContain("- src/old.ts");
+      expect(action.feedback?.details).toContain("Task boundary:");
+      expect(action.feedback?.details).toContain("- src/a.ts");
+      expect(action.feedback?.details).toContain("- src/b.ts");
+      expect(action.feedback?.details).toContain("Allowed supporting reads");
+      expect(action.feedback?.details).toContain("- src/c.ts");
+      expect(action.feedback?.details).toContain("- src/d.ts");
+      expect(action.feedback?.details).not.toContain("- src/old.ts");
     }
   });
 
@@ -95,7 +95,7 @@ describe("verifyCycle", () => {
     });
     const action = verifyCycle.evaluate(ctx);
     expect(action.type).toBe("regenerate");
-    if (action.type === "regenerate") expect(action.feedback?.content).not.toContain("Task boundary:");
+    if (action.type === "regenerate") expect(action.feedback?.details).not.toContain("Task boundary:");
   });
 
   test("uses global verify prompt when request explicitly opts into global scope", () => {
@@ -110,7 +110,7 @@ describe("verifyCycle", () => {
     });
     const action = verifyCycle.evaluate(ctx);
     expect(action.type).toBe("regenerate");
-    if (action.type === "regenerate") expect(action.feedback?.content).not.toContain("Task boundary:");
+    if (action.type === "regenerate") expect(action.feedback?.details).not.toContain("Task boundary:");
   });
 
   test("returns done when verify already ran", () => {
@@ -162,7 +162,7 @@ describe("verifyCycle", () => {
     expect(action.type).toBe("regenerate");
     if (action.type === "regenerate") {
       expect(action.mode).toBe("work");
-      expect(action.feedback?.content).toContain("missing export updatePost");
+      expect(action.feedback?.details).toContain("missing export updatePost");
     }
   });
 
@@ -224,9 +224,9 @@ describe("multiMatchEditEvaluator", () => {
     const action = multiMatchEditEvaluator.evaluate(ctx);
     expect(action.type).toBe("regenerate");
     if (action.type === "regenerate") {
-      expect(action.feedback?.content).toContain("next tool call must be edit-code");
-      expect(action.feedback?.content).toContain("Use path 'src/priority.ts' for edit-code");
-      expect(action.feedback?.content).toContain("do not use '.' or directory paths");
+      expect(action.feedback?.instruction).toContain("next tool call must be edit-code");
+      expect(action.feedback?.instruction).toContain("Use path 'src/priority.ts' for edit-code");
+      expect(action.feedback?.instruction).toContain("do not use '.' or directory paths");
     }
   });
 
@@ -241,7 +241,9 @@ describe("multiMatchEditEvaluator", () => {
     });
     const action = multiMatchEditEvaluator.evaluate(ctx);
     expect(action.type).toBe("regenerate");
-    if (action.type === "regenerate") expect(action.feedback?.content).toContain("Use a concrete file path for edit-code");
+    if (action.type === "regenerate") {
+      expect(action.feedback?.instruction).toContain("Use a concrete file path for edit-code");
+    }
   });
 
   test("returns done when edit-code was already used", () => {
@@ -450,9 +452,9 @@ describe("createGenerationInput", () => {
       mode: "work",
       lifecycleState: {
         feedback: [
-          { source: "verify", mode: "verify", content: "Task boundary:\n- src/a.ts" },
-          { source: "lint", mode: "work", content: "Lint errors detected" },
-          { source: "multi-match", mode: "work", content: "Use edit-code next" },
+          { source: "verify", mode: "verify", summary: "Run verification.", details: "Task boundary:\n- src/a.ts" },
+          { source: "lint", mode: "work", summary: "Lint errors detected" },
+          { source: "multi-match", mode: "work", summary: "Use edit-code next" },
         ],
       },
     });
@@ -465,22 +467,70 @@ describe("createGenerationInput", () => {
   });
 });
 
+describe("createLifecycleFeedbackText", () => {
+  test("renders summary, details, and instruction in a single lifecycle-owned format", () => {
+    const text = createLifecycleFeedbackText({
+      source: "lint",
+      mode: "work",
+      summary: "Lint errors detected in files you edited.",
+      details: "src/a.ts:1:1 error unexpected any",
+      instruction: "Fix the issues above, then stop.",
+    });
+
+    expect(text).toContain("SYSTEM: Lifecycle feedback (lint):");
+    expect(text).toContain("Lint errors detected in files you edited.");
+    expect(text).toContain("src/a.ts:1:1 error unexpected any");
+    expect(text).toContain("Fix the issues above, then stop.");
+  });
+});
+
 describe("consumeLifecycleFeedback", () => {
   test("returns and clears pending feedback for the active mode only", () => {
     const state = {
       feedback: [
-        { source: "verify" as const, mode: "verify" as const, content: "Task boundary:\n- src/a.ts" },
-        { source: "lint" as const, mode: "work" as const, content: "Lint errors detected" },
-        { source: "multi-match" as const, mode: "work" as const, content: "Use edit-code next" },
+        {
+          source: "verify" as const,
+          mode: "verify" as const,
+          summary: "Run verification.",
+          details: "Task boundary:\n- src/a.ts",
+        },
+        { source: "lint" as const, mode: "work" as const, summary: "Lint errors detected" },
+        { source: "multi-match" as const, mode: "work" as const, summary: "Use edit-code next" },
       ],
     };
 
     const consumed = consumeLifecycleFeedback(state, "work");
 
     expect(consumed).toEqual([
-      { source: "lint", mode: "work", content: "Lint errors detected" },
-      { source: "multi-match", mode: "work", content: "Use edit-code next" },
+      { source: "lint", mode: "work", summary: "Lint errors detected" },
+      { source: "multi-match", mode: "work", summary: "Use edit-code next" },
     ]);
-    expect(state.feedback).toEqual([{ source: "verify", mode: "verify", content: "Task boundary:\n- src/a.ts" }]);
+    expect(state.feedback).toEqual([
+      { source: "verify", mode: "verify", summary: "Run verification.", details: "Task boundary:\n- src/a.ts" },
+    ]);
+  });
+
+  test("does not leak consumed feedback into later prompt creation", () => {
+    const state = {
+      feedback: [{ source: "lint" as const, mode: "work" as const, summary: "Lint errors detected" }],
+    };
+
+    expect(
+      createGenerationInput({
+        baseAgentInput: "USER: fix it",
+        mode: "work",
+        lifecycleState: state,
+      }),
+    ).toContain("Lint errors detected");
+
+    consumeLifecycleFeedback(state, "work");
+
+    expect(
+      createGenerationInput({
+        baseAgentInput: "USER: fix it",
+        mode: "work",
+        lifecycleState: state,
+      }),
+    ).toBe("USER: fix it");
   });
 });

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -146,8 +146,11 @@ describe("verifyCycle", () => {
       mode: "verify",
       initialMode: "work",
       session,
-      currentError: { message: "verify failed: missing export updatePost in post-store.ts" },
-      result: { text: "Error: missing export updatePost in post-store.ts", toolCalls: [] },
+      result: { text: "Done.", toolCalls: [] },
+      lastVerifyOutcome: {
+        text: "Error: missing export updatePost in post-store.ts",
+        error: { message: "verify failed: missing export updatePost in post-store.ts" },
+      },
       observedTools: new Set(["scan-code"]),
     });
     const action = verifyCycle.evaluate(ctx);
@@ -167,6 +170,21 @@ describe("verifyCycle", () => {
       initialMode: "work",
       session,
       result: { text: "", toolCalls: [] },
+    });
+    expect(verifyCycle.evaluate(ctx).type).toBe("done");
+  });
+
+  test("ignores restored work result when verify outcome is missing", () => {
+    const session = createSessionContext();
+    session.mode = "verify";
+    recordCall(session, "run-command", { command: "bun run verify" });
+    const ctx = createMockContext({
+      mode: "verify",
+      initialMode: "work",
+      session,
+      currentError: undefined,
+      result: { text: "Done.", toolCalls: [] },
+      lastVerifyOutcome: undefined,
     });
     expect(verifyCycle.evaluate(ctx).type).toBe("done");
   });

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -3,7 +3,7 @@ import { createErrorStats } from "./error-handling";
 import { scheduleMemoryCommit, shouldCommitMemory } from "./lifecycle";
 import type { RunContext } from "./lifecycle-contract";
 import { recoveryActionForError } from "./lifecycle-evaluate";
-import { multiMatchEditEvaluator, verifyCycle } from "./lifecycle-evaluators";
+import { guardRecoveryEvaluator, multiMatchEditEvaluator, verifyCycle } from "./lifecycle-evaluators";
 import { consumeLifecycleFeedback, createGenerationInput, createLifecycleFeedbackText } from "./lifecycle-generate";
 import { defaultLifecyclePolicy } from "./lifecycle-policy";
 import { phasePrepare } from "./lifecycle-prepare";
@@ -205,6 +205,37 @@ describe("verifyCycle", () => {
       result: { text: "No issues found. 0 errors.", toolCalls: [] },
     });
     expect(verifyCycle.evaluate(ctx).type).toBe("done");
+  });
+});
+
+describe("guardRecoveryEvaluator", () => {
+  test("returns regenerate when guard-blocked error has pending guard feedback", () => {
+    const ctx = createMockContext({
+      currentError: { message: "Duplicate read-file call detected", category: "guard-blocked" },
+      result: { text: "Attempted read.", toolCalls: [] },
+      lifecycleState: {
+        feedback: [
+          {
+            source: "guard",
+            mode: "work",
+            summary: "The previous read-file call already used these arguments.",
+            instruction: "Reuse the earlier result or change approach instead of repeating the same call.",
+          },
+        ],
+        verifyOutcome: undefined,
+      },
+    });
+
+    expect(guardRecoveryEvaluator.evaluate(ctx)).toEqual({ type: "regenerate" });
+  });
+
+  test("returns done when no pending guard feedback exists", () => {
+    const ctx = createMockContext({
+      currentError: { message: "Duplicate read-file call detected", category: "guard-blocked" },
+      result: { text: "Attempted read.", toolCalls: [] },
+    });
+
+    expect(guardRecoveryEvaluator.evaluate(ctx)).toEqual({ type: "done" });
   });
 });
 

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -12,6 +12,7 @@ import {
 import { consumeLifecycleFeedback, createGenerationInput, createLifecycleFeedbackText } from "./lifecycle-generate";
 import { defaultLifecyclePolicy } from "./lifecycle-policy";
 import { phasePrepare } from "./lifecycle-prepare";
+import { updateRepeatedFailureState } from "./lifecycle-state";
 import { LIFECYCLE_ERROR_CODES, TOOL_ERROR_CODES } from "./tool-error-codes";
 import { createSessionContext, recordCall } from "./tool-guards";
 
@@ -316,6 +317,31 @@ describe("repeatedFailureEvaluator", () => {
     });
 
     expect(repeatedFailureEvaluator.evaluate(ctx)).toEqual({ type: "done" });
+  });
+
+  test("tracks different run-command failures as different repeated-failure streaks", () => {
+    const session = createSessionContext("task_repeat");
+    recordCall(session, "run-command", { command: "bun test src/a.test.ts" });
+
+    const ctx = createMockContext({
+      taskId: "task_repeat",
+      session,
+      currentError: {
+        message: "run-command failed: command exited with code 1",
+        category: "other",
+        code: "E_COMMAND_FAILED",
+        tool: "run-command",
+        source: "tool-error",
+      },
+    });
+
+    updateRepeatedFailureState(ctx);
+    expect(ctx.lifecycleState.repeatedFailure?.count).toBe(1);
+
+    recordCall(session, "run-command", { command: "bun test src/b.test.ts" });
+    updateRepeatedFailureState(ctx);
+    expect(ctx.lifecycleState.repeatedFailure?.count).toBe(1);
+    expect(ctx.lifecycleState.repeatedFailure?.signature).toContain("src/b.test.ts");
   });
 });
 

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -3,7 +3,12 @@ import { createErrorStats } from "./error-handling";
 import { scheduleMemoryCommit, shouldCommitMemory } from "./lifecycle";
 import type { RunContext } from "./lifecycle-contract";
 import { recoveryActionForError } from "./lifecycle-evaluate";
-import { guardRecoveryEvaluator, multiMatchEditEvaluator, repeatedFailureEvaluator, verifyCycle } from "./lifecycle-evaluators";
+import {
+  guardRecoveryEvaluator,
+  multiMatchEditEvaluator,
+  repeatedFailureEvaluator,
+  verifyCycle,
+} from "./lifecycle-evaluators";
 import { consumeLifecycleFeedback, createGenerationInput, createLifecycleFeedbackText } from "./lifecycle-generate";
 import { defaultLifecyclePolicy } from "./lifecycle-policy";
 import { phasePrepare } from "./lifecycle-prepare";

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -256,7 +256,7 @@ describe("repeatedFailureEvaluator", () => {
         repeatedFailure: {
           signature: "other:tool-error:run-command:E_COMMAND_FAILED",
           count: 2,
-          surfacedCount: 0,
+          status: "pending",
         },
       },
     });
@@ -268,7 +268,7 @@ describe("repeatedFailureEvaluator", () => {
       expect(action.feedback?.details).toContain("command exited with code 1");
       expect(action.feedback?.instruction).toContain("Change approach");
     }
-    expect(ctx.lifecycleState.repeatedFailure?.surfacedCount).toBe(2);
+    expect(ctx.lifecycleState.repeatedFailure?.status).toBe("surfaced");
   });
 
   test("returns done for repeated guard-blocked failures", () => {
@@ -281,7 +281,31 @@ describe("repeatedFailureEvaluator", () => {
         repeatedFailure: {
           signature: "guard-blocked:tool-error:none:E_GUARD_BLOCKED",
           count: 2,
-          surfacedCount: 0,
+          status: "pending",
+        },
+      },
+    });
+
+    expect(repeatedFailureEvaluator.evaluate(ctx)).toEqual({ type: "done" });
+  });
+
+  test("returns done after the repeated failure streak was already surfaced", () => {
+    const ctx = createMockContext({
+      currentError: {
+        message: "run-command failed: command exited with code 1",
+        category: "other",
+        code: "E_COMMAND_FAILED",
+        tool: "run-command",
+        source: "tool-error",
+      },
+      result: { text: "Attempted fix.", toolCalls: [] },
+      lifecycleState: {
+        feedback: [],
+        verifyOutcome: undefined,
+        repeatedFailure: {
+          signature: "other:tool-error:run-command:E_COMMAND_FAILED",
+          count: 3,
+          status: "surfaced",
         },
       },
     });

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,7 +1,13 @@
 import { createErrorStats } from "./error-handling";
-import type { LifecycleEventName, LifecycleInput, RunContext, ToolOutputEvent } from "./lifecycle-contract";
+import type {
+  LifecycleEventName,
+  LifecycleInput,
+  RunContext,
+  ToolOutputEvent,
+} from "./lifecycle-contract";
 import { phaseEvaluate } from "./lifecycle-evaluate";
 import { phaseFinalize } from "./lifecycle-finalize";
+import { createLifecycleFeedbackForGuard } from "./lifecycle-guard-feedback";
 import { createModeAgent, phaseGenerate, shouldYieldNow } from "./lifecycle-generate";
 import { resolveLifecyclePolicy } from "./lifecycle-policy";
 import { phasePrepare } from "./lifecycle-prepare";
@@ -112,14 +118,9 @@ function createRunContext(
 
   session.onGuard = (event) => {
     previousOnGuard?.(event);
-    if (event.action !== "blocked" || !event.feedback) return;
-    ctx.lifecycleState.feedback.push({
-      source: "guard",
-      mode: event.feedback.mode ?? ctx.mode,
-      summary: event.feedback.summary,
-      details: event.feedback.details,
-      instruction: event.feedback.instruction,
-    });
+    const feedback = createLifecycleFeedbackForGuard(event, ctx.mode);
+    if (!feedback) return;
+    ctx.lifecycleState.feedback.push(feedback);
   };
 
   return ctx;

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -60,6 +60,8 @@ function createRunContext(
     policy: RunContext["policy"];
   },
 ): RunContext {
+  const session = params.prepared.session;
+  const previousOnGuard = session.onGuard;
   const agent = createModeAgent({
     soulPrompt: input.soulPrompt,
     mode: params.initialMode,
@@ -68,7 +70,7 @@ function createRunContext(
     tools: params.prepared.tools,
   });
 
-  return {
+  const ctx: RunContext = {
     request: input.request,
     workspace: input.workspace,
     taskId: input.taskId,
@@ -80,7 +82,7 @@ function createRunContext(
     mode: params.initialMode,
     agentForMode: params.initialMode,
     model: params.model,
-    session: Object.assign(params.prepared.session, {
+    session: Object.assign(session, {
       mode: params.initialMode,
       onDebug: (event: `lifecycle.${string}`, data: Record<string, unknown>) => params.debug(event, data),
     }),
@@ -107,6 +109,20 @@ function createRunContext(
     toolCallStartedAt: new Map(),
     toolOutputHandler: null,
   };
+
+  session.onGuard = (event) => {
+    previousOnGuard?.(event);
+    if (event.action !== "blocked" || !event.feedback) return;
+    ctx.lifecycleState.feedback.push({
+      source: "guard",
+      mode: event.feedback.mode ?? ctx.mode,
+      summary: event.feedback.summary,
+      details: event.feedback.details,
+      instruction: event.feedback.instruction,
+    });
+  };
+
+  return ctx;
 }
 
 function attachToolOutputHandler(ctx: RunContext) {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -85,9 +85,13 @@ function createRunContext(
       onDebug: (event: `lifecycle.${string}`, data: Record<string, unknown>) => params.debug(event, data),
     }),
     agent,
-    agentInput: params.prepared.agentInput,
+    baseAgentInput: params.prepared.baseAgentInput,
     policy: params.policy,
     promptUsage: params.prepared.promptUsage,
+    lifecycleState: {
+      feedback: [],
+      verifyOutcome: undefined,
+    },
     observedTools: new Set(),
     modelCallCount: 0,
     promptTokensAccum: 0,
@@ -98,7 +102,6 @@ function createRunContext(
     regenerationCount: 0,
     regenerationLimitHit: false,
     sawEditFileMultiMatchError: false,
-    lastVerifyOutcome: undefined,
     errorStats: createErrorStats(),
     nativeIdQueue: new Map(),
     toolCallStartedAt: new Map(),
@@ -169,7 +172,7 @@ export async function runLifecycle(input: LifecycleInput) {
   if (ctx.promptUsage.activeSkillName) {
     emit({ type: "status", message: `skill:${ctx.promptUsage.activeSkillName}` });
   }
-  await phaseGenerate(ctx, ctx.agentInput, {
+  await phaseGenerate(ctx, {
     cycleLimit: policy.initialMaxSteps,
     timeoutMs: policy.stepTimeoutMs,
   });

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -99,6 +99,7 @@ function createRunContext(
     lifecycleState: {
       feedback: [],
       verifyOutcome: undefined,
+      repeatedFailure: undefined,
     },
     observedTools: new Set(),
     modelCallCount: 0,

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,14 +1,9 @@
 import { createErrorStats } from "./error-handling";
-import type {
-  LifecycleEventName,
-  LifecycleInput,
-  RunContext,
-  ToolOutputEvent,
-} from "./lifecycle-contract";
+import type { LifecycleEventName, LifecycleInput, RunContext, ToolOutputEvent } from "./lifecycle-contract";
 import { phaseEvaluate } from "./lifecycle-evaluate";
 import { phaseFinalize } from "./lifecycle-finalize";
-import { createLifecycleFeedbackForGuard } from "./lifecycle-guard-feedback";
 import { createModeAgent, phaseGenerate, shouldYieldNow } from "./lifecycle-generate";
+import { createLifecycleFeedbackForGuard } from "./lifecycle-guard-feedback";
 import { resolveLifecyclePolicy } from "./lifecycle-policy";
 import { phasePrepare } from "./lifecycle-prepare";
 import { resolveInitialMode } from "./lifecycle-resolve";

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -98,6 +98,7 @@ function createRunContext(
     regenerationCount: 0,
     regenerationLimitHit: false,
     sawEditFileMultiMatchError: false,
+    lastVerifyOutcome: undefined,
     errorStats: createErrorStats(),
     nativeIdQueue: new Map(),
     toolCallStartedAt: new Map(),

--- a/src/tool-guards.test.ts
+++ b/src/tool-guards.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { hashResultValue } from "./tool-execution";
-import { createSessionContext, recordCall, resetCycleStepCount, runGuards, type GuardEvent } from "./tool-guards";
+import { createSessionContext, type GuardEvent, recordCall, resetCycleStepCount, runGuards } from "./tool-guards";
 
 describe("guard events", () => {
   test("emits GuardEvent payload when a guard blocks", () => {

--- a/src/tool-guards.test.ts
+++ b/src/tool-guards.test.ts
@@ -1,16 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { hashResultValue } from "./tool-execution";
-import { createSessionContext, recordCall, resetCycleStepCount, runGuards } from "./tool-guards";
+import { createSessionContext, recordCall, resetCycleStepCount, runGuards, type GuardEvent } from "./tool-guards";
 
 describe("guard events", () => {
   test("emits GuardEvent payload when a guard blocks", () => {
-    const events: Array<{
-      guardId: string;
-      toolName: string;
-      action: string;
-      detail?: string;
-      feedback?: { summary: string; details?: string; instruction?: string };
-    }> = [];
+    const events: GuardEvent[] = [];
     const session = createSessionContext();
     session.onGuard = (event) => events.push(event);
 
@@ -25,10 +19,6 @@ describe("guard events", () => {
       toolName: "read-file",
       action: "blocked",
       detail: "duplicate-call",
-      feedback: {
-        summary: "The previous read-file call already used these arguments.",
-        instruction: "Reuse the earlier result or change approach instead of repeating the same call.",
-      },
     });
   });
 });

--- a/src/tool-guards.test.ts
+++ b/src/tool-guards.test.ts
@@ -4,7 +4,13 @@ import { createSessionContext, recordCall, resetCycleStepCount, runGuards } from
 
 describe("guard events", () => {
   test("emits GuardEvent payload when a guard blocks", () => {
-    const events: Array<{ guardId: string; toolName: string; action: string; detail?: string }> = [];
+    const events: Array<{
+      guardId: string;
+      toolName: string;
+      action: string;
+      detail?: string;
+      feedback?: { summary: string; details?: string; instruction?: string };
+    }> = [];
     const session = createSessionContext();
     session.onGuard = (event) => events.push(event);
 
@@ -19,6 +25,10 @@ describe("guard events", () => {
       toolName: "read-file",
       action: "blocked",
       detail: "duplicate-call",
+      feedback: {
+        summary: "The previous read-file call already used these arguments.",
+        instruction: "Reuse the earlier result or change approach instead of repeating the same call.",
+      },
     });
   });
 });

--- a/src/tool-guards.ts
+++ b/src/tool-guards.ts
@@ -1,4 +1,5 @@
 import { invariant } from "./assert";
+import type { AgentMode } from "./agent-contract";
 import { CONSECUTIVE_GUARD_BLOCK_LIMIT, TOOL_TIMEOUT_MS } from "./lifecycle-constants";
 import {
   extractFindPatterns,
@@ -13,7 +14,20 @@ import type { ToolCache } from "./tool-contract";
 const DEFAULT_CYCLE_STEP_LIMIT = 80;
 const DEFAULT_TOTAL_STEP_LIMIT = 200;
 
-export type GuardEvent = { guardId: string; toolName: string; action: "blocked" | "flag_set"; detail?: string };
+export type GuardFeedback = {
+  mode?: AgentMode;
+  summary: string;
+  details?: string;
+  instruction?: string;
+};
+
+export type GuardEvent = {
+  guardId: string;
+  toolName: string;
+  action: "blocked" | "flag_set";
+  detail?: string;
+  feedback?: GuardFeedback;
+};
 
 export type ToolCallRecord = {
   toolName: string;
@@ -50,7 +64,7 @@ const FILE_CHURN_MIN_EDITS = 5;
 const FILE_READ_ONLY_CHURN_MIN = 4;
 const DISCOVERY_LOOP_MIN_CALLS = 4;
 
-export type GuardReport = (action: "blocked" | "flag_set", detail?: string) => void;
+export type GuardReport = (action: "blocked" | "flag_set", detail?: string, feedback?: GuardFeedback) => void;
 
 export type GuardInput = {
   toolName: string;
@@ -155,6 +169,20 @@ function guardArgsEqual(a: Record<string, unknown>, b: Record<string, unknown>):
   return JSON.stringify(normalizeGuardArgValue(a)) === JSON.stringify(normalizeGuardArgValue(b));
 }
 
+function createGuardFeedback(input: {
+  summary: string;
+  details?: string;
+  instruction: string;
+  mode?: AgentMode;
+}): GuardFeedback {
+  return {
+    mode: input.mode,
+    summary: input.summary,
+    ...(input.details ? { details: input.details } : {}),
+    instruction: input.instruction,
+  };
+}
+
 const DUPLICATE_CALL_LOOKBACK = 3;
 
 const duplicateCallGuard: ToolGuard = {
@@ -167,7 +195,14 @@ const duplicateCallGuard: ToolGuard = {
     for (let i = lookback.length - 1; i >= 0; i -= 1) {
       const prior = lookback[i];
       if (prior.toolName === toolName && guardArgsEqual(prior.args, args)) {
-        report("blocked", "duplicate-call");
+        report(
+          "blocked",
+          "duplicate-call",
+          createGuardFeedback({
+            summary: `The previous ${toolName} call already used these arguments.`,
+            instruction: "Reuse the earlier result or change approach instead of repeating the same call.",
+          }),
+        );
         throw new Error(
           `Duplicate ${toolName} call detected with unchanged arguments. Reuse previous result or change inputs.`,
         );
@@ -218,7 +253,15 @@ const fileChurnGuard: ToolGuard = {
       const { readCount, editCount } = countsForPath(target);
 
       if (toolName === "read-file" && editCount === 0 && readCount >= FILE_READ_ONLY_CHURN_MIN) {
-        report("blocked", target);
+        report(
+          "blocked",
+          target,
+          createGuardFeedback({
+            summary: `You have already read "${target}" multiple times without making progress.`,
+            details: `read-file has already read "${target}" ${readCount} times in this task without edits.`,
+            instruction: "Use the content you already have, edit the file, or move to a different file.",
+          }),
+        );
         throw new Error(
           `File "${target}" has been read ${readCount} times without edits. Use the content you already have or move on.`,
         );
@@ -228,7 +271,15 @@ const fileChurnGuard: ToolGuard = {
       if (combined < FILE_CHURN_MIN_COMBINED || readCount < FILE_CHURN_MIN_READS || editCount < FILE_CHURN_MIN_EDITS)
         continue;
 
-      report("blocked", target);
+      report(
+        "blocked",
+        target,
+        createGuardFeedback({
+          summary: `You are stuck in a read/edit loop on "${target}".`,
+          details: `This task has already repeated reads and edits on "${target}" without converging.`,
+          instruction: "Use one consolidated edit or change approach instead of making another incremental pass.",
+        }),
+      );
       throw new Error(
         `Repeated read/edit loop detected for "${target}". Stop incremental tweaks. ` +
           "Use one consolidated edit (line-range block or edit-code), then run verify.",
@@ -425,7 +476,15 @@ const pingPongGuard: ToolGuard = {
     }
 
     if (alternations >= PING_PONG_MIN_ALTERNATIONS) {
-      report("blocked", `${toolName}<->${otherTool}`);
+      report(
+        "blocked",
+        `${toolName}<->${otherTool}`,
+        createGuardFeedback({
+          summary: `You are alternating between ${toolName} and ${otherTool} without changing strategy.`,
+          details: `Recent calls are bouncing between ${toolName} and ${otherTool} with unchanged arguments.`,
+          instruction: "Stop repeating the same two-step pattern. Change approach or change inputs.",
+        }),
+      );
       throw new Error(
         `Ping-pong loop detected: alternating between ${toolName} and ${otherTool} with unchanged arguments. ` +
           "Break the cycle by trying a different approach or different arguments.",
@@ -465,7 +524,15 @@ const staleResultGuard: ToolGuard = {
     }
 
     if (sameResultStreak >= STALE_RESULT_THRESHOLD) {
-      report("blocked", `${toolName}:${sameResultStreak}-same-results`);
+      report(
+        "blocked",
+        `${toolName}:${sameResultStreak}-same-results`,
+        createGuardFeedback({
+          summary: `${toolName} is returning the same result repeatedly.`,
+          details: `The same ${toolName} call has already produced the same result ${sameResultStreak} times in this task.`,
+          instruction: "Do not repeat the same call again. Change inputs or use a different approach.",
+        }),
+      );
       throw new Error(
         `${toolName} has returned the same result ${sameResultStreak} times with these arguments. ` +
           "The state has not changed. Try a different approach or different arguments.",
@@ -509,8 +576,8 @@ const GUARDS: ToolGuard[] = [
 export function runGuards(input: Omit<GuardInput, "report">): void {
   for (const guard of GUARDS) {
     if (guard.tools && !guard.tools.includes(input.toolName)) continue;
-    const report: GuardReport = (action, detail) => {
-      input.session.onGuard?.({ guardId: guard.id, toolName: input.toolName, action, detail });
+    const report: GuardReport = (action, detail, feedback) => {
+      input.session.onGuard?.({ guardId: guard.id, toolName: input.toolName, action, detail, feedback });
     };
     guard.check({ ...input, report });
   }

--- a/src/tool-guards.ts
+++ b/src/tool-guards.ts
@@ -1,5 +1,4 @@
 import { invariant } from "./assert";
-import type { AgentMode } from "./agent-contract";
 import { CONSECUTIVE_GUARD_BLOCK_LIMIT, TOOL_TIMEOUT_MS } from "./lifecycle-constants";
 import {
   extractFindPatterns,
@@ -14,19 +13,11 @@ import type { ToolCache } from "./tool-contract";
 const DEFAULT_CYCLE_STEP_LIMIT = 80;
 const DEFAULT_TOTAL_STEP_LIMIT = 200;
 
-export type GuardFeedback = {
-  mode?: AgentMode;
-  summary: string;
-  details?: string;
-  instruction?: string;
-};
-
 export type GuardEvent = {
   guardId: string;
   toolName: string;
   action: "blocked" | "flag_set";
   detail?: string;
-  feedback?: GuardFeedback;
 };
 
 export type ToolCallRecord = {
@@ -64,7 +55,7 @@ const FILE_CHURN_MIN_EDITS = 5;
 const FILE_READ_ONLY_CHURN_MIN = 4;
 const DISCOVERY_LOOP_MIN_CALLS = 4;
 
-export type GuardReport = (action: "blocked" | "flag_set", detail?: string, feedback?: GuardFeedback) => void;
+export type GuardReport = (action: "blocked" | "flag_set", detail?: string) => void;
 
 export type GuardInput = {
   toolName: string;
@@ -169,20 +160,6 @@ function guardArgsEqual(a: Record<string, unknown>, b: Record<string, unknown>):
   return JSON.stringify(normalizeGuardArgValue(a)) === JSON.stringify(normalizeGuardArgValue(b));
 }
 
-function createGuardFeedback(input: {
-  summary: string;
-  details?: string;
-  instruction: string;
-  mode?: AgentMode;
-}): GuardFeedback {
-  return {
-    mode: input.mode,
-    summary: input.summary,
-    ...(input.details ? { details: input.details } : {}),
-    instruction: input.instruction,
-  };
-}
-
 const DUPLICATE_CALL_LOOKBACK = 3;
 
 const duplicateCallGuard: ToolGuard = {
@@ -195,14 +172,7 @@ const duplicateCallGuard: ToolGuard = {
     for (let i = lookback.length - 1; i >= 0; i -= 1) {
       const prior = lookback[i];
       if (prior.toolName === toolName && guardArgsEqual(prior.args, args)) {
-        report(
-          "blocked",
-          "duplicate-call",
-          createGuardFeedback({
-            summary: `The previous ${toolName} call already used these arguments.`,
-            instruction: "Reuse the earlier result or change approach instead of repeating the same call.",
-          }),
-        );
+        report("blocked", "duplicate-call");
         throw new Error(
           `Duplicate ${toolName} call detected with unchanged arguments. Reuse previous result or change inputs.`,
         );
@@ -253,15 +223,7 @@ const fileChurnGuard: ToolGuard = {
       const { readCount, editCount } = countsForPath(target);
 
       if (toolName === "read-file" && editCount === 0 && readCount >= FILE_READ_ONLY_CHURN_MIN) {
-        report(
-          "blocked",
-          target,
-          createGuardFeedback({
-            summary: `You have already read "${target}" multiple times without making progress.`,
-            details: `read-file has already read "${target}" ${readCount} times in this task without edits.`,
-            instruction: "Use the content you already have, edit the file, or move to a different file.",
-          }),
-        );
+        report("blocked", target);
         throw new Error(
           `File "${target}" has been read ${readCount} times without edits. Use the content you already have or move on.`,
         );
@@ -271,15 +233,7 @@ const fileChurnGuard: ToolGuard = {
       if (combined < FILE_CHURN_MIN_COMBINED || readCount < FILE_CHURN_MIN_READS || editCount < FILE_CHURN_MIN_EDITS)
         continue;
 
-      report(
-        "blocked",
-        target,
-        createGuardFeedback({
-          summary: `You are stuck in a read/edit loop on "${target}".`,
-          details: `This task has already repeated reads and edits on "${target}" without converging.`,
-          instruction: "Use one consolidated edit or change approach instead of making another incremental pass.",
-        }),
-      );
+      report("blocked", target);
       throw new Error(
         `Repeated read/edit loop detected for "${target}". Stop incremental tweaks. ` +
           "Use one consolidated edit (line-range block or edit-code), then run verify.",
@@ -476,15 +430,7 @@ const pingPongGuard: ToolGuard = {
     }
 
     if (alternations >= PING_PONG_MIN_ALTERNATIONS) {
-      report(
-        "blocked",
-        `${toolName}<->${otherTool}`,
-        createGuardFeedback({
-          summary: `You are alternating between ${toolName} and ${otherTool} without changing strategy.`,
-          details: `Recent calls are bouncing between ${toolName} and ${otherTool} with unchanged arguments.`,
-          instruction: "Stop repeating the same two-step pattern. Change approach or change inputs.",
-        }),
-      );
+      report("blocked", `${toolName}<->${otherTool}`);
       throw new Error(
         `Ping-pong loop detected: alternating between ${toolName} and ${otherTool} with unchanged arguments. ` +
           "Break the cycle by trying a different approach or different arguments.",
@@ -524,15 +470,7 @@ const staleResultGuard: ToolGuard = {
     }
 
     if (sameResultStreak >= STALE_RESULT_THRESHOLD) {
-      report(
-        "blocked",
-        `${toolName}:${sameResultStreak}-same-results`,
-        createGuardFeedback({
-          summary: `${toolName} is returning the same result repeatedly.`,
-          details: `The same ${toolName} call has already produced the same result ${sameResultStreak} times in this task.`,
-          instruction: "Do not repeat the same call again. Change inputs or use a different approach.",
-        }),
-      );
+      report("blocked", `${toolName}:${sameResultStreak}-same-results`);
       throw new Error(
         `${toolName} has returned the same result ${sameResultStreak} times with these arguments. ` +
           "The state has not changed. Try a different approach or different arguments.",
@@ -576,8 +514,8 @@ const GUARDS: ToolGuard[] = [
 export function runGuards(input: Omit<GuardInput, "report">): void {
   for (const guard of GUARDS) {
     if (guard.tools && !guard.tools.includes(input.toolName)) continue;
-    const report: GuardReport = (action, detail, feedback) => {
-      input.session.onGuard?.({ guardId: guard.id, toolName: input.toolName, action, detail, feedback });
+    const report: GuardReport = (action, detail) => {
+      input.session.onGuard?.({ guardId: guard.id, toolName: input.toolName, action, detail });
     };
     guard.check({ ...input, report });
   }


### PR DESCRIPTION
## Summary
- introduce task-scoped lifecycle state for feedback, verify outcomes, and repeated-failure tracking
- map selected guard blocks into lifecycle-owned recovery feedback without coupling guards to lifecycle policy
- refine repeated-failure detection so distinct failed attempts are not collapsed into one streak
- update lifecycle docs and audit skills to reinforce the lifecycle/guard boundary and style rules