### PR TITLE
feat(scan-code): enclosingSymbol and withinSymbol

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: pr
+description: Create a pull request for the current branch. Infers title and description from the diff, follows project PR conventions.
+---
+
+# PR
+
+Create a pull request for the current branch against `main`.
+
+## Conventions
+
+- Title: short, imperative, Conventional Commit format (`feat(scope): ...`), 60 char max, no trailing period
+- Body: follow `.github/pull_request_template.md` exactly — fill in each section, do not add or remove sections
+- Bullets: plain English, describe *what* changed and *why*, not implementation details — no code blocks
+
+## Workflow
+
+1. Run the review skill (`.agents/skills/review/SKILL.md`) first. If there are must-fix findings, stop and report them before creating the PR.
+2. Read `.github/pull_request_template.md` to get the required body structure
+3. Run `git log main..HEAD --oneline` to see commits on the branch
+4. Run `git diff main...HEAD --stat` to see changed files
+5. Run `git diff main...HEAD` to read the full diff
+6. Run `gh issue list` to check for an associated issue. If one matches the branch work, add `Fixes #<number>` as the first line of the body, before the template sections.
+7. Infer a title and fill in the template body from the above
+8. Check if the branch is already pushed: `git status -sb`
+9. If not pushed, push with `git push -u origin HEAD`
+10. Create the PR with `gh pr create`
+11. Return the PR URL
+
+## Output
+
+Return only the PR URL.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -55,7 +55,7 @@ A scan tool and an edit tool may both use ast-grep internally, but their input m
 Practical implications:
 
 - Query tools get their own simpler vocabulary even if a richer one exists internally
