### PR TITLE
refactor(cli): migrate commands to CliOutput

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,6 +19,8 @@ The CLI is the primary interface for working with Acolyte.
 
 Run `acolyte <command> help` for detailed usage.
 
+All list commands support `--json` for machine-readable output.
+
 ## Local models
 
 See [Configuration](./configuration.md) for OpenAI-compatible model setup.
@@ -27,6 +29,7 @@ See [Configuration](./configuration.md) for OpenAI-compatible model setup.
 
 ```bash
 acolyte memory list [all|user|project]
+acolyte memory list --json
 acolyte memory add --user "<text>"
 acolyte memory add --project "<text>"
 ```
@@ -35,6 +38,7 @@ acolyte memory add --project "<text>"
 
 ```bash
 acolyte config list [--project]
+acolyte config list --json
 acolyte config set <key> <value>
 acolyte config set --project <key> <value>
 acolyte config unset <key>

--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -7,6 +7,7 @@ import {
   parseRepeatableFlag,
   parseRequiredFlag,
   parseTailCount,
+  stripFlag,
 } from "./cli-args";
 
 describe("hasHelpFlag", () => {
@@ -73,6 +74,11 @@ describe("parseTailCount", () => {
   test("allows zero", () => expect(parseTailCount("0")).toBe(0));
   test("returns default for non-numeric", () => expect(parseTailCount("abc")).toBe(40));
   test("accepts custom default", () => expect(parseTailCount(undefined, 20)).toBe(20));
+});
+
+describe("stripFlag", () => {
+  test("removes matching flag", () => expect(stripFlag(["--json", "list"], "--json")).toEqual(["list"]));
+  test("preserves args when flag absent", () => expect(stripFlag(["list"], "--json")).toEqual(["list"]));
 });
 
 describe("parsePositional", () => {

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -42,6 +42,10 @@ export function parseTailCount(raw: string | undefined, defaultCount = 40): numb
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : defaultCount;
 }
 
+export function stripFlag(args: string[], flag: string): string[] {
+  return args.filter((a) => a !== flag);
+}
+
 export function parsePositional(args: string[], flagsWithValues: string[]): string[] {
   const flagSet = new Set(flagsWithValues);
   const positional: string[] = [];

--- a/src/cli-config.ts
+++ b/src/cli-config.ts
@@ -1,4 +1,4 @@
-import { hasBoolFlag } from "./cli-args";
+import { hasBoolFlag, stripFlag } from "./cli-args";
 import { formatUsage } from "./cli-help";
 import { type CliOutput, createJsonOutput, createTextOutput } from "./cli-output";
 import type {
@@ -63,8 +63,7 @@ export async function configMode(args: string[], deps: ConfigModeDeps): Promise<
     return;
   }
   const json = hasBoolFlag(args, "--json");
-  const cleanArgs = args.filter((a) => a !== "--json");
-  const [subcommandRaw, ...restArgs] = cleanArgs;
+  const [subcommandRaw, ...restArgs] = stripFlag(args, "--json");
   const isImplicitList = !subcommandRaw || subcommandRaw === "--user" || subcommandRaw === "--project";
   const subcommand = isImplicitList ? "list" : subcommandRaw;
   const listArgs = isImplicitList && subcommandRaw ? [subcommandRaw, ...restArgs] : restArgs;
@@ -79,19 +78,20 @@ export async function configMode(args: string[], deps: ConfigModeDeps): Promise<
       const scope = parsed.scope;
       const config = scope ? await readConfigForScope(scope) : await readConfig();
       const out: CliOutput = json ? createJsonOutput() : createTextOutput();
+      const suffix = json ? "" : ":";
       const rows: Record<string, string | undefined>[] = [];
-      if (scope) rows.push({ key: t("cli.config.scope"), value: scope });
+      if (scope) rows.push({ key: `${t("cli.config.scope")}${suffix}`, value: scope });
       for (const name of VALID_CONFIG_KEYS) {
         const value = (config as Record<string, unknown>)[name];
         if (value === undefined || value === "") continue;
         if (Array.isArray(value)) {
-          rows.push({ key: `${name}:`, value: value.join(", ") });
+          rows.push({ key: `${name}${suffix}`, value: value.join(", ") });
         } else if (typeof value === "object" && value !== null) {
           for (const [k, v] of Object.entries(value)) {
-            rows.push({ key: `${name}.${k}:`, value: String(v) });
+            rows.push({ key: `${name}.${k}${suffix}`, value: String(v) });
           }
         } else {
-          rows.push({ key: `${name}:`, value: String(value) });
+          rows.push({ key: `${name}${suffix}`, value: String(value) });
         }
       }
       out.addTable(rows);

--- a/src/cli-config.ts
+++ b/src/cli-config.ts
@@ -1,5 +1,6 @@
-import { alignCols } from "./chat-format";
+import { hasBoolFlag } from "./cli-args";
 import { formatUsage } from "./cli-help";
+import { type CliOutput, createJsonOutput, createTextOutput } from "./cli-output";
 import type {
   readConfigForScope as readConfigForScopeType,
   readConfig as readConfigType,
@@ -61,7 +62,9 @@ export async function configMode(args: string[], deps: ConfigModeDeps): Promise<
     commandHelp("config");
     return;
   }
-  const [subcommandRaw, ...restArgs] = args;
+  const json = hasBoolFlag(args, "--json");
+  const cleanArgs = args.filter((a) => a !== "--json");
+  const [subcommandRaw, ...restArgs] = cleanArgs;
   const isImplicitList = !subcommandRaw || subcommandRaw === "--user" || subcommandRaw === "--project";
   const subcommand = isImplicitList ? "list" : subcommandRaw;
   const listArgs = isImplicitList && subcommandRaw ? [subcommandRaw, ...restArgs] : restArgs;
@@ -75,22 +78,25 @@ export async function configMode(args: string[], deps: ConfigModeDeps): Promise<
       }
       const scope = parsed.scope;
       const config = scope ? await readConfigForScope(scope) : await readConfig();
-      const rows: string[][] = [];
-      if (scope) rows.push([t("cli.config.scope"), scope]);
+      const out: CliOutput = json ? createJsonOutput() : createTextOutput();
+      const entries: Record<string, string | undefined>[] = [];
+      if (scope) entries.push({ key: t("cli.config.scope"), value: scope });
       for (const name of VALID_CONFIG_KEYS) {
         const value = (config as Record<string, unknown>)[name];
         if (value === undefined || value === "") continue;
         if (Array.isArray(value)) {
-          rows.push([`${name}:`, value.join(", ")]);
+          entries.push({ key: `${name}:`, value: value.join(", ") });
         } else if (typeof value === "object" && value !== null) {
           for (const [k, v] of Object.entries(value)) {
-            rows.push([`${name}.${k}:`, String(v)]);
+            entries.push({ key: `${name}.${k}:`, value: String(v) });
           }
         } else {
-          rows.push([`${name}:`, String(value)]);
+          entries.push({ key: `${name}:`, value: String(value) });
         }
       }
-      for (const line of alignCols(rows)) printDim(line);
+      for (const entry of entries) out.addRow(entry);
+      const rendered = out.render();
+      if (rendered) printDim(rendered);
       return;
     }
     case "set": {

--- a/src/cli-config.ts
+++ b/src/cli-config.ts
@@ -79,22 +79,22 @@ export async function configMode(args: string[], deps: ConfigModeDeps): Promise<
       const scope = parsed.scope;
       const config = scope ? await readConfigForScope(scope) : await readConfig();
       const out: CliOutput = json ? createJsonOutput() : createTextOutput();
-      const entries: Record<string, string | undefined>[] = [];
-      if (scope) entries.push({ key: t("cli.config.scope"), value: scope });
+      const rows: Record<string, string | undefined>[] = [];
+      if (scope) rows.push({ key: t("cli.config.scope"), value: scope });
       for (const name of VALID_CONFIG_KEYS) {
         const value = (config as Record<string, unknown>)[name];
         if (value === undefined || value === "") continue;
         if (Array.isArray(value)) {
-          entries.push({ key: `${name}:`, value: value.join(", ") });
+          rows.push({ key: `${name}:`, value: value.join(", ") });
         } else if (typeof value === "object" && value !== null) {
           for (const [k, v] of Object.entries(value)) {
-            entries.push({ key: `${name}.${k}:`, value: String(v) });
+            rows.push({ key: `${name}.${k}:`, value: String(v) });
           }
         } else {
-          entries.push({ key: `${name}:`, value: String(value) });
+          rows.push({ key: `${name}:`, value: String(value) });
         }
       }
-      for (const entry of entries) out.addRow(entry);
+      out.addTable(rows);
       const rendered = out.render();
       if (rendered) printDim(rendered);
       return;

--- a/src/cli-daemon.test.ts
+++ b/src/cli-daemon.test.ts
@@ -128,4 +128,17 @@ describe("cli-daemon", () => {
       `),
     );
   });
