### PR TITLE
refactor(arch): standardize dependency injection pattern

### DIFF
--- a/.agents/skills/arch-audit/SKILL.md
+++ b/.agents/skills/arch-audit/SKILL.md
@@ -17,6 +17,7 @@ Flag layers that add little or no architectural value:
 - pass-through facade modules that only rename or re-export behavior
 - alias or wrapper layers without independent policy, invariants, or boundary value
 - dependency-injection bags that exceed practical seam or testing needs
+- singleton imports in library modules that should accept injected params (see DI section in `docs/architecture.md`)
 - thin wrappers that only forward calls without adding policy (for example `runX -> runY`)
 - facade-for-facade chains where each layer only forwards the call
 
@@ -45,6 +46,7 @@ Check that implementation matches intended architecture:
 - guard and evaluator extensibility without test-only production hacks
 - error contracts and typed error model consistency
 - assert patterns and exhaustiveness (`invariant`, `unreachable`, exhaustive `switch`)
+- DI convention: `*Deps` for config, `*Input` for runtime, defaults from `appConfig` at composition roots
 - design-pattern consistency for extension seams (policy tables, strategy maps, adapters)
 
 ### 4. Cohesion and responsibility

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,10 @@
+<!-- PR description style:
+  - Optional lead sentence for complex changes
+  - Flat bullet list of concrete changes
+  - Each bullet: dash, lowercase start, no trailing period
+  - Keep bullets short — one line, minimal inline code
+  - No sub-sections, no headers beyond "Summary"
+  - "Fixes #N" goes at the end
+-->
+
 ## Summary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ These must always hold. Break them and the system breaks.
 5. Cut releases only for user-facing features or meaningful bug fixes — not for internal refactors or tooling cleanup alone.
 6. PR titles follow the same Conventional Commit format. Summaries: short bullets, no prose.
 7. When creating or updating a pull request, read and follow the local PR template if the repo provides one.
+8. Branch names use hyphens, no slashes (e.g. `di-pattern`, not `refactor/di-pattern`).
 
 ## Code
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -111,6 +111,13 @@ Memory Engine
 - **integration:** memory context is injected during request setup; commit is best-effort background work at finalize.
 - **details:** see [Memory](./memory.md).
 
+## Dependency injection
+
+- **No container, no decorators** — dependencies are passed as typed parameters with defaults from `appConfig`.
+- **Deps vs input** — factory functions that need both configuration and runtime data take two arguments: a `*Deps` object for config that is fixed for the process lifetime, and an `*Input` object for per-request runtime data (e.g. `createFileToolkit(deps: ToolkitDeps, input: ToolkitInput)`).
+- **Defaults at the edge** — library modules accept injected params; composition roots (`cli-command-registry`, `server-chat-runtime`, `cli-chat`) read `appConfig` and pass values down.
+- **Tests inject directly** — tests pass config through the new params instead of mutating `appConfig`.
+
 ## Contracts
 
 - **error handling:** tools emit failures/error codes; lifecycle owns retry/regeneration policy.

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -42,17 +42,27 @@ resolve → prepare → generate → evaluate → finalize
 - Memory commit is scheduled as best-effort background work at finalize.
 - Commit failures are logged via lifecycle debug events and do not fail the user response.
 
-## Key files
-
-- `src/lifecycle.ts`
-- `src/lifecycle-*.ts`
-- `src/lifecycle-evaluators.ts` — post-generation evaluators including tool recovery
-- `src/lifecycle-guard-feedback.ts` — guard-event-to-feedback translation
-- `src/tool-recovery.ts` — `ToolRecovery` contract carried from tool errors into evaluators
-
 ## Tool recovery
 
 - `ToolRecovery` is a tool-owned contract for stable failure recovery.
 - Lifecycle consumes it generically; it does not hardcode tool-specific retry policy.
 - Recovery may include optional next-step hints like a suggested next tool or target paths when the tool can state them concretely.
 - Recovery may also declare which successful follow-up tool result resolves the failure, so lifecycle can clear it without tool-specific heuristics.
