### PR TITLE
fix(tui): output, lifecycle, and tooling fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules/
 .superset/
 coverage/
 Library/
+scripts/demo.sh

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -149,12 +149,11 @@ Every lifecycle event emits structured debug logs describing:
 The `acolyte trace` command converts daemon logs into timelines:
 
 ```
-task_id=task_abc123
-2026-03-10T10:00:01 lifecycle.tool.call tool=edit-file path=src/foo.ts
-2026-03-10T10:00:02 lifecycle.tool.result tool=edit-file duration_ms=45 is_error=false
-2026-03-10T10:00:02 lifecycle.guard guard=file-churn tool=read-file action=blocked
-2026-03-10T10:00:03 lifecycle.eval.decision evaluator=verifyCycle action=regenerate
-2026-03-10T10:00:05 lifecycle.summary model_calls=2 total_tool_calls=8 guard_blocked=1
+timestamp=... task_id=task_abc123 event=lifecycle.tool.call tool=edit-file path=src/foo.ts
+timestamp=... task_id=task_abc123 event=lifecycle.tool.result tool=edit-file duration_ms=45 is_error=false
+timestamp=... task_id=task_abc123 event=lifecycle.guard guard=file-churn tool=read-file action=blocked
+timestamp=... task_id=task_abc123 event=lifecycle.eval.decision evaluator=verify-cycle action=regenerate
+timestamp=... task_id=task_abc123 event=lifecycle.summary model_calls=2 read=3 search=1 write=1 guard_blocked=1
 ```
 
 These traces allow developers to debug agent behavior step-by-step.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test:tui": "bash scripts/run-test-suite.sh tui",
     "test:int": "bash scripts/run-test-suite.sh int",
     "test:perf": "bash scripts/run-test-suite.sh perf",
-    "verify": "bun run lint && bun run typecheck && bun test",
+    "audit": "bun audit",
+    "verify": "bun run lint && bun run typecheck && bun test && bun run audit",
     "benchmark": "bun run scripts/benchmark.ts",
     "release": "bash scripts/release.sh"
   },

--- a/scripts/fake-provider-server.ts
+++ b/scripts/fake-provider-server.ts
@@ -1,4 +1,4 @@
-type FakeProviderServer = {
+export type FakeProviderServer = {
   baseUrl: string;
   stop: () => void;
 };

--- a/src/agent-modes.ts
+++ b/src/agent-modes.ts
@@ -43,6 +43,7 @@ export const agentModes: Record<AgentMode, AgentModeDefinition> = {
       "Trust type signatures; do not add impossible null/undefined guards unless the declared types allow them.",
       "Never delete a file to recreate it — use `edit-file` to modify existing files.",
       "When a target file does not exist, say so instead of silently creating it.",
+      "Do not run verify, test, or build commands — the lifecycle verify phase handles verification automatically after your edits.",
       "After the last tool call, use the lifecycle signal format from the base instructions and keep the user-facing outcome to one sentence.",
     ],
   },

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -121,7 +121,10 @@ export function createAgentStream(
         }
 
         const stepText = stepTextParts.join("");