+
+  test("ps --json outputs JSON lines", async () => {
+    const { deps, output } = createDeps({
+      listRunningDaemons: async () => [
+        { port: 6767, pid: 1234, startedAt: new Date(Date.now() - 3600_000).toISOString() },
+      ],
+    });
+    await psMode(["--json"], deps);
+    const parsed = JSON.parse(output()) as Record<string, string>;
+    expect(parsed.port).toBe("6767");
+    expect(parsed.pid).toBe("1234");
+    expect(parsed.uptime).toBe("1h");
+  });
 });

--- a/src/cli-daemon.ts
+++ b/src/cli-daemon.ts
@@ -1,4 +1,5 @@
-import { alignCols } from "./chat-format";
+import { hasBoolFlag } from "./cli-args";
+import { type CliOutput, createJsonOutput, createTextOutput } from "./cli-output";
 import type { requestLocalServerShutdown } from "./cli-server";
 import { t } from "./i18n";
 import type {
@@ -95,13 +96,27 @@ export async function psMode(args: string[], deps: DaemonModeDeps): Promise<void
     deps.commandHelp("ps");
     return;
   }
-  if (args.length > 0) return deps.commandError("ps");
+  const json = hasBoolFlag(args, "--json");
+  const nonFlagArgs = args.filter((a) => a !== "--json");
+  if (nonFlagArgs.length > 0) return deps.commandError("ps");
   const daemons = await deps.listRunningDaemons();
   if (daemons.length === 0) {
     deps.printDim(t("cli.server.no_servers_running"));
     return;
   }
