### PR TITLE
feat(file-toolkit): gitignore-based file discovery

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -41,7 +41,7 @@ Shipped, user-visible capabilities.
 - Git status/diff.
 - Shell command execution.
 - Web search/fetch.
-- File discovery respects `.gitignore` and nested `.gitignore` files. Use `.acolyteignore` for project-specific exclusions that should not go in `.gitignore`.
+- File discovery respects `.gitignore` and nested `.gitignore` files.
 
 ## Memory
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -41,6 +41,7 @@ Shipped, user-visible capabilities.
 - Git status/diff.
 - Shell command execution.
 - Web search/fetch.
+- File discovery respects `.gitignore` and nested `.gitignore` files. Use `.acolyteignore` for project-specific exclusions that should not go in `.gitignore`.
 
 ## Memory
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -49,6 +49,7 @@ This reduces redundant I/O and avoids re-sending identical tool results to the m
 
 ## Key files
 
+- `src/gitignore.ts`
 - `src/file-toolkit.ts`
 - `src/code-toolkit.ts`
 - `src/git-toolkit.ts`

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -20,6 +20,16 @@ All tool calls run through guarded execution paths to ensure:
 - consistent error shaping
 - call recording for evaluators/debug
 
+## File discovery
+
+`collectWorkspaceFiles` determines what files are in scope for `find-files` and `search-files`. Three exclusion layers apply in order:
+
+1. **`IGNORED_DIRS`** — always excluded regardless of `.gitignore`: `node_modules`, `.git`, `.acolyte`
+2. **`.gitignore`** — workspace-root and nested `.gitignore` files are parsed and applied per-directory during traversal
+3. Nothing else is excluded by default — hidden directories and files are visible unless covered by the above
+
+Entries in `IGNORED_DIRS` take precedence and cannot be re-included by gitignore negation patterns.
+
 ## Tool result cache
 
 Read-only and search tools (`read-file`, `find-files`, `search-files`, `scan-code`) are cached per-task. Identical calls return the cached result without re-executing.

--- a/src/gitignore.test.ts
+++ b/src/gitignore.test.ts
@@ -1,13 +1,21 @@
 import { describe, expect, test } from "bun:test";
 import { compileGitignorePatterns, isIgnoredByPatterns } from "./gitignore";
 