-        if (stepText.length > 0) fullText += stepText;
+        if (stepText.length > 0) {
+          if (fullText.length > 0 && !fullText.endsWith("\n") && !fullText.endsWith(" ")) fullText += "\n";
+          fullText += stepText;
+        }
 
         if (pendingToolCalls.length === 0) {
           if (nudgeCount < maxNudges && allToolCalls.length > 0 && !lifecycleSignal && stepText.trim().length > 0) {

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -192,7 +192,7 @@ export function createAgentStream(
 
           try {
             const args = JSON.parse(tc.input);
-            const result = await tool.execute(args);
+            const result = await tool.execute(args, tc.toolCallId);
             streamController.enqueue({
               type: "tool-result",
               payload: { toolCallId: tc.toolCallId, toolName: tc.toolName, result },

--- a/src/chat-content-render.tsx
+++ b/src/chat-content-render.tsx
@@ -21,13 +21,13 @@ export function renderAssistantContent(content: string, wrapWidth: number): Reac
           if (token.kind === "code") {
             return (
               <Text key={tokenKey} color={palette.textCode}>
-                {token.text}
+                {token.text.slice(1, -1)}
               </Text>
             );
           }
           if (token.kind === "path") {
             return (
-              <Text key={tokenKey} underline color={palette.textPath}>
+              <Text key={tokenKey} color={palette.textCode}>
                 {token.text}
               </Text>
             );

--- a/src/chat-message-handler-stream.int.test.ts
+++ b/src/chat-message-handler-stream.int.test.ts
@@ -570,4 +570,56 @@ describe("chat message handler stream behavior", () => {
     expect(toolIndex).toBeGreaterThanOrEqual(0);
     expect(assistantIndex).toBeLessThan(toolIndex);
   });
+
+  test("batched tool calls each get their own tool row", async () => {
+    const { handleMessage, rows } = createMessageHandlerHarness({
+      client: createClient({
+        replyStream: async (_input, options) => {
+          options.onEvent({ type: "status", state: { kind: "running", mode: "work" } });
+          // Two tool calls in the same batch, different toolCallIds
+          options.onEvent({
+            type: "tool-call",
+            toolCallId: "call_A",
+            toolName: "edit-code",
+            args: { path: "a.ts" },
+          });
+          options.onEvent({
+            type: "tool-output",
+            toolCallId: "call_A",
+            toolName: "edit-code",
+            content: { kind: "edit-header", label: "Edit", path: "a.ts", files: 1, added: 1, removed: 1 },
+          });
+          options.onEvent({
+            type: "tool-result",
+            toolCallId: "call_A",
+            toolName: "edit-code",
+          });
+          options.onEvent({
+            type: "tool-call",
+            toolCallId: "call_B",
+            toolName: "edit-code",
+            args: { path: "b.ts" },
+          });
+          options.onEvent({
+            type: "tool-output",
+            toolCallId: "call_B",
+            toolName: "edit-code",
+            content: { kind: "edit-header", label: "Edit", path: "b.ts", files: 1, added: 1, removed: 1 },
+          });
+          options.onEvent({
+            type: "tool-result",
+            toolCallId: "call_B",
+            toolName: "edit-code",
+          });
+          return { model: "gpt-5-mini", output: "done" };
+        },
+        status: async () => ({}),
+      }),
+    });
+
+    await handleMessage("rename across files");
+
+    const toolRows = rows.filter((row) => row.kind === "tool");
+    expect(toolRows).toHaveLength(2);
+  });
 });

--- a/src/chat-message-handler-stream.int.test.ts
+++ b/src/chat-message-handler-stream.int.test.ts
@@ -532,4 +532,42 @@ describe("chat message handler stream behavior", () => {
     // Session B's history should include the new user message
     expect(currentSession.messages.some((msg) => msg.role === "user" && msg.content === "hello from B")).toBe(true);
   });
+
+  test("assistant text row stays before tool rows after finalization", async () => {
+    const { handleMessage, rows } = createMessageHandlerHarness({
+      client: createClient({
+        replyStream: async (_input, options) => {
+          options.onEvent({ type: "status", state: { kind: "running", mode: "work" } });
+          options.onEvent({ type: "text-delta", text: "I will run the command." });
+          options.onEvent({
+            type: "tool-call",
+            toolCallId: "call_1",
+            toolName: "run-command",
+            args: { command: "echo hi" },
+          });
+          options.onEvent({
+            type: "tool-output",
+            toolCallId: "call_1",
+            toolName: "run-command",
+            content: { kind: "tool-header", label: "Run", detail: "echo hi" },
+          });
+          options.onEvent({
+            type: "tool-result",
+            toolCallId: "call_1",
+            toolName: "run-command",
+          });
+          return { model: "gpt-5-mini", output: "I will run the command." };
+        },
+        status: async () => ({}),
+      }),
+    });
+
+    await handleMessage("do something");
+
+    const assistantIndex = rows.findIndex((row) => row.kind === "assistant");
+    const toolIndex = rows.findIndex((row) => row.kind === "tool");
+    expect(assistantIndex).toBeGreaterThanOrEqual(0);
+    expect(toolIndex).toBeGreaterThanOrEqual(0);
+    expect(assistantIndex).toBeLessThan(toolIndex);
+  });
 });

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -141,7 +141,15 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
       input.currentSession.messages.push(assistantMessage);
       input.currentSession.updatedAt = input.nowIso();
       const removeSet = new Set(streamingRowIds);
-      input.setRows((current) => [...current.filter((row) => !removeSet.has(row.id)), ...turn.rows]);
+      input.setRows((current) => {
+        const insertIndex = removeSet.size > 0 ? current.findIndex((row) => removeSet.has(row.id)) : -1;
+        const filtered = current.filter((row) => !removeSet.has(row.id));
+        if (insertIndex >= 0) {
+          filtered.splice(insertIndex, 0, ...turn.rows);
+          return filtered;
+        }
+        return [...filtered, ...turn.rows];
+      });
       invalidateRepoPathCandidates();
       input.currentSession.tokenUsage.push(turn.tokenEntry);
       input.setTokenUsage(() => [...input.currentSession.tokenUsage]);

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -106,8 +106,18 @@ function renderToolPart(
   }
   const text = renderToolOutputText(part);
   if (lineNumWidth > 0) {
-    const pad = " ".repeat(lineNumWidth + 2);
-    const display = part.kind === "truncated" ? `${"…".padStart(lineNumWidth)}  ${text.slice(2)}` : `${pad}${text}`;
+    if (part.kind === "text") {
+      return (
+        <Text key={`tool-${index}`}>
+          {"\n  "}
+          <Text dimColor>{text}</Text>
+        </Text>
+      );
+    }
+    const display =
+      part.kind === "truncated"
+        ? `${"…".padStart(lineNumWidth)}  ${text.slice(2)}`
+        : `${" ".repeat(lineNumWidth + 2)}${text}`;
     return (
       <Text key={`tool-${index}`}>
         {"\n  "}

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -135,10 +135,11 @@ function renderToolPart(
 
 function renderHeader(part: ToolOutputPart): React.ReactNode {
   if (part.kind === "edit-header") {
+    const path = part.path === "." ? "" : part.path;
     return (
       <>
-        <Text bold>{part.label} </Text>
-        <Text dimColor>{part.path} (</Text>
+        <Text bold>{part.label}</Text>
+        <Text dimColor>{path ? ` ${path}` : ""} (</Text>
         <Text color={palette.diffAddText}>{`+${part.added}`}</Text>
         <Text dimColor> </Text>
         <Text color={palette.diffRemoveText}>{`-${part.removed}`}</Text>
@@ -147,20 +148,23 @@ function renderHeader(part: ToolOutputPart): React.ReactNode {
     );
   }
   if (part.kind === "tool-header") {
+    const detail = part.detail === "." ? undefined : part.detail;
     return (
       <>
         <Text bold>{part.label}</Text>
-        {part.detail ? <Text dimColor>{` ${part.detail}`}</Text> : null}
+        {detail ? <Text dimColor>{` ${detail}`}</Text> : null}
       </>
     );
   }
   if (part.kind === "file-header") {
-    const shown = part.targets.join(", ");
+    const targets = part.targets.filter((t) => t !== ".");
+    const shown = targets.join(", ");
     const omitted = part.omitted && part.omitted > 0 ? `, +${part.omitted}` : "";
+    const detail = shown ? ` ${shown}${omitted}` : omitted ? ` ${omitted.slice(2)}` : "";
     return (
       <>
         <Text bold>{part.label}</Text>
-        <Text dimColor>{` ${shown}${omitted}`}</Text>
+        {detail ? <Text dimColor>{detail}</Text> : null}
       </>
     );
   }

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -241,8 +241,6 @@ type ChatTranscriptProps = {
   runningUsage?: { inputTokens: number; outputTokens: number } | null;
 };
 
-const MAX_TRANSCRIPT_WIDTH = 120;
-
 export function ChatTranscript(props: ChatTranscriptProps): React.ReactNode {
   const { rows, pendingState, pendingFrame, pendingStartedAt, runningUsage } = props;
   const pulsePeriod = 16;
@@ -278,8 +276,8 @@ export function ChatTranscript(props: ChatTranscriptProps): React.ReactNode {
     return "";
   })();
   const columns = process.stdout.columns ?? 120;
-  const contentWidth = Math.max(24, Math.min(MAX_TRANSCRIPT_WIDTH, columns - 2));
-  const toolContentWidth = Math.max(24, columns - 2);
+  const contentWidth = Math.max(24, columns - 2);
+  const toolContentWidth = contentWidth;
   return (
     <>
       {hasContent ? <Text> </Text> : null}

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -136,6 +136,34 @@ function renderHeader(part: ToolOutputPart): React.ReactNode {
       </>
     );
   }
+  if (part.kind === "tool-header") {
+    return (
+      <>
+        <Text bold>{part.label}</Text>
+        {part.detail ? <Text dimColor>{` ${part.detail}`}</Text> : null}
+      </>
+    );
+  }
+  if (part.kind === "file-header") {
+    const shown = part.targets.join(", ");
+    const omitted = part.omitted && part.omitted > 0 ? `, +${part.omitted}` : "";
+    return (
+      <>
+        <Text bold>{part.label}</Text>
+        <Text dimColor>{` ${shown}${omitted}`}</Text>
+      </>
+    );
+  }
+  if (part.kind === "scope-header") {
+    const display =
+      part.scope === "workspace" ? part.patterns.join(", ") : `${part.scope} [${part.patterns.join(", ")}]`;
+    return (
+      <>
+        <Text bold>{part.label}</Text>
+        <Text dimColor>{` ${display}`}</Text>
+      </>
+    );
+  }
   const text = renderToolOutputText(part);
   return <Text dimColor>{text}</Text>;
 }

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -105,11 +105,13 @@ function renderToolPart(
     );
   }
   const text = renderToolOutputText(part);
-  if (part.kind === "truncated" && lineNumWidth > 0) {
+  if (lineNumWidth > 0) {
+    const pad = " ".repeat(lineNumWidth + 2);
+    const display = part.kind === "truncated" ? `${"…".padStart(lineNumWidth)}  ${text.slice(2)}` : `${pad}${text}`;
     return (
       <Text key={`tool-${index}`}>
         {"\n  "}
-        <Text dimColor>{` ${"…".padStart(lineNumWidth)}  ${text.slice(2)}`}</Text>
+        <Text dimColor>{` ${display}`}</Text>
       </Text>
     );
   }

--- a/src/cli-run.test.ts
+++ b/src/cli-run.test.ts
@@ -82,7 +82,7 @@ describe("cli-run", () => {
     expect(tokenLine).toContain("3 calls");
   });
 
-  test("runMode disables verifier for single-shot runs", async () => {
+  test("runMode does not disable verifier", async () => {
     const { deps } = createRunDeps();
     let seenOptions: { resourceId?: string; workspace?: string; verifyScope?: string } | undefined;
     deps.handlePrompt = async (_prompt, _session, _client, options) => {
@@ -92,6 +92,6 @@ describe("cli-run", () => {
 
     await runMode(["do something"], deps);
 
-    expect(seenOptions?.verifyScope).toBe("none");
+    expect(seenOptions?.verifyScope).toBeUndefined();
   });
 });

--- a/src/cli-run.ts
+++ b/src/cli-run.ts
@@ -136,7 +136,6 @@ export async function runMode(args: string[], deps: RunModeDeps): Promise<void> 
   const startMs = Date.now();
   const success = await handlePrompt(parsed.prompt, session, client, {
     resourceId: runResourceId(session.id),
-    verifyScope: "none",
     workspace: parsed.workspace,
   });
   const durationMs = Date.now() - startMs;

--- a/src/cli-skill.model.test.ts
+++ b/src/cli-skill.model.test.ts
@@ -77,7 +77,7 @@ describe("cli-skill --model flag", () => {
     process.exitCode = prevExit;
   });
 
-  test("skillMode disables verifier for single-shot skill runs", async () => {
+  test("skillMode does not disable verifier", async () => {
     const { deps } = createSkillDeps();
     let seenOptions: { resourceId?: string; workspace?: string; verifyScope?: string } | undefined;
     deps.handlePrompt = async (_prompt, _session, _client, options) => {
@@ -90,7 +90,7 @@ describe("cli-skill --model flag", () => {
 
     await skillMode(["skill-name", "do something"], deps);
 
-    expect(seenOptions?.verifyScope).toBe("none");
+    expect(seenOptions?.verifyScope).toBeUndefined();
 
     process.exitCode = prevExit;
   });

--- a/src/cli-skill.ts
+++ b/src/cli-skill.ts
@@ -151,7 +151,6 @@ export async function skillMode(args: string[], deps: SkillModeDeps): Promise<vo
   const startMs = Date.now();
   const success = await handlePrompt(parsed.prompt, session, client, {
     resourceId: skillResourceId(session.id),
-    verifyScope: "none",
     workspace: parsed.workspace,
   });
   const durationMs = Date.now() - startMs;

--- a/src/cli-trace.test.ts
+++ b/src/cli-trace.test.ts
@@ -43,16 +43,19 @@ describe("traceMode", () => {
     expect(errorMsg).toContain("Unknown subcommand");
   });
 
-  test("task subcommand without id calls commandError", async () => {
-    let called = false;
-    const { deps } = createDeps({
-      commandError: (_name, msg) => {
-        called = true;
-        expect(msg).toContain("Missing task ID");
-      },
-    });
+  test("task subcommand without id traces latest task", async () => {
+    const log = [
+      '2026-01-01T00:00:00.000Z level=info msg="agent debug" task_id=task_latest event=lifecycle.start mode=work model=gpt-5',
+    ].join("\n");
+    const { deps, output } = createDeps({ readFile: async () => log });
     await traceMode(["task"], deps);
-    expect(called).toBe(true);
+    expect(output()).toContain("task_latest");
+  });
+
+  test("task subcommand without id and empty log prints no tasks", async () => {
+    const { deps, output } = createDeps();
+    await traceMode(["task"], deps);
+    expect(output()).toContain("No tasks");
   });
 
   test("missing log file prints error", async () => {

--- a/src/cli-trace.ts
+++ b/src/cli-trace.ts
@@ -163,7 +163,6 @@ function traceByTask(lines: LogLine[], taskIds: string[], out: CliOutput, print:
       continue;
     }
     if (i > 0) out.addSeparator();
-    out.addHeader(`task_id=${taskId}`);
     for (const line of selected) out.addRow(traceRowData(line));
   }
 }

--- a/src/cli-trace.ts
+++ b/src/cli-trace.ts
@@ -47,6 +47,7 @@ const traceEventSchema = z.enum([
   "lifecycle.eval.lint",
   "lifecycle.eval.guard_recovery",
   "lifecycle.eval.repeated_failure",
+  "lifecycle.eval.verify_cycle",
   "lifecycle.eval.verify_failure",
   "lifecycle.eval.tool_recovery",
   "lifecycle.summary",
@@ -94,6 +95,7 @@ const EVENT_FIELDS: Record<TraceEvent, FieldSpec[]> = {
   "lifecycle.eval.lint": ["files"],
   "lifecycle.eval.guard_recovery": ["mode"],
   "lifecycle.eval.repeated_failure": ["signature", "count", "code", "category"],
+  "lifecycle.eval.verify_cycle": ["used_write_tools", "verified", "verify_scope"],
   "lifecycle.eval.verify_failure": ["text_chars"],
   "lifecycle.eval.tool_recovery": ["recovery_tool", "recovery_kind"],
   "lifecycle.summary": [

--- a/src/cli-trace.ts
+++ b/src/cli-trace.ts
@@ -217,10 +217,14 @@ export async function traceMode(args: string[], deps: TraceModeDeps): Promise<vo
   const lines = parseLog(raw);
 
   if (subcommand === "task") {
-    const taskIds = parseTaskIdsArg(subcommandArg);
+    let taskIds = parseTaskIdsArg(subcommandArg);
     if (taskIds.length === 0) {
-      commandError("trace", t("cli.trace.missing_task_id"));
-      return;
+      const latest = listTasks(lines)[0];
+      if (!latest) {
+        printDim(t("cli.trace.no_tasks"));
+        return;
+      }
+      taskIds = [latest.taskId];
     }
     traceByTask(lines, taskIds, out, printDim);
   } else if (!subcommand || subcommand === "list") {

--- a/src/cli-visual.int.test.ts
+++ b/src/cli-visual.int.test.ts
@@ -489,7 +489,6 @@ describe("cli visual regression", () => {
       const out = await run(["trace", "task", "task_abc"]);
       expect(out).toBe(
         dedent(`
-          task_id=task_abc
           timestamp=2026-03-19T10:00:00Z task_id=task_abc event=lifecycle.start mode=work model=gpt-5-mini
           timestamp=2026-03-19T10:00:01Z task_id=task_abc event=lifecycle.tool.call tool=read-file path=src/cli.ts
           timestamp=2026-03-19T10:00:03Z task_id=task_abc event=lifecycle.summary model_calls=1 total_tool_calls=1 read=1 search=0 write=0 pre_write_discovery=0 regenerations=0 guard_blocked=0 guard_flag_set=0 has_error=false

--- a/src/code-ops.test.ts
+++ b/src/code-ops.test.ts
@@ -640,21 +640,21 @@ describe("editCode", () => {
     const dirPath = `/tmp/acolyte-test-ast-dir-${testUuid()}`;
     tempDirs.push(dirPath);
     await mkdir(dirPath, { recursive: true });
-    await writeFile(join(dirPath, "a.ts"), "const x = createId();\n", "utf8");
-    await writeFile(join(dirPath, "b.ts"), "const y = createId();\n", "utf8");
+    await writeFile(join(dirPath, "a.ts"), "const x = oldName();\n", "utf8");
+    await writeFile(join(dirPath, "b.ts"), "const y = oldName();\n", "utf8");
     tempFiles.push(join(dirPath, "a.ts"), join(dirPath, "b.ts"));
     const result = await editCode({
       workspace: dirPath,
       path: dirPath,
-      edits: [{ op: "rename", from: "createId", to: "generateId" }],
+      edits: [{ op: "rename", from: "oldName", to: "newName" }],
     });
     expect(result.matches).toBe(2);
     expect(result.diff).toContain("a.ts");
     expect(result.diff).toContain("b.ts");
     const aContent = await readFile(join(dirPath, "a.ts"), "utf8");
     const bContent = await readFile(join(dirPath, "b.ts"), "utf8");
-    expect(aContent).toContain("generateId");
-    expect(bContent).toContain("generateId");
+    expect(aContent).toContain("newName");
+    expect(bContent).toContain("newName");
   });
 
   test("rejects unsupported non-code files", async () => {

--- a/src/code-ops.test.ts
+++ b/src/code-ops.test.ts
@@ -636,17 +636,25 @@ describe("editCode", () => {
     });
   });
 
-  test("rejects directory paths", async () => {
+  test("applies edits across directory", async () => {
     const dirPath = `/tmp/acolyte-test-ast-dir-${testUuid()}`;
     tempDirs.push(dirPath);
     await mkdir(dirPath, { recursive: true });
-    await expect(
-      editCode({
-        workspace: WORKSPACE,
-        path: dirPath,
-        edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.debug($ARG)" }],
-      }),
-    ).rejects.toThrow("edit-code requires a file path");
+    await writeFile(join(dirPath, "a.ts"), "const x = createId();\n", "utf8");
+    await writeFile(join(dirPath, "b.ts"), "const y = createId();\n", "utf8");
+    tempFiles.push(join(dirPath, "a.ts"), join(dirPath, "b.ts"));
+    const result = await editCode({
+      workspace: dirPath,
+      path: dirPath,
+      edits: [{ op: "rename", from: "createId", to: "generateId" }],
+    });
+    expect(result.matches).toBe(2);
+    expect(result.diff).toContain("a.ts");
+    expect(result.diff).toContain("b.ts");
+    const aContent = await readFile(join(dirPath, "a.ts"), "utf8");
+    const bContent = await readFile(join(dirPath, "b.ts"), "utf8");
+    expect(aContent).toContain("generateId");
+    expect(bContent).toContain("generateId");
   });
 
   test("rejects unsupported non-code files", async () => {

--- a/src/code-ops.ts
+++ b/src/code-ops.ts
@@ -1,5 +1,5 @@
-import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import * as napi from "@ast-grep/napi";
 import { invariant } from "./assert";
 import type {
@@ -412,33 +412,55 @@ export type ScanCodeResult = {
   patterns: ScanCodePatternResult[];
 };
 
-export async function editCode(input: {
-  workspace: string;
-  path: string;
-  edits: EditCodeEdit[];
-}): Promise<EditCodeResult> {
-  const absPath = ensurePathWithinAllowedRoots(input.path, "AST edit", input.workspace);
-  const pathStats = await stat(absPath);
-  if (!pathStats.isFile()) throw new Error(`edit-code requires a file path, got: ${input.path}`);
-  if (!isParseable(absPath)) {
-    throw createToolError(
-      TOOL_ERROR_CODES.editCodeUnsupportedFile,
-      `edit-code requires a supported code file, got: ${input.path}`,
-      undefined,
-      editCodeRecovery(input.path, "use-supported-file"),
-    );
+async function collectParseableFiles(dirPath: string, maxFiles = 500): Promise<string[]> {
+  const files: string[] = [];
+  const stack = [dirPath];
+  while (stack.length > 0 && files.length < maxFiles) {
+    const dir = stack.pop();
+    if (!dir) break;
+    let entries: Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean }>;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      if (entry.name.startsWith(".") && entry.isDirectory()) continue;
+      if (entry.isDirectory() && IGNORED_DIRS.has(entry.name)) continue;
+      const abs = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(abs);
+        continue;
+      }
+      if (entry.isFile() && isParseable(abs)) files.push(abs);
+      if (files.length >= maxFiles) break;
+    }
   }
-  const original = await readFile(absPath, "utf8");
-  await ensureDynamicLanguages();
+  return files;
+}
 
+type EditCodeFileResult = {
+  matches: number;
+  affectedSymbols: string[];
+  diff: string;
+} | null;
+
+async function editCodeFile(
+  absPath: string,
+  workspace: string,
+  edits: EditCodeEdit[],
+  throwOnNoMatch: boolean,
+): Promise<EditCodeFileResult> {
   const langName = languageFromPath(absPath);
-  invariant(langName, `edit-code requires a supported code file, got: ${input.path}`);
+  if (!langName) return null;
   const langEnum = napi.Lang[langName as keyof typeof napi.Lang];
+  const original = await readFile(absPath, "utf8");
   let current = original;
   let totalMatches = 0;
   const affectedSymbols = new Set<string>();
 
-  for (const edit of input.edits) {
+  for (const edit of edits) {
     const tree = napi.parse(langEnum ?? langName, current);
     const pattern = isRenameEdit(edit) ? edit.from : ruleLabel(edit.rule);
     const replacement = isRenameEdit(edit) ? edit.to : edit.replacement;
@@ -461,31 +483,40 @@ export async function editCode(input: {
       matches = matches.filter((match) => matchIsWithinSymbol(match, symbol));
     }
     if (matches.length === 0) {
-      throw createToolError(
-        TOOL_ERROR_CODES.editCodeNoMatch,
-        `No AST matches found for ${isRenameEdit(edit) ? "rename target" : "rule"}: ${pattern}${edit.within ? ` within: ${edit.within}` : ""}${edit.withinSymbol ? ` withinSymbol: ${edit.withinSymbol}` : ""}`,
-        undefined,
-        editCodeRecovery(input.path, "refine-pattern"),
-      );
+      if (throwOnNoMatch) {
+        throw createToolError(
+          TOOL_ERROR_CODES.editCodeNoMatch,
+          `No AST matches found for ${isRenameEdit(edit) ? "rename target" : "rule"}: ${pattern}${edit.within ? ` within: ${edit.within}` : ""}${edit.withinSymbol ? ` withinSymbol: ${edit.withinSymbol}` : ""}`,
+          undefined,
+          editCodeRecovery(absPath, "refine-pattern"),
+        );
+      }
+      continue;
     }
     if (isRenameEdit(edit) && !edit.target && hasRenameModeConflict(matches)) {
-      throw createToolError(
-        TOOL_ERROR_CODES.editCodeNoMatch,
-        `Scoped rename target is ambiguous for ${edit.from}; retry with target: "local" or target: "member"${edit.withinSymbol ? ` withinSymbol: ${edit.withinSymbol}` : ""}`,
-        undefined,
-        editCodeRecovery(input.path, "clarify-rename-target"),
-      );
+      if (throwOnNoMatch) {
+        throw createToolError(
+          TOOL_ERROR_CODES.editCodeNoMatch,
+          `Scoped rename target is ambiguous for ${edit.from}; retry with target: "local" or target: "member"${edit.withinSymbol ? ` withinSymbol: ${edit.withinSymbol}` : ""}`,
+          undefined,
+          editCodeRecovery(absPath, "clarify-rename-target"),
+        );
+      }
+      continue;
     }
     const renameMode = isRenameEdit(edit) ? (requestedRenameMode(edit) ?? resolveRenameMode(matches)) : null;
     if (renameMode === "local") matches = matches.filter(isLocalRenameTarget);
     if (renameMode === "member") matches = matches.filter(isMemberRenameTarget);
     if (matches.length === 0) {
-      throw createToolError(
-        TOOL_ERROR_CODES.editCodeNoMatch,
-        `No AST matches found for ${isRenameEdit(edit) ? "rename target" : "rule"}: ${pattern}${edit.within ? ` within: ${edit.within}` : ""}${edit.withinSymbol ? ` withinSymbol: ${edit.withinSymbol}` : ""}${isRenameEdit(edit) && edit.target ? ` target: ${edit.target}` : ""}`,
-        undefined,
-        editCodeRecovery(input.path, "refine-pattern"),
-      );
+      if (throwOnNoMatch) {
+        throw createToolError(
+          TOOL_ERROR_CODES.editCodeNoMatch,
+          `No AST matches found for ${isRenameEdit(edit) ? "rename target" : "rule"}: ${pattern}${edit.within ? ` within: ${edit.within}` : ""}${edit.withinSymbol ? ` withinSymbol: ${edit.withinSymbol}` : ""}${isRenameEdit(edit) && edit.target ? ` target: ${edit.target}` : ""}`,
+          undefined,
+          editCodeRecovery(absPath, "refine-pattern"),
+        );
+      }
+      continue;
     }
     totalMatches += matches.length;
     for (const match of matches) {
@@ -504,7 +535,7 @@ export async function editCode(input: {
           TOOL_ERROR_CODES.editCodeReplacementMetaMismatch,
           `Replacement references metavariables not present in pattern: ${unknownReplacementMetavars.join(", ")}`,
           undefined,
-          editCodeRecovery(input.path, "fix-replacement"),
+          editCodeRecovery(absPath, "fix-replacement"),
         );
       }
     }
@@ -523,30 +554,92 @@ export async function editCode(input: {
     }
 
     replacements.sort((a, b) => b.start - a.start);
-    for (const replacement of replacements) {
-      current = current.slice(0, replacement.start) + replacement.replacement + current.slice(replacement.end);
+    for (const r of replacements) {
+      current = current.slice(0, r.start) + r.replacement + current.slice(r.end);
     }
   }
 
-  await mkdir(dirname(absPath), { recursive: true });
-  await writeFile(absPath, current, "utf8");
+  if (totalMatches === 0) return null;
 
-  const relativePath = displayPathForDiff(absPath, input.workspace);
-  const diff = createDiff(relativePath, original, current);
-  const affectedSymbolsList = Array.from(affectedSymbols);
-  const symbolsLine = affectedSymbolsList.length > 0 ? `symbols=${affectedSymbolsList.join(", ")}` : "";
-  const outputParts = [`path=${absPath}`, `edits=${input.edits.length}`, `matches=${totalMatches}`];
-  if (symbolsLine) outputParts.push(symbolsLine);
-  outputParts.push("", diff);
-  const output = outputParts.join("\n");
+  await writeFile(absPath, current, "utf8");
+  const diff = createDiff(displayPathForDiff(absPath, workspace), original, current);
+  return { matches: totalMatches, affectedSymbols: Array.from(affectedSymbols), diff };
+}
+
+export async function editCode(input: {
+  workspace: string;
+  path: string;
+  edits: EditCodeEdit[];
+}): Promise<EditCodeResult> {
+  const absPath = ensurePathWithinAllowedRoots(input.path, "AST edit", input.workspace);
+  const pathStats = await stat(absPath);
+
+  if (pathStats.isDirectory()) {
+    return editCodeDirectory(input.workspace, absPath, input.edits);
+  }
+
+  if (!pathStats.isFile()) throw new Error(`edit-code requires a file or directory path, got: ${input.path}`);
+  if (!isParseable(absPath)) {
+    throw createToolError(
+      TOOL_ERROR_CODES.editCodeUnsupportedFile,
+      `edit-code requires a supported code file, got: ${input.path}`,
+      undefined,
+      editCodeRecovery(input.path, "use-supported-file"),
+    );
+  }
+
+  await ensureDynamicLanguages();
+  const result = await editCodeFile(absPath, input.workspace, input.edits, true);
+  if (!result) {
+    throw createToolError(
+      TOOL_ERROR_CODES.editCodeNoMatch,
+      `No AST matches found in ${input.path}`,
+      undefined,
+      editCodeRecovery(input.path, "refine-pattern"),
+    );
+  }
+
+  const outputParts = [`path=${absPath}`, `edits=${input.edits.length}`, `matches=${result.matches}`];
+  if (result.affectedSymbols.length > 0) outputParts.push(`symbols=${result.affectedSymbols.join(", ")}`);
+  outputParts.push("", result.diff);
   return {
     path: absPath,
     edits: input.edits.length,
-    matches: totalMatches,
-    diff,
-    output,
-    affectedSymbols: affectedSymbolsList,
+    matches: result.matches,
+    diff: result.diff,
+    output: outputParts.join("\n"),
+    affectedSymbols: result.affectedSymbols,
   };
+}
+
+async function editCodeDirectory(workspace: string, dirPath: string, edits: EditCodeEdit[]): Promise<EditCodeResult> {
+  await ensureDynamicLanguages();
+  const files = await collectParseableFiles(dirPath);
+  const diffs: string[] = [];
+  let totalMatches = 0;
+  const allAffectedSymbols: string[] = [];
+
+  for (const absFile of files) {
+    const result = await editCodeFile(absFile, workspace, edits, false);
+    if (!result) continue;
+    totalMatches += result.matches;
+    allAffectedSymbols.push(...result.affectedSymbols);
+    diffs.push(result.diff);
+  }
+
+  if (totalMatches === 0) {
+    throw createToolError(
+      TOOL_ERROR_CODES.editCodeNoMatch,
+      `No AST matches found in directory: ${dirPath}`,
+      undefined,
+      editCodeRecovery(dirPath, "refine-pattern"),
+    );
+  }
+
+  const diff = diffs.join("\n");
+  const affectedSymbols = Array.from(new Set(allAffectedSymbols));
+  const output = [`path=${dirPath}`, `edits=${edits.length}`, `matches=${totalMatches}`, "", diff].join("\n");
+  return { path: dirPath, edits: edits.length, matches: totalMatches, diff, output, affectedSymbols };
 }
 
 export async function scanCode(input: {

--- a/src/code-toolkit.ts
+++ b/src/code-toolkit.ts
@@ -49,7 +49,7 @@ function formatScanCodeResult(result: ScanCodeResult): string {
 function createScanCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "scan-code",
-    label: t("tool.label.review"),
+    label: t("tool.label.scan"),
     category: "search",
     permissions: ["read"],
     description:
@@ -85,7 +85,7 @@ function createScanCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
             toolName: "scan-code",
             content: {
               kind: "file-header",
-              label: t("tool.label.review"),
+              label: t("tool.label.scan"),
               count: unique.length,
               targets: shown,
               omitted: remaining > 0 ? remaining : undefined,

--- a/src/code-toolkit.ts
+++ b/src/code-toolkit.ts
@@ -74,8 +74,8 @@ function createScanCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
       patterns: z.array(z.string().min(1)),
       output: z.string(),
     }),
-    execute: async (toolInput) => {
-      return runTool(input.session, "scan-code", toolInput, async (toolCallId) => {
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "scan-code", toolCallId, toolInput, async (callId) => {
         const paths = normalizeUniquePaths(toolInput.paths);
         const unique = Array.from(new Set(paths.map((path) => toDisplayPath(path, input.workspace))));
         if (unique.length > 0) {
@@ -90,7 +90,7 @@ function createScanCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
               targets: shown,
               omitted: remaining > 0 ? remaining : undefined,
             },
-            toolCallId,
+            toolCallId: callId,
           });
         }
         const baseBudget = deps.outputBudget.scanCode;
@@ -161,16 +161,16 @@ function createEditCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
       edits: z.array(editCodeEditSchema).min(1),
     }),
     outputSchema,
-    execute: async (toolInput) => {
-      return runTool(input.session, "edit-code", toolInput, async (toolCallId) => {
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "edit-code", toolCallId, toolInput, async (callId) => {
         const editResult = await editCode({
           workspace: input.workspace,
           path: toolInput.path,
           edits: toolInput.edits,
         });
-        emitDiffSummaryHeader(toolInput.path, editResult.output, toolCallId);
+        emitDiffSummaryHeader(toolInput.path, editResult.output, callId);
         for (const content of numberedUnifiedDiffLines(editResult.output))
-          input.onOutput({ toolName: "edit-code", content, toolCallId });
+          input.onOutput({ toolName: "edit-code", content, toolCallId: callId });
         const totals = summarizeUnifiedDiff(editResult.output);
         const result = compactToolOutput(editResult.output, deps.outputBudget.astEdit);
         return {

--- a/src/code-toolkit.ts
+++ b/src/code-toolkit.ts
@@ -136,7 +136,7 @@ function createEditCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
     category: "write",
     permissions: ["read", "write"],
     description:
-      'Edit code structurally with AST-aware operations. Pass `edits` as operation objects like {op:"rename", from, to, withinSymbol?, target?} or {op:"replace", rule, replacement, within?, withinSymbol?}. For `replace`, `rule` may be a string/pattern object shorthand or a recursive ast-grep rule object. `path` must be a specific file, not \'.\' or a directory. For non-code files use `edit-file`.',
+      'Edit code structurally with AST-aware operations. Pass `edits` as operation objects like {op:"rename", from, to, withinSymbol?, target?} or {op:"replace", rule, replacement, within?, withinSymbol?}. For `replace`, `rule` may be a string/pattern object shorthand or a recursive ast-grep rule object. `path` may be a file or directory (`.` for workspace-wide). For non-code files use `edit-file`.',
     instruction: [
       "Use `edit-code` for AST-aware refactors or structural code rewrites.",
       "Prefer explicit operation objects.",

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -76,8 +76,8 @@ function createFindFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
       paths: z.array(z.string().min(1)),
       output: z.string(),
     }),
-    execute: async (toolInput) => {
-      return runTool(input.session, "find-files", toolInput, async (toolCallId) => {
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "find-files", toolCallId, toolInput, async (callId) => {
         const maxResults = toolInput.maxResults ?? 40;
         const count = toolInput.patterns.length;
         const baseBudget = deps.outputBudget.findFiles;
@@ -92,7 +92,7 @@ function createFindFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
           toolInput.patterns,
           t("tool.label.find"),
           input.onOutput,
-          toolCallId,
+          callId,
           TOOL_OUTPUT_LIMITS.files,
           input.workspace,
         );
@@ -145,8 +145,8 @@ function createSearchFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
       entries: z.array(z.object({ path: z.string().min(1), hits: z.array(z.string().min(1)) })),
       output: z.string(),
     }),
-    execute: async (toolInput) => {
-      return runTool(input.session, "search-files", toolInput, async (toolCallId) => {
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "search-files", toolCallId, toolInput, async (callId) => {
         const maxResults = toolInput.maxResults ?? 20;
         const patterns =
           toolInput.patterns && toolInput.patterns.length > 0
@@ -165,7 +165,7 @@ function createSearchFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
           toolInput.paths,
           t("tool.label.search"),
           input.onOutput,
-          toolCallId,
+          callId,
           TOOL_OUTPUT_LIMITS.files,
           input.workspace,
         );
@@ -217,8 +217,8 @@ function createReadFileTool(deps: ToolkitDeps, input: ToolkitInput) {
       paths: z.array(z.object({ path: z.string().min(1), start: z.string().optional(), end: z.string().optional() })),
       output: z.string(),
     }),
-    execute: async (toolInput) => {
-      return runTool(input.session, "read-file", toolInput, async (toolCallId) => {
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "read-file", toolCallId, toolInput, async (callId) => {
         const entries = normalizeReadEntries(toolInput.paths);
         if (entries.length === 0) throw new Error("Read requires at least one non-empty path");
         const unique = Array.from(new Set(entries.map((entry) => toDisplayPath(entry.path, input.workspace))));
@@ -234,7 +234,7 @@ function createReadFileTool(deps: ToolkitDeps, input: ToolkitInput) {
               targets: shown,
               omitted: remaining > 0 ? remaining : undefined,
             },
-            toolCallId,
+            toolCallId: callId,
           });
         }
         const baseBudget = deps.outputBudget.read;
@@ -298,16 +298,16 @@ function createEditFileTool(deps: ToolkitDeps, input: ToolkitInput) {
         .min(1),
     }),
     outputSchema,
-    execute: async (toolInput) => {
-      return runTool(input.session, "edit-file", toolInput, async (toolCallId) => {
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "edit-file", toolCallId, toolInput, async (callId) => {
         const rawResult = await editFile({
           workspace: input.workspace,
           path: toolInput.path,
           edits: toolInput.edits,
         });
-        emitDiffSummaryHeader(toolInput.path, rawResult, toolCallId);
+        emitDiffSummaryHeader(toolInput.path, rawResult, callId);
         for (const content of numberedUnifiedDiffLines(rawResult))
-          input.onOutput({ toolName: "edit-file", content, toolCallId });
+          input.onOutput({ toolName: "edit-file", content, toolCallId: callId });
         const totals = summarizeUnifiedDiff(rawResult);
         const result = compactToolOutput(rawResult, deps.outputBudget.edit);
         return {
@@ -349,17 +349,17 @@ function createCreateFileTool(deps: ToolkitDeps, input: ToolkitInput) {
       removed: z.number().int().nonnegative(),
       output: z.string(),
     }),
-    execute: async (toolInput) => {
-      return runTool(input.session, "create-file", toolInput, async (toolCallId) => {
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "create-file", toolCallId, toolInput, async (callId) => {
         const rawResult = await writeTextFile({
           workspace: input.workspace,
           path: toolInput.path,
           content: toolInput.content,
           overwrite: true,
         });
-        emitDiffSummaryHeader(toolInput.path, rawResult, toolCallId);
+        emitDiffSummaryHeader(toolInput.path, rawResult, callId);
         for (const content of numberedUnifiedDiffLines(rawResult))
-          input.onOutput({ toolName: "create-file", content, toolCallId });
+          input.onOutput({ toolName: "create-file", content, toolCallId: callId });
         const totals = summarizeUnifiedDiff(rawResult);
         const result = compactToolOutput(rawResult, deps.outputBudget.create);
         return {
@@ -393,14 +393,14 @@ function createDeleteFileTool(deps: ToolkitDeps, input: ToolkitInput) {
       deleted: z.number().int().nonnegative(),
       output: z.string(),
     }),
-    execute: async (toolInput) => {
-      return runTool(input.session, "delete-file", toolInput, async (toolCallId) => {
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "delete-file", toolCallId, toolInput, async (callId) => {
         const paths = normalizeUniquePaths(toolInput.paths);
         const deleteDetail = paths.length > 0 ? formatDeletePaths(paths) : undefined;
         input.onOutput({
           toolName: "delete-file",
           content: { kind: "tool-header", label: t("tool.label.delete"), detail: deleteDetail },
-          toolCallId,
+          toolCallId: callId,
         });
         const resultParts: string[] = [];
         for (const path of paths) {

--- a/src/git-toolkit.ts
+++ b/src/git-toolkit.ts
@@ -101,15 +101,15 @@ function createGitStatusTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput
       output: z.string(),
     }),
     inputSchema: z.object({}).optional(),
-    execute: async () => {
-      return runTool(input.session, "git-status", {}, async (toolCallId) => {
+    execute: async (_toolInput, toolCallId) => {
+      return runTool(input.session, "git-status", toolCallId, {}, async (callId) => {
         input.onOutput({
           toolName: "git-status",
           content: { kind: "tool-header", label: t("tool.label.git_status") },
-          toolCallId,
+          toolCallId: callId,
         });
         const rawStatus = await git.statusShort();
-        emitHeadTailLines("git-status", rawStatus, input.onOutput, toolCallId);
+        emitHeadTailLines("git-status", rawStatus, input.onOutput, callId);
         const result = compactToolOutput(rawStatus, deps.outputBudget.gitStatus);
         return { kind: "git-status", output: result };
       });
@@ -136,15 +136,15 @@ function createGitDiffTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) 
       path: z.string().optional(),
       contextLines: z.number().int().min(0).max(20).optional(),
     }),
-    execute: async (toolInput) => {
-      return runTool(input.session, "git-diff", toolInput, async (toolCallId) => {
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "git-diff", toolCallId, toolInput, async (callId) => {
         input.onOutput({
           toolName: "git-diff",
           content: { kind: "tool-header", label: t("tool.label.git_diff"), detail: toolInput.path },
-          toolCallId,
+          toolCallId: callId,
         });
         const rawDiff = await git.diff({ path: toolInput.path, contextLines: toolInput.contextLines ?? 3 });
-        emitHeadTailLines("git-diff", rawDiff, input.onOutput, toolCallId, { headRows: 2, tailRows: 2 });
+        emitHeadTailLines("git-diff", rawDiff, input.onOutput, callId, { headRows: 2, tailRows: 2 });
         const result = compactToolOutput(rawDiff, deps.outputBudget.gitDiff);
         return { kind: "git-diff", path: toolInput.path, contextLines: toolInput.contextLines ?? 3, output: result };
       });
@@ -171,15 +171,15 @@ function createGitLogTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
       path: z.string().optional(),
       limit: z.number().int().min(1).max(50).optional(),
     }),
-    execute: async (toolInput) => {
-      return runTool(input.session, "git-log", toolInput, async (toolCallId) => {
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "git-log", toolCallId, toolInput, async (callId) => {
         input.onOutput({
           toolName: "git-log",
           content: { kind: "tool-header", label: t("tool.label.git_log"), detail: toolInput.path },
-          toolCallId,
+          toolCallId: callId,
         });
         const rawLog = await git.log({ path: toolInput.path, limit: toolInput.limit });
-        emitResultChunks("git-log", rawLog, input.onOutput, 4, toolCallId);
+        emitResultChunks("git-log", rawLog, input.onOutput, 4, callId);
         const result = compactToolOutput(rawLog, deps.outputBudget.gitDiff);
         return { kind: "git-log", path: toolInput.path, limit: toolInput.limit, output: result };
       });
@@ -208,19 +208,19 @@ function createGitShowTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) 
       path: z.string().optional(),
       contextLines: z.number().int().min(0).max(20).optional(),
     }),
-    execute: async (toolInput) => {
-      return runTool(input.session, "git-show", toolInput, async (toolCallId) => {
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "git-show", toolCallId, toolInput, async (callId) => {
         input.onOutput({
           toolName: "git-show",
           content: { kind: "tool-header", label: t("tool.label.git_show"), detail: toolInput.ref ?? toolInput.path },
-          toolCallId,
+          toolCallId: callId,
         });
         const rawShow = await git.show({
           ref: toolInput.ref,
           path: toolInput.path,
           contextLines: toolInput.contextLines ?? 3,
         });
-        emitHeadTailLines("git-show", stripGitShowMetadataForPreview(rawShow), input.onOutput, toolCallId);
+        emitHeadTailLines("git-show", stripGitShowMetadataForPreview(rawShow), input.onOutput, callId);
         const result = compactToolOutput(rawShow, deps.outputBudget.gitDiff);
         return {
           kind: "git-show",
@@ -253,25 +253,25 @@ function createGitAddTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
       paths: z.array(z.string().min(1)).max(200).optional(),
       all: z.boolean().optional(),
     }),
-    execute: async (toolInput) => {
-      return runTool(input.session, "git-add", toolInput, async (toolCallId) => {
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "git-add", toolCallId, toolInput, async (callId) => {
         const paths = (toolInput.paths ?? []).filter((p) => p.trim().length > 0);
         const addDetail = toolInput.all === true ? "all" : t("unit.file", { count: paths.length });
         input.onOutput({
           toolName: "git-add",
           content: { kind: "tool-header", label: t("tool.label.git_add"), detail: addDetail },
-          toolCallId,
+          toolCallId: callId,
         });
         const rawAdd = await git.add({ paths: toolInput.paths, all: toolInput.all });
         if (paths.length > 0) {
           for (const p of paths.slice(0, TOOL_OUTPUT_LIMITS.files)) {
-            input.onOutput({ toolName: "git-add", content: { kind: "text", text: p }, toolCallId });
+            input.onOutput({ toolName: "git-add", content: { kind: "text", text: p }, toolCallId: callId });
           }
           if (paths.length > TOOL_OUTPUT_LIMITS.files) {
             input.onOutput({
               toolName: "git-add",
               content: { kind: "truncated", count: paths.length - TOOL_OUTPUT_LIMITS.files, unit: "files" },
-              toolCallId,
+              toolCallId: callId,
             });
           }
         }
@@ -301,8 +301,8 @@ function createGitCommitTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput
       message: z.string().min(1),
       body: z.array(z.string().min(1)).max(10).optional(),
     }),
-    execute: async (toolInput) => {
-      return runTool(input.session, "git-commit", toolInput, async (toolCallId) => {
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "git-commit", toolCallId, toolInput, async (callId) => {
         const rawCommit = await git.commit({ message: toolInput.message, body: toolInput.body });
         const hashMatch = rawCommit.match(/^\[[\w/.-]+\s+([a-f0-9]+)\]/);
         const shortHash = hashMatch?.[1];
@@ -310,18 +310,18 @@ function createGitCommitTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput
         input.onOutput({
           toolName: "git-commit",
           content: { kind: "tool-header", label: t("tool.label.git_commit"), detail },
-          toolCallId,
+          toolCallId: callId,
         });
         if (toolInput.body && toolInput.body.length > 0) {
           const maxBodyLines = TOOL_OUTPUT_LIMITS.files;
           for (const line of toolInput.body.slice(0, maxBodyLines)) {
-            input.onOutput({ toolName: "git-commit", content: { kind: "text", text: line }, toolCallId });
+            input.onOutput({ toolName: "git-commit", content: { kind: "text", text: line }, toolCallId: callId });
           }
           if (toolInput.body.length > maxBodyLines) {
             input.onOutput({
               toolName: "git-commit",
               content: { kind: "truncated", count: toolInput.body.length - maxBodyLines, unit: "lines" },
-              toolCallId,
+              toolCallId: callId,
             });
           }
         }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -219,7 +219,7 @@ export const EN_MESSAGES = {
   "tool.label.git_show": "Git Show",
   "tool.label.git_status": "Git Status",
   "tool.label.read": "Read",
-  "tool.label.review": "Review",
+  "tool.label.scan": "Scan",
   "tool.label.run": "Run",
   "tool.label.search": "Search",
   "tool.label.web_fetch": "Web Fetch",

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -182,7 +182,6 @@ export type RunContext = {
   currentError?: LifecycleError;
   errorStats: Record<ErrorCategory, number>;
   result?: GenerateResult;
-  nativeIdQueue: Map<string, string[]>;
   toolCallStartedAt: Map<string, ToolCallStart>;
   toolOutputHandler: ((event: ToolOutputEvent) => void) | null;
   temperatures?: Partial<Record<AgentMode, number>>;

--- a/src/lifecycle-evaluate.ts
+++ b/src/lifecycle-evaluate.ts
@@ -7,7 +7,7 @@ import {
   lintEvaluator,
   repeatedFailureEvaluator,
   toolRecoveryEvaluator,
-  verifyCycle,
+  verifyEvaluator,
 } from "./lifecycle-evaluators";
 import { phaseGenerate, setMode, shouldYieldNow } from "./lifecycle-generate";
 import { defaultLifecyclePolicy, type LifecyclePolicy } from "./lifecycle-policy";
@@ -17,7 +17,7 @@ const EVALUATORS: Evaluator[] = [
   guardRecoveryEvaluator,
   toolRecoveryEvaluator,
   lintEvaluator,
-  verifyCycle,
+  verifyEvaluator,
   repeatedFailureEvaluator,
 ];
 

--- a/src/lifecycle-evaluate.ts
+++ b/src/lifecycle-evaluate.ts
@@ -51,7 +51,6 @@ export async function phaseEvaluate(ctx: RunContext, shouldYield: LifecycleInput
         mode: ctx.mode,
         tool_calls: ctx.result.toolCalls.length,
       });
-      break;
     }
     updateRepeatedFailureState(ctx);
 

--- a/src/lifecycle-evaluators.test.ts
+++ b/src/lifecycle-evaluators.test.ts
@@ -4,13 +4,13 @@ import {
   guardRecoveryEvaluator,
   repeatedFailureEvaluator,
   toolRecoveryEvaluator,
-  verifyCycle,
+  verifyEvaluator,
 } from "./lifecycle-evaluators";
 import { updateRepeatedFailureState } from "./lifecycle-state";
 import { createRunContext } from "./test-utils";
 import { createSessionContext, recordCall } from "./tool-guards";
 
-describe("verifyCycle", () => {
+describe("verifyEvaluator", () => {
   test("returns regenerate when write tools used without verify", () => {
     const session = createSessionContext("task_new");
     session.callLog = [
@@ -33,7 +33,7 @@ describe("verifyCycle", () => {
       result: { text: "Done.", toolCalls: [] },
       observedTools: new Set(["read-file", "edit-file"]),
     });
-    const action = verifyCycle.evaluate(ctx);
+    const action = verifyEvaluator.evaluate(ctx);
     expect(action.type).toBe("regenerate");
     if (action.type === "regenerate") {
       expect(action.mode).toBe("verify");
@@ -54,7 +54,7 @@ describe("verifyCycle", () => {
       result: { text: "Done.", toolCalls: [] },
       observedTools: new Set(["edit-file"]),
     });
-    const action = verifyCycle.evaluate(ctx);
+    const action = verifyEvaluator.evaluate(ctx);
     expect(action.type).toBe("regenerate");
     if (action.type === "regenerate") expect(action.feedback?.details).not.toContain("Task boundary:");
   });
@@ -69,7 +69,7 @@ describe("verifyCycle", () => {
       result: { text: "Done.", toolCalls: [] },
       observedTools: new Set(["edit-file"]),
     });
-    const action = verifyCycle.evaluate(ctx);
+    const action = verifyEvaluator.evaluate(ctx);
     expect(action.type).toBe("regenerate");
     if (action.type === "regenerate") expect(action.feedback?.details).not.toContain("Task boundary:");
   });
@@ -84,7 +84,7 @@ describe("verifyCycle", () => {
       result: { text: "Done.", toolCalls: [] },
       observedTools: new Set(["edit-file"]),
     });
-    expect(verifyCycle.evaluate(ctx).type).toBe("done");
+    expect(verifyEvaluator.evaluate(ctx).type).toBe("done");
   });
 
   test("returns done when verify already ran", () => {
@@ -97,7 +97,7 @@ describe("verifyCycle", () => {
       result: { text: "Done.", toolCalls: [] },
       observedTools: new Set(["edit-file"]),
     });
-    expect(verifyCycle.evaluate(ctx).type).toBe("done");
+    expect(verifyEvaluator.evaluate(ctx).type).toBe("done");
   });
 
   test("returns done when no write tools used", () => {
@@ -106,12 +106,12 @@ describe("verifyCycle", () => {
       result: { text: "Done.", toolCalls: [] },
       observedTools: new Set(["read-file", "search-files"]),
     });
-    expect(verifyCycle.evaluate(ctx).type).toBe("done");
+    expect(verifyEvaluator.evaluate(ctx).type).toBe("done");
   });
 
   test("returns done when no result", () => {
     const ctx = createRunContext({ result: undefined });
-    expect(verifyCycle.evaluate(ctx).type).toBe("done");
+    expect(verifyEvaluator.evaluate(ctx).type).toBe("done");
   });
 
   test("returns regenerate to work mode when verify reports issues", () => {
@@ -132,7 +132,7 @@ describe("verifyCycle", () => {
       },
       observedTools: new Set(["scan-code"]),
     });
-    const action = verifyCycle.evaluate(ctx);
+    const action = verifyEvaluator.evaluate(ctx);
     expect(action.type).toBe("regenerate");
     if (action.type === "regenerate") {
       expect(action.mode).toBe("work");
@@ -150,7 +150,7 @@ describe("verifyCycle", () => {
       session,
       result: { text: "", toolCalls: [] },
     });
-    expect(verifyCycle.evaluate(ctx).type).toBe("done");
+    expect(verifyEvaluator.evaluate(ctx).type).toBe("done");
   });
 
   test("ignores restored work result when verify outcome is missing", () => {
@@ -165,7 +165,7 @@ describe("verifyCycle", () => {
       result: { text: "Done.", toolCalls: [] },
       lifecycleState: { feedback: [], verifyOutcome: undefined },
     });
-    expect(verifyCycle.evaluate(ctx).type).toBe("done");
+    expect(verifyEvaluator.evaluate(ctx).type).toBe("done");
   });
 
   test("returns done for explicit no-issue verification summaries", () => {
@@ -178,7 +178,7 @@ describe("verifyCycle", () => {
       session,
       result: { text: "No issues found. 0 errors.", toolCalls: [] },
     });
-    expect(verifyCycle.evaluate(ctx).type).toBe("done");
+    expect(verifyEvaluator.evaluate(ctx).type).toBe("done");
   });
 });
 

--- a/src/lifecycle-evaluators.ts
+++ b/src/lifecycle-evaluators.ts
@@ -188,7 +188,7 @@ export const repeatedFailureEvaluator: Evaluator = {
   },
 };
 
-export const verifyCycle: Evaluator = {
+export const verifyEvaluator: Evaluator = {
   id: "verify-cycle",
   evaluate(ctx) {
     if (!ctx.result) return { type: "done" };

--- a/src/lifecycle-evaluators.ts
+++ b/src/lifecycle-evaluators.ts
@@ -198,10 +198,10 @@ export const verifyEvaluator: Evaluator = {
     if (ctx.mode !== "verify") {
       const usedWriteTools = WRITE_TOOLS.some((tool) => ctx.observedTools.has(tool));
       const verified = haveChangesBeenVerified(ctx.session, ctx.taskId);
-      ctx.debug("lifecycle.eval.verify-cycle", {
-        usedWriteTools,
+      ctx.debug("lifecycle.eval.verify_cycle", {
+        used_write_tools: usedWriteTools,
         verified,
-        verifyScope: ctx.request.verifyScope ?? null,
+        verify_scope: ctx.request.verifyScope ?? null,
       });
       if (ctx.initialMode === "work" && usedWriteTools && !verified) {
         return {

--- a/src/lifecycle-evaluators.ts
+++ b/src/lifecycle-evaluators.ts
@@ -197,7 +197,13 @@ export const verifyCycle: Evaluator = {
     // Work → Verify: trigger verify when write tools were used
     if (ctx.mode !== "verify") {
       const usedWriteTools = WRITE_TOOLS.some((tool) => ctx.observedTools.has(tool));
-      if (ctx.initialMode === "work" && usedWriteTools && !haveChangesBeenVerified(ctx.session, ctx.taskId)) {
+      const verified = haveChangesBeenVerified(ctx.session, ctx.taskId);
+      ctx.debug("lifecycle.eval.verify-cycle", {
+        usedWriteTools,
+        verified,
+        verifyScope: ctx.request.verifyScope ?? null,
+      });
+      if (ctx.initialMode === "work" && usedWriteTools && !verified) {
         return {
           type: "regenerate",
           feedback: {

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -1,6 +1,7 @@
 import type { Agent } from "./agent-contract";
 import { estimateTokens } from "./agent-input";
 import { createInstructions } from "./agent-instructions";
+import { agentModes } from "./agent-modes";
 import { createAgent } from "./agent-stream";
 import { appConfig } from "./app-config";
 import { LIFECYCLE_ERROR_CODES } from "./error-contract";
@@ -114,10 +115,15 @@ export function createModeAgent(input: {
   model: string;
   tools: Toolset;
 }): Agent {
+  const allowedTools = new Set(agentModes[input.mode].tools);
+  const filteredTools: Record<string, ToolDefinition> = {};
+  for (const [key, tool] of Object.entries(input.tools as Record<string, ToolDefinition>)) {
+    if (allowedTools.has(tool.id)) filteredTools[key] = tool;
+  }
   return createAgent({
     model: input.model,
     instructions: createInstructions(input.soulPrompt, input.mode, input.workspace),
-    tools: input.tools as Record<string, ToolDefinition>,
+    tools: filteredTools,
   });
 }
 

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -393,13 +393,6 @@ function processStreamChunk(ctx: RunContext, chunk: StreamChunk): void {
         });
         ctx.debug("lifecycle.tool.call", { tool: toolName, ...formatToolArgs(args) });
 
-        let queue = ctx.nativeIdQueue.get(toolName);
-        if (!queue) {
-          queue = [];
-          ctx.nativeIdQueue.set(toolName, queue);
-        }
-        queue.push(p.toolCallId);
-
         ctx.emit({ type: "tool-call", toolCallId: p.toolCallId, toolName, args });
       }
       break;
@@ -409,8 +402,6 @@ function processStreamChunk(ctx: RunContext, chunk: StreamChunk): void {
       if (p?.toolCallId && p?.toolName) {
         const toolName = p.toolName;
         const started = ctx.toolCallStartedAt.get(p.toolCallId);
-        const queue = ctx.nativeIdQueue.get(toolName);
-        if (queue?.[queue.length - 1] === p.toolCallId) queue.pop();
         const resultRecord =
           typeof p.result === "object" && p.result !== null ? (p.result as Record<string, unknown>) : null;
         const isError = Boolean(resultRecord && "error" in resultRecord);

--- a/src/lifecycle.int.test.ts
+++ b/src/lifecycle.int.test.ts
@@ -214,4 +214,44 @@ describe("lifecycle integration", () => {
     expect(phases).toContain("work:tool-call");
     expect(phases).toContain("verify:done");
   });
+
+  test("verify mode cannot use write tools", async () => {
+    // Write a fresh file so previous test edits don't interfere.
+    await writeFile(join(workspace, "b.ts"), "export const y = 1;\n", "utf8");
+    let turnCount = 0;
+    const toolErrors: string[] = [];
+
+    setupFakeProvider((ctx) => {
+      turnCount += 1;
+      // Turn 1 (work): edit a file, signal done
+      if (turnCount === 1) {
+        const toolName = pickFunctionToolName(ctx.body.tools, "edit-file", ["edit"]);
+        return createToolCallsPayload(ctx.model, ctx.responseCounter, [
+          {
+            id: `fc_${ctx.responseCounter}`,
+            callId: `call_${ctx.responseCounter}`,
+            name: toolName,
+            args: JSON.stringify({
+              path: join(workspace, "b.ts"),
+              edits: [{ find: "export const y = 1;", replace: "export const y = 6;" }],
+            }),
+          },
+        ]);
+      }
+      if (turnCount === 2) {
+        return createMessagePayload(ctx.model, ctx.responseCounter, "Done.\n\n@signal done");
+      }
+      // Turn 3+ (verify): check that edit-file is NOT in the available tools
+      const tools = (ctx.body.tools ?? []).map((t) => t.name).filter(Boolean);
+      const hasEditFile = tools.includes("edit-file");
+      const hasEditCode = tools.includes("edit-code");
+      if (hasEditFile) toolErrors.push("edit-file available in verify mode");
+      if (hasEditCode) toolErrors.push("edit-code available in verify mode");
+      return createMessagePayload(ctx.model, ctx.responseCounter, "Verified.\n\n@signal done");
+    });
+
+    await run("update x to 6");
+
+    expect(toolErrors).toEqual([]);
+  });
 });

--- a/src/lifecycle.int.test.ts
+++ b/src/lifecycle.int.test.ts
@@ -1,0 +1,217 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createMessagePayload,
+  createToolCallsPayload,
+  type FakeProviderRequestContext,
+  type FakeProviderServer,
+  pickFunctionToolName,
+  startFakeProviderServer,
+} from "../scripts/fake-provider-server";
+import { appConfig } from "./app-config";
+import { runLifecycle } from "./lifecycle";
+
+let fake: FakeProviderServer;
+let workspace: string;
+let savedBaseUrl: string;
+let savedApiKey: string | undefined;
+
+beforeAll(async () => {
+  workspace = await mkdtemp(join(tmpdir(), "acolyte-lifecycle-int-"));
+  await writeFile(join(workspace, "a.ts"), "export const x = 1;\n", "utf8");
+
+  savedBaseUrl = appConfig.openai.baseUrl;
+  savedApiKey = appConfig.openai.apiKey;
+});
+
+afterAll(async () => {
+  (appConfig.openai as { baseUrl: string }).baseUrl = savedBaseUrl;
+  (appConfig.openai as { apiKey: string | undefined }).apiKey = savedApiKey;
+  await rm(workspace, { recursive: true, force: true });
+});
+
+function setupFakeProvider(handler: (ctx: FakeProviderRequestContext) => Record<string, unknown>): void {
+  if (fake) fake.stop();
+  fake = startFakeProviderServer({ handleRequest: handler });
+  (appConfig.openai as { baseUrl: string }).baseUrl = fake.baseUrl;
+  (appConfig.openai as { apiKey: string | undefined }).apiKey = "fake-key";
+}
+
+function run(message: string) {
+  return runLifecycle({
+    request: { model: "gpt-5-mini", message, history: [], useMemory: false },
+    soulPrompt: "",
+    workspace,
+  });
+}
+
+describe("lifecycle integration", () => {
+  afterAll(() => {
+    if (fake) fake.stop();
+  });
+
+  test("@signal done with write tools triggers verify cycle", async () => {
+    const phases: string[] = [];
+
+    let turnCount = 0;
+    setupFakeProvider((ctx) => {
+      turnCount += 1;
+
+      // Turn 1 (work): call edit-file
+      if (turnCount === 1) {
+        const toolName = pickFunctionToolName(ctx.body.tools, "edit-file", ["edit"]);
+        phases.push("work:tool-call");
+        return createToolCallsPayload(ctx.model, ctx.responseCounter, [
+          {
+            id: `fc_${ctx.responseCounter}`,
+            callId: `call_${ctx.responseCounter}`,
+            name: toolName,
+            args: JSON.stringify({
+              path: join(workspace, "a.ts"),
+              edits: [{ find: "export const x = 1;", replace: "export const x = 2;" }],
+            }),
+          },
+        ]);
+      }
+
+      // Turn 2 (work continued): signal done after tool result
+      if (turnCount === 2) {
+        phases.push("work:done");
+        return createMessagePayload(ctx.model, ctx.responseCounter, "Updated x to 2.\n\n@signal done");
+      }
+
+      // Turn 3+ (verify): respond with done
+      phases.push("verify:done");
+      return createMessagePayload(ctx.model, ctx.responseCounter, "Verification passed.\n\n@signal done");
+    });
+
+    await run("update x to 2");
+
+    expect(phases).toContain("work:tool-call");
+    expect(phases).toContain("work:done");
+    expect(phases).toContain("verify:done");
+  });
+
+  test("@signal no_op without write tools does not trigger verify", async () => {
+    const phases: string[] = [];
+
+    setupFakeProvider((ctx) => {
+      phases.push("work:done");
+      return createMessagePayload(ctx.model, ctx.responseCounter, "Nothing to do.\n\n@signal no_op");
+    });
+
+    const reply = await run("hello");
+
+    expect(phases).toEqual(["work:done"]);
+    expect(reply.output).toContain("Nothing to do.");
+  });
+
+  test("@signal blocked with write tools still triggers verify", async () => {
+    let turnCount = 0;
+    const phases: string[] = [];
+
+    setupFakeProvider((ctx) => {
+      turnCount += 1;
+      if (turnCount === 1) {
+        const toolName = pickFunctionToolName(ctx.body.tools, "edit-file", ["edit"]);
+        phases.push("work:tool-call");
+        return createToolCallsPayload(ctx.model, ctx.responseCounter, [
+          {
+            id: `fc_${ctx.responseCounter}`,
+            callId: `call_${ctx.responseCounter}`,
+            name: toolName,
+            args: JSON.stringify({
+              path: join(workspace, "a.ts"),
+              edits: [{ find: "export const x = 1;", replace: "export const x = 3;" }],
+            }),
+          },
+        ]);
+      }
+      if (turnCount === 2) {
+        phases.push("work:blocked");
+        return createMessagePayload(ctx.model, ctx.responseCounter, "Cannot proceed.\n\n@signal blocked");
+      }
+      phases.push("verify:done");
+      return createMessagePayload(ctx.model, ctx.responseCounter, "Verified.\n\n@signal done");
+    });
+
+    await run("update x to 3");
+
+    expect(phases).toContain("work:tool-call");
+    expect(phases).toContain("work:blocked");
+    expect(phases).toContain("verify:done");
+  });
+
+  test("verifyScope none skips verify even with write tools", async () => {
+    let turnCount = 0;
+    const phases: string[] = [];
+
+    setupFakeProvider((ctx) => {
+      turnCount += 1;
+      if (turnCount === 1) {
+        const toolName = pickFunctionToolName(ctx.body.tools, "edit-file", ["edit"]);
+        phases.push("work:tool-call");
+        return createToolCallsPayload(ctx.model, ctx.responseCounter, [
+          {
+            id: `fc_${ctx.responseCounter}`,
+            callId: `call_${ctx.responseCounter}`,
+            name: toolName,
+            args: JSON.stringify({
+              path: join(workspace, "a.ts"),
+              edits: [{ find: "export const x = 1;", replace: "export const x = 4;" }],
+            }),
+          },
+        ]);
+      }
+      phases.push("work:done");
+      return createMessagePayload(ctx.model, ctx.responseCounter, "Done.\n\n@signal done");
+    });
+
+    await runLifecycle({
+      request: { model: "gpt-5-mini", message: "update x", history: [], useMemory: false, verifyScope: "none" },
+      soulPrompt: "",
+      workspace,
+    });
+
+    expect(phases).toContain("work:tool-call");
+    expect(phases).toContain("work:done");
+    expect(phases).not.toContain("verify:done");
+  });
+
+  test("no signal with write tools still triggers verify", async () => {
+    let turnCount = 0;
+    const phases: string[] = [];
+
+    setupFakeProvider((ctx) => {
+      turnCount += 1;
+      if (turnCount === 1) {
+        const toolName = pickFunctionToolName(ctx.body.tools, "edit-file", ["edit"]);
+        phases.push("work:tool-call");
+        return createToolCallsPayload(ctx.model, ctx.responseCounter, [
+          {
+            id: `fc_${ctx.responseCounter}`,
+            callId: `call_${ctx.responseCounter}`,
+            name: toolName,
+            args: JSON.stringify({
+              path: join(workspace, "a.ts"),
+              edits: [{ find: "export const x = 1;", replace: "export const x = 5;" }],
+            }),
+          },
+        ]);
+      }
+      if (turnCount === 2) {
+        phases.push("work:text");
+        return createMessagePayload(ctx.model, ctx.responseCounter, "Updated the file.");
+      }
+      phases.push("verify:done");
+      return createMessagePayload(ctx.model, ctx.responseCounter, "Verified.\n\n@signal done");
+    });
+
+    await run("update x to 5");
+
+    expect(phases).toContain("work:tool-call");
+    expect(phases).toContain("verify:done");
+  });
+});

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -131,7 +131,6 @@ function createRunContext(
     regenerationCount: 0,
     regenerationLimitHit: false,
     errorStats: createErrorStats(),
-    nativeIdQueue: new Map(),
     toolCallStartedAt: new Map(),
     toolOutputHandler: null,
   };
@@ -151,12 +150,9 @@ function attachToolOutputHandler(ctx: RunContext) {
     const rendered = renderToolOutputPart(event.content);
     if (!rendered.trim()) return;
     const toolName = event.toolName;
-    const queue = ctx.nativeIdQueue.get(toolName);
-    const resolvedToolCallId = queue?.[queue.length - 1] ?? event.toolCallId ?? toolName;
+    const resolvedToolCallId = event.toolCallId ?? toolName;
     ctx.debug("lifecycle.tool.output", {
       tool: toolName,
-      stream_tool_call_id: event.toolCallId ?? null,
-      emitted_tool_call_id: resolvedToolCallId,
       preview: rendered.length > 120 ? `${rendered.slice(0, 119)}…` : rendered,
     });
     ctx.emit({

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -5,8 +5,7 @@ export const palette = {
   mascotEyes: "#FFD84D",
 
   // Text
-  textCode: "#B7C0CC",
-  textPath: "#A8B1BC",
+  textCode: "#D4B3FF",
   textMuted: "#6B7280",
 
   // Diff

--- a/src/server-rpc.int.test.ts
+++ b/src/server-rpc.int.test.ts
@@ -80,7 +80,7 @@ async function startRpcTestServerProcess(
     stderr: "pipe",
   });
   serverProcs.push(proc);
-  await waitForServer(`http://127.0.0.1:${port}/healthz`, 10_000);
+  await waitForServer(`http://127.0.0.1:${port}/healthz`, 15_000);
   return proc;
 }
 

--- a/src/shell-toolkit.ts
+++ b/src/shell-toolkit.ts
@@ -34,16 +34,17 @@ function createRunCommandTool(deps: ToolkitDeps, input: ToolkitInput) {
       exitCode: z.number().int().optional(),
       output: z.string(),
     }),
-    execute: async (toolInput) => {
+    execute: async (toolInput, toolCallId) => {
       return runTool(
         input.session,
         "run-command",
+        toolCallId,
         toolInput,
-        async (toolCallId) => {
+        async (callId) => {
           input.onOutput({
             toolName: "run-command",
             content: { kind: "tool-header", label: t("tool.label.run"), detail: compactDetail(toolInput.command) },
-            toolCallId,
+            toolCallId: callId,
           });
           const headRows = 2;
           const tailRows = 2;
@@ -97,7 +98,7 @@ function createRunCommandTool(deps: ToolkitDeps, input: ToolkitInput) {
             input.onOutput({
               toolName: "run-command",
               content: { kind: "shell-output", stream: entry.stream, text: entry.text },
-              toolCallId,
+              toolCallId: callId,
             });
           };
           if (streamed.length > headRows + tailRows) {
@@ -106,11 +107,11 @@ function createRunCommandTool(deps: ToolkitDeps, input: ToolkitInput) {
             input.onOutput({
               toolName: "run-command",
               content: { kind: "truncated", count: omitted, unit: "lines" },
-              toolCallId,
+              toolCallId: callId,
             });
             for (const line of streamed.slice(streamed.length - tailRows)) emitLine(line);
           } else if (streamed.length === 0) {
-            input.onOutput({ toolName: "run-command", content: { kind: "no-output" }, toolCallId });
+            input.onOutput({ toolName: "run-command", content: { kind: "no-output" }, toolCallId: callId });
           } else {
             for (const line of streamed.slice(0, TOOL_OUTPUT_LIMITS.run)) emitLine(line);
           }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -450,7 +450,6 @@ export function createRunContext(overrides: Partial<RunContext> = {}): RunContex
     regenerationCount: 0,
     regenerationLimitHit: false,
     errorStats: createErrorStats(),
-    nativeIdQueue: new Map(),
     toolCallStartedAt: new Map(),
     toolOutputHandler: null,
     ...overrides,

--- a/src/tool-contract.ts
+++ b/src/tool-contract.ts
@@ -14,7 +14,7 @@ export type ToolDefinition<TInput = unknown, TOutput = unknown> = {
   readonly instruction: string;
   readonly inputSchema: z.ZodType<TInput>;
   readonly outputSchema: z.ZodType<TOutput>;
-  readonly execute: (input: TInput) => Promise<TOutput>;
+  readonly execute: (input: TInput, toolCallId: string) => Promise<TOutput>;
 };
 
 export type ToolOutputBudgetEntry = { maxChars: number; maxLines: number };
@@ -61,6 +61,6 @@ export type ToolCache = {
 export function createTool<TInput, TOutput>(config: ToolDefinition<TInput, TOutput>): ToolDefinition<TInput, TOutput> {
   return {
     ...config,
-    execute: async (input) => config.outputSchema.parse(await config.execute(input)),
+    execute: async (input, toolCallId) => config.outputSchema.parse(await config.execute(input, toolCallId)),
   };
 }

--- a/src/tool-execution.ts
+++ b/src/tool-execution.ts
@@ -1,6 +1,5 @@
 import { invariant } from "./assert";
 import { ERROR_KINDS, LIFECYCLE_ERROR_CODES } from "./error-contract";
-import { createId } from "./short-id";
 import { ToolError } from "./tool-error";
 import { recordCall, runGuards, type SessionContext } from "./tool-guards";
 import type { ToolRecovery } from "./tool-recovery";
@@ -35,20 +34,15 @@ export function hashResultValue(value: unknown): string | undefined {
   hasher.update(str);
   return hasher.digest("hex").slice(0, 16);
 }
-export function streamCallId(toolName: string): string {
-  return `${toolName}_${createId()}`;
-}
-
 export function runTool(
   session: SessionContext,
   toolId: string,
+  toolCallId: string,
   args: object,
   execute: (toolCallId: string) => Promise<unknown>,
   options?: { timeoutMs?: number },
 ): Promise<unknown> {
-  return withToolError(toolId, () =>
-    guardedExecute(toolId, args, session, () => execute(streamCallId(toolId)), options),
-  );
+  return withToolError(toolId, () => guardedExecute(toolId, args, session, () => execute(toolCallId), options));
 }
 
 export async function withToolError<T>(toolId: string, task: () => Promise<T>): Promise<T> {

--- a/src/tool-guards.int.test.ts
+++ b/src/tool-guards.int.test.ts
@@ -86,7 +86,7 @@ async function runGuardIntegrationScenario(
       });
       serverProcs.push(serverProc);
 
-      await waitForServer(`http://127.0.0.1:${port}/v1/status`, 10_000);
+      await waitForServer(`http://127.0.0.1:${port}/healthz`, 15_000);
 
       const client = createClient({ apiUrl: `http://127.0.0.1:${port}` });
       return client.replyStream(

--- a/src/tool-output-content.ts
+++ b/src/tool-output-content.ts
@@ -47,7 +47,7 @@ export const toolOutputPartSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("no-output") }),
   z.object({
     kind: z.literal("truncated"),
-    count: z.number().int().nonnegative(),
+    count: z.number().int().nonnegative().optional(),
     unit: z.string().optional(),
   }),
 ]);
@@ -84,6 +84,7 @@ export function renderToolOutputPart(content: ToolOutputPart): string {
     case "no-output":
       return t("tool.content.no_output");
     case "truncated": {
+      if (!content.count) return "…";
       const unitKey =
         content.unit === "lines"
           ? "unit.line"
@@ -120,8 +121,10 @@ export function formatToolOutput(items: ToolOutputPart[]): string {
   const diffIndent = hasFileHeaders ? "  " : "";
   const lines = body.map((item) => {
     if (item.kind === "diff") return `${diffIndent}${renderDiffLine(item, numWidth)}`;
-    if (item.kind === "truncated" && numWidth > 0)
-      return `${diffIndent}${"…".padStart(numWidth)} ${renderToolOutputPart(item).slice(2)}`;
+    if (item.kind === "truncated" && numWidth > 0) {
+      const suffix = renderToolOutputPart(item).slice(2);
+      return suffix ? `${diffIndent}${"…".padStart(numWidth)} ${suffix}` : `${diffIndent}${"…".padStart(numWidth)}`;
+    }
     return renderToolOutputPart(item);
   });
   return `${header}\n${lines.map((line) => `  ${line}`).join("\n")}`;

--- a/src/tool-output-content.ts
+++ b/src/tool-output-content.ts
@@ -116,10 +116,12 @@ export function formatToolOutput(items: ToolOutputPart[]): string {
     (max, item) => (item.kind === "diff" ? Math.max(max, String(item.lineNumber).length) : max),
     0,
   );
+  const hasFileHeaders = numWidth > 0 && body.some((item) => item.kind === "text");
+  const diffIndent = hasFileHeaders ? "  " : "";
   const lines = body.map((item) => {
-    if (item.kind === "diff") return renderDiffLine(item, numWidth);
+    if (item.kind === "diff") return `${diffIndent}${renderDiffLine(item, numWidth)}`;
     if (item.kind === "truncated" && numWidth > 0)
-      return `${"…".padStart(numWidth)} ${renderToolOutputPart(item).slice(2)}`;
+      return `${diffIndent}${"…".padStart(numWidth)} ${renderToolOutputPart(item).slice(2)}`;
     return renderToolOutputPart(item);
   });
   return `${header}\n${lines.map((line) => `  ${line}`).join("\n")}`;

--- a/src/tool-output-format.test.ts
+++ b/src/tool-output-format.test.ts
@@ -122,4 +122,122 @@ describe("numberedUnifiedDiffLines", () => {
     expect(numberedUnifiedDiffLines("")).toEqual([]);
     expect(numberedUnifiedDiffLines("just some text\nno diff here")).toEqual([]);
   });
+
+  test("multi-file diff emits per-file text headers with add/remove counts", () => {
+    const diff = [
+      "diff --git a/a.ts b/a.ts",
+      "--- a/a.ts",
+      "+++ b/a.ts",
+      "@@ -1,2 +1,2 @@",
+      "-old a",
+      "+new a",
+      " ctx a",
+      "diff --git a/b.ts b/b.ts",
+      "--- a/b.ts",
+      "+++ b/b.ts",
+      "@@ -1,2 +1,2 @@",
+      "-old b",
+      "+new b",
+      " ctx b",
+    ].join("\n");
+    const items = numberedUnifiedDiffLines(diff);
+    const textParts = items.filter((i) => i.kind === "text");
+    expect(textParts).toEqual([
+      { kind: "text", text: "a.ts (+1 -1)" },
+      { kind: "text", text: "b.ts (+1 -1)" },
+    ]);
+  });
+
+  test("single-file diff has no per-file text header", () => {
+    const diff = [
+      "diff --git a/a.ts b/a.ts",
+      "--- a/a.ts",
+      "+++ b/a.ts",
+      "@@ -1,2 +1,2 @@",
+      "-old",
+      "+new",
+      " ctx",
+    ].join("\n");
+    const items = numberedUnifiedDiffLines(diff);
+    expect(items.filter((i) => i.kind === "text")).toEqual([]);
+  });
+
+  test("per-file text headers are always kept during context filtering", () => {
+    // Build a multi-file diff where context filtering would normally skip lines.
+    // Each file has one change surrounded by many context lines.
+    const makeFile = (name: string, ctxCount: number): string[] => {
+      const lines = [`diff --git a/${name} b/${name}`, `--- a/${name}`, `+++ b/${name}`];
+      lines.push(`@@ -1,${ctxCount + 2} +1,${ctxCount + 2} @@`);
+      for (let i = 0; i < ctxCount; i++) lines.push(` context line ${i}`);
+      lines.push("-old line");
+      lines.push("+new line");
+      for (let i = 0; i < ctxCount; i++) lines.push(` trailing context ${i}`);
+      return lines;
+    };
+    const diff = [...makeFile("a.ts", 10), ...makeFile("b.ts", 10)].join("\n");
+    const items = numberedUnifiedDiffLines(diff);
+    const textParts = items.filter((i) => i.kind === "text");
+    expect(textParts).toHaveLength(2);
+    expect(textParts[0]).toEqual(expect.objectContaining({ kind: "text", text: expect.stringContaining("a.ts") }));
+    expect(textParts[1]).toEqual(expect.objectContaining({ kind: "text", text: expect.stringContaining("b.ts") }));
+  });
+
+  test("multi-file truncation cuts at file boundary and reports remaining files", () => {
+    // Build enough files to exceed NUMBERED_DIFF_PREVIEW_MAX_LINES (160).
+    // Each file has multiple changes to produce enough output after context filtering.
+    const makeFile = (name: string): string[] => [
+      `diff --git a/${name} b/${name}`,
+      `--- a/${name}`,
+      `+++ b/${name}`,
+      `@@ -1,30 +1,30 @@`,
+      "-import { createId } from './short-id';",
+      "+import { generateId } from './short-id';",
+      ...Array.from({ length: 10 }, (_, i) => ` middle line ${i}`),
+      `-  const id = createId();`,
+      `+  const id = generateId();`,
+      ...Array.from({ length: 10 }, (_, i) => ` trailing line ${i}`),
+      "-  return createId();",
+      "+  return generateId();",
+      ...Array.from({ length: 5 }, (_, i) => ` end line ${i}`),
+    ];
+    const files = Array.from({ length: 30 }, (_, i) => `file${i}.ts`);
+    const diff = files.flatMap((name) => makeFile(name)).join("\n");
+    const items = numberedUnifiedDiffLines(diff);
+
+    // Should not cut mid-file — last item should be a truncated marker.
+    const lastItem = items[items.length - 1];
+    expect(lastItem?.kind).toBe("truncated");
+
+    // Every file header must be followed by at least one diff line (no orphan headers).
+    for (let i = 0; i < items.length; i++) {
+      if (items[i]?.kind === "text") {
+        const next = items.slice(i + 1).find((p) => p.kind !== "truncated");
+        if (next) expect(next.kind).toBe("diff");
+      }
+    }
+  });
+
+  test("orphan file headers with no diff content are removed", () => {
+    // Two files but the second has only context lines (no changes) — its header should be removed.
+    const diff = [
+      "diff --git a/a.ts b/a.ts",
+      "--- a/a.ts",
+      "+++ b/a.ts",
+      "@@ -1,2 +1,2 @@",
+      "-old",
+      "+new",
+      " ctx",
+      "diff --git a/b.ts b/b.ts",
+      "--- a/b.ts",
+      "+++ b/b.ts",
+      "@@ -1,3 +1,3 @@",
+      " only context",
+      " more context",
+      " trailing",
+    ].join("\n");
+    const items = numberedUnifiedDiffLines(diff);
+    const textParts = items.filter((i) => i.kind === "text");
+    // b.ts has no changes so its header should not appear; a.ts keeps its header.
+    expect(textParts).toEqual([{ kind: "text", text: "a.ts (+1 -1)" }]);
+  });
 });

--- a/src/tool-output-format.test.ts
+++ b/src/tool-output-format.test.ts
@@ -182,39 +182,26 @@ describe("numberedUnifiedDiffLines", () => {
     expect(textParts[1]).toEqual(expect.objectContaining({ kind: "text", text: expect.stringContaining("b.ts") }));
   });
 
-  test("multi-file truncation cuts at file boundary and reports remaining files", () => {
-    // Build enough files to exceed NUMBERED_DIFF_PREVIEW_MAX_LINES (160).
-    // Each file has multiple changes to produce enough output after context filtering.
+  test("multi-file diff includes all files without truncation", () => {
     const makeFile = (name: string): string[] => [
       `diff --git a/${name} b/${name}`,
       `--- a/${name}`,
       `+++ b/${name}`,
-      `@@ -1,30 +1,30 @@`,
-      "-import { createId } from './short-id';",
-      "+import { generateId } from './short-id';",
-      ...Array.from({ length: 10 }, (_, i) => ` middle line ${i}`),
-      `-  const id = createId();`,
-      `+  const id = generateId();`,
-      ...Array.from({ length: 10 }, (_, i) => ` trailing line ${i}`),
-      "-  return createId();",
-      "+  return generateId();",
-      ...Array.from({ length: 5 }, (_, i) => ` end line ${i}`),
+      `@@ -1,10 +1,10 @@`,
+      "-import { old } from './mod';",
+      "+import { new_ } from './mod';",
+      ...Array.from({ length: 5 }, (_, i) => ` line ${i}`),
+      "-  return old();",
+      "+  return new_();",
     ];
-    const files = Array.from({ length: 30 }, (_, i) => `file${i}.ts`);
+    const files = Array.from({ length: 20 }, (_, i) => `file${i}.ts`);
     const diff = files.flatMap((name) => makeFile(name)).join("\n");
     const items = numberedUnifiedDiffLines(diff);
 
-    // Should not cut mid-file — last item should be a truncated marker.
+    const fileHeaders = items.filter((i) => i.kind === "text");
+    expect(fileHeaders).toHaveLength(20);
     const lastItem = items[items.length - 1];
-    expect(lastItem?.kind).toBe("truncated");
-
-    // Every file header must be followed by at least one diff line (no orphan headers).
-    for (let i = 0; i < items.length; i++) {
-      if (items[i]?.kind === "text") {
-        const next = items.slice(i + 1).find((p) => p.kind !== "truncated");
-        if (next) expect(next.kind).toBe("diff");
-      }
-    }
+    expect(lastItem?.kind).toBe("diff");
   });
 
   test("orphan file headers with no diff content are removed", () => {

--- a/src/tool-output-format.ts
+++ b/src/tool-output-format.ts
@@ -412,17 +412,30 @@ export function numberedUnifiedDiffLines(rawResult: string): ToolOutputPart[] {
   let newLine = 0;
   let inHunk = false;
   let fileCount = 0;
-  const fileHeaders: Array<{ index: number; path: string }> = [];
+  let pendingFilePath: string | null = null;
+  let fileParts: ToolOutputPart[] = [];
+  let fileAdded = 0;
+  let fileRemoved = 0;
+
+  const flushFile = (): void => {
+    if (!pendingFilePath || (fileAdded === 0 && fileRemoved === 0)) {
+      fileParts = [];
+      return;
+    }
+    rendered.push({ kind: "text", text: `${pendingFilePath} (+${fileAdded} -${fileRemoved})` });
+    for (const part of fileParts) rendered.push(part);
+    fileParts = [];
+  };
 
   for (const line of lines) {
     if (line.startsWith("diff --git ")) {
+      flushFile();
       fileCount += 1;
       inHunk = false;
+      fileAdded = 0;
+      fileRemoved = 0;
       const pathMatch = line.match(/^diff --git a\/.+ b\/(.+)$/);
-      const filePath = pathMatch?.[1] ?? line.slice("diff --git ".length);
-      fileHeaders.push({ index: rendered.length, path: filePath });
-      // Reserve a slot for the file header — filled in after parsing.
-      rendered.push({ kind: "text", text: filePath });
+      pendingFilePath = pathMatch?.[1] ?? line.slice("diff --git ".length);
       continue;
     }
     if (line.startsWith("--- ") || line.startsWith("+++ ")) continue;
@@ -437,69 +450,24 @@ export function numberedUnifiedDiffLines(rawResult: string): ToolOutputPart[] {
     }
     if (!inHunk) continue;
     if (line.startsWith("+")) {
-      rendered.push({ kind: "diff", lineNumber: newLine, marker: "add", text: line.slice(1) });
+      fileParts.push({ kind: "diff", lineNumber: newLine, marker: "add", text: line.slice(1) });
+      fileAdded += 1;
       newLine += 1;
       continue;
     }
     if (line.startsWith("-")) {
-      rendered.push({ kind: "diff", lineNumber: oldLine, marker: "remove", text: line.slice(1) });
+      fileParts.push({ kind: "diff", lineNumber: oldLine, marker: "remove", text: line.slice(1) });
+      fileRemoved += 1;
       oldLine += 1;
       continue;
     }
     if (line.startsWith(" ")) {
-      rendered.push({ kind: "diff", lineNumber: newLine, marker: "context", text: line.slice(1) });
+      fileParts.push({ kind: "diff", lineNumber: newLine, marker: "context", text: line.slice(1) });
       oldLine += 1;
       newLine += 1;
     }
   }
-  // Update reserved file header slots with final add/remove counts.
-  for (let i = 0; i < fileHeaders.length; i++) {
-    const header = fileHeaders[i];
-    if (!header) continue;
-    const nextHeaderIndex =
-      i + 1 < fileHeaders.length ? (fileHeaders[i + 1]?.index ?? rendered.length) : rendered.length;
-    let added = 0;
-    let removed = 0;
-    for (let j = header.index + 1; j < nextHeaderIndex; j++) {
-      const part = rendered[j];
-      if (part?.kind === "diff" && part.marker === "add") added += 1;
-      if (part?.kind === "diff" && part.marker === "remove") removed += 1;
-    }
-    rendered[header.index] =
-      added > 0 || removed > 0
-        ? { kind: "text", text: `${header.path} (+${added} -${removed})` }
-        : { kind: "text", text: "" };
-  }
-  // Strip orphan file headers (no changes) and all headers for single-file diffs.
-  {
-    const stripAll = fileCount <= 1;
-    const filtered = rendered.filter(
-      (part) => part.kind !== "text" || (!stripAll && (part as { text: string }).text.length > 0),
-    );
-    rendered.splice(0, rendered.length, ...filtered);
-  }
-  if (rendered.length === 0) {
-    oldLine = 1;
-    newLine = 1;
-    for (const line of lines) {
-      if (line.startsWith("diff --git ") || line.startsWith("--- ") || line.startsWith("+++ ") || line.startsWith("@@"))
-        continue;
-      if (line.startsWith("+")) {
-        rendered.push({ kind: "diff", lineNumber: newLine, marker: "add", text: line.slice(1) });
-        newLine += 1;
-        continue;
-      }
-      if (line.startsWith("-")) {
-        rendered.push({ kind: "diff", lineNumber: oldLine, marker: "remove", text: line.slice(1) });
-        oldLine += 1;
-        continue;
-      }
-      if (line.startsWith(" ")) {
-        rendered.push({ kind: "diff", lineNumber: newLine, marker: "context", text: line.slice(1) });
-        oldLine += 1;
-        newLine += 1;
-      }
-    }
-  }
-  return rendered;
+  flushFile();
+  // Strip per-file headers for single-file diffs — the caller's edit-header covers it.
+  return fileCount <= 1 ? rendered.filter((part) => part.kind !== "text") : rendered;
 }

--- a/src/tool-output-format.ts
+++ b/src/tool-output-format.ts
@@ -521,17 +521,16 @@ export function numberedUnifiedDiffLines(rawResult: string): ToolOutputPart[] {
     }
   }
   const filteredOutput: ToolOutputPart[] = [];
-  let skippedCount = 0;
+  let skipping = false;
   for (let i = 0; i < rendered.length; i++) {
     if (keep[i]) {
-      if (skippedCount > 0) filteredOutput.push({ kind: "truncated", count: skippedCount, unit: "lines" });
-      skippedCount = 0;
+      if (skipping) filteredOutput.push({ kind: "truncated" });
+      skipping = false;
       filteredOutput.push(rendered[i] as ToolOutputPart);
     } else {
-      skippedCount += 1;
+      skipping = true;
     }
   }
-  if (skippedCount > 0) filteredOutput.push({ kind: "truncated", count: skippedCount, unit: "lines" });
   if (filteredOutput.length <= NUMBERED_DIFF_PREVIEW_MAX_LINES) return filteredOutput;
 
   // Truncate at a file boundary to avoid cutting mid-file.

--- a/src/tool-output-format.ts
+++ b/src/tool-output-format.ts
@@ -416,7 +416,19 @@ export function numberedUnifiedDiffLines(rawResult: string): ToolOutputPart[] {
   let oldLine = 0;
   let newLine = 0;
   let inHunk = false;
+  let fileCount = 0;
   for (const line of lines) {
+    if (line.startsWith("diff --git ")) {
+      fileCount += 1;
+      inHunk = false;
+      if (fileCount > 1) {
+        const pathMatch = line.match(/^diff --git a\/.+ b\/(.+)$/);
+        const path = pathMatch?.[1] ?? line.slice("diff --git ".length);
+        rendered.push({ kind: "text", text: path });
+      }
+      continue;
+    }
+    if (line.startsWith("--- ") || line.startsWith("+++ ")) continue;
     if (line.startsWith("@@")) {
       const match = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
       if (match) {
@@ -426,7 +438,7 @@ export function numberedUnifiedDiffLines(rawResult: string): ToolOutputPart[] {
       }
       continue;
     }
-    if (!inHunk || line.startsWith("diff --git ") || line.startsWith("--- ") || line.startsWith("+++ ")) continue;
+    if (!inHunk) continue;
     if (line.startsWith("+")) {
       rendered.push({ kind: "diff", lineNumber: newLine, marker: "add", text: line.slice(1) });
       newLine += 1;

--- a/src/tool-output-format.ts
+++ b/src/tool-output-format.ts
@@ -19,8 +19,6 @@ export const TOOL_OUTPUT_LIMITS = {
   status: 6,
 } as const;
 
-const NUMBERED_DIFF_PREVIEW_MAX_LINES = 160;
-
 export function summarizeUnifiedDiff(rawResult: string): UnifiedDiffSummary {
   let files = 0;
   let added = 0;
@@ -503,53 +501,5 @@ export function numberedUnifiedDiffLines(rawResult: string): ToolOutputPart[] {
       }
     }
   }
-  if (rendered.length === 0) return [];
-  const contextRadius = 3;
-  const keep = new Uint8Array(rendered.length);
-  for (let i = 0; i < rendered.length; i++) {
-    const part = rendered[i];
-    // Always keep file headers.
-    if (part?.kind === "text") {
-      keep[i] = 1;
-      continue;
-    }
-    // Keep change lines and their surrounding context.
-    if (part?.kind === "diff" && part.marker !== "context") {
-      for (let j = Math.max(0, i - contextRadius); j <= Math.min(rendered.length - 1, i + contextRadius); j++) {
-        keep[j] = 1;
-      }
-    }
-  }
-  const filteredOutput: ToolOutputPart[] = [];
-  let skipping = false;
-  for (let i = 0; i < rendered.length; i++) {
-    if (keep[i]) {
-      if (skipping) filteredOutput.push({ kind: "truncated" });
-      skipping = false;
-      filteredOutput.push(rendered[i] as ToolOutputPart);
-    } else {
-      skipping = true;
-    }
-  }
-  if (filteredOutput.length <= NUMBERED_DIFF_PREVIEW_MAX_LINES) return filteredOutput;
-
-  // Truncate at a file boundary to avoid cutting mid-file.
-  // Find the first file header that starts beyond the budget.
-  let cutIndex = filteredOutput.length;
-  for (let i = NUMBERED_DIFF_PREVIEW_MAX_LINES; i < filteredOutput.length; i++) {
-    if (filteredOutput[i]?.kind === "text") {
-      cutIndex = i;
-      break;
-    }
-  }
-  if (cutIndex < filteredOutput.length) {
-    const remainingFiles = filteredOutput.slice(cutIndex).filter((p) => p.kind === "text").length;
-    return [...filteredOutput.slice(0, cutIndex), { kind: "truncated", count: remainingFiles, unit: "files" }];
-  }
-  // No file boundary found after budget — single file overflow, truncate lines.
-  const omitted = filteredOutput.length - NUMBERED_DIFF_PREVIEW_MAX_LINES;
-  return [
-    ...filteredOutput.slice(0, NUMBERED_DIFF_PREVIEW_MAX_LINES),
-    { kind: "truncated", count: omitted, unit: "lines" },
-  ];
+  return rendered;
 }

--- a/src/tool-output-format.ts
+++ b/src/tool-output-format.ts
@@ -20,7 +20,6 @@ export const TOOL_OUTPUT_LIMITS = {
 } as const;
 
 const NUMBERED_DIFF_PREVIEW_MAX_LINES = 160;
-const NUMBERED_DIFF_SOURCE_MAX_LINES = NUMBERED_DIFF_PREVIEW_MAX_LINES * 2;
 
 export function summarizeUnifiedDiff(rawResult: string): UnifiedDiffSummary {
   let files = 0;
@@ -398,46 +397,34 @@ export function emitSearchSummary(
     });
 }
 
-function unifiedDiffLines(rawResult: string, maxLines = 120): string[] {
-  const marker = "\ndiff --git ";
-  const index = rawResult.indexOf(marker);
-  const start = index >= 0 ? index + 1 : rawResult.indexOf("diff --git ");
+function unifiedDiffLines(rawResult: string): string[] {
+  const start = rawResult.indexOf("diff --git ");
   if (start < 0) return [];
-  const lines = rawResult
+  return rawResult
     .slice(start)
     .split("\n")
     .map((line) => line.trimEnd());
-  if (lines.length > maxLines) return lines.slice(0, maxLines);
-  return lines;
 }
 
 export function numberedUnifiedDiffLines(rawResult: string): ToolOutputPart[] {
-  const lines = unifiedDiffLines(rawResult, NUMBERED_DIFF_SOURCE_MAX_LINES);
+  const lines = unifiedDiffLines(rawResult);
   if (lines.length === 0) return [];
   const rendered: ToolOutputPart[] = [];
   let oldLine = 0;
   let newLine = 0;
   let inHunk = false;
   let fileCount = 0;
-  let pendingFilePath: string | null = null;
-  let fileAdded = 0;
-  let fileRemoved = 0;
-
-  const flushFileHeader = (): void => {
-    if (!pendingFilePath) return;
-    rendered.push({ kind: "text", text: `${pendingFilePath} (+${fileAdded} -${fileRemoved})` });
-    pendingFilePath = null;
-    fileAdded = 0;
-    fileRemoved = 0;
-  };
+  const fileHeaders: Array<{ index: number; path: string }> = [];
 
   for (const line of lines) {
     if (line.startsWith("diff --git ")) {
-      flushFileHeader();
       fileCount += 1;
       inHunk = false;
       const pathMatch = line.match(/^diff --git a\/.+ b\/(.+)$/);
-      pendingFilePath = pathMatch?.[1] ?? line.slice("diff --git ".length);
+      const filePath = pathMatch?.[1] ?? line.slice("diff --git ".length);
+      fileHeaders.push({ index: rendered.length, path: filePath });
+      // Reserve a slot for the file header — filled in after parsing.
+      rendered.push({ kind: "text", text: filePath });
       continue;
     }
     if (line.startsWith("--- ") || line.startsWith("+++ ")) continue;
@@ -453,13 +440,11 @@ export function numberedUnifiedDiffLines(rawResult: string): ToolOutputPart[] {
     if (!inHunk) continue;
     if (line.startsWith("+")) {
       rendered.push({ kind: "diff", lineNumber: newLine, marker: "add", text: line.slice(1) });
-      fileAdded += 1;
       newLine += 1;
       continue;
     }
     if (line.startsWith("-")) {
       rendered.push({ kind: "diff", lineNumber: oldLine, marker: "remove", text: line.slice(1) });
-      fileRemoved += 1;
       oldLine += 1;
       continue;
     }
@@ -469,10 +454,30 @@ export function numberedUnifiedDiffLines(rawResult: string): ToolOutputPart[] {
       newLine += 1;
     }
   }
-  flushFileHeader();
-  // Strip per-file text headers for single-file diffs — the caller's edit-header covers it.
-  if (fileCount <= 1) {
-    const filtered = rendered.filter((part) => part.kind !== "text");
+  // Update reserved file header slots with final add/remove counts.
+  for (let i = 0; i < fileHeaders.length; i++) {
+    const header = fileHeaders[i];
+    if (!header) continue;
+    const nextHeaderIndex =
+      i + 1 < fileHeaders.length ? (fileHeaders[i + 1]?.index ?? rendered.length) : rendered.length;
+    let added = 0;
+    let removed = 0;
+    for (let j = header.index + 1; j < nextHeaderIndex; j++) {
+      const part = rendered[j];
+      if (part?.kind === "diff" && part.marker === "add") added += 1;
+      if (part?.kind === "diff" && part.marker === "remove") removed += 1;
+    }
+    rendered[header.index] =
+      added > 0 || removed > 0
+        ? { kind: "text", text: `${header.path} (+${added} -${removed})` }
+        : { kind: "text", text: "" };
+  }
+  // Strip orphan file headers (no changes) and all headers for single-file diffs.
+  {
+    const stripAll = fileCount <= 1;
+    const filtered = rendered.filter(
+      (part) => part.kind !== "text" || (!stripAll && (part as { text: string }).text.length > 0),
+    );
     rendered.splice(0, rendered.length, ...filtered);
   }
   if (rendered.length === 0) {
@@ -500,12 +505,19 @@ export function numberedUnifiedDiffLines(rawResult: string): ToolOutputPart[] {
   }
   if (rendered.length === 0) return [];
   const contextRadius = 3;
-  const isChange = rendered.map((line) => line.kind === "diff" && line.marker !== "context");
   const keep = new Uint8Array(rendered.length);
   for (let i = 0; i < rendered.length; i++) {
-    if (!isChange[i]) continue;
-    for (let j = Math.max(0, i - contextRadius); j <= Math.min(rendered.length - 1, i + contextRadius); j++) {
-      keep[j] = 1;
+    const part = rendered[i];
+    // Always keep file headers.
+    if (part?.kind === "text") {
+      keep[i] = 1;
+      continue;
+    }
+    // Keep change lines and their surrounding context.
+    if (part?.kind === "diff" && part.marker !== "context") {
+      for (let j = Math.max(0, i - contextRadius); j <= Math.min(rendered.length - 1, i + contextRadius); j++) {
+        keep[j] = 1;
+      }
     }
   }
   const filteredOutput: ToolOutputPart[] = [];
@@ -520,12 +532,25 @@ export function numberedUnifiedDiffLines(rawResult: string): ToolOutputPart[] {
     }
   }
   if (skippedCount > 0) filteredOutput.push({ kind: "truncated", count: skippedCount, unit: "lines" });
-  if (filteredOutput.length > NUMBERED_DIFF_PREVIEW_MAX_LINES) {
-    const omitted = filteredOutput.length - NUMBERED_DIFF_PREVIEW_MAX_LINES;
-    return [
-      ...filteredOutput.slice(0, NUMBERED_DIFF_PREVIEW_MAX_LINES),
-      { kind: "truncated", count: omitted, unit: "lines" },
-    ];
+  if (filteredOutput.length <= NUMBERED_DIFF_PREVIEW_MAX_LINES) return filteredOutput;
+
+  // Truncate at a file boundary to avoid cutting mid-file.
+  // Find the first file header that starts beyond the budget.
+  let cutIndex = filteredOutput.length;
+  for (let i = NUMBERED_DIFF_PREVIEW_MAX_LINES; i < filteredOutput.length; i++) {
+    if (filteredOutput[i]?.kind === "text") {
+      cutIndex = i;
+      break;
+    }
   }
-  return filteredOutput;
+  if (cutIndex < filteredOutput.length) {
+    const remainingFiles = filteredOutput.slice(cutIndex).filter((p) => p.kind === "text").length;
+    return [...filteredOutput.slice(0, cutIndex), { kind: "truncated", count: remainingFiles, unit: "files" }];
+  }
+  // No file boundary found after budget — single file overflow, truncate lines.
+  const omitted = filteredOutput.length - NUMBERED_DIFF_PREVIEW_MAX_LINES;
+  return [
+    ...filteredOutput.slice(0, NUMBERED_DIFF_PREVIEW_MAX_LINES),
+    { kind: "truncated", count: omitted, unit: "lines" },
+  ];
 }

--- a/src/tool-output-format.ts
+++ b/src/tool-output-format.ts
@@ -1,4 +1,5 @@
 import { isAbsolute, relative } from "node:path";
+import { t } from "./i18n";
 import type { ToolOutputPart } from "./tool-output-content";
 
 export type ToolOutputListener = (event: { toolName: string; content: ToolOutputPart; toolCallId?: string }) => void;
@@ -49,9 +50,10 @@ export function createDiffSummaryEmitter<TToolName extends string>(input: {
   return (path, rawResult, toolCallId) => {
     const { files, added, removed } = summarizeUnifiedDiff(rawResult);
     const touchedFiles = files > 0 ? files : 1;
+    const displayPath = touchedFiles > 1 ? t("unit.file", { count: touchedFiles }) : path;
     onOutput({
       toolName,
-      content: { kind: "edit-header", label, path, files: touchedFiles, added, removed },
+      content: { kind: "edit-header", label, path: displayPath, files: touchedFiles, added, removed },
       toolCallId,
     });
   };
@@ -417,15 +419,25 @@ export function numberedUnifiedDiffLines(rawResult: string): ToolOutputPart[] {
   let newLine = 0;
   let inHunk = false;
   let fileCount = 0;
+  let pendingFilePath: string | null = null;
+  let fileAdded = 0;
+  let fileRemoved = 0;
+
+  const flushFileHeader = (): void => {
+    if (!pendingFilePath) return;
+    rendered.push({ kind: "text", text: `${pendingFilePath} (+${fileAdded} -${fileRemoved})` });
+    pendingFilePath = null;
+    fileAdded = 0;
+    fileRemoved = 0;
+  };
+
   for (const line of lines) {
     if (line.startsWith("diff --git ")) {
+      flushFileHeader();
       fileCount += 1;
       inHunk = false;
-      if (fileCount > 1) {
-        const pathMatch = line.match(/^diff --git a\/.+ b\/(.+)$/);
-        const path = pathMatch?.[1] ?? line.slice("diff --git ".length);
-        rendered.push({ kind: "text", text: path });
-      }
+      const pathMatch = line.match(/^diff --git a\/.+ b\/(.+)$/);
+      pendingFilePath = pathMatch?.[1] ?? line.slice("diff --git ".length);
       continue;
     }
     if (line.startsWith("--- ") || line.startsWith("+++ ")) continue;
@@ -441,11 +453,13 @@ export function numberedUnifiedDiffLines(rawResult: string): ToolOutputPart[] {
     if (!inHunk) continue;
     if (line.startsWith("+")) {
       rendered.push({ kind: "diff", lineNumber: newLine, marker: "add", text: line.slice(1) });
+      fileAdded += 1;
       newLine += 1;
       continue;
     }
     if (line.startsWith("-")) {
       rendered.push({ kind: "diff", lineNumber: oldLine, marker: "remove", text: line.slice(1) });
+      fileRemoved += 1;
       oldLine += 1;
       continue;
     }
@@ -454,6 +468,12 @@ export function numberedUnifiedDiffLines(rawResult: string): ToolOutputPart[] {
       oldLine += 1;
       newLine += 1;
     }
+  }
+  flushFileHeader();
+  // Strip per-file text headers for single-file diffs — the caller's edit-header covers it.
+  if (fileCount <= 1) {
+    const filtered = rendered.filter((part) => part.kind !== "text");
+    rendered.splice(0, rendered.length, ...filtered);
   }
   if (rendered.length === 0) {
     oldLine = 1;

--- a/src/tool-output.tui.test.tsx
+++ b/src/tool-output.tui.test.tsx
@@ -334,6 +334,44 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
     );
   });
 
+  test("multi-file edit-header with per-file sub-headers", () => {
+    const items: ToolOutputPart[] = [
+      { kind: "edit-header", label: "Edit", path: "14 files", files: 14, added: 28, removed: 28 },
+      { kind: "text", text: "src/short-id.ts (+1 -1)" },
+      { kind: "diff", lineNumber: 2, marker: "remove", text: "export function createId(size = 8): string {" },
+      { kind: "diff", lineNumber: 2, marker: "add", text: "export function generateId(size = 8): string {" },
+      { kind: "text", text: "src/chat-contract.ts (+2 -2)" },
+      { kind: "diff", lineNumber: 4, marker: "remove", text: 'import { createId } from "./short-id";' },
+      { kind: "diff", lineNumber: 4, marker: "add", text: 'import { generateId } from "./short-id";' },
+    ];
+    expect(formatToolOutput(items)).toBe(
+      dedent(`
+        Edit 14 files (+28 -28)
+          src/short-id.ts (+1 -1)
+            2 -export function createId(size = 8): string {
+            2 +export function generateId(size = 8): string {
+          src/chat-contract.ts (+2 -2)
+            4 -import { createId } from "./short-id";
+            4 +import { generateId } from "./short-id";
+      `),
+    );
+  });
+
+  test("single-file edit has no per-file sub-header", () => {
+    const items: ToolOutputPart[] = [
+      { kind: "edit-header", label: "Edit", path: "notes.ts", files: 1, added: 1, removed: 1 },
+      { kind: "diff", lineNumber: 2, marker: "remove", text: "old" },
+      { kind: "diff", lineNumber: 2, marker: "add", text: "new" },
+    ];
+    expect(formatToolOutput(items)).toBe(
+      dedent(`
+        Edit notes.ts (+1 -1)
+          2 -old
+          2 +new
+      `),
+    );
+  });
+
   test("truncated without unit", () => {
     const items: ToolOutputPart[] = [
       { kind: "tool-header", label: "Find", detail: "*.ts" },

--- a/src/tool-output.tui.test.tsx
+++ b/src/tool-output.tui.test.tsx
@@ -334,24 +334,45 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
     );
   });
 
+  test("diff context gaps show ellipsis without line count", () => {
+    const items: ToolOutputPart[] = [
+      { kind: "edit-header", label: "Edit", path: "notes.ts", files: 1, added: 1, removed: 1 },
+      { kind: "diff", lineNumber: 1, marker: "context", text: "const a = 1;" },
+      { kind: "truncated" },
+      { kind: "diff", lineNumber: 10, marker: "remove", text: "const y = 2;" },
+      { kind: "diff", lineNumber: 10, marker: "add", text: "const y = 3;" },
+      { kind: "diff", lineNumber: 11, marker: "context", text: "const b = 4;" },
+    ];
+    expect(formatToolOutput(items)).toBe(
+      dedent(`
+        Edit notes.ts (+1 -1)
+           1  const a = 1;
+           …
+          10 -const y = 2;
+          10 +const y = 3;
+          11  const b = 4;
+      `),
+    );
+  });
+
   test("multi-file edit-header with per-file sub-headers", () => {
     const items: ToolOutputPart[] = [
       { kind: "edit-header", label: "Edit", path: "14 files", files: 14, added: 28, removed: 28 },
       { kind: "text", text: "src/short-id.ts (+1 -1)" },
-      { kind: "diff", lineNumber: 2, marker: "remove", text: "export function createId(size = 8): string {" },
+      { kind: "diff", lineNumber: 2, marker: "remove", text: "export function generateId(size = 8): string {" },
       { kind: "diff", lineNumber: 2, marker: "add", text: "export function generateId(size = 8): string {" },
       { kind: "text", text: "src/chat-contract.ts (+2 -2)" },
-      { kind: "diff", lineNumber: 4, marker: "remove", text: 'import { createId } from "./short-id";' },
+      { kind: "diff", lineNumber: 4, marker: "remove", text: 'import { generateId } from "./short-id";' },
       { kind: "diff", lineNumber: 4, marker: "add", text: 'import { generateId } from "./short-id";' },
     ];
     expect(formatToolOutput(items)).toBe(
       dedent(`
         Edit 14 files (+28 -28)
           src/short-id.ts (+1 -1)
-            2 -export function createId(size = 8): string {
+            2 -export function generateId(size = 8): string {
             2 +export function generateId(size = 8): string {
           src/chat-contract.ts (+2 -2)
-            4 -import { createId } from "./short-id";
+            4 -import { generateId } from "./short-id";
             4 +import { generateId } from "./short-id";
       `),
     );

--- a/src/tool-registry.int.test.ts
+++ b/src/tool-registry.int.test.ts
@@ -5,9 +5,9 @@ import { toolsForAgent } from "./tool-registry";
 describe("tool error wrapper integration", () => {
   test("preserves guard-blocked code from guarded execution", async () => {
     const { tools } = toolsForAgent({ workspace: process.cwd() });
-    await tools.runCommand.execute({ command: "echo verify" });
+    await tools.runCommand.execute({ command: "echo verify" }, "test-call-1");
     try {
-      await tools.runCommand.execute({ command: "echo verify" });
+      await tools.runCommand.execute({ command: "echo verify" }, "test-call-2");
       throw new Error("expected duplicate verify guard to block");
     } catch (error) {
       expect(error).toBeInstanceOf(Error);

--- a/src/tool-utils.ts
+++ b/src/tool-utils.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join, relative, resolve } from "node:path";
 import { type GitignoreContext, isIgnoredByPatterns, loadGitignoreContext } from "./gitignore";
 
+const DIFF_CONTEXT_RADIUS = 2;
+
 const TEMP_ROOTS = Array.from(new Set([resolve(tmpdir()), resolve("/tmp"), resolve("/private/tmp")]));
 const GIT_ENV_KEYS = [
   "GIT_ALTERNATE_OBJECT_DIRECTORIES",
@@ -344,15 +346,13 @@ function minimalUnifiedDiff(path: string, oldLines: string[], newLines: string[]
   while (oi < n) diffLines.push(`-${oldLines[oi++]}`);
   while (ni < m) diffLines.push(`+${newLines[ni++]}`);
 
-  // Group into hunks with enough context for the display filter (contextRadius = 3).
-  const contextSize = 5;
   const isChange = diffLines.map((l) => !l.startsWith(" "));
   const hunkRanges: Array<{ start: number; end: number }> = [];
   let hunkStart = -1;
   for (let i = 0; i < diffLines.length; i++) {
     if (isChange[i]) {
-      if (hunkStart === -1) hunkStart = Math.max(0, i - contextSize);
-      const hunkEnd = Math.min(diffLines.length, i + contextSize + 1);
+      if (hunkStart === -1) hunkStart = Math.max(0, i - DIFF_CONTEXT_RADIUS);
+      const hunkEnd = Math.min(diffLines.length, i + DIFF_CONTEXT_RADIUS + 1);
       if (hunkRanges.length > 0 && hunkStart <= hunkRanges[hunkRanges.length - 1].end) {
         hunkRanges[hunkRanges.length - 1].end = hunkEnd;
       } else {

--- a/src/web-toolkit.ts
+++ b/src/web-toolkit.ts
@@ -74,8 +74,8 @@ function createWebSearchTool(deps: ToolkitDeps, input: ToolkitInput) {
       query: z.string().min(1),
       output: z.string(),
     }),
-    execute: async (toolInput) => {
-      return runTool(input.session, "web-search", toolInput, async (toolCallId) => {
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "web-search", toolCallId, toolInput, async (callId) => {
         input.onOutput({
           toolName: "web-search",
           content: {
@@ -83,13 +83,13 @@ function createWebSearchTool(deps: ToolkitDeps, input: ToolkitInput) {
             label: t("tool.label.web_search"),
             detail: `"${compactDetail(toolInput.query)}"`,
           },
-          toolCallId,
+          toolCallId: callId,
         });
         const result = compactToolOutput(
           await searchWeb(toolInput.query, toolInput.maxResults ?? WEB_SEARCH_MAX_RESULTS),
           deps.outputBudget.webSearch,
         );
-        emitResultChunks("web-search", webSearchStreamRows(result, toolInput.query), input.onOutput, 80, toolCallId);
+        emitResultChunks("web-search", webSearchStreamRows(result, toolInput.query), input.onOutput, 80, callId);
         return { kind: "web-search", query: toolInput.query, output: result };
       });
     },
@@ -114,12 +114,12 @@ function createWebFetchTool(deps: ToolkitDeps, input: ToolkitInput) {
       url: z.string().min(1),
       output: z.string(),
     }),
-    execute: async (toolInput) => {
-      return runTool(input.session, "web-fetch", toolInput, async (toolCallId) => {
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "web-fetch", toolCallId, toolInput, async (callId) => {
         input.onOutput({
           toolName: "web-fetch",
           content: { kind: "tool-header", label: t("tool.label.web_fetch"), detail: toolInput.url },
-          toolCallId,
+          toolCallId: callId,
         });
         const result = compactToolOutput(
           await fetchWeb(toolInput.url, toolInput.maxChars ?? 5000),


### PR DESCRIPTION
## Summary

- Per-file headers with add/remove counts in multi-file edit diffs
- Single-pass diff context filtering at source
- Thread model toolCallId through tool execution, remove nativeIdQueue
- Workspace-wide AST rename/replace via directory paths in edit-code
- Filter tools by mode grants in verify mode
- Do not skip evaluators when lifecycle signal is accepted
- Enable verify for run and skill CLI paths
- Preserve assistant text position during turn finalization
- Preserve partial content and streaming rows on interrupt
- Bold labels and workspace dot omission across all tool headers
- Strip backticks from code tokens, brand-tinted inline code color
- Remove transcript width cap
- Lifecycle integration tests using fake provider server