-  const rows: string[][] = [[t("cli.server.col.port"), t("cli.server.col.pid"), t("cli.server.col.uptime")]];
-  for (const d of daemons) rows.push([String(d.port), String(d.pid), formatUptime(d.startedAt)]);
-  for (const line of alignCols(rows)) deps.printDim(line);
+  const out: CliOutput = json ? createJsonOutput() : createTextOutput();
+  out.addTable(
+    daemons.map((d) => ({
+      port: String(d.port),
+      pid: String(d.pid),
+      uptime: formatUptime(d.startedAt),
+    })),
+    {
+      port: t("cli.server.col.port"),
+      pid: t("cli.server.col.pid"),
+      uptime: t("cli.server.col.uptime"),
+    },
+  );
+  const rendered = out.render();
+  if (rendered) deps.printDim(rendered);
 }

--- a/src/cli-daemon.ts
+++ b/src/cli-daemon.ts
@@ -1,4 +1,4 @@
-import { hasBoolFlag } from "./cli-args";
+import { hasBoolFlag, stripFlag } from "./cli-args";
 import { type CliOutput, createJsonOutput, createTextOutput } from "./cli-output";
 import type { requestLocalServerShutdown } from "./cli-server";
 import { t } from "./i18n";
@@ -97,8 +97,8 @@ export async function psMode(args: string[], deps: DaemonModeDeps): Promise<void
     return;
   }
   const json = hasBoolFlag(args, "--json");