-- Mutation tools can borrow query-like concepts (e.g. `withinSymbol`) but only as **scoping constraints**, not as a general query language
+- Mutation tools may expose scoping constraints (e.g. `withinSymbol`, `within`) that narrow where the edit applies — these are targeting aids, not a query language
 - New capabilities in the underlying engine (e.g. new ast-grep rule types) should be evaluated **separately for query and mutation exposure**
 
 Internal implementations may share compilers, rule objects, or AST helpers, but these should remain implementation details.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -41,6 +41,25 @@ Read-only and search tools (`read-file`, `find-files`, `search-files`, `scan-cod
 
 This reduces redundant I/O and avoids re-sending identical tool results to the model.
 
+## Query vs mutation tools
+
+Tools are divided into two categories with fundamentally different design constraints.
+
+**Query tools** (`read-file`, `find-files`, `search-files`, `scan-code`) are read-only and exploratory. Their contracts should be simple and discoverable — the caller is asking *“show me what’s there.”* Input schemas should reflect the user's mental model of searching, not the engine's internal capabilities.
+
+**Mutation tools** (`edit-file`, `create-file`, `delete-file`, `edit-code`) change workspace state. Their contracts can be more expressive because precise targeting matters — the cost of a wrong match is a bad edit.
+
+The key principle: **do not unify query and mutation contracts just because they share an implementation.**  
+A scan tool and an edit tool may both use ast-grep internally, but their input models serve different purposes and should be designed independently. Leaking mutation rule language into query tools couples them unnecessarily and complicates the caller’s mental model.
+
+Practical implications:
+
+- Query tools get their own simpler vocabulary even if a richer one exists internally
+- Mutation tools can borrow query-like concepts (e.g. `withinSymbol`) but only as **scoping constraints**, not as a general query language
+- New capabilities in the underlying engine (e.g. new ast-grep rule types) should be evaluated **separately for query and mutation exposure**
+
+Internal implementations may share compilers, rule objects, or AST helpers, but these should remain implementation details.
+
 ## Extension seams
 
 - Add tools by extending toolkit modules.

--- a/src/code-ops.test.ts
+++ b/src/code-ops.test.ts
@@ -757,6 +757,26 @@ describe("editCode", () => {
     expect(content).toContain("print(");
     expect(content).not.toContain("println(");
   });
+
+  test("includes affectedSymbols in result", async () => {
+    const filePath = `/tmp/acolyte-test-ast-affected-${testUuid()}.ts`;
+    tempFiles.push(filePath);
+    await writeFile(
+      filePath,
+      ['function processItems() { console.log("processing"); }', 'function other() { console.log("other"); }', ""].join(
+        "\n",
+      ),
+      "utf8",
+    );
+    const result = await editCode({
+      workspace: WORKSPACE,
+      path: filePath,
+      edits: [
+        { op: "replace", rule: "console.log($ARG)", replacement: "logger.info($ARG)", withinSymbol: "processItems" },
+      ],
+    });
+    expect(result.affectedSymbols).toEqual(["processItems"]);
+  });
 });
 
 describe("scanCode", () => {

--- a/src/code-ops.test.ts
+++ b/src/code-ops.test.ts
@@ -836,4 +836,62 @@ describe("scanCode", () => {
     expect(result.patterns[0]?.matches[0]?.captures.$NAME).toBe("hello");
     expect(result.patterns[1]?.matches[0]?.captures.$ARG).toBe('"test"');
   });
+
+  test("includes enclosingSymbol for match inside a function", async () => {
+    const filePath = `/tmp/acolyte-test-scan-enclosing-fn-${testUuid()}.ts`;
+    tempFiles.push(filePath);
+    await writeFile(
+      filePath,
+      ["function processItems() {", "  console.log('processing');", "}", ""].join("\n"),
+      "utf8",
+    );
+    const result = await scanCode({ workspace: WORKSPACE, paths: [filePath], pattern: "console.log($ARG)" });
+    expect(result.patterns[0]?.matches[0]?.enclosingSymbol).toBe("processItems");
+  });
+
+  test("includes enclosingSymbol for match inside a class", async () => {
+    const filePath = `/tmp/acolyte-test-scan-enclosing-class-${testUuid()}.ts`;
+    tempFiles.push(filePath);
+    await writeFile(
+      filePath,
+      ["class MyService {", "  run() {", "    console.log('run');", "  }", "}", ""].join("\n"),
+      "utf8",
+    );
+    const result = await scanCode({ workspace: WORKSPACE, paths: [filePath], pattern: "console.log($ARG)" });
+    const match = result.patterns[0]?.matches[0];
+    expect(match?.enclosingSymbol).toBe("run");
+  });
+
+  test("enclosingSymbol is undefined at top-level", async () => {
+    const filePath = `/tmp/acolyte-test-scan-enclosing-top-${testUuid()}.ts`;
+    tempFiles.push(filePath);
+    await writeFile(filePath, "console.log('top-level');\n", "utf8");
+    const result = await scanCode({ workspace: WORKSPACE, paths: [filePath], pattern: "console.log($ARG)" });
+    expect(result.patterns[0]?.matches[0]?.enclosingSymbol).toBeUndefined();
+  });
+
+  test("includes enclosingSymbol for match inside a TypeScript type alias", async () => {
+    const filePath = `/tmp/acolyte-test-scan-enclosing-type-${testUuid()}.ts`;
+    tempFiles.push(filePath);
+    await writeFile(filePath, 'type Status = "active" | "inactive";\n', "utf8");
+    const result = await scanCode({ workspace: WORKSPACE, paths: [filePath], pattern: '"active"' });
+    expect(result.patterns[0]?.matches[0]?.enclosingSymbol).toBe("Status");
+  });
+
+  test("withinSymbol scopes scan to TypeScript enum", async () => {
+    const filePath = `/tmp/acolyte-test-scan-within-enum-${testUuid()}.ts`;
+    tempFiles.push(filePath);
+    await writeFile(
+      filePath,
+      ["enum Color {", "  Red = 1,", "  Green = 2,", "}", "enum Size {", "  Small = 1,", "}", ""].join("\n"),
+      "utf8",
+    );
+    const result = await scanCode({
+      workspace: WORKSPACE,
+      paths: [filePath],
+      pattern: "1",
+      withinSymbol: "Color",
+    });
+    expect(result.matches).toBe(1);
+  });
 });

--- a/src/code-ops.test.ts
+++ b/src/code-ops.test.ts
@@ -897,21 +897,4 @@ describe("scanCode", () => {
     const result = await scanCode({ workspace: WORKSPACE, paths: [filePath], pattern: '"active"' });
     expect(result.patterns[0]?.matches[0]?.enclosingSymbol).toBe("Status");
   });
-
-  test("withinSymbol scopes scan to TypeScript enum", async () => {
-    const filePath = `/tmp/acolyte-test-scan-within-enum-${testUuid()}.ts`;
-    tempFiles.push(filePath);
-    await writeFile(
-      filePath,
-      ["enum Color {", "  Red = 1,", "  Green = 2,", "}", "enum Size {", "  Small = 1,", "}", ""].join("\n"),
-      "utf8",
-    );
-    const result = await scanCode({
-      workspace: WORKSPACE,
-      paths: [filePath],
-      pattern: "1",
-      withinSymbol: "Color",
-    });
-    expect(result.matches).toBe(1);
-  });
 });

--- a/src/code-ops.ts
+++ b/src/code-ops.ts
@@ -393,6 +393,7 @@ export type EditCodeResult = {
   matches: number;
   diff: string;
   output: string;
+  affectedSymbols: string[];
 };
 
 export type ScanCodeMatch = {
@@ -438,6 +439,7 @@ export async function editCode(input: {
   const langEnum = napi.Lang[langName as keyof typeof napi.Lang];
   let current = original;
   let totalMatches = 0;
+  const affectedSymbols = new Set<string>();
 
   for (const edit of input.edits) {
     const tree = napi.parse(langEnum ?? langName, current);
@@ -489,6 +491,10 @@ export async function editCode(input: {
       );
     }
     totalMatches += matches.length;
+    for (const match of matches) {
+      const sym = findEnclosingSymbol(match);
+      if (sym) affectedSymbols.add(sym);
+    }
 
     const patternMetavars = isRenameEdit(edit)
       ? []
@@ -530,13 +536,19 @@ export async function editCode(input: {
 
   const relativePath = displayPathForDiff(absPath, input.workspace);
   const diff = createDiff(relativePath, original, current);
-  const output = [`path=${absPath}`, `edits=${input.edits.length}`, `matches=${totalMatches}`, "", diff].join("\n");
+  const affectedSymbolsList = Array.from(affectedSymbols);
+  const symbolsLine = affectedSymbolsList.length > 0 ? `symbols=${affectedSymbolsList.join(", ")}` : "";
+  const outputParts = [`path=${absPath}`, `edits=${input.edits.length}`, `matches=${totalMatches}`];
+  if (symbolsLine) outputParts.push(symbolsLine);
+  outputParts.push("", diff);
+  const output = outputParts.join("\n");
   return {
     path: absPath,
     edits: input.edits.length,
     matches: totalMatches,
     diff,
     output,
+    affectedSymbols: affectedSymbolsList,
   };
 }
 

--- a/src/code-ops.ts
+++ b/src/code-ops.ts
@@ -558,7 +558,6 @@ export async function scanCode(input: {
   pattern: string | string[];
   language?: string;
   maxResults?: number;
-  withinSymbol?: string;
 }): Promise<ScanCodeResult> {
   const maxResults = input.maxResults ?? 50;
   const patterns = Array.isArray(input.pattern) ? input.pattern : [input.pattern];
@@ -583,7 +582,6 @@ export async function scanCode(input: {
       const found = tree.root().findAll({ rule: { pattern: result.pattern } });
       for (const match of found) {
         if (totalMatches() >= maxResults) return;
-        if (input.withinSymbol && !matchIsWithinSymbol(match, input.withinSymbol)) continue;
         const range = match.range();
         const text = match.text().split("\n")[0] ?? "";
         const captures: Record<string, string> = {};

--- a/src/code-ops.ts
+++ b/src/code-ops.ts
@@ -397,7 +397,7 @@ export type EditCodeResult = {
 };
 
 export type ScanCodeMatch = {
-  relPath: string;
+  path: string;
   line: number;
   text: string;
   captures: Record<string, string>;
@@ -569,7 +569,7 @@ export async function scanCode(input: {
 
   const totalMatches = () => results.reduce((sum, result) => sum + result.matches.length, 0);
 
-  const scanFile = (relPath: string, content: string, lang: string): void => {
+  const scanFile = (path: string, content: string, lang: string): void => {
     const langEnum = napi.Lang[lang as keyof typeof napi.Lang];
     let tree: ReturnType<typeof napi.parse>;
     try {
@@ -592,7 +592,7 @@ export async function scanCode(input: {
           if (captured) captures[metavar] = captured.text();
         }
         const enclosingSymbol = findEnclosingSymbol(match) ?? undefined;
-        result.matches.push({ relPath, line: range.start.line + 1, text, captures, enclosingSymbol });
+        result.matches.push({ path, line: range.start.line + 1, text, captures, enclosingSymbol });
       }
     }
   };

--- a/src/code-ops.ts
+++ b/src/code-ops.ts
@@ -146,24 +146,39 @@ function resolveReplacementMetavariable(match: napi.SgNode, metavar: string, sou
   return captured.text();
 }
 
+function extractSymbolName(node: napi.SgNode): string | null {
+  const kind = node.kind();
+  if (
+    kind === "class_declaration" ||
+    kind === "function_declaration" ||
+    kind === "generator_function_declaration" ||
+    kind === "method_definition" ||
+    kind === "interface_declaration" ||
+    kind === "type_alias_declaration" ||
+    kind === "enum_declaration" ||
+    kind === "variable_declarator"
+  ) {
+    return node.field("name")?.text() ?? null;
+  }
+  if (kind === "function_expression") {
+    const name = node.field("name");
+    return name ? name.text() : null;
+  }
+  return null;
+}
+
 function nodeHasWithinSymbol(node: napi.SgNode, symbol: string): boolean {
-  if (node.kind() === "class_declaration") {
-    const name = node.field("name");
-    return name?.text() === symbol;
+  return extractSymbolName(node) === symbol;
+}
+
+function findEnclosingSymbol(node: napi.SgNode): string | null {
+  let current: napi.SgNode | null = node.parent();
+  while (current) {
+    const name = extractSymbolName(current);
+    if (name) return name;
+    current = current.parent();
   }
-  if (node.kind() === "function_declaration") {
-    const name = node.field("name");
-    return name?.text() === symbol;
-  }
-  if (node.kind() === "method_definition") {
-    const name = node.field("name");
-    return name?.text() === symbol;
-  }
-  if (node.kind() === "variable_declarator") {
-    const name = node.field("name");
-    return name?.text() === symbol;
-  }
-  return false;
+  return null;
 }
 
 function matchIsWithinSymbol(match: napi.SgNode, symbol: string): boolean {
@@ -385,6 +400,7 @@ export type ScanCodeMatch = {
   line: number;
   text: string;
   captures: Record<string, string>;
+  enclosingSymbol?: string;
 };
 
 export type ScanCodePatternResult = {
@@ -530,6 +546,7 @@ export async function scanCode(input: {
   pattern: string | string[];
   language?: string;
   maxResults?: number;
+  withinSymbol?: string;
 }): Promise<ScanCodeResult> {
   const maxResults = input.maxResults ?? 50;
   const patterns = Array.isArray(input.pattern) ? input.pattern : [input.pattern];
@@ -554,6 +571,7 @@ export async function scanCode(input: {
       const found = tree.root().findAll({ rule: { pattern: result.pattern } });
       for (const match of found) {
         if (totalMatches() >= maxResults) return;
+        if (input.withinSymbol && !matchIsWithinSymbol(match, input.withinSymbol)) continue;
         const range = match.range();
         const text = match.text().split("\n")[0] ?? "";
         const captures: Record<string, string> = {};
@@ -561,7 +579,8 @@ export async function scanCode(input: {
           const captured = match.getMatch(metavar.slice(1));
           if (captured) captures[metavar] = captured.text();
         }
-        result.matches.push({ relPath, line: range.start.line + 1, text, captures });
+        const enclosingSymbol = findEnclosingSymbol(match) ?? undefined;
+        result.matches.push({ relPath, line: range.start.line + 1, text, captures, enclosingSymbol });
       }
     }
   };

--- a/src/code-toolkit.ts
+++ b/src/code-toolkit.ts
@@ -36,7 +36,8 @@ function formatScanCodeResult(result: ScanCodeResult): string {
               .map(([key, value]) => `${key}=${value}`)
               .join(", ")}}`
           : "";
-      lines.push(`${match.relPath}:${match.line}: ${truncated}${captureStr}`);
+      const symbolStr = match.enclosingSymbol ? ` [${match.enclosingSymbol}]` : "";
+      lines.push(`${match.relPath}:${match.line}:${symbolStr} ${truncated}${captureStr}`);
     }
     if (multi && patternResult.matches.length === 0) lines.push("No matches.");
   }