-function makeCtx(dir: string, lines: string[]) {
+function createContext(dir: string, lines: string[]) {
   return { dir, patterns: compileGitignorePatterns(lines) };
 }
 
 function ignored(lines: string[], path: string, isDir = false): boolean {
-  return isIgnoredByPatterns([makeCtx("/repo", lines)], `/repo/${path}`, isDir);
+  return isIgnoredByPatterns([createContext("/repo", lines)], `/repo/${path}`, isDir);
 }
+
+describe("malformed patterns", () => {
+  test("does not throw on a pattern with an out-of-order character class range", () => {
+    // [z-a] is a valid gitignore pattern but produces an invalid JS regex — should be silently dropped
+    expect(() => compileGitignorePatterns(["file[z-a].ts"])).not.toThrow();
+    expect(compileGitignorePatterns(["file[z-a].ts"])).toHaveLength(0);
+  });
+});
 
 describe("comments and blank lines", () => {
   test("ignores blank lines", () => {
@@ -142,8 +150,8 @@ describe("character classes", () => {
 
 describe("nested gitignore contexts", () => {
   test("child context applies only within its directory", () => {
-    const root = makeCtx("/repo", ["*.log"]);
-    const child = makeCtx("/repo/src", ["*.generated.ts"]);
+    const root = createContext("/repo", ["*.log"]);
+    const child = createContext("/repo/src", ["*.generated.ts"]);
     const contexts = [root, child];
 
     expect(isIgnoredByPatterns(contexts, "/repo/error.log", false)).toBe(true);
@@ -152,8 +160,8 @@ describe("nested gitignore contexts", () => {
   });
 
   test("child negation does not affect root patterns", () => {
-    const root = makeCtx("/repo", ["*.log"]);
-    const child = makeCtx("/repo/src", ["!error.log"]);
+    const root = createContext("/repo", ["*.log"]);
+    const child = createContext("/repo/src", ["!error.log"]);
     const contexts = [root, child];
 
     // Root-level log is ignored by root pattern; child negation only applies within /repo/src

--- a/src/gitignore.test.ts
+++ b/src/gitignore.test.ts
@@ -146,6 +146,11 @@ describe("character classes", () => {
     expect(ignored(["file[a-z].ts"], "filea.ts")).toBe(true);
     expect(ignored(["file[a-z].ts"], "fileA.ts")).toBe(false);
   });
+
+  test("negated class excludes listed characters", () => {
+    expect(ignored(["file[!abc].ts"], "filed.ts")).toBe(true);
+    expect(ignored(["file[!abc].ts"], "filea.ts")).toBe(false);
+  });
 });
 
 describe("nested gitignore contexts", () => {

--- a/src/gitignore.test.ts
+++ b/src/gitignore.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import { compileGitignorePatterns, isIgnoredByPatterns } from "./gitignore";
+
+function makeCtx(dir: string, lines: string[]) {
+  return { dir, patterns: compileGitignorePatterns(lines) };
+}
+
+function ignored(lines: string[], path: string, isDir = false): boolean {
+  return isIgnoredByPatterns([makeCtx("/repo", lines)], `/repo/${path}`, isDir);
+}
+
+describe("comments and blank lines", () => {
+  test("ignores blank lines", () => {
+    expect(ignored(["", "  "], "foo.ts")).toBe(false);
+  });
+
+  test("ignores comment lines", () => {
+    expect(ignored(["# this is a comment", "*.log"], "foo.ts")).toBe(false);
+  });
+
+  test("escaped hash is a literal pattern", () => {
+    expect(ignored(["\\#special"], "#special")).toBe(true);
+  });
+});
+
+describe("literal patterns", () => {
+  test("matches exact filename anywhere in tree", () => {
+    expect(ignored([".env"], ".env")).toBe(true);
+    expect(ignored([".env"], "src/.env")).toBe(true);
+  });
+
+  test("does not match partial filename", () => {
+    expect(ignored([".env"], ".envrc")).toBe(false);
+  });
+});
+
+describe("wildcard *", () => {
+  test("matches any filename with extension", () => {
+    expect(ignored(["*.log"], "error.log")).toBe(true);
+    expect(ignored(["*.log"], "logs/error.log")).toBe(true);
+  });
+
+  test("does not cross directory boundary", () => {
+    expect(ignored(["*.log"], "logs/sub/error.log")).toBe(true);
+    expect(ignored(["src/*.ts"], "src/foo.ts")).toBe(true);
+    expect(ignored(["src/*.ts"], "src/sub/foo.ts")).toBe(false);
+  });
+
+  test("matches prefix wildcard", () => {
+    expect(ignored(["foo*"], "foobar")).toBe(true);
+    expect(ignored(["foo*"], "foo")).toBe(true);
+    expect(ignored(["foo*"], "bar")).toBe(false);
+  });
+});
+
+describe("wildcard ?", () => {
+  test("matches exactly one character", () => {
+    expect(ignored(["fo?"], "foo")).toBe(true);
+    expect(ignored(["fo?"], "fo")).toBe(false);
+    expect(ignored(["fo?"], "fooo")).toBe(false);
+  });
+
+  test("does not match path separator", () => {
+    expect(ignored(["a?b"], "a/b")).toBe(false);
+  });
+});
+
+describe("double star **", () => {
+  test("leading **/ matches in any directory", () => {
+    expect(ignored(["**/logs"], "logs", true)).toBe(true);
+    expect(ignored(["**/logs"], "src/logs", true)).toBe(true);
+    expect(ignored(["**/logs"], "a/b/logs", true)).toBe(true);
+  });
+
+  test("trailing /** matches everything inside", () => {
+    expect(ignored(["src/**"], "src/foo.ts")).toBe(true);
+    expect(ignored(["src/**"], "src/sub/foo.ts")).toBe(true);
+  });
+
+  test("internal /**/ matches zero or more directories", () => {
+    expect(ignored(["a/**/b"], "a/b")).toBe(true);
+    expect(ignored(["a/**/b"], "a/x/b")).toBe(true);
+    expect(ignored(["a/**/b"], "a/x/y/b")).toBe(true);
+  });
+});
+
+describe("anchored patterns", () => {
+  test("leading slash anchors to root", () => {
+    expect(ignored(["/dist"], "dist", true)).toBe(true);
+    expect(ignored(["/dist"], "src/dist", true)).toBe(false);
+  });
+
+  test("pattern with internal slash anchors to root", () => {
+    expect(ignored(["src/generated"], "src/generated", true)).toBe(true);
+    expect(ignored(["src/generated"], "lib/src/generated", true)).toBe(false);
+  });
+});
+
+describe("directory-only patterns", () => {
+  test("trailing slash matches directories only", () => {
+    expect(ignored(["dist/"], "dist", true)).toBe(true);
+    expect(ignored(["dist/"], "dist", false)).toBe(false);
+  });
+
+  test("trailing slash with wildcard", () => {
+    expect(ignored(["*.tmp/"], "cache.tmp", true)).toBe(true);
+    expect(ignored(["*.tmp/"], "cache.tmp", false)).toBe(false);
+  });
+});
+
+describe("negation", () => {
+  test("negation re-includes a previously ignored path", () => {
+    expect(ignored(["*.log", "!important.log"], "important.log")).toBe(false);
+    expect(ignored(["*.log", "!important.log"], "error.log")).toBe(true);
+  });
+
+  test("later positive pattern overrides negation", () => {
+    expect(ignored(["*.log", "!important.log", "important.log"], "important.log")).toBe(true);
+  });
+
+  test("negation does not affect unrelated paths", () => {
+    // dist/ is a dirOnly pattern — it matches the directory, not files inside it.
+    // Files inside an ignored directory are excluded by traversal, not by pattern matching.
+    // A negation can re-include a specific file ignored by a non-dirOnly pattern.
+    expect(ignored(["dist/**", "!dist/keep.ts"], "dist/other.ts", false)).toBe(true);
+    expect(ignored(["dist/**", "!dist/keep.ts"], "dist/keep.ts", false)).toBe(false);
+  });
+});
+
+describe("character classes", () => {
+  test("matches characters in class", () => {
+    expect(ignored(["file[123].ts"], "file1.ts")).toBe(true);
+    expect(ignored(["file[123].ts"], "file2.ts")).toBe(true);
+    expect(ignored(["file[123].ts"], "file4.ts")).toBe(false);
+  });
+
+  test("range in class", () => {
+    expect(ignored(["file[a-z].ts"], "filea.ts")).toBe(true);
+    expect(ignored(["file[a-z].ts"], "fileA.ts")).toBe(false);
+  });
+});
+
+describe("nested gitignore contexts", () => {
+  test("child context applies only within its directory", () => {
+    const root = makeCtx("/repo", ["*.log"]);
+    const child = makeCtx("/repo/src", ["*.generated.ts"]);
+    const contexts = [root, child];
+
+    expect(isIgnoredByPatterns(contexts, "/repo/error.log", false)).toBe(true);
+    expect(isIgnoredByPatterns(contexts, "/repo/src/foo.generated.ts", false)).toBe(true);
+    expect(isIgnoredByPatterns(contexts, "/repo/lib/foo.generated.ts", false)).toBe(false);
+  });
+
+  test("child negation does not affect root patterns", () => {
+    const root = makeCtx("/repo", ["*.log"]);
+    const child = makeCtx("/repo/src", ["!error.log"]);
+    const contexts = [root, child];
+
+    // Root-level log is ignored by root pattern; child negation only applies within /repo/src
+    expect(isIgnoredByPatterns(contexts, "/repo/error.log", false)).toBe(true);
+    expect(isIgnoredByPatterns(contexts, "/repo/src/error.log", false)).toBe(false);
+  });
+});

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -42,7 +42,7 @@ function globToRegex(glob: string, anchored: boolean): string {
         re += "[^/]";
         break; // exactly one non-separator character
       default:
-        re += token.startsWith("[") && token.endsWith("]") ? token : escapeRegex(token);
+        re += token.startsWith("[") && token.endsWith("]") ? token.replace(/^\[!/, "[^") : escapeRegex(token);
     }
   }
 

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -20,52 +20,25 @@ function escapeRegex(char: string): string {
 // to a regex string. `anchored` is true when the pattern must match from the
 // root of the gitignore directory (i.e. it originally contained a slash).
 function globToRegex(glob: string, anchored: boolean): string {
-  // Anchored patterns match from the root; unanchored match at any path segment.
   let re = anchored ? "^" : "(^|/)";
-  let i = 0;
 
-  while (i < glob.length) {
-    const ch = glob[i];
+  // Leading **/ is only special at position 0 — handle it before tokenising.
+  if (glob.startsWith("**/")) {
+    re += "(.+/)?";
+    glob = glob.slice(3);
+  }
 
-    // Detect /**/ and /** at the slash so the slash is consumed as part of the
-    // double-star token rather than emitted as a literal separator.
-    if (ch === "/" && glob[i + 1] === "*" && glob[i + 2] === "*") {
-      if (glob[i + 3] === "/") {
-        re += "/(.+/)?"; // /**/ — zero or more intermediate directories
-        i += 4;
-      } else {
-        re += "/.*"; // /** — slash followed by anything
-        i += 3;
-      }
-      continue;
-    }
-
-    if (ch === "*" && glob[i + 1] === "*") {
-      if (i === 0 && glob[i + 2] === "/") {
-        re += "(.+/)?"; // leading **/ — any number of leading directories
-        i += 3;
-      } else {
-        re += ".*"; // bare ** — match everything including slashes
-        i += 2;
-      }
-    } else if (ch === "*") {
-      re += "[^/]*"; // single * — anything within one path segment
-      i += 1;
-    } else if (ch === "?") {
-      re += "[^/]"; // ? — exactly one non-separator character
-      i += 1;
-    } else if (ch === "[") {
-      const close = glob.indexOf("]", i + 1);
-      if (close === -1) {
-        re += escapeRegex(ch); // unclosed bracket — treat as literal
-        i += 1;
-      } else {
-        re += glob.slice(i, close + 1); // character class — pass through verbatim
-        i = close + 1;
-      }
-    } else {
-      re += escapeRegex(ch);
-      i += 1;
+  // Tokenise in priority order so longer patterns win over shorter ones.
+  for (const [token] of glob.matchAll(/\/\*\*\/|\/\*\*|\*\*|\*|\?|\[[^\]]*\]|\[|[^*?[/]+|\//g)) {
+    switch (token) {
+      case "/**/": re += "/(.+/)?"; break; // zero or more intermediate directories
+      case "/**":  re += "/.*";     break; // slash + anything
+      case "**":   re += ".*";      break; // anything including slashes
+      case "*":    re += "[^/]*";   break; // anything within one segment
+      case "?":    re += "[^/]";    break; // exactly one non-separator character
+      default:
+        // Complete character class [a-z] — pass through; bare [ or literal run — escape.
+        re += token.startsWith("[") && token.endsWith("]") ? token : escapeRegex(token);
     }
   }
 

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -16,19 +16,14 @@ function escapeRegex(char: string): string {
   return char.replace(/[.+^${}()|[\]\\]/g, "\\$&");
 }
 
-// Convert a normalised gitignore glob (no leading/trailing slash, no ! prefix)
-// to a regex string. `anchored` is true when the pattern must match from the
-// root of the gitignore directory (i.e. it originally contained a slash).
 function globToRegex(glob: string, anchored: boolean): string {
   let re = anchored ? "^" : "(^|/)";
 
-  // Leading **/ is only special at position 0 — handle it before tokenising.
   if (glob.startsWith("**/")) {
-    re += "(.+/)?";
+    re += "(.+/)?"; // leading **/ — any number of leading directories
     glob = glob.slice(3);
   }
 
-  // Tokenise in priority order so longer patterns win over shorter ones.
   for (const [token] of glob.matchAll(/\/\*\*\/|\/\*\*|\*\*|\*|\?|\[[^\]]*\]|\[|[^*?[/]+|\//g)) {
     switch (token) {
       case "/**/":
@@ -47,7 +42,6 @@ function globToRegex(glob: string, anchored: boolean): string {
         re += "[^/]";
         break; // exactly one non-separator character
       default:
-        // Complete character class [a-z] — pass through; bare [ or literal run — escape.
         re += token.startsWith("[") && token.endsWith("]") ? token : escapeRegex(token);
     }
   }
@@ -63,8 +57,6 @@ type ParsedPattern = {
   anchored: boolean;
 };
 
-// Parse a raw gitignore line into its component parts, or return null if the
-// line should be skipped (blank, comment, or empty after stripping modifiers).
 function parseGitignorePattern(raw: string): ParsedPattern | null {
   let p = raw.trim();
 
@@ -78,8 +70,6 @@ function parseGitignorePattern(raw: string): ParsedPattern | null {
   const dirOnly = p.endsWith("/");
   if (dirOnly) p = p.slice(0, -1);
 
-  // A pattern is anchored when it contains a slash anywhere other than the
-  // trailing slash already stripped above — or when it starts with a slash.
   const hasLeadingSlash = p.startsWith("/");
   if (hasLeadingSlash) p = p.slice(1);
   const anchored = hasLeadingSlash || p.includes("/");

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -112,11 +112,7 @@ export function compileGitignorePatterns(lines: string[]): CompiledPattern[] {
   return out;
 }
 
-export function isIgnoredByPatterns(
-  contexts: GitignoreContext[],
-  absPath: string,
-  isDir: boolean,
-): boolean {
+export function isIgnoredByPatterns(contexts: GitignoreContext[], absPath: string, isDir: boolean): boolean {
   let ignored = false;
 
   for (const ctx of contexts) {

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -16,88 +16,100 @@ function escapeRegex(char: string): string {
   return char.replace(/[.+^${}()|[\]\\]/g, "\\$&");
 }
 
-function compileGitignorePattern(raw: string): CompiledPattern | null {
-  let pattern = raw.trim();
-
-  // Empty lines and comments
-  if (!pattern || pattern.startsWith("#")) return null;
-
-  // Escaped hash is a literal hash
-  if (pattern.startsWith("\\#")) pattern = pattern.slice(1);
-
-  // Negation
-  const negated = pattern.startsWith("!");
-  if (negated) pattern = pattern.slice(1).trim();
-  if (!pattern) return null;
-
-  // Directory-only pattern
-  const dirOnly = pattern.endsWith("/");
-  if (dirOnly) pattern = pattern.slice(0, -1);
-
-  // A pattern is anchored if it contains a slash anywhere (other than the
-  // trailing slash already removed) — or has a leading slash.
-  const hasLeadingSlash = pattern.startsWith("/");
-  if (hasLeadingSlash) pattern = pattern.slice(1);
-  const anchored = hasLeadingSlash || pattern.includes("/");
-
-  // Convert gitignore glob syntax to a regex string.
-  let regexStr = anchored ? "^" : "(^|/)";
+// Convert a normalised gitignore glob (no leading/trailing slash, no ! prefix)
+// to a regex string. `anchored` is true when the pattern must match from the
+// root of the gitignore directory (i.e. it originally contained a slash).
+function globToRegex(glob: string, anchored: boolean): string {
+  // Anchored patterns match from the root; unanchored match at any path segment.
+  let re = anchored ? "^" : "(^|/)";
   let i = 0;
 
-  while (i < pattern.length) {
-    const ch = pattern[i];
+  while (i < glob.length) {
+    const ch = glob[i];
 
-    // /**/ and /** must be detected at the slash, so the slash is consumed as
-    // part of the double-star sequence rather than emitted separately.
-    if (ch === "/" && pattern[i + 1] === "*" && pattern[i + 2] === "*") {
-      if (pattern[i + 3] === "/") {
-        // /**/ — match a single slash or slash + one-or-more path segments + slash
-        regexStr += "/(.+/)?";
+    // Detect /**/ and /** at the slash so the slash is consumed as part of the
+    // double-star token rather than emitted as a literal separator.
+    if (ch === "/" && glob[i + 1] === "*" && glob[i + 2] === "*") {
+      if (glob[i + 3] === "/") {
+        re += "/(.+/)?"; // /**/ — zero or more intermediate directories
         i += 4;
       } else {
-        // /** at end — match slash and everything inside
-        regexStr += "/.*";
+        re += "/.*"; // /** — slash followed by anything
         i += 3;
       }
       continue;
     }
 
-    if (ch === "*" && pattern[i + 1] === "*") {
-      if (i === 0 && pattern[i + 2] === "/") {
-        // Leading **/ — match any number of leading directories
-        regexStr += "(.+/)?";
+    if (ch === "*" && glob[i + 1] === "*") {
+      if (i === 0 && glob[i + 2] === "/") {
+        re += "(.+/)?"; // leading **/ — any number of leading directories
         i += 3;
       } else {
-        // Bare ** (no surrounding slashes) — match everything
-        regexStr += ".*";
+        re += ".*"; // bare ** — match everything including slashes
         i += 2;
       }
     } else if (ch === "*") {
-      regexStr += "[^/]*";
+      re += "[^/]*"; // single * — anything within one path segment
       i += 1;
     } else if (ch === "?") {
-      regexStr += "[^/]";
+      re += "[^/]"; // ? — exactly one non-separator character
       i += 1;
     } else if (ch === "[") {
-      const close = pattern.indexOf("]", i + 1);
+      const close = glob.indexOf("]", i + 1);
       if (close === -1) {
-        regexStr += escapeRegex(ch);
+        re += escapeRegex(ch); // unclosed bracket — treat as literal
         i += 1;
       } else {
-        // Pass character classes through verbatim
-        regexStr += pattern.slice(i, close + 1);
+        re += glob.slice(i, close + 1); // character class — pass through verbatim
         i = close + 1;
       }
     } else {
-      regexStr += escapeRegex(ch);
+      re += escapeRegex(ch);
       i += 1;
     }
   }
 
-  regexStr += "(/|$)";
+  re += "(/|$)";
+  return re;
+}
 
+type ParsedPattern = {
+  glob: string;
+  negated: boolean;
+  dirOnly: boolean;
+  anchored: boolean;
+};
+
+// Parse a raw gitignore line into its component parts, or return null if the
+// line should be skipped (blank, comment, or empty after stripping modifiers).
+function parseGitignorePattern(raw: string): ParsedPattern | null {
+  let p = raw.trim();
+
+  if (!p || p.startsWith("#")) return null;
+  if (p.startsWith("\\#")) p = p.slice(1); // escaped hash → literal #
+
+  const negated = p.startsWith("!");
+  if (negated) p = p.slice(1).trim();
+  if (!p) return null;
+
+  const dirOnly = p.endsWith("/");
+  if (dirOnly) p = p.slice(0, -1);
+
+  // A pattern is anchored when it contains a slash anywhere other than the
+  // trailing slash already stripped above — or when it starts with a slash.
+  const hasLeadingSlash = p.startsWith("/");
+  if (hasLeadingSlash) p = p.slice(1);
+  const anchored = hasLeadingSlash || p.includes("/");
+
+  return { glob: p, negated, dirOnly, anchored };
+}
+
+function compileGitignorePattern(raw: string): CompiledPattern | null {
+  const parsed = parseGitignorePattern(raw);
+  if (!parsed) return null;
   try {
-    return { regex: new RegExp(regexStr), negated, dirOnly };
+    const regex = new RegExp(globToRegex(parsed.glob, parsed.anchored));
+    return { regex, negated: parsed.negated, dirOnly: parsed.dirOnly };
   } catch {
     return null;
   }

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -31,11 +31,21 @@ function globToRegex(glob: string, anchored: boolean): string {
   // Tokenise in priority order so longer patterns win over shorter ones.
   for (const [token] of glob.matchAll(/\/\*\*\/|\/\*\*|\*\*|\*|\?|\[[^\]]*\]|\[|[^*?[/]+|\//g)) {
     switch (token) {
-      case "/**/": re += "/(.+/)?"; break; // zero or more intermediate directories
-      case "/**":  re += "/.*";     break; // slash + anything
-      case "**":   re += ".*";      break; // anything including slashes
-      case "*":    re += "[^/]*";   break; // anything within one segment
-      case "?":    re += "[^/]";    break; // exactly one non-separator character
+      case "/**/":
+        re += "/(.+/)?";
+        break; // zero or more intermediate directories
+      case "/**":
+        re += "/.*";
+        break; // slash + anything
+      case "**":
+        re += ".*";
+        break; // anything including slashes
+      case "*":
+        re += "[^/]*";
+        break; // anything within one segment
+      case "?":
+        re += "[^/]";
+        break; // exactly one non-separator character
       default:
         // Complete character class [a-z] — pass through; bare [ or literal run — escape.
         re += token.startsWith("[") && token.endsWith("]") ? token : escapeRegex(token);

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -12,8 +12,8 @@ export type GitignoreContext = {
   dir: string;
 };
 
-function escapeRegex(char: string): string {
-  return char.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+function escapeRegex(s: string): string {
+  return s.replace(/[.+^${}()|[\]\\]/g, "\\$&");
 }
 
 function globToRegex(glob: string, anchored: boolean): string {
@@ -97,6 +97,7 @@ export function compileGitignorePatterns(lines: string[]): CompiledPattern[] {
   return out;
 }
 
+// contexts must be ordered outermost-first (root before nested subdirectories).
 export function isIgnoredByPatterns(contexts: GitignoreContext[], absPath: string, isDir: boolean): boolean {
   let ignored = false;
 

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -1,0 +1,150 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+type CompiledPattern = {
+  regex: RegExp;
+  negated: boolean;
+  dirOnly: boolean;
+};
+
+export type GitignoreContext = {
+  patterns: CompiledPattern[];
+  dir: string;
+};
+
+function escapeRegex(char: string): string {
+  return char.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+}
+
+function compileGitignorePattern(raw: string): CompiledPattern | null {
+  let pattern = raw.trim();
+
+  // Empty lines and comments
+  if (!pattern || pattern.startsWith("#")) return null;
+
+  // Escaped hash is a literal hash
+  if (pattern.startsWith("\\#")) pattern = pattern.slice(1);
+
+  // Negation
+  const negated = pattern.startsWith("!");
+  if (negated) pattern = pattern.slice(1).trim();
+  if (!pattern) return null;
+
+  // Directory-only pattern
+  const dirOnly = pattern.endsWith("/");
+  if (dirOnly) pattern = pattern.slice(0, -1);
+
+  // A pattern is anchored if it contains a slash anywhere (other than the
+  // trailing slash already removed) — or has a leading slash.
+  const hasLeadingSlash = pattern.startsWith("/");
+  if (hasLeadingSlash) pattern = pattern.slice(1);
+  const anchored = hasLeadingSlash || pattern.includes("/");
+
+  // Convert gitignore glob syntax to a regex string.
+  let regexStr = anchored ? "^" : "(^|/)";
+  let i = 0;
+
+  while (i < pattern.length) {
+    const ch = pattern[i];
+
+    // /**/ and /** must be detected at the slash, so the slash is consumed as
+    // part of the double-star sequence rather than emitted separately.
+    if (ch === "/" && pattern[i + 1] === "*" && pattern[i + 2] === "*") {
+      if (pattern[i + 3] === "/") {
+        // /**/ — match a single slash or slash + one-or-more path segments + slash
+        regexStr += "/(.+/)?";
+        i += 4;
+      } else {
+        // /** at end — match slash and everything inside
+        regexStr += "/.*";
+        i += 3;
+      }
+      continue;
+    }
+
+    if (ch === "*" && pattern[i + 1] === "*") {
+      if (i === 0 && pattern[i + 2] === "/") {
+        // Leading **/ — match any number of leading directories
+        regexStr += "(.+/)?";
+        i += 3;
+      } else {
+        // Bare ** (no surrounding slashes) — match everything
+        regexStr += ".*";
+        i += 2;
+      }
+    } else if (ch === "*") {
+      regexStr += "[^/]*";
+      i += 1;
+    } else if (ch === "?") {
+      regexStr += "[^/]";
+      i += 1;
+    } else if (ch === "[") {
+      const close = pattern.indexOf("]", i + 1);
+      if (close === -1) {
+        regexStr += escapeRegex(ch);
+        i += 1;
+      } else {
+        // Pass character classes through verbatim
+        regexStr += pattern.slice(i, close + 1);
+        i = close + 1;
+      }
+    } else {
+      regexStr += escapeRegex(ch);
+      i += 1;
+    }
+  }
+
+  regexStr += "(/|$)";
+
+  return { regex: new RegExp(regexStr), negated, dirOnly };
+}
+
+export function compileGitignorePatterns(lines: string[]): CompiledPattern[] {
+  const out: CompiledPattern[] = [];
+  for (const line of lines) {
+    const compiled = compileGitignorePattern(line);
+    if (compiled) out.push(compiled);
+  }
+  return out;
+}
+
+export function isIgnoredByPatterns(
+  contexts: GitignoreContext[],
+  absPath: string,
+  isDir: boolean,
+): boolean {
+  let ignored = false;
+
+  for (const ctx of contexts) {
+    // Compute path relative to the gitignore's directory
+    const prefix = ctx.dir.endsWith("/") ? ctx.dir : `${ctx.dir}/`;
+    if (!absPath.startsWith(prefix)) continue;
+    const rel = absPath.slice(prefix.length);
+
+    for (const pattern of ctx.patterns) {
+      if (pattern.dirOnly && !isDir) continue;
+      if (pattern.regex.test(rel)) {
+        ignored = !pattern.negated;
+      }
+    }
+  }
+
+  return ignored;
+}
+
+export async function loadGitignoreContext(dir: string): Promise<GitignoreContext | null> {
+  const lines: string[] = [];
+
+  for (const filename of [".gitignore", ".acolyteignore"]) {
+    try {
+      const content = await readFile(join(dir, filename), "utf8");
+      lines.push(...content.split("\n"));
+    } catch {
+      // File does not exist — skip
+    }
+  }
+
+  const patterns = compileGitignorePatterns(lines);
+  if (patterns.length === 0) return null;
+  return { patterns, dir };
+}

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -96,7 +96,11 @@ function compileGitignorePattern(raw: string): CompiledPattern | null {
 
   regexStr += "(/|$)";
 
-  return { regex: new RegExp(regexStr), negated, dirOnly };
+  try {
+    return { regex: new RegExp(regexStr), negated, dirOnly };
+  } catch {
+    return null;
+  }
 }
 
 export function compileGitignorePatterns(lines: string[]): CompiledPattern[] {

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -135,13 +135,11 @@ export function isIgnoredByPatterns(
 export async function loadGitignoreContext(dir: string): Promise<GitignoreContext | null> {
   const lines: string[] = [];
 
-  for (const filename of [".gitignore", ".acolyteignore"]) {
-    try {
-      const content = await readFile(join(dir, filename), "utf8");
-      lines.push(...content.split("\n"));
-    } catch {
-      // File does not exist — skip
-    }
+  try {
+    const content = await readFile(join(dir, ".gitignore"), "utf8");
+    lines.push(...content.split("\n"));
+  } catch {
+    // File does not exist — skip
   }
 
   const patterns = compileGitignorePatterns(lines);

--- a/src/tool-utils.test.ts
+++ b/src/tool-utils.test.ts
@@ -34,18 +34,6 @@ describe("collectWorkspaceFiles — gitignore integration", () => {
     expect(files).toContain(".gitignore");
   });
 
-  test("respects .acolyteignore patterns", async () => {
-    const root = await createWorkspace({
-      ".acolyteignore": "scratch/\n",
-      "src/index.ts": "",
-      "scratch/notes.md": "",
-    });
-
-    const files = await collectWorkspaceFiles(root);
-    expect(files).toContain("src/index.ts");
-    expect(files).not.toContain("scratch/notes.md");
-  });
-
   test("respects nested .gitignore files", async () => {
     const root = await createWorkspace({
       "src/.gitignore": "*.generated.ts\n",

--- a/src/tool-utils.test.ts
+++ b/src/tool-utils.test.ts
@@ -1,0 +1,75 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tempDir } from "./test-utils";
+import { collectWorkspaceFiles } from "./tool-utils";
+
+const dirs = tempDir();
+
+afterAll(() => dirs.cleanupDirs());
+
+async function createWorkspace(files: Record<string, string>): Promise<string> {
+  const root = dirs.createDir("acolyte-tool-utils-");
+  for (const [relPath, content] of Object.entries(files)) {
+    const abs = join(root, relPath);
+    await mkdir(abs.slice(0, abs.lastIndexOf("/")), { recursive: true });
+    await writeFile(abs, content);
+  }
+  return root;
+}
+
+describe("collectWorkspaceFiles — gitignore integration", () => {
+  test("respects .gitignore patterns", async () => {
+    const root = await createWorkspace({
+      ".gitignore": "dist/\n*.log\n",
+      "src/index.ts": "",
+      "dist/bundle.js": "",
+      "error.log": "",
+    });
+
+    const files = await collectWorkspaceFiles(root);
+    expect(files).toContain("src/index.ts");
+    expect(files).not.toContain("dist/bundle.js");
+    expect(files).not.toContain("error.log");
+    expect(files).toContain(".gitignore");
+  });
+
+  test("respects .acolyteignore patterns", async () => {
+    const root = await createWorkspace({
+      ".acolyteignore": "scratch/\n",
+      "src/index.ts": "",
+      "scratch/notes.md": "",
+    });
+
+    const files = await collectWorkspaceFiles(root);
+    expect(files).toContain("src/index.ts");
+    expect(files).not.toContain("scratch/notes.md");
+  });
+
+  test("respects nested .gitignore files", async () => {
+    const root = await createWorkspace({
+      "src/.gitignore": "*.generated.ts\n",
+      "src/foo.ts": "",
+      "src/foo.generated.ts": "",
+      "lib/foo.generated.ts": "",
+    });
+
+    const files = await collectWorkspaceFiles(root);
+    expect(files).toContain("src/foo.ts");
+    expect(files).not.toContain("src/foo.generated.ts");
+    expect(files).toContain("lib/foo.generated.ts");
+  });
+
+  test("always excludes .git and node_modules regardless of .gitignore", async () => {
+    const root = await createWorkspace({
+      "src/index.ts": "",
+      "node_modules/pkg/index.js": "",
+      ".git/config": "",
+    });
+
+    const files = await collectWorkspaceFiles(root);
+    expect(files).toContain("src/index.ts");
+    expect(files.some((f) => f.startsWith("node_modules/"))).toBe(false);
+    expect(files.some((f) => f.startsWith(".git/"))).toBe(false);
+  });
+});

--- a/src/tool-utils.test.ts
+++ b/src/tool-utils.test.ts
@@ -48,6 +48,17 @@ describe("collectWorkspaceFiles — gitignore integration", () => {
     expect(files).toContain("lib/foo.generated.ts");
   });
 
+  test("traverses hidden directories not in IGNORED_DIRS", async () => {
+    const root = await createWorkspace({
+      ".github/workflows/ci.yml": "",
+      "src/index.ts": "",
+    });
+
+    const files = await collectWorkspaceFiles(root);
+    expect(files).toContain(".github/workflows/ci.yml");
+    expect(files).toContain("src/index.ts");
+  });
+
   test("always excludes .git and node_modules regardless of .gitignore", async () => {
     const root = await createWorkspace({
       "src/index.ts": "",

--- a/src/tool-utils.ts
+++ b/src/tool-utils.ts
@@ -113,7 +113,9 @@ export function detectLineWidth(workspace: string): number | null {
   return null;
 }
 
-export const IGNORED_DIRS = new Set(["node_modules", ".git", ".acolyte", "dist", "build", ".next", "coverage"]);
+// Directories always excluded regardless of .gitignore — these are either internal
+// runtime directories or universally irrelevant to any project's source.
+export const IGNORED_DIRS = new Set(["node_modules", ".git", ".acolyte"]);
 
 const BINARY_EXTENSIONS = new Set([
   ".png",

--- a/src/tool-utils.ts
+++ b/src/tool-utils.ts
@@ -195,7 +195,6 @@ export async function collectWorkspaceFiles(workspace: string, maxEntries = 5000
     entries.sort((a, b) => a.name.localeCompare(b.name));
 
     for (const entry of entries) {
-      if (entry.name.startsWith(".") && entry.isDirectory()) continue;
       if (entry.isDirectory() && IGNORED_DIRS.has(entry.name)) continue;
       const rel = current.rel ? `${current.rel}/${entry.name}` : entry.name;
       const abs = join(current.abs, entry.name);

--- a/src/tool-utils.ts
+++ b/src/tool-utils.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { readdir, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, relative, resolve } from "node:path";
+import { type GitignoreContext, isIgnoredByPatterns, loadGitignoreContext } from "./gitignore";
 
 const TEMP_ROOTS = Array.from(new Set([resolve(tmpdir()), resolve("/tmp"), resolve("/private/tmp")]));
 const GIT_ENV_KEYS = [
@@ -174,7 +175,11 @@ export function isBinaryExtension(path: string): boolean {
 
 export async function collectWorkspaceFiles(workspace: string, maxEntries = 5000): Promise<string[]> {
   const out: string[] = [];
-  const stack: Array<{ abs: string; rel: string }> = [{ abs: workspace, rel: "" }];
+  const rootContext = await loadGitignoreContext(workspace);
+  const rootContexts: GitignoreContext[] = rootContext ? [rootContext] : [];
+  const stack: Array<{ abs: string; rel: string; contexts: GitignoreContext[] }> = [
+    { abs: workspace, rel: "", contexts: rootContexts },
+  ];
 
   while (stack.length > 0 && out.length < maxEntries) {
     const current = stack.pop();
@@ -192,8 +197,12 @@ export async function collectWorkspaceFiles(workspace: string, maxEntries = 5000
       if (entry.isDirectory() && IGNORED_DIRS.has(entry.name)) continue;
       const rel = current.rel ? `${current.rel}/${entry.name}` : entry.name;
       const abs = join(current.abs, entry.name);
-      if (entry.isDirectory()) {
-        stack.push({ abs, rel });
+      const isDir = entry.isDirectory();
+      if (isIgnoredByPatterns(current.contexts, abs, isDir)) continue;
+      if (isDir) {
+        const childContext = await loadGitignoreContext(abs);
+        const childContexts = childContext ? [...current.contexts, childContext] : current.contexts;
+        stack.push({ abs, rel, contexts: childContexts });
       } else if (entry.isFile()) {
         out.push(rel);
       }


### PR DESCRIPTION
Fixes #13

## Summary

- File discovery (`find-files`, `search-files`) now respects `.gitignore` and nested `.gitignore` files
- Removed blanket hidden-directory skip — hidden dirs are now visible unless excluded by `.gitignore` or `IGNORED_DIRS`
- Trimmed `IGNORED_DIRS` to universal entries only: `node_modules`, `.git`, `.acolyte`
- Hardened `compileGitignorePattern` to catch invalid regex from malformed character classes