+
+## Key files
+
+- `src/lifecycle.ts` — Main orchestrator that coordinates all phases.
+- `src/lifecycle-constants.ts` — Configuration constants for step limits, timeouts, and thresholds.
+- `src/lifecycle-contract.ts` — Type definitions for lifecycle events, inputs, and runtime contexts.
+- `src/lifecycle-evaluate.ts` — Evaluation phase logic with recovery and verification.
+- `src/lifecycle-evaluators.ts` — Post-generation evaluators including tool recovery.
+- `src/lifecycle-finalize.ts` — Finalization phase including token accounting and tool statistics.
+- `src/lifecycle-generate.ts` — Generation phase with agent creation and yield detection.
+- `src/lifecycle-guard-feedback.ts` — Guard-event-to-feedback translation.
+- `src/lifecycle-policy.ts` — Lifecycle policy configuration and constraints.
+- `src/lifecycle-prepare.ts` — Preparation phase including input validation and token estimation.
+- `src/lifecycle-resolve.ts` — Initial mode and model selection for the request.
+- `src/lifecycle-signal.ts` — Extraction and parsing of agent signals from output.
+- `src/lifecycle-state.ts` — State validation and transitions through the lifecycle.
+- `src/lifecycle-usage.ts` — Token usage tracking and prompt breakdown totals.
+- `src/tool-recovery.ts` — Tool recovery contract carried from tool errors into evaluators.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -92,3 +92,15 @@ The observation/reflection model is inspired by [Mastra's Observational Memory](
   - `MemoryNormalizeStrategy`
   - `MemorySelectionStrategy`
 - Keep lifecycle contract stable while swapping strategies/storage behind sources.
+
+## Key files
+
+- `src/memory.ts` — Top-level memory operations (list, add, remove).
+- `src/memory-contract.ts` — Type definitions for entries, scopes, and distill records.
+- `src/memory-pipeline.ts` — Staged pipeline (ingest, normalize, select, inject, commit).
+- `src/memory-registry.ts` — Source composition, strategy injection, and pipeline orchestration.
+- `src/memory-source-distill.ts` — Distill memory source with observer and reflector agents.
+- `src/memory-source-stored.ts` — Stored markdown memory source.
+- `src/memory-distill-prompts.ts` — Observer and reflector prompt templates.
+- `src/memory-distill-store.ts` — Atomic file-based distill record persistence.
+- `src/memory-store.ts` — Memory store interface for list, add, and remove.

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -25,6 +25,6 @@ Acolyte uses two explicit operating modes to shape behavior: `work` and `verify`
 
 ## Key files
 
-- `src/agent-modes.ts`
-- `src/lifecycle-resolve.ts`
-- `src/lifecycle-evaluators.ts`
+- `src/agent-modes.ts` — Mode configurations with tool grants and preambles.
+- `src/lifecycle-resolve.ts` — Mode and model selection during task execution.
+- `src/lifecycle-evaluators.ts` — Mode-aware post-generation evaluators.

--- a/docs/sessions-tasks.md
+++ b/docs/sessions-tasks.md
@@ -29,11 +29,11 @@ accepted → queued → running → completed|failed|cancelled
 
 ## Key files
 
-- `src/task-contract.ts`
-- `src/task-registry.ts`
-- `src/rpc-queue.ts`
-- `src/server-rpc.ts`
+- `src/task-contract.ts` — Task state schema and transition validation.
+- `src/task-registry.ts` — Task state transitions and persistence.
+- `src/rpc-queue.ts` — Request queuing with abort and position tracking.
+- `src/server-rpc.ts` — RPC server for chat requests and task state management.
 
----
+## Further reading
 
-For a deeper look at the daemon architecture and task flow, read [How It Works](https://crisu.me/blog/how-it-works).
+[How It Works](https://crisu.me/blog/how-it-works) — Daemon architecture and task flow.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -68,10 +68,14 @@ Internal implementations may share compilers, rule objects, or AST helpers, but 
 
 ## Key files
 
-- `src/gitignore.ts`
-- `src/file-toolkit.ts`
-- `src/code-toolkit.ts`
-- `src/git-toolkit.ts`
-- `src/tool-registry.ts`
-- `src/tool-guards.ts`
-- `src/tool-cache.ts`
+- `src/gitignore.ts` — Gitignore pattern compilation and evaluation.
+- `src/file-toolkit.ts` — File operations (read, write, find, search, edit).
+- `src/code-toolkit.ts` — Code manipulation for scanning and editing source files.
+- `src/git-toolkit.ts` — Git operations (status, diff, log, show, add, commit).
+- `src/tool-registry.ts` — Tool registration, permission filtering, and agent-facing surface.
+- `src/tool-guards.ts` — Pre-execution guards including limits and path validation.
+- `src/tool-cache.ts` — Per-task result caching with stable key generation.
+
+## Further reading
+
+[Edit the Tree](https://crisu.me/blog/edit-the-tree) — AST-based code editing and scanning.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -59,18 +59,18 @@ Components register handlers through `useInput`. Only handlers with `isActive: t
 
 ## Key files
 
-- `src/tui/index.ts` — public API surface
-- `src/tui/components.tsx` — `Box`, `Text`, `Static` primitives
-- `src/tui/dom.ts` — TUI DOM node types
-- `src/tui/serialize.ts` — tree-to-string serialization with static/active split
-- `src/tui/render.ts` — terminal render loop, raw mode, cursor management
-- `src/tui/input.ts` — raw stdin dispatcher
-- `src/tui/context.ts` — `AppContext`, `InputContext`, `KeyEvent`
-- `src/tui/hooks.ts` — `useApp`, `useInput`
-- `src/tui/host-config.ts` — React reconciler host config
-- `src/tui/styles.ts` — ANSI escape sequences, color mapping
-- `src/tui/reconciler.ts` — React reconciler instance
+- `src/tui/index.ts` — Public API surface.
+- `src/tui/components.tsx` — `Box`, `Text`, `Static` primitives.
+- `src/tui/dom.ts` — TUI DOM node types.
+- `src/tui/serialize.ts` — Tree-to-string serialization with static/active split.
+- `src/tui/render.ts` — Terminal render loop, raw mode, cursor management.
+- `src/tui/input.ts` — Raw stdin dispatcher.
+- `src/tui/context.ts` — `AppContext`, `InputContext`, `KeyEvent`.
+- `src/tui/hooks.ts` — `useApp`, `useInput`.
+- `src/tui/host-config.ts` — React reconciler host config.
+- `src/tui/styles.ts` — ANSI escape sequences, color mapping.
+- `src/tui/reconciler.ts` — React reconciler instance.
 
----
+## Further reading
 
-For the story behind the TUI design, read [No More Ink](https://crisu.me/blog/no-more-ink).
+[No More Ink](https://crisu.me/blog/no-more-ink) — The story behind the TUI design.

--- a/docs/why-acolyte.md
+++ b/docs/why-acolyte.md
@@ -51,10 +51,8 @@ The system prompt is measured and reserved before history allocation begins. Rem
 
 The CLI ships a custom React-based TUI: fuzzy search and autocomplete with suggestion and correction for file paths, sessions, commands, and skills. A model picker queries provider APIs for available models. Tool output is structured with typed rendering. AST-based editing and scanning run through [ast-grep](https://ast-grep.github.io/).
 
----
+## Next steps
 
-For a detailed comparison with other open-source agents, see [Comparison](./comparison.md).
-
-Measured code quality metrics are available in [Benchmarks](./benchmarks.md).
-
-The background on why Acolyte was built is covered in [Meet Acolyte](https://crisu.me/blog/meet-acolyte).
+- [Architecture](./architecture.md) — How the system is built.
+- [Comparison](./comparison.md) — How Acolyte compares to other open-source agents.
+- [Benchmarks](./benchmarks.md) — Measured code quality metrics.

--- a/src/agent-input.ts
+++ b/src/agent-input.ts
@@ -113,9 +113,16 @@ function resolveMessageTokenCap(
   return Math.min(maxPerMessageTokens, 200);
 }
 
+export type InputBudget = {
+  maxHistoryMessages: number;
+  maxMessageTokens: number;
+  maxAttachmentMessageTokens: number;
+  maxPinnedMessageTokens: number;
+};
+
 export function createAgentInput(
   req: ChatRequest,
-  options?: { systemPromptTokens?: number; toolTokens?: number },
+  options?: { systemPromptTokens?: number; toolTokens?: number; budget?: InputBudget },
 ): {
   input: string;
   usage: {
@@ -137,7 +144,7 @@ export function createAgentInput(
   const toolTokens = options?.toolTokens ?? 0;
   const lines: string[] = [];
   const usedIds = new Set<string>();
-  const budget = appConfig.agent.inputBudget;
+  const budget = options?.budget ?? appConfig.agent.inputBudget;
 
   const userLine = `USER: ${truncateByTokens(req.message.trim(), budget.maxMessageTokens)}`;
   const userTokens = estimateTokens(userLine);

--- a/src/agent-model.ts
+++ b/src/agent-model.ts
@@ -4,7 +4,7 @@ import type { Provider } from "./provider-contract";
 
 export type ProviderCredentialsMap = Partial<Record<Provider, ProviderCredentials>>;
 
-const defaultCredentials = (): ProviderCredentialsMap => ({
+export const defaultCredentials = (): ProviderCredentialsMap => ({
   openai: appConfig.openai,
   anthropic: appConfig.anthropic,
   google: appConfig.google,

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -1,4 +1,5 @@
 import type { AgentMode } from "./agent-contract";
+import type { ChatRequest } from "./api";
 import { appConfig } from "./app-config";
 import { dispatchSlashCommand } from "./chat-commands";
 import type { ChatMessage } from "./chat-contract";
@@ -51,6 +52,7 @@ type CreateMessageHandlerInput = {
   nowIso: () => string;
   setInterrupt: (handler: (() => void) | null) => void;
   useMemory?: boolean;
+  modeModels?: ChatRequest["modeModels"];
   graduate?: () => void;
   clearTranscript: (sessionId?: string) => void;
 };
@@ -104,7 +106,7 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
         userText,
         history: [...fileContextMessages, ...input.currentSession.messages],
         model: input.currentSession.model,
-        modeModels: appConfig.models,
+        modeModels: input.modeModels ?? appConfig.models,
         sessionId: input.currentSession.id,
         useMemory: input.useMemory,
         signal: controller.signal,

--- a/src/chat-skill-activator.ts
+++ b/src/chat-skill-activator.ts
@@ -1,11 +1,11 @@
 import { appConfig } from "./app-config";
 import type { ChatMessage, ChatRow } from "./chat-contract";
-import { compactText } from "./compact-text";
+import { type CompactBudget, compactText } from "./compact-text";
 import type { Session } from "./session-contract";
 import { findSkillByName, readSkillInstructions } from "./skills";
 
 type CreateSkillActivatorDeps = {
-  skillBudget?: { maxChars?: number; maxLines?: number };
+  skillBudget?: CompactBudget;
 };
 
 type CreateSkillActivatorInput = {

--- a/src/chat-skill-activator.ts
+++ b/src/chat-skill-activator.ts
@@ -4,6 +4,10 @@ import { compactText } from "./compact-text";
 import type { Session } from "./session-contract";
 import { findSkillByName, readSkillInstructions } from "./skills";
 
+type CreateSkillActivatorDeps = {
+  skillBudget?: { maxChars?: number; maxLines?: number };
+};
+
 type CreateSkillActivatorInput = {
   currentSession: Session;
   setRows: (updater: (current: ChatRow[]) => ChatRow[]) => void;
@@ -13,14 +17,16 @@ type CreateSkillActivatorInput = {
 };
 
 export function createSkillActivator(
+  deps: CreateSkillActivatorDeps,
   input: CreateSkillActivatorInput,
 ): (skillName: string, args: string) => Promise<boolean> {
+  const skillBudget = deps.skillBudget ?? appConfig.agent.skillBudget;
   return async (skillName, args) => {
     const skill = findSkillByName(skillName);
     if (!skill) return false;
     try {
       const instructions = await readSkillInstructions(skill.path, args || undefined);
-      const compactedInstructions = compactText(instructions, appConfig.agent.skillBudget);
+      const compactedInstructions = compactText(instructions, skillBudget);
       const msg = input.createMessage("system", `Active skill (${skill.name}):\n${compactedInstructions}`);
       input.currentSession.messages.push(msg);
       input.currentSession.updatedAt = input.nowIso();

--- a/src/chat-ui.tsx
+++ b/src/chat-ui.tsx
@@ -194,13 +194,16 @@ function ChatApp(props: ChatAppProps) {
     };
   }, []);
 
-  const activateSkill = createSkillActivator({
-    currentSession,
-    setRows,
-    createMessage,
-    nowIso,
-    persist,
-  });
+  const activateSkill = createSkillActivator(
+    {},
+    {
+      currentSession,
+      setRows,
+      createMessage,
+      nowIso,
+      persist,
+    },
+  );
 
   const { openSkillsPanel, openResumePanel, openModelPanel, handlePickerSelect } = createPickerHandlers({
     store,

--- a/src/cli-skill.ts
+++ b/src/cli-skill.ts
@@ -4,6 +4,7 @@ import type { attachFileToSession as attachFileToSessionType } from "./cli-chat"
 import { formatRunSummary } from "./cli-format";
 import type { handlePrompt as handlePromptType } from "./cli-prompt";
 import type { createClient as createClientType } from "./client-factory";
+import type { CompactBudget } from "./compact-text";
 import type { readResolvedConfigSync as readResolvedConfigSyncType } from "./config";
 import { t } from "./i18n";
 import { userResourceIdFor } from "./resource-id";
@@ -17,7 +18,7 @@ type SkillModeDeps = {
   apiUrlForPort: typeof apiUrlForPortType;
   appModel: typeof appConfigType.model;
   attachFileToSession: typeof attachFileToSessionType;
-  compactText: (text: string, budget: { maxChars?: number; maxLines?: number }) => string;
+  compactText: (text: string, budget: CompactBudget) => string;
   createClient: typeof createClientType;
   createMessage: typeof createMessageType;
   createSession: typeof createSessionType;
@@ -33,7 +34,7 @@ type SkillModeDeps = {
   serverApiKey: typeof appConfigType.server.apiKey;
   serverEntry: string;
   serverPort: typeof appConfigType.server.port;
-  skillBudget: { maxChars?: number; maxLines?: number };
+  skillBudget: CompactBudget;
   commandError: (name: string, message?: string) => void;
   commandHelp: (name: string) => void;
 };

--- a/src/client-factory.ts
+++ b/src/client-factory.ts
@@ -1,4 +1,3 @@
-import { appConfig } from "./app-config";
 import { invariant } from "./assert";
 import type { Client, ClientOptions } from "./client-contract";
 import { RpcClient } from "./client-rpc";
@@ -6,7 +5,5 @@ import { RpcClient } from "./client-rpc";
 export function createClient(options: ClientOptions): Client {
   const apiUrl = options.apiUrl;
   invariant(apiUrl, "apiUrl is required");
-  const apiKey = options.apiKey ?? appConfig.server.apiKey;
-  const replyTimeoutMs = options.replyTimeoutMs;
-  return new RpcClient(apiUrl, apiKey, replyTimeoutMs);
+  return new RpcClient(apiUrl, options.apiKey, options.replyTimeoutMs);
 }

--- a/src/code-toolkit.ts
+++ b/src/code-toolkit.ts
@@ -47,8 +47,6 @@ function formatScanCodeResult(result: ScanCodeResult): string {
 }
 
 function createScanCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
-  const { outputBudget } = deps;
-  const { workspace, session, onOutput } = input;
   return createTool({
     id: "scan-code",
     label: t("tool.label.review"),
@@ -77,13 +75,13 @@ function createScanCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
       output: z.string(),
     }),
     execute: async (toolInput) => {
-      return runTool(session, "scan-code", toolInput, async (toolCallId) => {
+      return runTool(input.session, "scan-code", toolInput, async (toolCallId) => {
         const paths = normalizeUniquePaths(toolInput.paths);
-        const unique = Array.from(new Set(paths.map((path) => toDisplayPath(path, workspace))));
+        const unique = Array.from(new Set(paths.map((path) => toDisplayPath(path, input.workspace))));
         if (unique.length > 0) {
           const shown = unique.slice(0, 4);
           const remaining = unique.length - shown.length;
-          onOutput({
+          input.onOutput({
             toolName: "scan-code",
             content: {
               kind: "file-header",
@@ -95,14 +93,14 @@ function createScanCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
             toolCallId,
           });
         }
-        const baseBudget = outputBudget.scanCode;
+        const baseBudget = deps.outputBudget.scanCode;
         const count = paths.length * toolInput.patterns.length;
         const budget = {
           maxChars: Math.max(400, Math.floor(baseBudget.maxChars / count) * count),
           maxLines: Math.max(20, Math.floor(baseBudget.maxLines / count) * count),
         };
         const rawScan = await scanCode({
-          workspace,
+          workspace: input.workspace,
           paths,
           pattern: toolInput.patterns,
           language: toolInput.language,
@@ -116,12 +114,10 @@ function createScanCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
 }
 
 function createEditCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
-  const { outputBudget } = deps;
-  const { workspace, session, onOutput } = input;
   const emitDiffSummaryHeader = createDiffSummaryEmitter({
     toolName: "edit-code",
     label: t("tool.label.edit"),
-    onOutput,
+    onOutput: input.onOutput,
   });
   const outputSchema = z.object({
     kind: z.literal("edit-code"),
@@ -166,17 +162,17 @@ function createEditCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
     }),
     outputSchema,
     execute: async (toolInput) => {
-      return runTool(session, "edit-code", toolInput, async (toolCallId) => {
+      return runTool(input.session, "edit-code", toolInput, async (toolCallId) => {
         const editResult = await editCode({
-          workspace,
+          workspace: input.workspace,
           path: toolInput.path,
           edits: toolInput.edits,
         });
         emitDiffSummaryHeader(toolInput.path, editResult.output, toolCallId);
         for (const content of numberedUnifiedDiffLines(editResult.output))
-          onOutput({ toolName: "edit-code", content, toolCallId });
+          input.onOutput({ toolName: "edit-code", content, toolCallId });
         const totals = summarizeUnifiedDiff(editResult.output);
-        const result = compactToolOutput(editResult.output, outputBudget.astEdit);
+        const result = compactToolOutput(editResult.output, deps.outputBudget.astEdit);
         return {
           kind: "edit-code",
           path: toolInput.path,

--- a/src/code-toolkit.ts
+++ b/src/code-toolkit.ts
@@ -1,10 +1,9 @@
 import { isAbsolute, relative } from "node:path";
 import { z } from "zod";
-import { appConfig } from "./app-config";
 import { editCodeEditSchema } from "./code-contract";
 import { editCode, type ScanCodeResult, scanCode } from "./code-ops";
 import { t } from "./i18n";
-import { createTool, type ToolkitInput } from "./tool-contract";
+import { createTool, type ToolkitDeps, type ToolkitInput } from "./tool-contract";
 import { runTool } from "./tool-execution";
 import { compactToolOutput } from "./tool-output";
 import { createDiffSummaryEmitter, numberedUnifiedDiffLines, summarizeUnifiedDiff } from "./tool-output-format";
@@ -47,7 +46,8 @@ function formatScanCodeResult(result: ScanCodeResult): string {
   return lines.join("\n");
 }
 
-function createScanCodeTool(input: ToolkitInput) {
+function createScanCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
+  const { outputBudget } = deps;
   const { workspace, session, onOutput } = input;
   return createTool({
     id: "scan-code",
@@ -95,7 +95,7 @@ function createScanCodeTool(input: ToolkitInput) {
             toolCallId,
           });
         }
-        const baseBudget = appConfig.agent.toolOutputBudget.scanCode;
+        const baseBudget = outputBudget.scanCode;
         const count = paths.length * toolInput.patterns.length;
         const budget = {
           maxChars: Math.max(400, Math.floor(baseBudget.maxChars / count) * count),
@@ -115,7 +115,8 @@ function createScanCodeTool(input: ToolkitInput) {
   });
 }
 
-function createEditCodeTool(input: ToolkitInput) {
+function createEditCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
+  const { outputBudget } = deps;
   const { workspace, session, onOutput } = input;
   const emitDiffSummaryHeader = createDiffSummaryEmitter({
     toolName: "edit-code",
@@ -175,7 +176,7 @@ function createEditCodeTool(input: ToolkitInput) {
         for (const content of numberedUnifiedDiffLines(editResult.output))
           onOutput({ toolName: "edit-code", content, toolCallId });
         const totals = summarizeUnifiedDiff(editResult.output);
-        const result = compactToolOutput(editResult.output, appConfig.agent.toolOutputBudget.astEdit);
+        const result = compactToolOutput(editResult.output, outputBudget.astEdit);
         return {
           kind: "edit-code",
           path: toolInput.path,
@@ -192,9 +193,9 @@ function createEditCodeTool(input: ToolkitInput) {
   });
 }
 
-export function createCodeToolkit(input: ToolkitInput) {
+export function createCodeToolkit(deps: ToolkitDeps, input: ToolkitInput) {
   return {
-    scanCode: createScanCodeTool(input),
-    editCode: createEditCodeTool(input),
+    scanCode: createScanCodeTool(deps, input),
+    editCode: createEditCodeTool(deps, input),
   };
 }

--- a/src/compact-text.ts
+++ b/src/compact-text.ts
@@ -1,3 +1,5 @@
+export type CompactBudget = { maxChars?: number; maxLines?: number };
+
 export const DEFAULT_MAX_CHARS = 4000;
 export const DEFAULT_MAX_LINES = 120;
 
@@ -20,7 +22,7 @@ export function truncateMiddle(text: string, maxChars: number): string {
   return `${text.slice(0, headChars)}…${text.slice(text.length - tailChars)}`;
 }
 
-export function compactText(raw: string, options: { maxChars?: number; maxLines?: number } = {}): string {
+export function compactText(raw: string, options: CompactBudget = {}): string {
   const maxChars = options.maxChars ?? DEFAULT_MAX_CHARS;
   const maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
   const source = raw.trim();

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -1,9 +1,8 @@
 import { isAbsolute, relative } from "node:path";
 import { z } from "zod";
-import { appConfig } from "./app-config";
 import { deleteTextFile, editFile, findFiles, readSnippets, searchFiles, writeTextFile } from "./file-ops";
 import { t } from "./i18n";
-import { createTool, type ToolkitInput } from "./tool-contract";
+import { createTool, type ToolkitDeps, type ToolkitInput } from "./tool-contract";
 import { runTool } from "./tool-execution";
 import { compactToolOutput } from "./tool-output";
 import {
@@ -55,7 +54,8 @@ function normalizeReadEntries(paths: ReadPathInput[]): NormalizedReadEntry[] {
   return Array.from(deduped.values());
 }
 
-function createFindFilesTool(input: ToolkitInput) {
+function createFindFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
+  const { outputBudget } = deps;
   const { workspace, session, onOutput } = input;
   return createTool({
     id: "find-files",
@@ -82,7 +82,7 @@ function createFindFilesTool(input: ToolkitInput) {
       return runTool(session, "find-files", toolInput, async (toolCallId) => {
         const maxResults = toolInput.maxResults ?? 40;
         const count = toolInput.patterns.length;
-        const baseBudget = appConfig.agent.toolOutputBudget.findFiles;
+        const baseBudget = outputBudget.findFiles;
         const budget = {
           maxChars: Math.max(400, Math.floor(baseBudget.maxChars / count) * count),
           maxLines: Math.max(20, Math.floor(baseBudget.maxLines / count) * count),
@@ -111,7 +111,8 @@ function createFindFilesTool(input: ToolkitInput) {
   });
 }
 
-function createSearchFilesTool(input: ToolkitInput) {
+function createSearchFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
+  const { outputBudget } = deps;
   const { workspace, session, onOutput } = input;
   return createTool({
     id: "search-files",
@@ -159,7 +160,7 @@ function createSearchFilesTool(input: ToolkitInput) {
               : [];
         const result = compactToolOutput(
           await searchFiles(workspace, patterns, maxResults, toolInput.paths),
-          appConfig.agent.toolOutputBudget.searchFiles,
+          outputBudget.searchFiles,
         );
         const summaryEntries = searchResultSummaryEntries(result, patterns);
         emitSearchSummary(
@@ -185,7 +186,8 @@ function createSearchFilesTool(input: ToolkitInput) {
   });
 }
 
-function createReadFileTool(input: ToolkitInput) {
+function createReadFileTool(deps: ToolkitDeps, input: ToolkitInput) {
+  const { outputBudget } = deps;
   const { workspace, session, onOutput } = input;
   return createTool({
     id: "read-file",
@@ -241,7 +243,7 @@ function createReadFileTool(input: ToolkitInput) {
             toolCallId,
           });
         }
-        const baseBudget = appConfig.agent.toolOutputBudget.read;
+        const baseBudget = outputBudget.read;
         const count = entries.length;
         const budget = {
           maxChars: Math.max(400, Math.floor(baseBudget.maxChars / count) * count),
@@ -254,7 +256,8 @@ function createReadFileTool(input: ToolkitInput) {
   });
 }
 
-function createEditFileTool(input: ToolkitInput) {
+function createEditFileTool(deps: ToolkitDeps, input: ToolkitInput) {
+  const { outputBudget } = deps;
   const { workspace, session, onOutput } = input;
   const emitDiffSummaryHeader = createDiffSummaryEmitter({
     toolName: "edit-file",
@@ -314,7 +317,7 @@ function createEditFileTool(input: ToolkitInput) {
         for (const content of numberedUnifiedDiffLines(rawResult))
           onOutput({ toolName: "edit-file", content, toolCallId });
         const totals = summarizeUnifiedDiff(rawResult);
-        const result = compactToolOutput(rawResult, appConfig.agent.toolOutputBudget.edit);
+        const result = compactToolOutput(rawResult, outputBudget.edit);
         return {
           kind: "edit-file",
           path: toolInput.path,
@@ -328,7 +331,8 @@ function createEditFileTool(input: ToolkitInput) {
   });
 }
 
-function createCreateFileTool(input: ToolkitInput) {
+function createCreateFileTool(deps: ToolkitDeps, input: ToolkitInput) {
+  const { outputBudget } = deps;
   const { workspace, session, onOutput } = input;
   const emitDiffSummaryHeader = createDiffSummaryEmitter({
     toolName: "create-file",
@@ -367,7 +371,7 @@ function createCreateFileTool(input: ToolkitInput) {
         for (const content of numberedUnifiedDiffLines(rawResult))
           onOutput({ toolName: "create-file", content, toolCallId });
         const totals = summarizeUnifiedDiff(rawResult);
-        const result = compactToolOutput(rawResult, appConfig.agent.toolOutputBudget.create);
+        const result = compactToolOutput(rawResult, outputBudget.create);
         return {
           kind: "create-file",
           path: toolInput.path,
@@ -381,7 +385,8 @@ function createCreateFileTool(input: ToolkitInput) {
   });
 }
 
-function createDeleteFileTool(input: ToolkitInput) {
+function createDeleteFileTool(deps: ToolkitDeps, input: ToolkitInput) {
+  const { outputBudget } = deps;
   const { workspace, session, onOutput } = input;
   return createTool({
     id: "delete-file",
@@ -415,20 +420,20 @@ function createDeleteFileTool(input: ToolkitInput) {
           resultParts.push(rawResult);
         }
         const rawResult = resultParts.join("\n\n");
-        const result = compactToolOutput(rawResult, appConfig.agent.toolOutputBudget.edit);
+        const result = compactToolOutput(rawResult, outputBudget.edit);
         return { kind: "delete-file", paths, deleted: paths.length, output: result };
       });
     },
   });
 }
 
-export function createFileToolkit(input: ToolkitInput) {
+export function createFileToolkit(deps: ToolkitDeps, input: ToolkitInput) {
   return {
-    findFiles: createFindFilesTool(input),
-    searchFiles: createSearchFilesTool(input),
-    readFile: createReadFileTool(input),
-    editFile: createEditFileTool(input),
-    createFile: createCreateFileTool(input),
-    deleteFile: createDeleteFileTool(input),
+    findFiles: createFindFilesTool(deps, input),
+    searchFiles: createSearchFilesTool(deps, input),
+    readFile: createReadFileTool(deps, input),
+    editFile: createEditFileTool(deps, input),
+    createFile: createCreateFileTool(deps, input),
+    deleteFile: createDeleteFileTool(deps, input),
   };
 }

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -55,8 +55,6 @@ function normalizeReadEntries(paths: ReadPathInput[]): NormalizedReadEntry[] {
 }
 
 function createFindFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
-  const { outputBudget } = deps;
-  const { workspace, session, onOutput } = input;
   return createTool({
     id: "find-files",
     label: t("tool.label.find"),
@@ -79,24 +77,24 @@ function createFindFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
       output: z.string(),
     }),
     execute: async (toolInput) => {
-      return runTool(session, "find-files", toolInput, async (toolCallId) => {
+      return runTool(input.session, "find-files", toolInput, async (toolCallId) => {
         const maxResults = toolInput.maxResults ?? 40;
         const count = toolInput.patterns.length;
-        const baseBudget = outputBudget.findFiles;
+        const baseBudget = deps.outputBudget.findFiles;
         const budget = {
           maxChars: Math.max(400, Math.floor(baseBudget.maxChars / count) * count),
           maxLines: Math.max(20, Math.floor(baseBudget.maxLines / count) * count),
         };
-        const result = compactToolOutput(await findFiles(workspace, toolInput.patterns, maxResults), budget);
+        const result = compactToolOutput(await findFiles(input.workspace, toolInput.patterns, maxResults), budget);
         const paths = findResultPaths(result);
         emitFindSummary(
           paths,
           toolInput.patterns,
           t("tool.label.find"),
-          onOutput,
+          input.onOutput,
           toolCallId,
           TOOL_OUTPUT_LIMITS.files,
-          workspace,
+          input.workspace,
         );
         return {
           kind: "find-files",
@@ -112,8 +110,6 @@ function createFindFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
 }
 
 function createSearchFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
-  const { outputBudget } = deps;
-  const { workspace, session, onOutput } = input;
   return createTool({
     id: "search-files",
     label: t("tool.label.search"),
@@ -150,7 +146,7 @@ function createSearchFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
       output: z.string(),
     }),
     execute: async (toolInput) => {
-      return runTool(session, "search-files", toolInput, async (toolCallId) => {
+      return runTool(input.session, "search-files", toolInput, async (toolCallId) => {
         const maxResults = toolInput.maxResults ?? 20;
         const patterns =
           toolInput.patterns && toolInput.patterns.length > 0
@@ -159,8 +155,8 @@ function createSearchFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
               ? [toolInput.pattern]
               : [];
         const result = compactToolOutput(
-          await searchFiles(workspace, patterns, maxResults, toolInput.paths),
-          outputBudget.searchFiles,
+          await searchFiles(input.workspace, patterns, maxResults, toolInput.paths),
+          deps.outputBudget.searchFiles,
         );
         const summaryEntries = searchResultSummaryEntries(result, patterns);
         emitSearchSummary(
@@ -168,10 +164,10 @@ function createSearchFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
           patterns,
           toolInput.paths,
           t("tool.label.search"),
-          onOutput,
+          input.onOutput,
           toolCallId,
           TOOL_OUTPUT_LIMITS.files,
-          workspace,
+          input.workspace,
         );
         return {
           kind: "search-files",
@@ -187,8 +183,6 @@ function createSearchFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
 }
 
 function createReadFileTool(deps: ToolkitDeps, input: ToolkitInput) {
-  const { outputBudget } = deps;
-  const { workspace, session, onOutput } = input;
   return createTool({
     id: "read-file",
     label: t("tool.label.read"),
@@ -224,14 +218,14 @@ function createReadFileTool(deps: ToolkitDeps, input: ToolkitInput) {
       output: z.string(),
     }),
     execute: async (toolInput) => {
-      return runTool(session, "read-file", toolInput, async (toolCallId) => {
+      return runTool(input.session, "read-file", toolInput, async (toolCallId) => {
         const entries = normalizeReadEntries(toolInput.paths);
         if (entries.length === 0) throw new Error("Read requires at least one non-empty path");
-        const unique = Array.from(new Set(entries.map((entry) => toDisplayPath(entry.path, workspace))));
+        const unique = Array.from(new Set(entries.map((entry) => toDisplayPath(entry.path, input.workspace))));
         if (unique.length > 0) {
           const shown = unique.slice(0, TOOL_OUTPUT_LIMITS.inlineFiles);
           const remaining = unique.length - shown.length;
-          onOutput({
+          input.onOutput({
             toolName: "read-file",
             content: {
               kind: "file-header",
@@ -243,13 +237,13 @@ function createReadFileTool(deps: ToolkitDeps, input: ToolkitInput) {
             toolCallId,
           });
         }
-        const baseBudget = outputBudget.read;
+        const baseBudget = deps.outputBudget.read;
         const count = entries.length;
         const budget = {
           maxChars: Math.max(400, Math.floor(baseBudget.maxChars / count) * count),
           maxLines: Math.max(20, Math.floor(baseBudget.maxLines / count) * count),
         };
-        const result = compactToolOutput(await readSnippets(workspace, entries), budget);
+        const result = compactToolOutput(await readSnippets(input.workspace, entries), budget);
         return { kind: "read-file", paths: entries, output: result };
       });
     },
@@ -257,12 +251,10 @@ function createReadFileTool(deps: ToolkitDeps, input: ToolkitInput) {
 }
 
 function createEditFileTool(deps: ToolkitDeps, input: ToolkitInput) {
-  const { outputBudget } = deps;
-  const { workspace, session, onOutput } = input;
   const emitDiffSummaryHeader = createDiffSummaryEmitter({
     toolName: "edit-file",
     label: t("tool.label.edit"),
-    onOutput,
+    onOutput: input.onOutput,
   });
   const outputSchema = z.object({
     kind: z.literal("edit-file"),
@@ -307,17 +299,17 @@ function createEditFileTool(deps: ToolkitDeps, input: ToolkitInput) {
     }),
     outputSchema,
     execute: async (toolInput) => {
-      return runTool(session, "edit-file", toolInput, async (toolCallId) => {
+      return runTool(input.session, "edit-file", toolInput, async (toolCallId) => {
         const rawResult = await editFile({
-          workspace,
+          workspace: input.workspace,
           path: toolInput.path,
           edits: toolInput.edits,
         });
         emitDiffSummaryHeader(toolInput.path, rawResult, toolCallId);
         for (const content of numberedUnifiedDiffLines(rawResult))
-          onOutput({ toolName: "edit-file", content, toolCallId });
+          input.onOutput({ toolName: "edit-file", content, toolCallId });
         const totals = summarizeUnifiedDiff(rawResult);
-        const result = compactToolOutput(rawResult, outputBudget.edit);
+        const result = compactToolOutput(rawResult, deps.outputBudget.edit);
         return {
           kind: "edit-file",
           path: toolInput.path,
@@ -332,12 +324,10 @@ function createEditFileTool(deps: ToolkitDeps, input: ToolkitInput) {
 }
 
 function createCreateFileTool(deps: ToolkitDeps, input: ToolkitInput) {
-  const { outputBudget } = deps;
-  const { workspace, session, onOutput } = input;
   const emitDiffSummaryHeader = createDiffSummaryEmitter({
     toolName: "create-file",
     label: t("tool.label.create"),
-    onOutput,
+    onOutput: input.onOutput,
   });
   return createTool({
     id: "create-file",
@@ -360,18 +350,18 @@ function createCreateFileTool(deps: ToolkitDeps, input: ToolkitInput) {
       output: z.string(),
     }),
     execute: async (toolInput) => {
-      return runTool(session, "create-file", toolInput, async (toolCallId) => {
+      return runTool(input.session, "create-file", toolInput, async (toolCallId) => {
         const rawResult = await writeTextFile({
-          workspace,
+          workspace: input.workspace,
           path: toolInput.path,
           content: toolInput.content,
           overwrite: true,
         });
         emitDiffSummaryHeader(toolInput.path, rawResult, toolCallId);
         for (const content of numberedUnifiedDiffLines(rawResult))
-          onOutput({ toolName: "create-file", content, toolCallId });
+          input.onOutput({ toolName: "create-file", content, toolCallId });
         const totals = summarizeUnifiedDiff(rawResult);
-        const result = compactToolOutput(rawResult, outputBudget.create);
+        const result = compactToolOutput(rawResult, deps.outputBudget.create);
         return {
           kind: "create-file",
           path: toolInput.path,
@@ -386,8 +376,6 @@ function createCreateFileTool(deps: ToolkitDeps, input: ToolkitInput) {
 }
 
 function createDeleteFileTool(deps: ToolkitDeps, input: ToolkitInput) {
-  const { outputBudget } = deps;
-  const { workspace, session, onOutput } = input;
   return createTool({
     id: "delete-file",
     label: t("tool.label.delete"),
@@ -406,21 +394,21 @@ function createDeleteFileTool(deps: ToolkitDeps, input: ToolkitInput) {
       output: z.string(),
     }),
     execute: async (toolInput) => {
-      return runTool(session, "delete-file", toolInput, async (toolCallId) => {
+      return runTool(input.session, "delete-file", toolInput, async (toolCallId) => {
         const paths = normalizeUniquePaths(toolInput.paths);
         const deleteDetail = paths.length > 0 ? formatDeletePaths(paths) : undefined;
-        onOutput({
+        input.onOutput({
           toolName: "delete-file",
           content: { kind: "tool-header", label: t("tool.label.delete"), detail: deleteDetail },
           toolCallId,
         });
         const resultParts: string[] = [];
         for (const path of paths) {
-          const rawResult = await deleteTextFile({ workspace, path });
+          const rawResult = await deleteTextFile({ workspace: input.workspace, path });
           resultParts.push(rawResult);
         }
         const rawResult = resultParts.join("\n\n");
-        const result = compactToolOutput(rawResult, outputBudget.edit);
+        const result = compactToolOutput(rawResult, deps.outputBudget.edit);
         return { kind: "delete-file", paths, deleted: paths.length, output: result };
       });
     },

--- a/src/git-toolkit.ts
+++ b/src/git-toolkit.ts
@@ -1,8 +1,7 @@
 import { z } from "zod";
-import { appConfig } from "./app-config";
 import { gitAdd, gitCommit, gitDiff, gitLog, gitShow, gitStatusShort } from "./git-ops";
 import { t } from "./i18n";
-import type { ToolkitInput } from "./tool-contract";
+import type { ToolkitDeps, ToolkitInput } from "./tool-contract";
 import { createTool } from "./tool-contract";
 import { runTool } from "./tool-execution";
 import { compactToolOutput } from "./tool-output";
@@ -88,7 +87,8 @@ function stripGitShowMetadataForPreview(rawText: string): string {
     .join("\n");
 }
 
-function createGitStatusTool(git: GitOps, input: ToolkitInput) {
+function createGitStatusTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
+  const { outputBudget } = deps;
   const { session, onOutput } = input;
   return createTool({
     id: "git-status",
@@ -112,14 +112,15 @@ function createGitStatusTool(git: GitOps, input: ToolkitInput) {
         });
         const rawStatus = await git.statusShort();
         emitHeadTailLines("git-status", rawStatus, onOutput, toolCallId);
-        const result = compactToolOutput(rawStatus, appConfig.agent.toolOutputBudget.gitStatus);
+        const result = compactToolOutput(rawStatus, outputBudget.gitStatus);
         return { kind: "git-status", output: result };
       });
     },
   });
 }
 
-function createGitDiffTool(git: GitOps, input: ToolkitInput) {
+function createGitDiffTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
+  const { outputBudget } = deps;
   const { session, onOutput } = input;
   return createTool({
     id: "git-diff",
@@ -148,14 +149,15 @@ function createGitDiffTool(git: GitOps, input: ToolkitInput) {
         });
         const rawDiff = await git.diff({ path: toolInput.path, contextLines: toolInput.contextLines ?? 3 });
         emitHeadTailLines("git-diff", rawDiff, onOutput, toolCallId, { headRows: 2, tailRows: 2 });
-        const result = compactToolOutput(rawDiff, appConfig.agent.toolOutputBudget.gitDiff);
+        const result = compactToolOutput(rawDiff, outputBudget.gitDiff);
         return { kind: "git-diff", path: toolInput.path, contextLines: toolInput.contextLines ?? 3, output: result };
       });
     },
   });
 }
 
-function createGitLogTool(git: GitOps, input: ToolkitInput) {
+function createGitLogTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
+  const { outputBudget } = deps;
   const { session, onOutput } = input;
   return createTool({
     id: "git-log",
@@ -184,14 +186,15 @@ function createGitLogTool(git: GitOps, input: ToolkitInput) {
         });
         const rawLog = await git.log({ path: toolInput.path, limit: toolInput.limit });
         emitResultChunks("git-log", rawLog, onOutput, 4, toolCallId);
-        const result = compactToolOutput(rawLog, appConfig.agent.toolOutputBudget.gitDiff);
+        const result = compactToolOutput(rawLog, outputBudget.gitDiff);
         return { kind: "git-log", path: toolInput.path, limit: toolInput.limit, output: result };
       });
     },
   });
 }
 
-function createGitShowTool(git: GitOps, input: ToolkitInput) {
+function createGitShowTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
+  const { outputBudget } = deps;
   const { session, onOutput } = input;
   return createTool({
     id: "git-show",
@@ -226,7 +229,7 @@ function createGitShowTool(git: GitOps, input: ToolkitInput) {
           contextLines: toolInput.contextLines ?? 3,
         });
         emitHeadTailLines("git-show", stripGitShowMetadataForPreview(rawShow), onOutput, toolCallId);
-        const result = compactToolOutput(rawShow, appConfig.agent.toolOutputBudget.gitDiff);
+        const result = compactToolOutput(rawShow, outputBudget.gitDiff);
         return {
           kind: "git-show",
           ref: toolInput.ref,
@@ -239,7 +242,8 @@ function createGitShowTool(git: GitOps, input: ToolkitInput) {
   });
 }
 
-function createGitAddTool(git: GitOps, input: ToolkitInput) {
+function createGitAddTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
+  const { outputBudget } = deps;
   const { session, onOutput } = input;
   return createTool({
     id: "git-add",
@@ -281,14 +285,15 @@ function createGitAddTool(git: GitOps, input: ToolkitInput) {
             });
           }
         }
-        const result = compactToolOutput(rawAdd, appConfig.agent.toolOutputBudget.gitStatus);
+        const result = compactToolOutput(rawAdd, outputBudget.gitStatus);
         return { kind: "git-add", all: toolInput.all, paths: toolInput.paths, output: result };
       });
     },
   });
 }
 
-function createGitCommitTool(git: GitOps, input: ToolkitInput) {
+function createGitCommitTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
+  const { outputBudget } = deps;
   const { session, onOutput } = input;
   return createTool({
     id: "git-commit",
@@ -332,21 +337,21 @@ function createGitCommitTool(git: GitOps, input: ToolkitInput) {
             });
           }
         }
-        const result = compactToolOutput(rawCommit, appConfig.agent.toolOutputBudget.gitDiff);
+        const result = compactToolOutput(rawCommit, outputBudget.gitDiff);
         return { kind: "git-commit", message: toolInput.message, body: toolInput.body, output: result };
       });
     },
   });
 }
 
-export function createGitToolkit(input: ToolkitInput) {
+export function createGitToolkit(deps: ToolkitDeps, input: ToolkitInput) {
   const git = createGitOps(input.workspace);
   return {
-    gitStatus: createGitStatusTool(git, input),
-    gitDiff: createGitDiffTool(git, input),
-    gitLog: createGitLogTool(git, input),
-    gitShow: createGitShowTool(git, input),
-    gitAdd: createGitAddTool(git, input),
-    gitCommit: createGitCommitTool(git, input),
+    gitStatus: createGitStatusTool(git, deps, input),
+    gitDiff: createGitDiffTool(git, deps, input),
+    gitLog: createGitLogTool(git, deps, input),
+    gitShow: createGitShowTool(git, deps, input),
+    gitAdd: createGitAddTool(git, deps, input),
+    gitCommit: createGitCommitTool(git, deps, input),
   };
 }

--- a/src/git-toolkit.ts
+++ b/src/git-toolkit.ts
@@ -88,8 +88,6 @@ function stripGitShowMetadataForPreview(rawText: string): string {
 }
 
 function createGitStatusTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
-  const { outputBudget } = deps;
-  const { session, onOutput } = input;
   return createTool({
     id: "git-status",
     label: t("tool.label.git_status"),
@@ -104,15 +102,15 @@ function createGitStatusTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput
     }),
     inputSchema: z.object({}).optional(),
     execute: async () => {
-      return runTool(session, "git-status", {}, async (toolCallId) => {
-        onOutput({
+      return runTool(input.session, "git-status", {}, async (toolCallId) => {
+        input.onOutput({
           toolName: "git-status",
           content: { kind: "tool-header", label: t("tool.label.git_status") },
           toolCallId,
         });
         const rawStatus = await git.statusShort();
-        emitHeadTailLines("git-status", rawStatus, onOutput, toolCallId);
-        const result = compactToolOutput(rawStatus, outputBudget.gitStatus);
+        emitHeadTailLines("git-status", rawStatus, input.onOutput, toolCallId);
+        const result = compactToolOutput(rawStatus, deps.outputBudget.gitStatus);
         return { kind: "git-status", output: result };
       });
     },
@@ -120,8 +118,6 @@ function createGitStatusTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput
 }
 
 function createGitDiffTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
-  const { outputBudget } = deps;
-  const { session, onOutput } = input;
   return createTool({
     id: "git-diff",
     label: t("tool.label.git_diff"),
@@ -141,15 +137,15 @@ function createGitDiffTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) 
       contextLines: z.number().int().min(0).max(20).optional(),
     }),
     execute: async (toolInput) => {
-      return runTool(session, "git-diff", toolInput, async (toolCallId) => {
-        onOutput({
+      return runTool(input.session, "git-diff", toolInput, async (toolCallId) => {
+        input.onOutput({
           toolName: "git-diff",
           content: { kind: "tool-header", label: t("tool.label.git_diff"), detail: toolInput.path },
           toolCallId,
         });
         const rawDiff = await git.diff({ path: toolInput.path, contextLines: toolInput.contextLines ?? 3 });
-        emitHeadTailLines("git-diff", rawDiff, onOutput, toolCallId, { headRows: 2, tailRows: 2 });
-        const result = compactToolOutput(rawDiff, outputBudget.gitDiff);
+        emitHeadTailLines("git-diff", rawDiff, input.onOutput, toolCallId, { headRows: 2, tailRows: 2 });
+        const result = compactToolOutput(rawDiff, deps.outputBudget.gitDiff);
         return { kind: "git-diff", path: toolInput.path, contextLines: toolInput.contextLines ?? 3, output: result };
       });
     },
@@ -157,8 +153,6 @@ function createGitDiffTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) 
 }
 
 function createGitLogTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
-  const { outputBudget } = deps;
-  const { session, onOutput } = input;
   return createTool({
     id: "git-log",
     label: t("tool.label.git_log"),
@@ -178,15 +172,15 @@ function createGitLogTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
       limit: z.number().int().min(1).max(50).optional(),
     }),
     execute: async (toolInput) => {
-      return runTool(session, "git-log", toolInput, async (toolCallId) => {
-        onOutput({
+      return runTool(input.session, "git-log", toolInput, async (toolCallId) => {
+        input.onOutput({
           toolName: "git-log",
           content: { kind: "tool-header", label: t("tool.label.git_log"), detail: toolInput.path },
           toolCallId,
         });
         const rawLog = await git.log({ path: toolInput.path, limit: toolInput.limit });
-        emitResultChunks("git-log", rawLog, onOutput, 4, toolCallId);
-        const result = compactToolOutput(rawLog, outputBudget.gitDiff);
+        emitResultChunks("git-log", rawLog, input.onOutput, 4, toolCallId);
+        const result = compactToolOutput(rawLog, deps.outputBudget.gitDiff);
         return { kind: "git-log", path: toolInput.path, limit: toolInput.limit, output: result };
       });
     },
@@ -194,8 +188,6 @@ function createGitLogTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
 }
 
 function createGitShowTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
-  const { outputBudget } = deps;
-  const { session, onOutput } = input;
   return createTool({
     id: "git-show",
     label: t("tool.label.git_show"),
@@ -217,8 +209,8 @@ function createGitShowTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) 
       contextLines: z.number().int().min(0).max(20).optional(),
     }),
     execute: async (toolInput) => {
-      return runTool(session, "git-show", toolInput, async (toolCallId) => {
-        onOutput({
+      return runTool(input.session, "git-show", toolInput, async (toolCallId) => {
+        input.onOutput({
           toolName: "git-show",
           content: { kind: "tool-header", label: t("tool.label.git_show"), detail: toolInput.ref ?? toolInput.path },
           toolCallId,
@@ -228,8 +220,8 @@ function createGitShowTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) 
           path: toolInput.path,
           contextLines: toolInput.contextLines ?? 3,
         });
-        emitHeadTailLines("git-show", stripGitShowMetadataForPreview(rawShow), onOutput, toolCallId);
-        const result = compactToolOutput(rawShow, outputBudget.gitDiff);
+        emitHeadTailLines("git-show", stripGitShowMetadataForPreview(rawShow), input.onOutput, toolCallId);
+        const result = compactToolOutput(rawShow, deps.outputBudget.gitDiff);
         return {
           kind: "git-show",
           ref: toolInput.ref,
@@ -243,8 +235,6 @@ function createGitShowTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) 
 }
 
 function createGitAddTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
-  const { outputBudget } = deps;
-  const { session, onOutput } = input;
   return createTool({
     id: "git-add",
     label: t("tool.label.git_add"),
@@ -264,10 +254,10 @@ function createGitAddTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
       all: z.boolean().optional(),
     }),
     execute: async (toolInput) => {
-      return runTool(session, "git-add", toolInput, async (toolCallId) => {
+      return runTool(input.session, "git-add", toolInput, async (toolCallId) => {
         const paths = (toolInput.paths ?? []).filter((p) => p.trim().length > 0);
         const addDetail = toolInput.all === true ? "all" : t("unit.file", { count: paths.length });
-        onOutput({
+        input.onOutput({
           toolName: "git-add",
           content: { kind: "tool-header", label: t("tool.label.git_add"), detail: addDetail },
           toolCallId,
@@ -275,17 +265,17 @@ function createGitAddTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
         const rawAdd = await git.add({ paths: toolInput.paths, all: toolInput.all });
         if (paths.length > 0) {
           for (const p of paths.slice(0, TOOL_OUTPUT_LIMITS.files)) {
-            onOutput({ toolName: "git-add", content: { kind: "text", text: p }, toolCallId });
+            input.onOutput({ toolName: "git-add", content: { kind: "text", text: p }, toolCallId });
           }
           if (paths.length > TOOL_OUTPUT_LIMITS.files) {
-            onOutput({
+            input.onOutput({
               toolName: "git-add",
               content: { kind: "truncated", count: paths.length - TOOL_OUTPUT_LIMITS.files, unit: "files" },
               toolCallId,
             });
           }
         }
-        const result = compactToolOutput(rawAdd, outputBudget.gitStatus);
+        const result = compactToolOutput(rawAdd, deps.outputBudget.gitStatus);
         return { kind: "git-add", all: toolInput.all, paths: toolInput.paths, output: result };
       });
     },
@@ -293,8 +283,6 @@ function createGitAddTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
 }
 
 function createGitCommitTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
-  const { outputBudget } = deps;
-  const { session, onOutput } = input;
   return createTool({
     id: "git-commit",
     label: t("tool.label.git_commit"),
@@ -314,12 +302,12 @@ function createGitCommitTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput
       body: z.array(z.string().min(1)).max(10).optional(),
     }),
     execute: async (toolInput) => {
-      return runTool(session, "git-commit", toolInput, async (toolCallId) => {
+      return runTool(input.session, "git-commit", toolInput, async (toolCallId) => {
         const rawCommit = await git.commit({ message: toolInput.message, body: toolInput.body });
         const hashMatch = rawCommit.match(/^\[[\w/.-]+\s+([a-f0-9]+)\]/);
         const shortHash = hashMatch?.[1];
         const detail = shortHash ? `${toolInput.message} (${shortHash})` : toolInput.message;
-        onOutput({
+        input.onOutput({
           toolName: "git-commit",
           content: { kind: "tool-header", label: t("tool.label.git_commit"), detail },
           toolCallId,
@@ -327,17 +315,17 @@ function createGitCommitTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput
         if (toolInput.body && toolInput.body.length > 0) {
           const maxBodyLines = TOOL_OUTPUT_LIMITS.files;
           for (const line of toolInput.body.slice(0, maxBodyLines)) {
-            onOutput({ toolName: "git-commit", content: { kind: "text", text: line }, toolCallId });
+            input.onOutput({ toolName: "git-commit", content: { kind: "text", text: line }, toolCallId });
           }
           if (toolInput.body.length > maxBodyLines) {
-            onOutput({
+            input.onOutput({
               toolName: "git-commit",
               content: { kind: "truncated", count: toolInput.body.length - maxBodyLines, unit: "lines" },
               toolCallId,
             });
           }
         }
-        const result = compactToolOutput(rawCommit, outputBudget.gitDiff);
+        const result = compactToolOutput(rawCommit, deps.outputBudget.gitDiff);
         return { kind: "git-commit", message: toolInput.message, body: toolInput.body, output: result };
       });
     },

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -40,12 +40,5 @@ export function createTranslator(locale: TranslationLocale): Translator {
 }
 
 export function t<K extends TranslationKey>(key: K, ...args: TranslationArgs<K>): string {
-  const vars = (args[0] ?? undefined) as Record<string, TranslationValue> | undefined;
-  const locale: TranslationLocale = appConfig.locale;
-  const templates = TRANSLATIONS[locale] ?? TRANSLATIONS.en;
-  if (vars && "count" in vars && Number(vars.count) === 1) {
-    const oneKey = `${key}.one` as TranslationKey;
-    if (oneKey in templates) return interpolate(templates[oneKey], vars);
-  }
-  return interpolate(templates[key] ?? key, vars);
+  return createTranslator(appConfig.locale)(key, ...args);
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -17,12 +17,26 @@ type TranslationVarsFor<K extends TranslationKey> = [ExtractTemplateVars<(typeof
 
 type TranslationArgs<K extends TranslationKey> = [TranslationVarsFor<K>] extends [never] ? [] : [TranslationVarsFor<K>];
 
+export type Translator = <K extends TranslationKey>(key: K, ...args: TranslationArgs<K>) => string;
+
 function interpolate(template: string, vars?: Record<string, TranslationValue>): string {
   if (!vars) return template;
   return template.replace(/\{([A-Za-z0-9_]+)\}/g, (_match, name: string) => {
     const value = vars[name];
     return value === undefined ? `{${name}}` : String(value);
   });
+}
+
+export function createTranslator(locale: TranslationLocale): Translator {
+  return <K extends TranslationKey>(key: K, ...args: TranslationArgs<K>): string => {
+    const vars = (args[0] ?? undefined) as Record<string, TranslationValue> | undefined;
+    const templates = TRANSLATIONS[locale] ?? TRANSLATIONS.en;
+    if (vars && "count" in vars && Number(vars.count) === 1) {
+      const oneKey = `${key}.one` as TranslationKey;
+      if (oneKey in templates) return interpolate(templates[oneKey], vars);
+    }
+    return interpolate(templates[key] ?? key, vars);
+  };
 }
 
 export function t<K extends TranslationKey>(key: K, ...args: TranslationArgs<K>): string {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -27,18 +27,23 @@ function interpolate(template: string, vars?: Record<string, TranslationValue>):
   });
 }
 
+function translate(templates: Record<string, string>, key: string, vars?: Record<string, TranslationValue>): string {
+  if (vars && "count" in vars && Number(vars.count) === 1) {
+    const oneKey = `${key}.one`;
+    if (oneKey in templates) return interpolate(templates[oneKey], vars);
+  }
+  return interpolate(templates[key] ?? key, vars);
+}
+
 export function createTranslator(locale: TranslationLocale): Translator {
-  return <K extends TranslationKey>(key: K, ...args: TranslationArgs<K>): string => {
-    const vars = (args[0] ?? undefined) as Record<string, TranslationValue> | undefined;
-    const templates = TRANSLATIONS[locale] ?? TRANSLATIONS.en;
-    if (vars && "count" in vars && Number(vars.count) === 1) {
-      const oneKey = `${key}.one` as TranslationKey;
-      if (oneKey in templates) return interpolate(templates[oneKey], vars);
-    }
-    return interpolate(templates[key] ?? key, vars);
-  };
+  const templates = TRANSLATIONS[locale] ?? TRANSLATIONS.en;
+  return (key, ...args) => translate(templates, key, args[0] as Record<string, TranslationValue> | undefined);
 }
 
 export function t<K extends TranslationKey>(key: K, ...args: TranslationArgs<K>): string {
-  return createTranslator(appConfig.locale)(key, ...args);
+  return translate(
+    TRANSLATIONS[appConfig.locale] ?? TRANSLATIONS.en,
+    key,
+    args[0] as Record<string, TranslationValue> | undefined,
+  );
 }

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -185,6 +185,7 @@ export type RunContext = {
   nativeIdQueue: Map<string, string[]>;
   toolCallStartedAt: Map<string, ToolCallStart>;
   toolOutputHandler: ((event: ToolOutputEvent) => void) | null;
+  temperatures?: Partial<Record<AgentMode, number>>;
 };
 
 type GuardStats = { blocked: number; flagSet: number };

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -248,7 +248,7 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
 
   try {
     resetTimeout();
-    const temperature = appConfig.temperatures[ctx.mode];
+    const temperature = ctx.temperatures?.[ctx.mode] ?? appConfig.temperatures[ctx.mode];
     const streamOutput = await ctx.agent.stream(prompt, {
       toolChoice: "auto",
       ...(typeof temperature === "number" ? { temperature } : {}),

--- a/src/lifecycle-resolve.ts
+++ b/src/lifecycle-resolve.ts
@@ -9,9 +9,10 @@ export function resolveModeModel(
   mode: AgentMode,
   requestModel: string,
   modeModels?: ChatRequest["modeModels"],
+  configuredModels?: Partial<Record<AgentMode, string>>,
 ): ModeResolution {
   const requestModeModel = modeModels?.[mode]?.trim();
-  const configuredModeModel = appConfig.models[mode]?.trim();
+  const configuredModeModel = (configuredModels ?? appConfig.models)[mode]?.trim();
   const trimmedRequestModel = requestModel.trim();
   let requestedModel = "";
   if (requestModeModel && requestModeModel.length > 0) {

--- a/src/memory-registry.ts
+++ b/src/memory-registry.ts
@@ -56,6 +56,10 @@ export function resolveMemorySources(ids: readonly MemorySourceId[]): readonly M
   return resolved.length > 0 ? resolved : DEFAULT_MEMORY_SOURCE_IDS.map((id) => AVAILABLE_MEMORY_SOURCES[id]);
 }
 
+export type MemoryConfig = {
+  sources: readonly MemorySourceId[];
+};
+
 export const DEFAULT_MEMORY_SOURCES: readonly MemorySource[] = resolveMemorySources(appConfig.memory.sources);
 
 export function createMemoryRegistry(

--- a/src/memory-source-distill.test.ts
+++ b/src/memory-source-distill.test.ts
@@ -316,8 +316,7 @@ describe("distillMemorySource", () => {
           }
           return "";
         },
-        {},
-        { ...testDistillConfig, reflectionThresholdTokens: 1, maxOutputTokens: 10_000 },
+        { config: { ...testDistillConfig, reflectionThresholdTokens: 1, maxOutputTokens: 10_000 } },
       );
       if (!source.commit) throw new Error("expected commit handler");
       await source.commit({
@@ -359,8 +358,7 @@ describe("distillMemorySource", () => {
           if (systemPrompt === REFLECTOR_PROMPT) return "compact";
           return "";
         },
-        {},
-        { ...testDistillConfig, reflectionThresholdTokens: 5, maxOutputTokens: 10_000 },
+        { config: { ...testDistillConfig, reflectionThresholdTokens: 5, maxOutputTokens: 10_000 } },
       );
       if (!source.commit) throw new Error("expected commit handler");
       await source.commit({
@@ -395,8 +393,7 @@ describe("distillMemorySource", () => {
           }
           return "";
         },
-        {},
-        { ...testDistillConfig, reflectionThresholdTokens: 1, maxOutputTokens: 100_000 },
+        { config: { ...testDistillConfig, reflectionThresholdTokens: 1, maxOutputTokens: 100_000 } },
       );
       if (!source.commit) throw new Error("expected commit handler");
       await source.commit({
@@ -419,8 +416,7 @@ describe("distillMemorySource", () => {
             return "[session] fact line\nCurrent task: Implement rolling context\nNext step: Add continuation fields";
           return "";
         },
-        {},
-        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+        { config: { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 } },
       );
       if (!source.commit) throw new Error("expected commit handler");
       await source.commit({
@@ -442,8 +438,7 @@ describe("distillMemorySource", () => {
             return "[session] fact line\n- Current task: Bullet task\n* Next step: Bullet next";
           return "";
         },
-        {},
-        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+        { config: { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 } },
       );
       if (!source.commit) throw new Error("expected commit handler");
       await source.commit({
@@ -470,8 +465,7 @@ describe("distillMemorySource", () => {
             ].join("\n");
           return "";
         },
-        {},
-        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+        { config: { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 } },
       );
       if (!source.commit) throw new Error("expected commit handler");
       await source.commit({
@@ -501,8 +495,7 @@ describe("distillMemorySource", () => {
           if (systemPrompt === OBSERVER_PROMPT) return " [session] prefers   short answers ";
           return "";
         },
-        {},
-        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+        { config: { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 } },
       );
       if (!source.commit) throw new Error("expected commit handler");
       await source.commit({
@@ -521,8 +514,7 @@ describe("distillMemorySource", () => {
           if (systemPrompt !== OBSERVER_PROMPT) return "";
           return ["untagged fact should be dropped", "Current task: keep tagged facts only"].join("\n");
         },
-        {},
-        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+        { config: { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 } },
       );
       if (!source.commit) throw new Error("expected commit handler");
       await source.commit({
@@ -548,8 +540,7 @@ describe("distillMemorySource", () => {
             "[user] prefers concise replies",
           ].join("\n");
         },
-        {},
-        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+        { config: { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 } },
       );
       if (!source.commit) throw new Error("expected commit handler");
       await source.commit({
@@ -581,8 +572,7 @@ describe("distillMemorySource", () => {
             "[session] valid session fact",
           ].join("\n");
         },
-        {},
-        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+        { config: { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 } },
       );
       if (!source.commit) throw new Error("expected commit handler");
       const metrics = await source.commit({
@@ -606,8 +596,10 @@ describe("distillMemorySource", () => {
       const source = createDistillMemorySource(
         store,
         async (systemPrompt) => (systemPrompt === OBSERVER_PROMPT ? "scope fact" : ""),
-        { commitScope: "project" },
-        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+        {
+          commitScope: "project",
+          config: { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+        },
       );
       if (!source.commit) throw new Error("expected commit handler");
       await source.commit({
@@ -638,8 +630,7 @@ describe("distillMemorySource", () => {
             "Next step: add promotion tests",
           ].join("\n");
         },
-        {},
-        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+        { config: { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 } },
       );
       if (!source.commit) throw new Error("expected commit handler");
       await source.commit({
@@ -679,8 +670,7 @@ describe("distillMemorySource", () => {
             "[proj] malformed tag dropped",
           ].join("\n");
         },
-        {},
-        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+        { config: { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 } },
       );
       if (!source.commit) throw new Error("expected commit handler");
       const metrics = await source.commit({
@@ -759,8 +749,7 @@ describe("distillMemorySource", () => {
             if (systemPrompt !== OBSERVER_PROMPT) return "";
             return fixture.observed;
           },
-          {},
-          fixtureConfig,
+          { config: fixtureConfig },
         );
         if (!source.commit) throw new Error("expected commit handler");
         const metrics = await source.commit({

--- a/src/memory-source-distill.test.ts
+++ b/src/memory-source-distill.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import { appConfig } from "./app-config";
 import type { DistillRecord } from "./memory-contract";
 import { OBSERVER_PROMPT, REFLECTOR_PROMPT } from "./memory-distill-prompts";
 import type { DistillStore } from "./memory-distill-store";
-import { createDistillMemorySource } from "./memory-source-distill";
+import { createDistillMemorySource, type DistillConfig } from "./memory-source-distill";
+
+const testDistillConfig: DistillConfig = {
+  model: "test-model",
+  messageThreshold: 1,
+  reflectionThresholdTokens: 50,
+  maxOutputTokens: 200,
+};
 
 function createMockStore(
   records: DistillRecord[] = [],
@@ -281,216 +287,180 @@ describe("distillMemorySource", () => {
     });
 
     test("reflects only observations created since latest reflection", async () => {
-      const originalDistillConfig = { ...appConfig.distill };
-      (appConfig as { distill: typeof appConfig.distill }).distill = {
-        ...appConfig.distill,
-        messageThreshold: 1,
-        reflectionThresholdTokens: 1,
-        maxOutputTokens: 10_000,
-      };
-      try {
-        const store = createMockStore([
-          {
-            id: "dst_obs_old",
-            sessionId: "sess_test0001",
-            tier: "observation",
-            content: "old observation",
-            createdAt: "2026-03-04T10:00:00.000Z",
-            tokenEstimate: 3,
-          },
-          {
-            id: "dst_ref_old",
-            sessionId: "sess_test0001",
-            tier: "reflection",
-            content: "old reflection",
-            createdAt: "2026-03-04T10:30:00.000Z",
-            tokenEstimate: 3,
-          },
-        ]);
-        const reflectorInputs: string[] = [];
-        const source = createDistillMemorySource(store, async (systemPrompt, input) => {
+      const store = createMockStore([
+        {
+          id: "dst_obs_old",
+          sessionId: "sess_test0001",
+          tier: "observation",
+          content: "old observation",
+          createdAt: "2026-03-04T10:00:00.000Z",
+          tokenEstimate: 3,
+        },
+        {
+          id: "dst_ref_old",
+          sessionId: "sess_test0001",
+          tier: "reflection",
+          content: "old reflection",
+          createdAt: "2026-03-04T10:30:00.000Z",
+          tokenEstimate: 3,
+        },
+      ]);
+      const reflectorInputs: string[] = [];
+      const source = createDistillMemorySource(
+        store,
+        async (systemPrompt, input) => {
           if (systemPrompt === OBSERVER_PROMPT) return "[session] new observation";
           if (systemPrompt === REFLECTOR_PROMPT) {
             reflectorInputs.push(input);
             return "new reflection";
           }
           return "";
-        });
-        if (!source.commit) throw new Error("expected commit handler");
-        await source.commit({
-          sessionId: "sess_test0001",
-          messages: [{ role: "user", content: "hello" }],
-          output: "done",
-        });
+        },
+        {},
+        { ...testDistillConfig, reflectionThresholdTokens: 1, maxOutputTokens: 10_000 },
+      );
+      if (!source.commit) throw new Error("expected commit handler");
+      await source.commit({
+        sessionId: "sess_test0001",
+        messages: [{ role: "user", content: "hello" }],
+        output: "done",
+      });
 
-        expect(reflectorInputs.length).toBeGreaterThan(0);
-        const latestReflectorInput = reflectorInputs[reflectorInputs.length - 1];
-        expect(latestReflectorInput).toContain("new observation");
-        expect(latestReflectorInput).not.toContain("old observation");
-      } finally {
-        (appConfig as { distill: typeof appConfig.distill }).distill = originalDistillConfig;
-      }
+      expect(reflectorInputs.length).toBeGreaterThan(0);
+      const latestReflectorInput = reflectorInputs[reflectorInputs.length - 1];
+      expect(latestReflectorInput).toContain("new observation");
+      expect(latestReflectorInput).not.toContain("old observation");
     });
 
     test("removes consolidated observations and old reflections after writing new reflection", async () => {
-      const originalDistillConfig = { ...appConfig.distill };
-      (appConfig as { distill: typeof appConfig.distill }).distill = {
-        ...appConfig.distill,
-        messageThreshold: 1,
-        reflectionThresholdTokens: 5,
-        maxOutputTokens: 10_000,
-      };
-      try {
-        const store = createMockStore([
-          {
-            id: "dst_obs_old",
-            sessionId: "sess_test0001",
-            tier: "observation",
-            content: "old observation that was before the reflection",
-            createdAt: "2026-03-04T10:00:00.000Z",
-            tokenEstimate: 10,
-          },
-          {
-            id: "dst_ref_old",
-            sessionId: "sess_test0001",
-            tier: "reflection",
-            content: "old reflection",
-            createdAt: "2026-03-04T10:30:00.000Z",
-            tokenEstimate: 4,
-          },
-        ]);
-        const source = createDistillMemorySource(store, async (systemPrompt) => {
+      const store = createMockStore([
+        {
+          id: "dst_obs_old",
+          sessionId: "sess_test0001",
+          tier: "observation",
+          content: "old observation that was before the reflection",
+          createdAt: "2026-03-04T10:00:00.000Z",
+          tokenEstimate: 10,
+        },
+        {
+          id: "dst_ref_old",
+          sessionId: "sess_test0001",
+          tier: "reflection",
+          content: "old reflection",
+          createdAt: "2026-03-04T10:30:00.000Z",
+          tokenEstimate: 4,
+        },
+      ]);
+      const source = createDistillMemorySource(
+        store,
+        async (systemPrompt) => {
           if (systemPrompt === OBSERVER_PROMPT)
             return "[session] a new observation with enough tokens to exceed the reflection threshold for this test";
           if (systemPrompt === REFLECTOR_PROMPT) return "compact";
           return "";
-        });
-        if (!source.commit) throw new Error("expected commit handler");
-        await source.commit({
-          sessionId: "sess_test0001",
-          messages: [{ role: "user", content: "hello" }],
-          output: "done",
-        });
+        },
+        {},
+        { ...testDistillConfig, reflectionThresholdTokens: 5, maxOutputTokens: 10_000 },
+      );
+      if (!source.commit) throw new Error("expected commit handler");
+      await source.commit({
+        sessionId: "sess_test0001",
+        messages: [{ role: "user", content: "hello" }],
+        output: "done",
+      });
 
-        // New observation and reflection were written
-        expect(store.written.filter((e) => e.tier === "observation")).toHaveLength(1);
-        expect(store.written.filter((e) => e.tier === "reflection")).toHaveLength(1);
-        // Old observation (pre-reflection) and old reflection were GC'd
-        // The new observation (post-old-reflection, consolidated into new reflection) was also GC'd
-        expect(store.removed).toContain("dst_ref_old");
-        expect(store.removed.some((id) => id !== "dst_ref_old")).toBe(true);
-        // Only the new reflection remains in the store
-        const remaining = await store.list("sess_test0001");
-        expect(remaining).toHaveLength(1);
-        expect(remaining[0]?.tier).toBe("reflection");
-      } finally {
-        (appConfig as { distill: typeof appConfig.distill }).distill = originalDistillConfig;
-      }
+      // New observation and reflection were written
+      expect(store.written.filter((e) => e.tier === "observation")).toHaveLength(1);
+      expect(store.written.filter((e) => e.tier === "reflection")).toHaveLength(1);
+      // Old observation (pre-reflection) and old reflection were GC'd
+      // The new observation (post-old-reflection, consolidated into new reflection) was also GC'd
+      expect(store.removed).toContain("dst_ref_old");
+      expect(store.removed.some((id) => id !== "dst_ref_old")).toBe(true);
+      // Only the new reflection remains in the store
+      const remaining = await store.list("sess_test0001");
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]?.tier).toBe("reflection");
     });
 
     test("skips writing reflection when retry compression cannot reduce size", async () => {
-      const originalDistillConfig = { ...appConfig.distill };
-      (appConfig as { distill: typeof appConfig.distill }).distill = {
-        ...appConfig.distill,
-        messageThreshold: 1,
-        reflectionThresholdTokens: 1,
-        maxOutputTokens: 100_000,
-      };
-      try {
-        const store = createMockStore();
-        let reflectionCalls = 0;
-        const source = createDistillMemorySource(store, async (systemPrompt) => {
+      const store = createMockStore();
+      let reflectionCalls = 0;
+      const source = createDistillMemorySource(
+        store,
+        async (systemPrompt) => {
           if (systemPrompt === OBSERVER_PROMPT) return "[session] tiny observation";
           if (systemPrompt === REFLECTOR_PROMPT) {
             reflectionCalls += 1;
             return "x".repeat(2_000);
           }
           return "";
-        });
-        if (!source.commit) throw new Error("expected commit handler");
-        await source.commit({
-          sessionId: "sess_test0001",
-          messages: [{ role: "user", content: "hello" }],
-          output: "done",
-        });
+        },
+        {},
+        { ...testDistillConfig, reflectionThresholdTokens: 1, maxOutputTokens: 100_000 },
+      );
+      if (!source.commit) throw new Error("expected commit handler");
+      await source.commit({
+        sessionId: "sess_test0001",
+        messages: [{ role: "user", content: "hello" }],
+        output: "done",
+      });
 
-        expect(reflectionCalls).toBe(3);
-        expect(store.written.filter((entry) => entry.tier === "observation")).toHaveLength(1);
-        expect(store.written.filter((entry) => entry.tier === "reflection")).toHaveLength(0);
-      } finally {
-        (appConfig as { distill: typeof appConfig.distill }).distill = originalDistillConfig;
-      }
+      expect(reflectionCalls).toBe(3);
+      expect(store.written.filter((entry) => entry.tier === "observation")).toHaveLength(1);
+      expect(store.written.filter((entry) => entry.tier === "reflection")).toHaveLength(0);
     });
 
     test("stores parsed continuation fields from observation output", async () => {
-      const originalDistillConfig = { ...appConfig.distill };
-      (appConfig as { distill: typeof appConfig.distill }).distill = {
-        ...appConfig.distill,
-        messageThreshold: 1,
-        reflectionThresholdTokens: 999_999,
-        maxOutputTokens: 10_000,
-      };
-      try {
-        const store = createMockStore();
-        const source = createDistillMemorySource(store, async (systemPrompt) => {
+      const store = createMockStore();
+      const source = createDistillMemorySource(
+        store,
+        async (systemPrompt) => {
           if (systemPrompt === OBSERVER_PROMPT)
             return "[session] fact line\nCurrent task: Implement rolling context\nNext step: Add continuation fields";
           return "";
-        });
-        if (!source.commit) throw new Error("expected commit handler");
-        await source.commit({
-          sessionId: "sess_test0001",
-          messages: [{ role: "user", content: "hello" }],
-          output: "done",
-        });
-        const writtenObservation = store.written.find((entry) => entry.tier === "observation");
-        expect(writtenObservation?.currentTask).toBe("Implement rolling context");
-        expect(writtenObservation?.nextStep).toBe("Add continuation fields");
-      } finally {
-        (appConfig as { distill: typeof appConfig.distill }).distill = originalDistillConfig;
-      }
+        },
+        {},
+        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+      );
+      if (!source.commit) throw new Error("expected commit handler");
+      await source.commit({
+        sessionId: "sess_test0001",
+        messages: [{ role: "user", content: "hello" }],
+        output: "done",
+      });
+      const writtenObservation = store.written.find((entry) => entry.tier === "observation");
+      expect(writtenObservation?.currentTask).toBe("Implement rolling context");
+      expect(writtenObservation?.nextStep).toBe("Add continuation fields");
     });
 
     test("stores parsed continuation fields from bullet observation output", async () => {
-      const originalDistillConfig = { ...appConfig.distill };
-      (appConfig as { distill: typeof appConfig.distill }).distill = {
-        ...appConfig.distill,
-        messageThreshold: 1,
-        reflectionThresholdTokens: 999_999,
-        maxOutputTokens: 10_000,
-      };
-      try {
-        const store = createMockStore();
-        const source = createDistillMemorySource(store, async (systemPrompt) => {
+      const store = createMockStore();
+      const source = createDistillMemorySource(
+        store,
+        async (systemPrompt) => {
           if (systemPrompt === OBSERVER_PROMPT)
             return "[session] fact line\n- Current task: Bullet task\n* Next step: Bullet next";
           return "";
-        });
-        if (!source.commit) throw new Error("expected commit handler");
-        await source.commit({
-          sessionId: "sess_test0001",
-          messages: [{ role: "user", content: "hello" }],
-          output: "done",
-        });
-        const writtenObservation = store.written.find((entry) => entry.tier === "observation");
-        expect(writtenObservation?.currentTask).toBe("Bullet task");
-        expect(writtenObservation?.nextStep).toBe("Bullet next");
-      } finally {
-        (appConfig as { distill: typeof appConfig.distill }).distill = originalDistillConfig;
-      }
+        },
+        {},
+        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+      );
+      if (!source.commit) throw new Error("expected commit handler");
+      await source.commit({
+        sessionId: "sess_test0001",
+        messages: [{ role: "user", content: "hello" }],
+        output: "done",
+      });
+      const writtenObservation = store.written.find((entry) => entry.tier === "observation");
+      expect(writtenObservation?.currentTask).toBe("Bullet task");
+      expect(writtenObservation?.nextStep).toBe("Bullet next");
     });
 
     test("stores last continuation fields when multiple lines are present", async () => {
-      const originalDistillConfig = { ...appConfig.distill };
-      (appConfig as { distill: typeof appConfig.distill }).distill = {
-        ...appConfig.distill,
-        messageThreshold: 1,
-        reflectionThresholdTokens: 999_999,
-        maxOutputTokens: 10_000,
-      };
-      try {
-        const store = createMockStore();
-        const source = createDistillMemorySource(store, async (systemPrompt) => {
+      const store = createMockStore();
+      const source = createDistillMemorySource(
+        store,
+        async (systemPrompt) => {
           if (systemPrompt === OBSERVER_PROMPT)
             return [
               "Current task: Old task",
@@ -499,95 +469,77 @@ describe("distillMemorySource", () => {
               "Next step: New step",
             ].join("\n");
           return "";
-        });
-        if (!source.commit) throw new Error("expected commit handler");
-        await source.commit({
-          sessionId: "sess_test0001",
-          messages: [{ role: "user", content: "hello" }],
-          output: "done",
-        });
-        const writtenObservation = store.written.find((entry) => entry.tier === "observation");
-        expect(writtenObservation?.currentTask).toBe("New task");
-        expect(writtenObservation?.nextStep).toBe("New step");
-      } finally {
-        (appConfig as { distill: typeof appConfig.distill }).distill = originalDistillConfig;
-      }
+        },
+        {},
+        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+      );
+      if (!source.commit) throw new Error("expected commit handler");
+      await source.commit({
+        sessionId: "sess_test0001",
+        messages: [{ role: "user", content: "hello" }],
+        output: "done",
+      });
+      const writtenObservation = store.written.find((entry) => entry.tier === "observation");
+      expect(writtenObservation?.currentTask).toBe("New task");
+      expect(writtenObservation?.nextStep).toBe("New step");
     });
 
     test("skips consecutive duplicate observations", async () => {
-      const originalDistillConfig = { ...appConfig.distill };
-      (appConfig as { distill: typeof appConfig.distill }).distill = {
-        ...appConfig.distill,
-        messageThreshold: 1,
-        reflectionThresholdTokens: 999_999,
-        maxOutputTokens: 10_000,
-      };
-      try {
-        const store = createMockStore([
-          {
-            id: "dst_obs_prev",
-            sessionId: "sess_test0001",
-            tier: "observation",
-            content: "prefers short answers",
-            createdAt: "2026-03-04T10:00:00.000Z",
-            tokenEstimate: 6,
-          },
-        ]);
-        const source = createDistillMemorySource(store, async (systemPrompt) => {
+      const store = createMockStore([
+        {
+          id: "dst_obs_prev",
+          sessionId: "sess_test0001",
+          tier: "observation",
+          content: "prefers short answers",
+          createdAt: "2026-03-04T10:00:00.000Z",
+          tokenEstimate: 6,
+        },
+      ]);
+      const source = createDistillMemorySource(
+        store,
+        async (systemPrompt) => {
           if (systemPrompt === OBSERVER_PROMPT) return " [session] prefers   short answers ";
           return "";
-        });
-        if (!source.commit) throw new Error("expected commit handler");
-        await source.commit({
-          sessionId: "sess_test0001",
-          messages: [{ role: "user", content: "hello" }],
-          output: "done",
-        });
-        expect(store.written).toHaveLength(0);
-      } finally {
-        (appConfig as { distill: typeof appConfig.distill }).distill = originalDistillConfig;
-      }
+        },
+        {},
+        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+      );
+      if (!source.commit) throw new Error("expected commit handler");
+      await source.commit({
+        sessionId: "sess_test0001",
+        messages: [{ role: "user", content: "hello" }],
+        output: "done",
+      });
+      expect(store.written).toHaveLength(0);
     });
 
     test("drops untagged fact lines during session commit", async () => {
-      const originalDistillConfig = { ...appConfig.distill };
-      (appConfig as { distill: typeof appConfig.distill }).distill = {
-        ...appConfig.distill,
-        messageThreshold: 1,
-        reflectionThresholdTokens: 999_999,
-        maxOutputTokens: 10_000,
-      };
-      try {
-        const store = createMockStore();
-        const source = createDistillMemorySource(store, async (systemPrompt) => {
+      const store = createMockStore();
+      const source = createDistillMemorySource(
+        store,
+        async (systemPrompt) => {
           if (systemPrompt !== OBSERVER_PROMPT) return "";
           return ["untagged fact should be dropped", "Current task: keep tagged facts only"].join("\n");
-        });
-        if (!source.commit) throw new Error("expected commit handler");
-        await source.commit({
-          sessionId: "sess_test0001",
-          messages: [{ role: "user", content: "hello" }],
-          output: "done",
-        });
-        const sessionEntry = store.written.find((entry) => entry.sessionId === "sess_test0001");
-        expect(sessionEntry?.content).toContain("Current task: keep tagged facts only");
-        expect(sessionEntry?.content).not.toContain("untagged fact should be dropped");
-      } finally {
-        (appConfig as { distill: typeof appConfig.distill }).distill = originalDistillConfig;
-      }
+        },
+        {},
+        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+      );
+      if (!source.commit) throw new Error("expected commit handler");
+      await source.commit({
+        sessionId: "sess_test0001",
+        messages: [{ role: "user", content: "hello" }],
+        output: "done",
+      });
+      const sessionEntry = store.written.find((entry) => entry.sessionId === "sess_test0001");
+      expect(sessionEntry?.content).toContain("Current task: keep tagged facts only");
+      expect(sessionEntry?.content).not.toContain("untagged fact should be dropped");
     });
 
     test("keeps continuation lines in session scope even if tagged as project/user", async () => {
-      const originalDistillConfig = { ...appConfig.distill };
-      (appConfig as { distill: typeof appConfig.distill }).distill = {
-        ...appConfig.distill,
-        messageThreshold: 1,
-        reflectionThresholdTokens: 999_999,
-        maxOutputTokens: 10_000,
-      };
-      try {
-        const store = createMockStore();
-        const source = createDistillMemorySource(store, async (systemPrompt) => {
+      const store = createMockStore();
+      const source = createDistillMemorySource(
+        store,
+        async (systemPrompt) => {
           if (systemPrompt !== OBSERVER_PROMPT) return "";
           return [
             "[project] Current task: should stay session scoped",
@@ -595,37 +547,31 @@ describe("distillMemorySource", () => {
             "[project] repo uses Bun",
             "[user] prefers concise replies",
           ].join("\n");
-        });
-        if (!source.commit) throw new Error("expected commit handler");
-        await source.commit({
-          sessionId: "sess_test0001",
-          resourceId: "proj_abc123",
-          messages: [{ role: "user", content: "hello" }],
-          output: "done",
-        });
-        const byScope = new Map(store.written.map((entry) => [entry.sessionId, entry.content]));
-        expect(byScope.get("sess_test0001")).toContain("Current task: should stay session scoped");
-        expect(byScope.get("sess_test0001")).toContain("Next step: should stay session scoped");
-        expect(byScope.get("proj_abc123")).toBe("repo uses Bun");
-        const userScopeKey = [...byScope.keys()].find((key) => key.startsWith("user_"));
-        expect(userScopeKey).toBeDefined();
-        expect(userScopeKey ? byScope.get(userScopeKey) : "").toBe("prefers concise replies");
-      } finally {
-        (appConfig as { distill: typeof appConfig.distill }).distill = originalDistillConfig;
-      }
+        },
+        {},
+        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+      );
+      if (!source.commit) throw new Error("expected commit handler");
+      await source.commit({
+        sessionId: "sess_test0001",
+        resourceId: "proj_abc123",
+        messages: [{ role: "user", content: "hello" }],
+        output: "done",
+      });
+      const byScope = new Map(store.written.map((entry) => [entry.sessionId, entry.content]));
+      expect(byScope.get("sess_test0001")).toContain("Current task: should stay session scoped");
+      expect(byScope.get("sess_test0001")).toContain("Next step: should stay session scoped");
+      expect(byScope.get("proj_abc123")).toBe("repo uses Bun");
+      const userScopeKey = [...byScope.keys()].find((key) => key.startsWith("user_"));
+      expect(userScopeKey).toBeDefined();
+      expect(userScopeKey ? byScope.get(userScopeKey) : "").toBe("prefers concise replies");
     });
 
     test("silently drops malformed scope tags and commits valid facts", async () => {
-      const originalDistillConfig = { ...appConfig.distill };
-      (appConfig as { distill: typeof appConfig.distill }).distill = {
-        ...appConfig.distill,
-        messageThreshold: 1,
-        reflectionThresholdTokens: 999_999,
-        maxOutputTokens: 10_000,
-      };
-      try {
-        const store = createMockStore();
-        const source = createDistillMemorySource(store, async (systemPrompt) => {
+      const store = createMockStore();
+      const source = createDistillMemorySource(
+        store,
+        async (systemPrompt) => {
           if (systemPrompt !== OBSERVER_PROMPT) return "";
           return [
             "[project] valid project fact",
@@ -634,71 +580,55 @@ describe("distillMemorySource", () => {
             "[usr] malformed tag dropped",
             "[session] valid session fact",
           ].join("\n");
-        });
-        if (!source.commit) throw new Error("expected commit handler");
-        const metrics = await source.commit({
-          sessionId: "sess_test0001",
-          resourceId: "proj_abc123",
-          messages: [{ role: "user", content: "hello" }],
-          output: "done",
-        });
-        // Malformed tags are silently dropped; valid facts are committed.
-        expect(store.written.length).toBeGreaterThan(0);
-        expect(metrics).toEqual({
-          projectPromotedFacts: 1,
-          userPromotedFacts: 1,
-          sessionScopedFacts: 1,
-          droppedUntaggedFacts: 0,
-        });
-      } finally {
-        (appConfig as { distill: typeof appConfig.distill }).distill = originalDistillConfig;
-      }
+        },
+        {},
+        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+      );
+      if (!source.commit) throw new Error("expected commit handler");
+      const metrics = await source.commit({
+        sessionId: "sess_test0001",
+        resourceId: "proj_abc123",
+        messages: [{ role: "user", content: "hello" }],
+        output: "done",
+      });
+      // Malformed tags are silently dropped; valid facts are committed.
+      expect(store.written.length).toBeGreaterThan(0);
+      expect(metrics).toEqual({
+        projectPromotedFacts: 1,
+        userPromotedFacts: 1,
+        sessionScopedFacts: 1,
+        droppedUntaggedFacts: 0,
+      });
     });
 
     test("commitScope writes only the targeted scope", async () => {
-      const originalDistillConfig = { ...appConfig.distill };
-      (appConfig as { distill: typeof appConfig.distill }).distill = {
-        ...appConfig.distill,
-        messageThreshold: 1,
-        reflectionThresholdTokens: 999_999,
-        maxOutputTokens: 10_000,
-      };
-      try {
-        const store = createMockStore();
-        const source = createDistillMemorySource(
-          store,
-          async (systemPrompt) => (systemPrompt === OBSERVER_PROMPT ? "scope fact" : ""),
-          { commitScope: "project" },
-        );
-        if (!source.commit) throw new Error("expected commit handler");
-        await source.commit({
-          sessionId: "sess_test0001",
-          workspace: "/tmp/acolyte-project",
-          messages: [{ role: "user", content: "hello" }],
-          output: "done",
-        });
+      const store = createMockStore();
+      const source = createDistillMemorySource(
+        store,
+        async (systemPrompt) => (systemPrompt === OBSERVER_PROMPT ? "scope fact" : ""),
+        { commitScope: "project" },
+        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+      );
+      if (!source.commit) throw new Error("expected commit handler");
+      await source.commit({
+        sessionId: "sess_test0001",
+        workspace: "/tmp/acolyte-project",
+        messages: [{ role: "user", content: "hello" }],
+        output: "done",
+      });
 
-        expect(store.written.filter((entry) => entry.tier === "observation")).toHaveLength(1);
-        const keys = store.written.map((entry) => entry.sessionId);
-        expect(keys.some((key) => key.startsWith("proj_"))).toBe(true);
-        expect(keys.some((key) => key === "sess_test0001")).toBe(false);
-        expect(keys.some((key) => key.startsWith("user_"))).toBe(false);
-      } finally {
-        (appConfig as { distill: typeof appConfig.distill }).distill = originalDistillConfig;
-      }
+      expect(store.written.filter((entry) => entry.tier === "observation")).toHaveLength(1);
+      const keys = store.written.map((entry) => entry.sessionId);
+      expect(keys.some((key) => key.startsWith("proj_"))).toBe(true);
+      expect(keys.some((key) => key === "sess_test0001")).toBe(false);
+      expect(keys.some((key) => key.startsWith("user_"))).toBe(false);
     });
 
     test("session commit promotes [project] and [user] lines to scoped stores", async () => {
-      const originalDistillConfig = { ...appConfig.distill };
-      (appConfig as { distill: typeof appConfig.distill }).distill = {
-        ...appConfig.distill,
-        messageThreshold: 1,
-        reflectionThresholdTokens: 999_999,
-        maxOutputTokens: 10_000,
-      };
-      try {
-        const store = createMockStore();
-        const source = createDistillMemorySource(store, async (systemPrompt) => {
+      const store = createMockStore();
+      const source = createDistillMemorySource(
+        store,
+        async (systemPrompt) => {
           if (systemPrompt !== OBSERVER_PROMPT) return "";
           return [
             "[project] repo uses Bun",
@@ -707,42 +637,36 @@ describe("distillMemorySource", () => {
             "Current task: stabilize memory",
             "Next step: add promotion tests",
           ].join("\n");
-        });
-        if (!source.commit) throw new Error("expected commit handler");
-        await source.commit({
-          sessionId: "sess_test0001",
-          resourceId: "proj_abc123",
-          messages: [{ role: "user", content: "hello" }],
-          output: "done",
-        });
+        },
+        {},
+        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+      );
+      if (!source.commit) throw new Error("expected commit handler");
+      await source.commit({
+        sessionId: "sess_test0001",
+        resourceId: "proj_abc123",
+        messages: [{ role: "user", content: "hello" }],
+        output: "done",
+      });
 
-        const byScope = new Map(store.written.map((entry) => [entry.sessionId, entry.content]));
-        expect(byScope.get("sess_test0001")).toContain("fix failing tests");
-        expect(byScope.get("sess_test0001")).toContain("Current task: stabilize memory");
-        expect(byScope.get("sess_test0001")).toContain("Next step: add promotion tests");
-        expect(byScope.get("sess_test0001")).not.toContain("[project]");
-        expect(byScope.get("sess_test0001")).not.toContain("repo uses Bun");
-        expect(byScope.get("sess_test0001")).not.toContain("prefers short answers");
-        expect(byScope.get("proj_abc123")).toBe("repo uses Bun");
-        const userScopeKey = [...byScope.keys()].find((key) => key.startsWith("user_"));
-        expect(userScopeKey).toBeDefined();
-        expect(userScopeKey ? byScope.get(userScopeKey) : "").toBe("prefers short answers");
-      } finally {
-        (appConfig as { distill: typeof appConfig.distill }).distill = originalDistillConfig;
-      }
+      const byScope = new Map(store.written.map((entry) => [entry.sessionId, entry.content]));
+      expect(byScope.get("sess_test0001")).toContain("fix failing tests");
+      expect(byScope.get("sess_test0001")).toContain("Current task: stabilize memory");
+      expect(byScope.get("sess_test0001")).toContain("Next step: add promotion tests");
+      expect(byScope.get("sess_test0001")).not.toContain("[project]");
+      expect(byScope.get("sess_test0001")).not.toContain("repo uses Bun");
+      expect(byScope.get("sess_test0001")).not.toContain("prefers short answers");
+      expect(byScope.get("proj_abc123")).toBe("repo uses Bun");
+      const userScopeKey = [...byScope.keys()].find((key) => key.startsWith("user_"));
+      expect(userScopeKey).toBeDefined();
+      expect(userScopeKey ? byScope.get(userScopeKey) : "").toBe("prefers short answers");
     });
 
     test("returns scoped promotion and drop metrics for mixed observations", async () => {
-      const originalDistillConfig = { ...appConfig.distill };
-      (appConfig as { distill: typeof appConfig.distill }).distill = {
-        ...appConfig.distill,
-        messageThreshold: 1,
-        reflectionThresholdTokens: 999_999,
-        maxOutputTokens: 10_000,
-      };
-      try {
-        const store = createMockStore();
-        const source = createDistillMemorySource(store, async (systemPrompt) => {
+      const store = createMockStore();
+      const source = createDistillMemorySource(
+        store,
+        async (systemPrompt) => {
           if (systemPrompt !== OBSERVER_PROMPT) return "";
           return [
             "[project] project fact one",
@@ -754,7 +678,90 @@ describe("distillMemorySource", () => {
             "untagged dropped fact",
             "[proj] malformed tag dropped",
           ].join("\n");
-        });
+        },
+        {},
+        { ...testDistillConfig, reflectionThresholdTokens: 999_999, maxOutputTokens: 10_000 },
+      );
+      if (!source.commit) throw new Error("expected commit handler");
+      const metrics = await source.commit({
+        sessionId: "sess_test0001",
+        resourceId: "proj_abc123",
+        messages: [{ role: "user", content: "hello" }],
+        output: "done",
+      });
+      // Malformed tag is silently dropped; valid facts are committed.
+      expect(metrics).toEqual({
+        projectPromotedFacts: 2,
+        userPromotedFacts: 1,
+        sessionScopedFacts: 3,
+        droppedUntaggedFacts: 1,
+      });
+      expect(store.written.length).toBeGreaterThan(0);
+    });
+
+    test("quality fixtures classify observer output into promote, drop, or reject paths", async () => {
+      const fixtureConfig: DistillConfig = {
+        ...testDistillConfig,
+        reflectionThresholdTokens: 999_999,
+        maxOutputTokens: 10_000,
+      };
+      const fixtures = [
+        {
+          name: "good_scoped_output",
+          observed: [
+            "[project] uses bun test",
+            "[user] prefers concise responses",
+            "[session] fixing failing memory tests",
+            "Current task: stabilize memory quality",
+            "Next step: add regression coverage",
+          ].join("\n"),
+          expectedMetrics: {
+            projectPromotedFacts: 1,
+            userPromotedFacts: 1,
+            sessionScopedFacts: 3,
+            droppedUntaggedFacts: 0,
+          },
+          expectedWriteCount: 3,
+        },
+        {
+          name: "mixed_output_with_untagged_fact",
+          observed: ["[project] uses bun test", "untagged fact", "Current task: stabilize memory quality"].join("\n"),
+          expectedMetrics: {
+            projectPromotedFacts: 1,
+            userPromotedFacts: 0,
+            sessionScopedFacts: 1,
+            droppedUntaggedFacts: 1,
+          },
+          expectedWriteCount: 2,
+        },
+        {
+          name: "malformed_tag_silently_dropped",
+          observed: [
+            "[project] uses bun test",
+            "[proj] malformed tag silently dropped",
+            "Current task: stabilize memory quality",
+          ].join("\n"),
+          expectedMetrics: {
+            projectPromotedFacts: 1,
+            userPromotedFacts: 0,
+            sessionScopedFacts: 1,
+            droppedUntaggedFacts: 0,
+          },
+          expectedWriteCount: 2,
+        },
+      ] as const;
+
+      for (const fixture of fixtures) {
+        const store = createMockStore();
+        const source = createDistillMemorySource(
+          store,
+          async (systemPrompt) => {
+            if (systemPrompt !== OBSERVER_PROMPT) return "";
+            return fixture.observed;
+          },
+          {},
+          fixtureConfig,
+        );
         if (!source.commit) throw new Error("expected commit handler");
         const metrics = await source.commit({
           sessionId: "sess_test0001",
@@ -762,92 +769,8 @@ describe("distillMemorySource", () => {
           messages: [{ role: "user", content: "hello" }],
           output: "done",
         });
-        // Malformed tag is silently dropped; valid facts are committed.
-        expect(metrics).toEqual({
-          projectPromotedFacts: 2,
-          userPromotedFacts: 1,
-          sessionScopedFacts: 3,
-          droppedUntaggedFacts: 1,
-        });
-        expect(store.written.length).toBeGreaterThan(0);
-      } finally {
-        (appConfig as { distill: typeof appConfig.distill }).distill = originalDistillConfig;
-      }
-    });
-
-    test("quality fixtures classify observer output into promote, drop, or reject paths", async () => {
-      const originalDistillConfig = { ...appConfig.distill };
-      (appConfig as { distill: typeof appConfig.distill }).distill = {
-        ...appConfig.distill,
-        messageThreshold: 1,
-        reflectionThresholdTokens: 999_999,
-        maxOutputTokens: 10_000,
-      };
-      try {
-        const fixtures = [
-          {
-            name: "good_scoped_output",
-            observed: [
-              "[project] uses bun test",
-              "[user] prefers concise responses",
-              "[session] fixing failing memory tests",
-              "Current task: stabilize memory quality",
-              "Next step: add regression coverage",
-            ].join("\n"),
-            expectedMetrics: {
-              projectPromotedFacts: 1,
-              userPromotedFacts: 1,
-              sessionScopedFacts: 3,
-              droppedUntaggedFacts: 0,
-            },
-            expectedWriteCount: 3,
-          },
-          {
-            name: "mixed_output_with_untagged_fact",
-            observed: ["[project] uses bun test", "untagged fact", "Current task: stabilize memory quality"].join("\n"),
-            expectedMetrics: {
-              projectPromotedFacts: 1,
-              userPromotedFacts: 0,
-              sessionScopedFacts: 1,
-              droppedUntaggedFacts: 1,
-            },
-            expectedWriteCount: 2,
-          },
-          {
-            name: "malformed_tag_silently_dropped",
-            observed: [
-              "[project] uses bun test",
-              "[proj] malformed tag silently dropped",
-              "Current task: stabilize memory quality",
-            ].join("\n"),
-            expectedMetrics: {
-              projectPromotedFacts: 1,
-              userPromotedFacts: 0,
-              sessionScopedFacts: 1,
-              droppedUntaggedFacts: 0,
-            },
-            expectedWriteCount: 2,
-          },
-        ] as const;
-
-        for (const fixture of fixtures) {
-          const store = createMockStore();
-          const source = createDistillMemorySource(store, async (systemPrompt) => {
-            if (systemPrompt !== OBSERVER_PROMPT) return "";
-            return fixture.observed;
-          });
-          if (!source.commit) throw new Error("expected commit handler");
-          const metrics = await source.commit({
-            sessionId: "sess_test0001",
-            resourceId: "proj_abc123",
-            messages: [{ role: "user", content: "hello" }],
-            output: "done",
-          });
-          expect(metrics, fixture.name).toEqual(fixture.expectedMetrics);
-          expect(store.written.length, fixture.name).toBe(fixture.expectedWriteCount);
-        }
-      } finally {
-        (appConfig as { distill: typeof appConfig.distill }).distill = originalDistillConfig;
+        expect(metrics, fixture.name).toEqual(fixture.expectedMetrics);
+        expect(store.written.length, fixture.name).toBe(fixture.expectedWriteCount);
       }
     });
   });

--- a/src/memory-source-distill.ts
+++ b/src/memory-source-distill.ts
@@ -25,6 +25,7 @@ type DistillSourceOptions = {
   id?: string;
   loadScope?: DistillScope;
   commitScope?: DistillScope | "none";
+  config?: DistillConfig;
 };
 
 const CHARS_PER_TOKEN_ESTIMATE = 4;
@@ -304,9 +305,9 @@ export function createDistillMemorySource(
   injectedStore?: DistillStore,
   runner: DistillRunner = runDistillLLM,
   options: DistillSourceOptions = {},
-  config: DistillConfig = defaultDistillConfig(),
 ): MemorySource {
   const ds = injectedStore ?? store;
+  const config = options.config ?? defaultDistillConfig();
   const id = options.id ?? "distill_session";
   const loadScope = options.loadScope ?? "session";
   const commitScope = options.commitScope ?? "session";

--- a/src/memory-source-distill.ts
+++ b/src/memory-source-distill.ts
@@ -9,6 +9,13 @@ import { normalizeModel } from "./provider-config";
 import { defaultUserResourceId, parseResourceId, projectResourceIdFromWorkspace, type ResourceId } from "./resource-id";
 import { createId } from "./short-id";
 
+export type DistillConfig = {
+  model: string;
+  messageThreshold: number;
+  reflectionThresholdTokens: number;
+  maxOutputTokens: number;
+};
+
 const store: DistillStore = createFileDistillStore();
 const REFLECTION_RETRY_LIMIT = 2;
 
@@ -37,9 +44,9 @@ function clampToTokenEstimate(content: string, maxTokens: number): string {
   return clamped;
 }
 
-function needsReflectionRetry(reflected: string, sourceTokenEstimate: number): boolean {
+function needsReflectionRetry(reflected: string, sourceTokenEstimate: number, config: DistillConfig): boolean {
   const reflectedTokens = estimateTokens(reflected);
-  return reflectedTokens >= sourceTokenEstimate || reflectedTokens > appConfig.distill.reflectionThresholdTokens;
+  return reflectedTokens >= sourceTokenEstimate || reflectedTokens > config.reflectionThresholdTokens;
 }
 
 function parseContinuationState(text: string): { currentTask?: string; nextStep?: string } {
@@ -155,6 +162,8 @@ function splitScopedObservation(observed: string): {
 
 export type DistillRunner = (systemPrompt: string, userContent: string) => Promise<string>;
 
+const defaultDistillConfig = (): DistillConfig => appConfig.distill;
+
 async function runDistillLLM(systemPrompt: string, userContent: string): Promise<string> {
   const model = createModel(normalizeModel(appConfig.distill.model));
   const result = await model.doGenerate({
@@ -234,6 +243,7 @@ async function commitDistillForKey(
   key: string,
   observed: string,
   runner: DistillRunner,
+  config: DistillConfig,
 ): Promise<void> {
   const existingEntries = await ds.list(key);
   const latestObservation = existingEntries.filter((e) => e.tier === "observation").slice(-1)[0];
@@ -258,7 +268,7 @@ async function commitDistillForKey(
     ? observations.filter((e) => e.createdAt > latestReflection.createdAt)
     : observations;
   const totalTokens = pendingObservations.reduce((sum, e) => sum + e.tokenEstimate, 0);
-  if (totalTokens < appConfig.distill.reflectionThresholdTokens) return;
+  if (totalTokens < config.reflectionThresholdTokens) return;
 
   const allObservations = pendingObservations.map((o) => o.content).join("\n\n---\n\n");
   let reflected = "";
@@ -268,11 +278,11 @@ async function commitDistillForKey(
         ? ""
         : "\n\nCompression retry: keep all critical facts while reducing length and merging redundant details.";
     const reflectedRaw = await runner(REFLECTOR_PROMPT, `${allObservations}${promptSuffix}`);
-    reflected = clampToTokenEstimate(reflectedRaw, appConfig.distill.maxOutputTokens);
+    reflected = clampToTokenEstimate(reflectedRaw, config.maxOutputTokens);
     if (!reflected.trim()) return;
-    if (!needsReflectionRetry(reflected, totalTokens)) break;
+    if (!needsReflectionRetry(reflected, totalTokens, config)) break;
   }
-  if (needsReflectionRetry(reflected, totalTokens)) return;
+  if (needsReflectionRetry(reflected, totalTokens, config)) return;
 
   const reflection: DistillRecord = {
     id: `dst_${createId()}`,
@@ -294,6 +304,7 @@ export function createDistillMemorySource(
   injectedStore?: DistillStore,
   runner: DistillRunner = runDistillLLM,
   options: DistillSourceOptions = {},
+  config: DistillConfig = defaultDistillConfig(),
 ): MemorySource {
   const ds = injectedStore ?? store;
   const id = options.id ?? "distill_session";
@@ -312,17 +323,17 @@ export function createDistillMemorySource(
       if (commitScope === "none") return;
       const key = resolveDistillScopeKey(commitScope, ctx);
       if (!key) return;
-      if (ctx.messages.length < appConfig.distill.messageThreshold) return;
+      if (ctx.messages.length < config.messageThreshold) return;
 
       const recentMessages = ctx.messages.slice(-DISTILL_CONTEXT_MESSAGE_WINDOW);
       const distillInput = [...recentMessages, { role: "assistant", content: ctx.output }]
         .map((m) => `${m.role}: ${m.content}`)
         .join("\n\n");
       const observedRaw = await runner(OBSERVER_PROMPT, distillInput);
-      const observed = clampToTokenEstimate(observedRaw, appConfig.distill.maxOutputTokens);
+      const observed = clampToTokenEstimate(observedRaw, config.maxOutputTokens);
       if (!observed.trim()) return;
       if (commitScope !== "session") {
-        await commitDistillForKey(ds, key, observed, runner);
+        await commitDistillForKey(ds, key, observed, runner, config);
         const observedFactCount = observed.split(/\r?\n/).filter((line) => line.trim()).length;
         return {
           projectPromotedFacts: commitScope === "project" ? observedFactCount : 0,
@@ -334,16 +345,16 @@ export function createDistillMemorySource(
 
       const scoped = splitScopedObservation(observed);
       if (scoped.session) {
-        await commitDistillForKey(ds, key, scoped.session, runner);
+        await commitDistillForKey(ds, key, scoped.session, runner, config);
       }
 
       if (scoped.project) {
         const projectKey = resolveDistillScopeKey("project", ctx);
-        if (projectKey) await commitDistillForKey(ds, projectKey, scoped.project, runner);
+        if (projectKey) await commitDistillForKey(ds, projectKey, scoped.project, runner, config);
       }
       if (scoped.user) {
         const userKey = resolveDistillScopeKey("user", ctx);
-        if (userKey) await commitDistillForKey(ds, userKey, scoped.user, runner);
+        if (userKey) await commitDistillForKey(ds, userKey, scoped.user, runner, config);
       }
       return {
         projectPromotedFacts: scoped.projectCount,

--- a/src/memory-source-distill.ts
+++ b/src/memory-source-distill.ts
@@ -16,7 +16,11 @@ export type DistillConfig = {
   maxOutputTokens: number;
 };
 
-const store: DistillStore = createFileDistillStore();
+let defaultStore: DistillStore | null = null;
+function getDefaultStore(): DistillStore {
+  if (!defaultStore) defaultStore = createFileDistillStore();
+  return defaultStore;
+}
 const REFLECTION_RETRY_LIMIT = 2;
 
 type DistillScope = "session" | "project" | "user";
@@ -306,7 +310,7 @@ export function createDistillMemorySource(
   runner: DistillRunner = runDistillLLM,
   options: DistillSourceOptions = {},
 ): MemorySource {
-  const ds = injectedStore ?? store;
+  const ds = injectedStore ?? getDefaultStore();
   const config = options.config ?? defaultDistillConfig();
   const id = options.id ?? "distill_session";
   const loadScope = options.loadScope ?? "session";

--- a/src/model-factory.ts
+++ b/src/model-factory.ts
@@ -2,21 +2,11 @@ import { createAnthropic } from "@ai-sdk/anthropic";
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import { createOpenAI } from "@ai-sdk/openai";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
-import { appConfig } from "./app-config";
+import { defaultCredentials, type ProviderCredentialsMap } from "./agent-model";
 import { unreachable } from "./assert";
-import type { ProviderCredentials } from "./provider-config";
 import { providerFromModel } from "./provider-config";
-import type { Provider } from "./provider-contract";
 
-export type ModelCredentials = Partial<Record<Provider, ProviderCredentials>>;
-
-const defaultCredentials = (): ModelCredentials => ({
-  openai: appConfig.openai,
-  anthropic: appConfig.anthropic,
-  google: appConfig.google,
-});
-
-export function createModel(qualifiedModel: string, credentials?: ModelCredentials): LanguageModelV3 {
+export function createModel(qualifiedModel: string, credentials?: ProviderCredentialsMap): LanguageModelV3 {
   const creds = credentials ?? defaultCredentials();
   const provider = providerFromModel(qualifiedModel);
   const slash = qualifiedModel.indexOf("/");

--- a/src/model-factory.ts
+++ b/src/model-factory.ts
@@ -4,32 +4,44 @@ import { createOpenAI } from "@ai-sdk/openai";
 import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { appConfig } from "./app-config";
 import { unreachable } from "./assert";
+import type { ProviderCredentials } from "./provider-config";
 import { providerFromModel } from "./provider-config";
+import type { Provider } from "./provider-contract";
 
-export function createModel(qualifiedModel: string): LanguageModelV3 {
+export type ModelCredentials = Partial<Record<Provider, ProviderCredentials>>;
+
+const defaultCredentials = (): ModelCredentials => ({
+  openai: appConfig.openai,
+  anthropic: appConfig.anthropic,
+  google: appConfig.google,
+});
+
+export function createModel(qualifiedModel: string, credentials?: ModelCredentials): LanguageModelV3 {
+  const creds = credentials ?? defaultCredentials();
   const provider = providerFromModel(qualifiedModel);
   const slash = qualifiedModel.indexOf("/");
   const modelId = slash >= 0 ? qualifiedModel.slice(slash + 1) : qualifiedModel;
+  const providerCreds = creds[provider] ?? {};
 
   switch (provider) {
     case "anthropic": {
       const anthropic = createAnthropic({
-        apiKey: appConfig.anthropic.apiKey,
-        ...(appConfig.anthropic.baseUrl ? { baseURL: appConfig.anthropic.baseUrl } : {}),
+        apiKey: providerCreds.apiKey,
+        ...(providerCreds.baseUrl ? { baseURL: providerCreds.baseUrl } : {}),
       });
       return anthropic(modelId);
     }
     case "google": {
       const google = createGoogleGenerativeAI({
-        apiKey: appConfig.google.apiKey,
-        ...(appConfig.google.baseUrl ? { baseURL: appConfig.google.baseUrl } : {}),
+        apiKey: providerCreds.apiKey,
+        ...(providerCreds.baseUrl ? { baseURL: providerCreds.baseUrl } : {}),
       });
       return google(modelId);
     }
     case "openai": {
       const openai = createOpenAI({
-        apiKey: appConfig.openai.apiKey,
-        ...(appConfig.openai.baseUrl ? { baseURL: appConfig.openai.baseUrl } : {}),
+        apiKey: providerCreds.apiKey,
+        ...(providerCreds.baseUrl ? { baseURL: providerCreds.baseUrl } : {}),
       });
       return openai(modelId);
     }

--- a/src/provider-models.test.ts
+++ b/src/provider-models.test.ts
@@ -1,27 +1,15 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { appConfig } from "./app-config";
 import { getAvailableModels, invalidateModelsCache } from "./provider-models";
 
-let savedApiKey: string | undefined;
-let savedBaseUrl: string | undefined;
-let savedAnthropicApiKey: string | undefined;
-let savedGoogleApiKey: string | undefined;
+const OPENAI_BASE_URL = "https://api.openai.com/v1";
+const ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1";
+const GOOGLE_BASE_URL = "https://generativelanguage.googleapis.com";
 
 beforeEach(() => {
-  savedApiKey = appConfig.openai.apiKey;
-  savedBaseUrl = appConfig.openai.baseUrl;
-  savedAnthropicApiKey = appConfig.anthropic.apiKey;
-  savedGoogleApiKey = appConfig.google.apiKey;
-  (appConfig.openai as { apiKey: string | undefined }).apiKey = "test-key";
-  (appConfig.anthropic as { apiKey: string | undefined }).apiKey = undefined;
-  (appConfig.google as { apiKey: string | undefined }).apiKey = undefined;
+  invalidateModelsCache();
 });
 
 afterEach(() => {
-  (appConfig.openai as { apiKey: string | undefined }).apiKey = savedApiKey;
-  (appConfig.openai as { baseUrl: string | undefined }).baseUrl = savedBaseUrl;
-  (appConfig.anthropic as { apiKey: string | undefined }).apiKey = savedAnthropicApiKey;
-  (appConfig.google as { apiKey: string | undefined }).apiKey = savedGoogleApiKey;
   invalidateModelsCache();
   mock.restore();
 });
@@ -38,7 +26,7 @@ describe("getAvailableModels", () => {
     }) as unknown as typeof fetch;
 
     try {
-      const models = await getAvailableModels();
+      const models = await getAvailableModels({ openai: { apiKey: "test-key", baseUrl: OPENAI_BASE_URL } });
       expect(models).toContain("gpt-5-mini");
       expect(models).toContain("gpt-5.2");
       expect(models).toEqual([...models].sort());
@@ -56,9 +44,10 @@ describe("getAvailableModels", () => {
     }) as unknown as typeof fetch;
 
     try {
-      await getAvailableModels();
+      const creds = { openai: { apiKey: "test-key", baseUrl: OPENAI_BASE_URL } };
+      await getAvailableModels(creds);
       const first = fetchCount;
-      await getAvailableModels();
+      await getAvailableModels(creds);
       expect(fetchCount).toBe(first);
     } finally {
       globalThis.fetch = originalFetch;
@@ -72,7 +61,7 @@ describe("getAvailableModels", () => {
     }) as unknown as typeof fetch;
 
     try {
-      const models = await getAvailableModels();
+      const models = await getAvailableModels({ openai: { apiKey: "test-key", baseUrl: OPENAI_BASE_URL } });
       expect(models).toEqual([]);
     } finally {
       globalThis.fetch = originalFetch;
@@ -80,8 +69,6 @@ describe("getAvailableModels", () => {
   });
 
   test("prefixes models from local OpenAI-compatible endpoints", async () => {
-    (appConfig.openai as { apiKey: string | undefined }).apiKey = undefined;
-    (appConfig.openai as { baseUrl: string }).baseUrl = "http://localhost:11434/v1";
     let authHeader: string | null = null;
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
@@ -90,7 +77,7 @@ describe("getAvailableModels", () => {
     }) as unknown as typeof fetch;
 
     try {
-      const models = await getAvailableModels();
+      const models = await getAvailableModels({ openai: { baseUrl: "http://localhost:11434/v1" } });
       expect(models).toEqual(["openai-compatible/qwen2.5-coder:3b"]);
       expect(authHeader).toBeNull();
     } finally {
@@ -99,8 +86,6 @@ describe("getAvailableModels", () => {
   });
 
   test("sends configured api key for openai-compatible model discovery", async () => {
-    (appConfig.openai as { apiKey: string | undefined }).apiKey = "test-key";
-    (appConfig.openai as { baseUrl: string }).baseUrl = "http://localhost:11434/v1";
     let authHeader: string | null = null;
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
@@ -109,7 +94,7 @@ describe("getAvailableModels", () => {
     }) as unknown as typeof fetch;
 
     try {
-      await getAvailableModels();
+      await getAvailableModels({ openai: { apiKey: "test-key", baseUrl: "http://localhost:11434/v1" } });
       expect(authHeader ?? "").toBe("Bearer test-key");
     } finally {
       globalThis.fetch = originalFetch;
@@ -117,8 +102,6 @@ describe("getAvailableModels", () => {
   });
 
   test("fetches anthropic models with correct headers", async () => {
-    (appConfig.openai as { apiKey: string | undefined }).apiKey = undefined;
-    (appConfig.anthropic as { apiKey: string | undefined }).apiKey = "sk-ant-test";
     let capturedHeaders: Record<string, string> = {};
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(async (_url: string | URL | Request, init?: RequestInit) => {
@@ -130,7 +113,7 @@ describe("getAvailableModels", () => {
     }) as unknown as typeof fetch;
 
     try {
-      const models = await getAvailableModels();
+      const models = await getAvailableModels({ anthropic: { apiKey: "sk-ant-test", baseUrl: ANTHROPIC_BASE_URL } });
       expect(models).toContain("claude-sonnet-4-6");
       expect(models).toContain("claude-haiku-4-5-20251001");
       expect(capturedHeaders["x-api-key"]).toBe("sk-ant-test");
@@ -141,8 +124,6 @@ describe("getAvailableModels", () => {
   });
 
   test("fetches google models with api key as query param and strips models/ prefix", async () => {
-    (appConfig.openai as { apiKey: string | undefined }).apiKey = undefined;
-    (appConfig.google as { apiKey: string | undefined }).apiKey = "goog-test-key";
     let capturedUrl = "";
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(async (url: string | URL | Request) => {
@@ -154,7 +135,7 @@ describe("getAvailableModels", () => {
     }) as unknown as typeof fetch;
 
     try {
-      const models = await getAvailableModels();
+      const models = await getAvailableModels({ google: { apiKey: "goog-test-key", baseUrl: GOOGLE_BASE_URL } });
       expect(models).toContain("gemini-2.5-pro");
       expect(models).toContain("gemini-2.0-flash");
       expect(capturedUrl).toContain("key=goog-test-key");
@@ -164,7 +145,6 @@ describe("getAvailableModels", () => {
   });
 
   test("deduplicates models across providers", async () => {
-    (appConfig.anthropic as { apiKey: string | undefined }).apiKey = "sk-ant-test";
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(async (url: string | URL | Request) => {
       const urlStr = typeof url === "string" ? url : url instanceof URL ? url.toString() : url.url;
@@ -175,7 +155,10 @@ describe("getAvailableModels", () => {
     }) as unknown as typeof fetch;
 
     try {
-      const models = await getAvailableModels();
+      const models = await getAvailableModels({
+        openai: { apiKey: "test-key", baseUrl: OPENAI_BASE_URL },
+        anthropic: { apiKey: "sk-ant-test", baseUrl: ANTHROPIC_BASE_URL },
+      });
       const sharedCount = models.filter((m) => m === "shared-model").length;
       expect(sharedCount).toBe(1);
     } finally {

--- a/src/provider-models.ts
+++ b/src/provider-models.ts
@@ -1,6 +1,6 @@
-import { appConfig } from "./app-config";
+import { defaultCredentials, type ProviderCredentialsMap } from "./agent-model";
 import { unreachable } from "./assert";
-import { isProviderAvailable, type ProviderCredentials } from "./provider-config";
+import { isProviderAvailable } from "./provider-config";
 import type { Provider } from "./provider-contract";
 
 function normalizeBaseUrl(url: string): string {
@@ -85,14 +85,6 @@ async function fetchProviderModels(provider: Provider, config: ProviderFetchConf
     return [];
   }
 }
-
-type ProviderCredentialsMap = Partial<Record<Provider, ProviderCredentials>>;
-
-const defaultCredentials = (): ProviderCredentialsMap => ({
-  openai: appConfig.openai,
-  anthropic: appConfig.anthropic,
-  google: appConfig.google,
-});
 
 function providerConfig(provider: Provider, credentials: ProviderCredentialsMap): ProviderFetchConfig {
   const creds = credentials[provider] ?? {};

--- a/src/provider-models.ts
+++ b/src/provider-models.ts
@@ -1,6 +1,6 @@
 import { appConfig } from "./app-config";
 import { unreachable } from "./assert";
-import { isProviderAvailable } from "./provider-config";
+import { isProviderAvailable, type ProviderCredentials } from "./provider-config";
 import type { Provider } from "./provider-contract";
 
 function normalizeBaseUrl(url: string): string {
@@ -86,38 +86,39 @@ async function fetchProviderModels(provider: Provider, config: ProviderFetchConf
   }
 }
 
-function providerConfig(provider: Provider): ProviderFetchConfig {
-  switch (provider) {
-    case "openai":
-      return { apiKey: appConfig.openai.apiKey, baseUrl: appConfig.openai.baseUrl };
-    case "anthropic":
-      return { apiKey: appConfig.anthropic.apiKey, baseUrl: appConfig.anthropic.baseUrl };
-    case "google":
-      return { apiKey: appConfig.google.apiKey, baseUrl: appConfig.google.baseUrl };
-    default:
-      return unreachable(provider);
-  }
+type ProviderCredentialsMap = Partial<Record<Provider, ProviderCredentials>>;
+
+const defaultCredentials = (): ProviderCredentialsMap => ({
+  openai: appConfig.openai,
+  anthropic: appConfig.anthropic,
+  google: appConfig.google,
+});
+
+function providerConfig(provider: Provider, credentials: ProviderCredentialsMap): ProviderFetchConfig {
+  const creds = credentials[provider] ?? {};
+  return { apiKey: creds.apiKey, baseUrl: creds.baseUrl ?? "" };
 }
 
-function availableProviders(): Provider[] {
+function availableProviders(credentials: ProviderCredentialsMap): Provider[] {
   const providers: Provider[] = [];
-  if (isProviderAvailable("openai", appConfig.openai)) providers.push("openai");
-  if (isProviderAvailable("anthropic", appConfig.anthropic)) providers.push("anthropic");
-  if (isProviderAvailable("google", appConfig.google)) providers.push("google");
+  if (isProviderAvailable("openai", credentials.openai ?? {})) providers.push("openai");
+  if (isProviderAvailable("anthropic", credentials.anthropic ?? {})) providers.push("anthropic");
+  if (isProviderAvailable("google", credentials.google ?? {})) providers.push("google");
   return providers;
 }
 
-export async function getAvailableModels(): Promise<string[]> {
+export async function getAvailableModels(credentials?: ProviderCredentialsMap): Promise<string[]> {
   const now = Date.now();
   if (modelsCache && now - modelsCache.fetchedAt < CACHE_TTL_MS) return modelsCache.models;
 
   if (inflight) return inflight;
 
+  const creds = credentials ?? defaultCredentials();
   inflight = (async () => {
-    const providers = availableProviders();
+    const providers = availableProviders(creds);
     const results = await Promise.all(
       providers.map(async (provider) => {
-        const config = providerConfig(provider);
+        const config = providerConfig(provider, creds);
         const models = await fetchProviderModels(provider, config);
         return models.map((id) => normalizeDiscoveredModel(provider, id, config));
       }),

--- a/src/provider-models.ts
+++ b/src/provider-models.ts
@@ -17,12 +17,19 @@ const CACHE_TTL_MS = 60_000;
 let modelsCache: {
   models: string[];
   fetchedAt: number;
+  credentialsKey: string;
 } | null = null;
 
 let inflight: Promise<string[]> | null = null;
 
 export function invalidateModelsCache(): void {
   modelsCache = null;
+}
+
+function credentialsCacheKey(credentials: ProviderCredentialsMap): string {
+  return [credentials.openai?.apiKey ?? "", credentials.anthropic?.apiKey ?? "", credentials.google?.apiKey ?? ""].join(
+    "\0",
+  );
 }
 
 async function fetchOpenAIModels(config: ProviderFetchConfig): Promise<string[]> {
@@ -87,8 +94,16 @@ async function fetchProviderModels(provider: Provider, config: ProviderFetchConf
 }
 
 function providerConfig(provider: Provider, credentials: ProviderCredentialsMap): ProviderFetchConfig {
-  const creds = credentials[provider] ?? {};
-  return { apiKey: creds.apiKey, baseUrl: creds.baseUrl ?? "" };
+  switch (provider) {
+    case "openai":
+    case "anthropic":
+    case "google": {
+      const creds = credentials[provider] ?? {};
+      return { apiKey: creds.apiKey, baseUrl: creds.baseUrl ?? "" };
+    }
+    default:
+      return unreachable(provider);
+  }
 }
 
 function availableProviders(credentials: ProviderCredentialsMap): Provider[] {
@@ -101,11 +116,12 @@ function availableProviders(credentials: ProviderCredentialsMap): Provider[] {
 
 export async function getAvailableModels(credentials?: ProviderCredentialsMap): Promise<string[]> {
   const now = Date.now();
-  if (modelsCache && now - modelsCache.fetchedAt < CACHE_TTL_MS) return modelsCache.models;
+  const creds = credentials ?? defaultCredentials();
+  const key = credentialsCacheKey(creds);
+  if (modelsCache && now - modelsCache.fetchedAt < CACHE_TTL_MS && modelsCache.credentialsKey === key)
+    return modelsCache.models;
 
   if (inflight) return inflight;
-
-  const creds = credentials ?? defaultCredentials();
   inflight = (async () => {
     const providers = availableProviders(creds);
     const results = await Promise.all(
@@ -126,7 +142,7 @@ export async function getAvailableModels(credentials?: ProviderCredentialsMap): 
       }
     }
     models.sort((a, b) => a.localeCompare(b));
-    modelsCache = { models, fetchedAt: now };
+    modelsCache = { models, fetchedAt: now, credentialsKey: key };
     return models;
   })();
 

--- a/src/shell-toolkit.ts
+++ b/src/shell-toolkit.ts
@@ -1,14 +1,14 @@
 import { z } from "zod";
-import { appConfig } from "./app-config";
 import { compactDetail } from "./compact-text";
 import { t } from "./i18n";
 import { runShellCommand } from "./shell-ops";
-import { createTool, type ToolkitInput } from "./tool-contract";
+import { createTool, type ToolkitDeps, type ToolkitInput } from "./tool-contract";
 import { runTool } from "./tool-execution";
 import { compactToolOutput } from "./tool-output";
 import { TOOL_OUTPUT_LIMITS } from "./tool-output-format";
 
-function createRunCommandTool(input: ToolkitInput) {
+function createRunCommandTool(deps: ToolkitDeps, input: ToolkitInput) {
+  const { outputBudget } = deps;
   const { workspace, session, onOutput } = input;
 
   const parseExitCode = (result: string): number | undefined => {
@@ -117,7 +117,7 @@ function createRunCommandTool(input: ToolkitInput) {
           } else {
             for (const line of streamed.slice(0, TOOL_OUTPUT_LIMITS.run)) emitLine(line);
           }
-          const result = compactToolOutput(rawResult, appConfig.agent.toolOutputBudget.run);
+          const result = compactToolOutput(rawResult, outputBudget.run);
           return {
             kind: "run-command",
             command: toolInput.command,
@@ -131,8 +131,8 @@ function createRunCommandTool(input: ToolkitInput) {
   });
 }
 
-export function createShellToolkit(input: ToolkitInput) {
+export function createShellToolkit(deps: ToolkitDeps, input: ToolkitInput) {
   return {
-    runCommand: createRunCommandTool(input),
+    runCommand: createRunCommandTool(deps, input),
   };
 }

--- a/src/shell-toolkit.ts
+++ b/src/shell-toolkit.ts
@@ -8,9 +8,6 @@ import { compactToolOutput } from "./tool-output";
 import { TOOL_OUTPUT_LIMITS } from "./tool-output-format";
 
 function createRunCommandTool(deps: ToolkitDeps, input: ToolkitInput) {
-  const { outputBudget } = deps;
-  const { workspace, session, onOutput } = input;
-
   const parseExitCode = (result: string): number | undefined => {
     const match = result.match(/^exit_code=(\d+)$/m);
     if (!match?.[1]) return undefined;
@@ -39,11 +36,11 @@ function createRunCommandTool(deps: ToolkitDeps, input: ToolkitInput) {
     }),
     execute: async (toolInput) => {
       return runTool(
-        session,
+        input.session,
         "run-command",
         toolInput,
         async (toolCallId) => {
-          onOutput({
+          input.onOutput({
             toolName: "run-command",
             content: { kind: "tool-header", label: t("tool.label.run"), detail: compactDetail(toolInput.command) },
             toolCallId,
@@ -73,7 +70,7 @@ function createRunCommandTool(deps: ToolkitDeps, input: ToolkitInput) {
             }
           };
           const rawResult = await runShellCommand(
-            workspace,
+            input.workspace,
             toolInput.command,
             toolInput.timeoutMs ?? 60_000,
             ({ stream, text }) => {
@@ -97,7 +94,7 @@ function createRunCommandTool(deps: ToolkitDeps, input: ToolkitInput) {
           flushRemainder("stdout");
           flushRemainder("stderr");
           const emitLine = (entry: { stream: "stdout" | "stderr"; text: string }): void => {
-            onOutput({
+            input.onOutput({
               toolName: "run-command",
               content: { kind: "shell-output", stream: entry.stream, text: entry.text },
               toolCallId,
@@ -106,18 +103,18 @@ function createRunCommandTool(deps: ToolkitDeps, input: ToolkitInput) {
           if (streamed.length > headRows + tailRows) {
             const omitted = streamed.length - (headRows + tailRows);
             for (const line of streamed.slice(0, headRows)) emitLine(line);
-            onOutput({
+            input.onOutput({
               toolName: "run-command",
               content: { kind: "truncated", count: omitted, unit: "lines" },
               toolCallId,
             });
             for (const line of streamed.slice(streamed.length - tailRows)) emitLine(line);
           } else if (streamed.length === 0) {
-            onOutput({ toolName: "run-command", content: { kind: "no-output" }, toolCallId });
+            input.onOutput({ toolName: "run-command", content: { kind: "no-output" }, toolCallId });
           } else {
             for (const line of streamed.slice(0, TOOL_OUTPUT_LIMITS.run)) emitLine(line);
           }
-          const result = compactToolOutput(rawResult, outputBudget.run);
+          const result = compactToolOutput(rawResult, deps.outputBudget.run);
           return {
             kind: "run-command",
             command: toolInput.command,

--- a/src/soul.int.test.ts
+++ b/src/soul.int.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { createId } from "./short-id";
 import { createSoulPrompt, formatMemoryResumeBlock, loadAgentsPrompt, loadSoulPrompt, loadSystemPrompt } from "./soul";
 import { tempDir } from "./test-utils";
 
@@ -53,9 +54,12 @@ describe("soul prompt loading", () => {
   });
 
   test("createSoulPrompt emits load_empty debug event when no memory is available", async () => {
+    const dir = createDir("acolyte-empty-memory-");
     const events: string[] = [];
     await createSoulPrompt({
-      sessionId: "sess_test0001",
+      sessionId: `sess_${createId()}`,
+      resourceId: `user_${createId()}`,
+      workspace: dir,
       onDebug: (event) => {
         events.push(event);
       },

--- a/src/soul.ts
+++ b/src/soul.ts
@@ -47,6 +47,7 @@ type CreateSoulPromptOptions = {
   resourceId?: ResourceId;
   workspace?: string;
   useMemory?: boolean;
+  memoryBudgetTokens?: number;
   onDebug?: (event: string, fields?: Record<string, unknown>) => void;
 };
 
@@ -63,21 +64,22 @@ export function formatMemoryResumeBlock(continuation: { currentTask?: string; ne
 export async function createSoulPrompt(options: CreateSoulPromptOptions = {}): Promise<SoulPromptResult> {
   const cwd = options.cwd ?? process.cwd();
   const base = loadSystemPrompt(cwd);
+  const budgetTokens = options.memoryBudgetTokens ?? appConfig.memory.budgetTokens;
   const debugBaseFields = {
-    budgetTokens: appConfig.memory.budgetTokens,
+    budgetTokens,
     sourceStrategy: appConfig.memory.sources.join(","),
   };
   if (options.useMemory === false) {
     options.onDebug?.("lifecycle.memory.load_skipped", { ...debugBaseFields, reason: "request_disabled" });
     return { prompt: base, memoryTokens: 0 };
   }
-  if (appConfig.memory.budgetTokens <= 0) {
+  if (budgetTokens <= 0) {
     options.onDebug?.("lifecycle.memory.load_skipped", { ...debugBaseFields, reason: "budget_disabled" });
     return { prompt: base, memoryTokens: 0 };
   }
   const memoryContext = await loadMemoryContext(
     { sessionId: options.sessionId, resourceId: options.resourceId, workspace: options.workspace },
-    appConfig.memory.budgetTokens,
+    budgetTokens,
   );
   const memoryPrompt = memoryContext.prompt;
   if (!memoryPrompt) {

--- a/src/tool-contract.ts
+++ b/src/tool-contract.ts
@@ -17,6 +17,27 @@ export type ToolDefinition<TInput = unknown, TOutput = unknown> = {
   readonly execute: (input: TInput) => Promise<TOutput>;
 };
 
+export type ToolOutputBudgetEntry = { maxChars: number; maxLines: number };
+
+export type ToolOutputBudget = {
+  findFiles: ToolOutputBudgetEntry;
+  searchFiles: ToolOutputBudgetEntry;
+  webSearch: ToolOutputBudgetEntry;
+  webFetch: ToolOutputBudgetEntry;
+  read: ToolOutputBudgetEntry;
+  gitStatus: ToolOutputBudgetEntry;
+  gitDiff: ToolOutputBudgetEntry;
+  run: ToolOutputBudgetEntry;
+  edit: ToolOutputBudgetEntry;
+  astEdit: ToolOutputBudgetEntry;
+  scanCode: ToolOutputBudgetEntry;
+  create: ToolOutputBudgetEntry;
+};
+
+export type ToolkitDeps = {
+  outputBudget: ToolOutputBudget;
+};
+
 export type ToolkitInput = {
   workspace: string;
   session: SessionContext;

--- a/src/tool-output.ts
+++ b/src/tool-output.ts
@@ -1,6 +1,6 @@
-import { compactText, DEFAULT_MAX_CHARS, DEFAULT_MAX_LINES } from "./compact-text";
+import { type CompactBudget, compactText, DEFAULT_MAX_CHARS, DEFAULT_MAX_LINES } from "./compact-text";
 
-export function compactToolOutput(raw: string, options: { maxChars?: number; maxLines?: number } = {}): string {
+export function compactToolOutput(raw: string, options: CompactBudget = {}): string {
   const maxChars = options.maxChars ?? DEFAULT_MAX_CHARS;
   const maxLines = options.maxLines ?? DEFAULT_MAX_LINES;
   const source = raw.trim();

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -1,11 +1,12 @@
 import { resolve } from "node:path";
+import { appConfig } from "./app-config";
 import { invariant } from "./assert";
 import { createCodeToolkit } from "./code-toolkit";
 import { createFileToolkit } from "./file-toolkit";
 import { createGitToolkit } from "./git-toolkit";
 import { createShellToolkit } from "./shell-toolkit";
 import { createToolCache } from "./tool-cache";
-import type { ToolCategory, ToolDefinition, ToolkitInput, ToolPermission } from "./tool-contract";
+import type { ToolCategory, ToolDefinition, ToolkitDeps, ToolkitInput, ToolPermission } from "./tool-contract";
 import { createSessionContext, type SessionContext } from "./tool-guards";
 import type { ToolOutputListener } from "./tool-output-format";
 import { createWebToolkit } from "./web-toolkit";
@@ -27,36 +28,45 @@ type AnyToolDefinition = ToolDefinition<unknown>;
 
 export const TOOLKIT_REGISTRY: {
   id: string;
-  createToolkit: (input: ToolkitInput) => ToolMap;
+  createToolkit: (deps: ToolkitDeps, input: ToolkitInput) => ToolMap;
 }[] = [
   {
     id: "file",
-    createToolkit: (input) => createFileToolkit(input),
+    createToolkit: (deps, input) => createFileToolkit(deps, input),
   },
   {
     id: "code",
-    createToolkit: (input) => createCodeToolkit(input),
+    createToolkit: (deps, input) => createCodeToolkit(deps, input),
   },
   {
     id: "web",
-    createToolkit: (input) => createWebToolkit(input),
+    createToolkit: (deps, input) => createWebToolkit(deps, input),
   },
   {
     id: "shell",
-    createToolkit: (input) => createShellToolkit(input),
+    createToolkit: (deps, input) => createShellToolkit(deps, input),
   },
   {
     id: "git",
-    createToolkit: (input) => createGitToolkit(input),
+    createToolkit: (deps, input) => createGitToolkit(deps, input),
   },
 ];
 
 const noopOutput: ToolOutputListener = () => {};
 
-function collectTools(workspace: string, session: SessionContext, onOutput: ToolOutputListener = noopOutput): ToolMap {
+const defaultToolkitDeps = (): ToolkitDeps => ({
+  outputBudget: appConfig.agent.toolOutputBudget,
+});
+
+function collectTools(
+  workspace: string,
+  session: SessionContext,
+  onOutput: ToolOutputListener = noopOutput,
+  deps: ToolkitDeps = defaultToolkitDeps(),
+): ToolMap {
   const combined: ToolMap = {};
   for (const toolkit of TOOLKIT_REGISTRY) {
-    Object.assign(combined, toolkit.createToolkit({ workspace, session, onOutput }));
+    Object.assign(combined, toolkit.createToolkit(deps, { workspace, session, onOutput }));
   }
   return combined;
 }

--- a/src/web-toolkit.ts
+++ b/src/web-toolkit.ts
@@ -1,8 +1,7 @@
 import { z } from "zod";
-import { appConfig } from "./app-config";
 import { compactDetail } from "./compact-text";
 import { t } from "./i18n";
-import { createTool, type ToolkitInput } from "./tool-contract";
+import { createTool, type ToolkitDeps, type ToolkitInput } from "./tool-contract";
 import { runTool } from "./tool-execution";
 import { compactToolOutput } from "./tool-output";
 import { emitResultChunks } from "./tool-output-format";
@@ -57,7 +56,8 @@ export function webSearchStreamRows(result: string, query?: string): string {
   return out.join("\n");
 }
 
-function createWebSearchTool(input: ToolkitInput) {
+function createWebSearchTool(deps: ToolkitDeps, input: ToolkitInput) {
+  const { outputBudget } = deps;
   const { session, onOutput } = input;
   return createTool({
     id: "web-search",
@@ -89,7 +89,7 @@ function createWebSearchTool(input: ToolkitInput) {
         });
         const result = compactToolOutput(
           await searchWeb(toolInput.query, toolInput.maxResults ?? WEB_SEARCH_MAX_RESULTS),
-          appConfig.agent.toolOutputBudget.webSearch,
+          outputBudget.webSearch,
         );
         emitResultChunks("web-search", webSearchStreamRows(result, toolInput.query), onOutput, 80, toolCallId);
         return { kind: "web-search", query: toolInput.query, output: result };
@@ -98,7 +98,8 @@ function createWebSearchTool(input: ToolkitInput) {
   });
 }
 
-function createWebFetchTool(input: ToolkitInput) {
+function createWebFetchTool(deps: ToolkitDeps, input: ToolkitInput) {
+  const { outputBudget } = deps;
   const { session, onOutput } = input;
   return createTool({
     id: "web-fetch",
@@ -126,7 +127,7 @@ function createWebFetchTool(input: ToolkitInput) {
         });
         const result = compactToolOutput(
           await fetchWeb(toolInput.url, toolInput.maxChars ?? 5000),
-          appConfig.agent.toolOutputBudget.webFetch,
+          outputBudget.webFetch,
         );
         return { kind: "web-fetch", url: toolInput.url, output: result };
       });
@@ -134,9 +135,9 @@ function createWebFetchTool(input: ToolkitInput) {
   });
 }
 
-export function createWebToolkit(input: ToolkitInput) {
+export function createWebToolkit(deps: ToolkitDeps, input: ToolkitInput) {
   return {
-    webSearch: createWebSearchTool(input),
-    webFetch: createWebFetchTool(input),
+    webSearch: createWebSearchTool(deps, input),
+    webFetch: createWebFetchTool(deps, input),
   };
 }

--- a/src/web-toolkit.ts
+++ b/src/web-toolkit.ts
@@ -57,8 +57,6 @@ export function webSearchStreamRows(result: string, query?: string): string {
 }
 
 function createWebSearchTool(deps: ToolkitDeps, input: ToolkitInput) {
-  const { outputBudget } = deps;
-  const { session, onOutput } = input;
   return createTool({
     id: "web-search",
     label: t("tool.label.web_search"),
@@ -77,8 +75,8 @@ function createWebSearchTool(deps: ToolkitDeps, input: ToolkitInput) {
       output: z.string(),
     }),
     execute: async (toolInput) => {
-      return runTool(session, "web-search", toolInput, async (toolCallId) => {
-        onOutput({
+      return runTool(input.session, "web-search", toolInput, async (toolCallId) => {
+        input.onOutput({
           toolName: "web-search",
           content: {
             kind: "tool-header",
@@ -89,9 +87,9 @@ function createWebSearchTool(deps: ToolkitDeps, input: ToolkitInput) {
         });
         const result = compactToolOutput(
           await searchWeb(toolInput.query, toolInput.maxResults ?? WEB_SEARCH_MAX_RESULTS),
-          outputBudget.webSearch,
+          deps.outputBudget.webSearch,
         );
-        emitResultChunks("web-search", webSearchStreamRows(result, toolInput.query), onOutput, 80, toolCallId);
+        emitResultChunks("web-search", webSearchStreamRows(result, toolInput.query), input.onOutput, 80, toolCallId);
         return { kind: "web-search", query: toolInput.query, output: result };
       });
     },
@@ -99,8 +97,6 @@ function createWebSearchTool(deps: ToolkitDeps, input: ToolkitInput) {
 }
 
 function createWebFetchTool(deps: ToolkitDeps, input: ToolkitInput) {
-  const { outputBudget } = deps;
-  const { session, onOutput } = input;
   return createTool({
     id: "web-fetch",
     label: t("tool.label.web_fetch"),
@@ -119,15 +115,15 @@ function createWebFetchTool(deps: ToolkitDeps, input: ToolkitInput) {
       output: z.string(),
     }),
     execute: async (toolInput) => {
-      return runTool(session, "web-fetch", toolInput, async (toolCallId) => {
-        onOutput({
+      return runTool(input.session, "web-fetch", toolInput, async (toolCallId) => {
+        input.onOutput({
           toolName: "web-fetch",
           content: { kind: "tool-header", label: t("tool.label.web_fetch"), detail: toolInput.url },
           toolCallId,
         });
         const result = compactToolOutput(
           await fetchWeb(toolInput.url, toolInput.maxChars ?? 5000),
-          outputBudget.webFetch,
+          deps.outputBudget.webFetch,
         );
         return { kind: "web-fetch", url: toolInput.url, output: result };
       });


### PR DESCRIPTION
## Summary

- Split toolkit deps from runtime input across all 5 toolkit files
- Inject provider credentials via params in model factory, provider models, and client factory
- Unify credential types and defaults into single canonical exports
- Extract translator factory in i18n, add skill budget deps
- Inject distill config via options, lazy-init default distill store
- Add budget, configured models, temperature, and memory params to lifecycle modules
- Refactor tests to use DI params instead of appConfig mutations
- Document DI convention in architecture docs and arch-audit skill

Fixes #26