@@ -59,12 +60,15 @@ function createScanCodeTool(input: ToolkitInput) {
       "Batch multiple files and patterns in one call.",
       "Use it to map structural targets before `edit-code`, not for plain text replacements or post-edit reassurance on a bounded named-file task.",
       "For keyword or regex searches prefer `search-files`.",
+      "Each match includes an `enclosingSymbol` in the output — use it directly as `withinSymbol` in a follow-up `edit-code` call.",
+      "Pass `withinSymbol` to narrow scan results to a specific named declaration.",
     ].join(" "),
     inputSchema: z.object({
       paths: z.array(z.string().min(1)).min(1),
       patterns: z.array(z.string().min(1)).min(1),
       language: z.string().optional(),
       maxResults: z.number().int().min(1).max(200).optional(),
+      withinSymbol: z.string().min(1).optional(),
     }),
     outputSchema: z.object({
       kind: z.literal("scan-code"),
@@ -103,6 +107,7 @@ function createScanCodeTool(input: ToolkitInput) {
           pattern: toolInput.patterns,
           language: toolInput.language,
           maxResults: toolInput.maxResults ?? 50,
+          withinSymbol: toolInput.withinSymbol,
         });
         const result = compactToolOutput(formatScanCodeResult(rawScan), budget);
         return { kind: "scan-code", paths, patterns: toolInput.patterns, output: result };

--- a/src/code-toolkit.ts
+++ b/src/code-toolkit.ts
@@ -37,7 +37,7 @@ function formatScanCodeResult(result: ScanCodeResult): string {
               .join(", ")}}`
           : "";
       const symbolStr = match.enclosingSymbol ? ` [${match.enclosingSymbol}]` : "";
-      lines.push(`${match.relPath}:${match.line}:${symbolStr} ${truncated}${captureStr}`);
+      lines.push(`${match.path}:${match.line}:${symbolStr} ${truncated}${captureStr}`);
     }
     if (multi && patternResult.matches.length === 0) lines.push("No matches.");
   }

--- a/src/code-toolkit.ts
+++ b/src/code-toolkit.ts
@@ -36,8 +36,10 @@ function formatScanCodeResult(result: ScanCodeResult): string {
               .map(([key, value]) => `${key}=${value}`)
               .join(", ")}}`
           : "";