-  const nonFlagArgs = args.filter((a) => a !== "--json");
-  if (nonFlagArgs.length > 0) return deps.commandError("ps");
+  const rest = stripFlag(args, "--json");
+  if (rest.length > 0) return deps.commandError("ps");
   const daemons = await deps.listRunningDaemons();
   if (daemons.length === 0) {
     deps.printDim(t("cli.server.no_servers_running"));

--- a/src/cli-history.test.ts
+++ b/src/cli-history.test.ts
@@ -78,7 +78,6 @@ describe("cli-history", () => {
     await historyMode([], deps);
     expect(output()).toBe(
       dedent(`
-        id   title           time
         aaa  First session   just now
         bbb  Second session  just now
       `),

--- a/src/cli-history.test.ts
+++ b/src/cli-history.test.ts
@@ -78,6 +78,7 @@ describe("cli-history", () => {
     await historyMode([], deps);
     expect(output()).toBe(
       dedent(`
+        id   title           time
         aaa  First session   just now
         bbb  Second session  just now
       `),

--- a/src/cli-history.test.ts
+++ b/src/cli-history.test.ts
@@ -83,4 +83,27 @@ describe("cli-history", () => {
       `),
     );
   });
+
+  test("--json outputs JSON lines", async () => {
+    const { deps, output } = createDeps({
+      readStore: async () => ({
+        activeSessionId: undefined,
+        sessions: [
+          {
+            id: "aaa",
+            createdAt: "9999-01-01T00:00:00.000Z",
+            updatedAt: "9999-01-01T00:00:00.000Z",
+            title: "First",
+            model: "gpt-4",
+            messages: [],
+            tokenUsage: [],
+          },
+        ],
+      }),
+    });
+    await historyMode(["--json"], deps);
+    const parsed = JSON.parse(output()) as Record<string, string>;
+    expect(parsed.id).toBe("aaa");
+    expect(parsed.title).toBe("First");
+  });
 });

--- a/src/cli-history.ts
+++ b/src/cli-history.ts
@@ -1,4 +1,6 @@
-import { alignCols, formatRelativeTime } from "./chat-format";
+import { formatRelativeTime } from "./chat-format";
+import { hasBoolFlag } from "./cli-args";
+import { type CliOutput, createJsonOutput, createTextOutput } from "./cli-output";
 import { truncateText } from "./compact-text";
 import { t } from "./i18n";
 import type { readStore as readStoreType } from "./storage";
@@ -11,30 +13,32 @@ type HistoryModeDeps = {
   commandHelp: (name: string) => void;
 };
 
-function listSessions(store: Awaited<ReturnType<typeof readStoreType>>, printDim: (message: string) => void): void {
-  if (store.sessions.length === 0) {
-    printDim(t("chat.picker.sessions.none"));
-    return;
-  }
-
-  const rows = store.sessions
-    .slice(0, 20)
-    .map((session) => [session.id, truncateText(session.title, 60), formatRelativeTime(session.updatedAt)]);
-  for (const line of alignCols(rows)) {
-    printDim(line);
-  }
-}
-
 export async function historyMode(args: string[], deps: HistoryModeDeps): Promise<void> {
   const { hasHelpFlag, printDim, readStore, commandError, commandHelp } = deps;
   if (hasHelpFlag(args)) {
     commandHelp("history");
     return;
   }
-  if (args.length > 0) {
+  const json = hasBoolFlag(args, "--json");
+  const nonFlagArgs = args.filter((a) => a !== "--json");
+  if (nonFlagArgs.length > 0) {
     commandError("history");
     return;
   }
   const store = await readStore();
-  listSessions(store, printDim);
+  if (store.sessions.length === 0) {
+    printDim(t("chat.picker.sessions.none"));
+    return;
+  }
+
+  const out: CliOutput = json ? createJsonOutput() : createTextOutput();
+  out.addTable(
+    store.sessions.slice(0, 20).map((session) => ({
+      id: session.id,
+      title: truncateText(session.title, 60),
+      time: formatRelativeTime(session.updatedAt),
+    })),
+  );
+  const rendered = out.render();
+  if (rendered) printDim(rendered);
 }

--- a/src/cli-history.ts
+++ b/src/cli-history.ts
@@ -1,5 +1,5 @@
 import { formatRelativeTime } from "./chat-format";
-import { hasBoolFlag } from "./cli-args";
+import { hasBoolFlag, stripFlag } from "./cli-args";
 import { type CliOutput, createJsonOutput, createTextOutput } from "./cli-output";
 import { truncateText } from "./compact-text";
 import { t } from "./i18n";
@@ -20,8 +20,8 @@ export async function historyMode(args: string[], deps: HistoryModeDeps): Promis
     return;
   }
   const json = hasBoolFlag(args, "--json");
-  const nonFlagArgs = args.filter((a) => a !== "--json");
-  if (nonFlagArgs.length > 0) {
+  const rest = stripFlag(args, "--json");
+  if (rest.length > 0) {
     commandError("history");
     return;
   }

--- a/src/cli-memory.ts
+++ b/src/cli-memory.ts
@@ -1,5 +1,7 @@
-import { alignCols, formatRelativeTime } from "./chat-format";
+import { formatRelativeTime } from "./chat-format";
+import { hasBoolFlag } from "./cli-args";
 import { formatUsage } from "./cli-help";
+import { type CliOutput, createJsonOutput, createTextOutput } from "./cli-output";
 import { truncateText } from "./compact-text";
 import { t } from "./i18n";
 import type { MemoryEntry } from "./memory-contract";
@@ -13,18 +15,20 @@ type MemoryModeDeps = {
   commandHelp: (name: string) => void;
 };
 
-function printMemoryRows(rows: readonly MemoryEntry[], printDim: (message: string) => void): void {
+function renderMemoryList(rows: readonly MemoryEntry[], out: CliOutput, printDim: (msg: string) => void): void {
   if (rows.length === 0) {
     printDim(t("cli.memory.none"));
     return;
   }
-
-  const formatted = rows
-    .slice(0, 50)
-    .map((row) => [row.id, truncateText(row.content, 80), formatRelativeTime(row.createdAt)]);
-  for (const line of alignCols(formatted)) {
-    printDim(line);
-  }
+  out.addTable(
+    rows.slice(0, 50).map((row) => ({
+      id: row.id,
+      content: truncateText(row.content, 80),
+      time: formatRelativeTime(row.createdAt),
+    })),
+  );
+  const rendered = out.render();
+  if (rendered) printDim(rendered);
 }
 
 export async function memoryMode(args: string[], deps: MemoryModeDeps): Promise<void> {
@@ -33,7 +37,10 @@ export async function memoryMode(args: string[], deps: MemoryModeDeps): Promise<
     commandHelp("memory");
     return;
   }
-  const [subcommand, ...rest] = args;
+  const json = hasBoolFlag(args, "--json");
+  const out: CliOutput = json ? createJsonOutput() : createTextOutput();
+  const cleanArgs = args.filter((a) => a !== "--json");
+  const [subcommand, ...rest] = cleanArgs;
   const validScopes = new Set(["all", "user", "project"]);
 
   if (subcommand === "list" || !subcommand) {
@@ -48,7 +55,7 @@ export async function memoryMode(args: string[], deps: MemoryModeDeps): Promise<
       return;
     }
     const rows = await store.list(scope as "all" | "user" | "project");
-    printMemoryRows(rows, printDim);
+    renderMemoryList(rows, out, printDim);
     return;
   }
 

--- a/src/cli-memory.ts
+++ b/src/cli-memory.ts
@@ -1,10 +1,9 @@
 import { formatRelativeTime } from "./chat-format";
-import { hasBoolFlag } from "./cli-args";
+import { hasBoolFlag, stripFlag } from "./cli-args";
 import { formatUsage } from "./cli-help";
 import { type CliOutput, createJsonOutput, createTextOutput } from "./cli-output";
 import { truncateText } from "./compact-text";
 import { t } from "./i18n";
-import type { MemoryEntry } from "./memory-contract";
 import type { MemoryStore } from "./memory-store";
 
 type MemoryModeDeps = {
@@ -15,22 +14,6 @@ type MemoryModeDeps = {
   commandHelp: (name: string) => void;
 };
 
-function renderMemoryList(rows: readonly MemoryEntry[], out: CliOutput, printDim: (msg: string) => void): void {
-  if (rows.length === 0) {
-    printDim(t("cli.memory.none"));
-    return;
-  }
-  out.addTable(
-    rows.slice(0, 50).map((row) => ({
-      id: row.id,
-      content: truncateText(row.content, 80),
-      time: formatRelativeTime(row.createdAt),
-    })),
-  );
-  const rendered = out.render();
-  if (rendered) printDim(rendered);
-}
-
 export async function memoryMode(args: string[], deps: MemoryModeDeps): Promise<void> {
   const { store, hasHelpFlag, printDim, commandError, commandHelp } = deps;
   if (hasHelpFlag(args)) {
@@ -38,9 +21,7 @@ export async function memoryMode(args: string[], deps: MemoryModeDeps): Promise<
     return;
   }
   const json = hasBoolFlag(args, "--json");
-  const out: CliOutput = json ? createJsonOutput() : createTextOutput();
-  const cleanArgs = args.filter((a) => a !== "--json");
-  const [subcommand, ...rest] = cleanArgs;
+  const [subcommand, ...rest] = stripFlag(args, "--json");
   const validScopes = new Set(["all", "user", "project"]);
 
   if (subcommand === "list" || !subcommand) {
@@ -55,7 +36,20 @@ export async function memoryMode(args: string[], deps: MemoryModeDeps): Promise<
       return;
     }
     const rows = await store.list(scope as "all" | "user" | "project");
-    renderMemoryList(rows, out, printDim);
+    if (rows.length === 0) {
+      printDim(t("cli.memory.none"));
+      return;
+    }
+    const out: CliOutput = json ? createJsonOutput() : createTextOutput();
+    out.addTable(
+      rows.slice(0, 50).map((row) => ({
+        id: row.id,
+        content: truncateText(row.content, 80),
+        time: formatRelativeTime(row.createdAt),
+      })),
+    );
+    const rendered = out.render();
+    if (rendered) printDim(rendered);
     return;
   }
 

--- a/src/cli-output.test.ts
+++ b/src/cli-output.test.ts
@@ -29,18 +29,32 @@ describe("createTextOutput", () => {
     expect(out.render()).toBe("a=1\n\nb=2");
   });
 
-  test("renders table with header row and aligned columns", () => {
+  test("renders table without headers when no labels provided", () => {
     const out = createTextOutput();
     out.addTable([
       { id: "task_a", model: "gpt-5-mini", status: "ok" },
       { id: "task_bb", model: "gpt-5", status: "error" },
     ]);
     const lines = out.render().split("\n");
+    expect(lines.length).toBe(2);
+    expect(lines[0]).toContain("task_a");
+    expect(lines[1]).toContain("task_bb");
+  });
+
+  test("renders table with header row when labels provided", () => {
+    const out = createTextOutput();
+    out.addTable(
+      [
+        { id: "task_a", model: "gpt-5-mini" },
+        { id: "task_bb", model: "gpt-5" },
+      ],
+      { id: "Task", model: "Model" },
+    );
+    const lines = out.render().split("\n");
     expect(lines.length).toBe(3);
-    expect(lines[0]).toContain("id");
-    expect(lines[0]).toContain("model");
+    expect(lines[0]).toContain("Task");
+    expect(lines[0]).toContain("Model");
     expect(lines[1]).toContain("task_a");
-    expect(lines[2]).toContain("task_bb");
   });
 
   test("renders empty for no content", () => {

--- a/src/cli-output.ts
+++ b/src/cli-output.ts
@@ -23,8 +23,8 @@ export function createTextOutput(): CliOutput {
     addTable: (rows, labels) => {
       if (rows.length === 0) return;
       const keys = Object.keys(rows[0]);
-      const headerRow = labels ? keys.map((k) => labels[k] ?? k) : keys;
-      const tableRows = [headerRow, ...rows.map((row) => keys.map((k) => row[k] ?? ""))];
+      const dataRows = rows.map((row) => keys.map((k) => row[k] ?? ""));
+      const tableRows = labels ? [keys.map((k) => labels[k] ?? k), ...dataRows] : dataRows;
       for (const line of alignCols(tableRows)) sections.push(line);
     },
     addHeader: (text) => sections.push(text),

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -120,7 +120,7 @@ export const EN_MESSAGES = {
   "cli.config.keys": "Keys: {keys}",
   "cli.config.removed": "Removed config {key} ({scope}).",
   "cli.config.saved": "Saved config {key} ({scope}).",
-  "cli.config.scope": "scope:",
+  "cli.config.scope": "scope",
   "cli.config.unknown_key": "Unknown config key: {key}",
   "cli.config.value_empty": "Config value cannot be empty",
   "cli.help.desc.config": "manage config",


### PR DESCRIPTION
## Summary

- migrate history, memory list, config list, and ps to shared CliOutput abstraction
- add --json flag to all migrated commands
- make table headers opt-in via labels parameter
- extract stripFlag helper to cli-args
- clean config JSON keys (no trailing colon)
- remove colon from cli.config.scope i18n value
- document --json support in docs/cli.md

Fixes #36