-      const symbolStr = match.enclosingSymbol ? ` [${match.enclosingSymbol}]` : "";
-      lines.push(`${match.path}:${match.line}:${symbolStr} ${truncated}${captureStr}`);
+      const prefix = match.enclosingSymbol
+        ? `${match.path}:${match.line}:[${match.enclosingSymbol}] `
+        : `${match.path}:${match.line}: `;
+      lines.push(`${prefix}${truncated}${captureStr}`.trimEnd());
     }
     if (multi && patternResult.matches.length === 0) lines.push("No matches.");
   }
@@ -61,14 +63,12 @@ function createScanCodeTool(input: ToolkitInput) {
       "Use it to map structural targets before `edit-code`, not for plain text replacements or post-edit reassurance on a bounded named-file task.",
       "For keyword or regex searches prefer `search-files`.",
       "Each match includes an `enclosingSymbol` in the output — use it directly as `withinSymbol` in a follow-up `edit-code` call.",
-      "Pass `withinSymbol` to narrow scan results to a specific named declaration.",
     ].join(" "),
     inputSchema: z.object({
       paths: z.array(z.string().min(1)).min(1),
       patterns: z.array(z.string().min(1)).min(1),
       language: z.string().optional(),
       maxResults: z.number().int().min(1).max(200).optional(),
-      withinSymbol: z.string().min(1).optional(),
     }),
     outputSchema: z.object({
       kind: z.literal("scan-code"),
@@ -107,7 +107,6 @@ function createScanCodeTool(input: ToolkitInput) {
           pattern: toolInput.patterns,
           language: toolInput.language,
           maxResults: toolInput.maxResults ?? 50,
-          withinSymbol: toolInput.withinSymbol,
         });
         const result = compactToolOutput(formatScanCodeResult(rawScan), budget);
         return { kind: "scan-code", paths, patterns: toolInput.patterns, output: result };
@@ -131,6 +130,7 @@ function createEditCodeTool(input: ToolkitInput) {
     removed: z.number().int().nonnegative(),
     matches: z.number().int().nonnegative(),
     edits: z.number().int().nonnegative(),
+    affectedSymbols: z.array(z.string()),
     output: z.string(),
   });
   return createTool({
@@ -184,6 +184,7 @@ function createEditCodeTool(input: ToolkitInput) {
           removed: totals.removed,
           matches: editResult.matches,
           edits: editResult.edits,
+          affectedSymbols: editResult.affectedSymbols,
           output: result,
         };
       });


### PR DESCRIPTION
## Summary

- Adds `enclosingSymbol` to scan-code matches so the model can use it directly as `withinSymbol` in a follow-up edit-code call
- Adds `withinSymbol` filtering to scan-code tool schema
- Widens `withinSymbol` recognition to cover TypeScript-specific declaration kinds
- Adds `affectedSymbols` to edit-code result
- Documents the query vs mutation tool design principle in `docs/tooling.md`