### PR TITLE
refactor(memory): migrate distill storage to SQLite

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -50,6 +50,7 @@ Shipped, user-visible capabilities.
 - Memory inspect/list/remove commands.
 - Context distillation with automatic observation and reflection.
 - Session-scoped distill memory.
+- SQLite-backed persistent storage for distill records.
 
 ## Safety and control
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -77,12 +77,12 @@ The observation/reflection model is inspired by [Mastra's Observational Memory](
 - Server runtime emits a dedicated `memory quality warning` log line for `lifecycle.memory.quality_warning` events.
 - Selection dedupes identical entry content to avoid wasting budget on repeats.
 - Normalization drops blank entries before selection.
-- Distill record writes are atomic (`temp file →rename`) to avoid partial files.
+- Distill record writes use SQLite with WAL mode for atomic persistence.
 
 ## Storage
 
 - Stored notes: `.acolyte/memory/{user|project}/*.md`
-- Distill records: `~/.acolyte/distill/<scopeKey>/*.json` where `<scopeKey>` is `sess_*`, `proj_*`, or `user_*`.
+- Distill records: `~/.acolyte/memory.db` (SQLite, keyed by `scope_key`: `sess_*`, `proj_*`, or `user_*`).
 
 ## Extension seams
 
@@ -102,5 +102,5 @@ The observation/reflection model is inspired by [Mastra's Observational Memory](
 - `src/memory-source-distill.ts` — Distill memory source with observer and reflector agents.
 - `src/memory-source-stored.ts` — Stored markdown memory source.
 - `src/memory-distill-prompts.ts` — Observer and reflector prompt templates.
-- `src/memory-distill-store.ts` — Atomic file-based distill record persistence.
+- `src/memory-distill-store.ts` — SQLite-based distill record persistence with legacy filesystem migration.
 - `src/memory-store.ts` — Memory store interface for list, add, and remove.

--- a/src/memory-distill-store.test.ts
+++ b/src/memory-distill-store.test.ts
@@ -1,22 +1,28 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import type { DistillRecord } from "./memory-contract";
-import { createFileDistillStore } from "./memory-distill-store";
+import { createSqliteDistillStore, migrateFromFilesystem } from "./memory-distill-store";
 import { tempDir } from "./test-utils";
 
 const { createDir, cleanupDirs } = tempDir();
 afterEach(cleanupDirs);
 
-describe("createFileDistillStore", () => {
+function createStore(dir: string) {
+  return createSqliteDistillStore(join(dir, "test.db"));
+}
+
+describe("createSqliteDistillStore", () => {
   test("list returns empty for nonexistent session", async () => {
-    const home = createDir("acolyte-distill-");
-    const store = createFileDistillStore(home);
+    const dir = createDir("acolyte-distill-");
+    const store = createStore(dir);
     const records = await store.list("sess_nonexistent");
     expect(records).toEqual([]);
   });
 
   test("write + list round-trips a record", async () => {
-    const home = createDir("acolyte-distill-");
-    const store = createFileDistillStore(home);
+    const dir = createDir("acolyte-distill-");
+    const store = createStore(dir);
     const record: DistillRecord = {
       id: "dst_test001",
       sessionId: "sess_abc123",
@@ -32,8 +38,8 @@ describe("createFileDistillStore", () => {
   });
 
   test("list returns records sorted chronologically", async () => {
-    const home = createDir("acolyte-distill-");
-    const store = createFileDistillStore(home);
+    const dir = createDir("acolyte-distill-");
+    const store = createStore(dir);
     const older: DistillRecord = {
       id: "dst_older001",
       sessionId: "sess_abc123",
@@ -58,8 +64,8 @@ describe("createFileDistillStore", () => {
   });
 
   test("list isolates sessions", async () => {
-    const home = createDir("acolyte-distill-");
-    const store = createFileDistillStore(home);
+    const dir = createDir("acolyte-distill-");
+    const store = createStore(dir);
     const record1: DistillRecord = {
       id: "dst_sess1rec",
       sessionId: "sess_session1",
@@ -87,8 +93,8 @@ describe("createFileDistillStore", () => {
   });
 
   test("remove deletes a record by id and scope key", async () => {
-    const home = createDir("acolyte-distill-");
-    const store = createFileDistillStore(home);
+    const dir = createDir("acolyte-distill-");
+    const store = createStore(dir);
     const record: DistillRecord = {
       id: "dst_rmtest01",
       sessionId: "sess_abc123",
@@ -104,39 +110,33 @@ describe("createFileDistillStore", () => {
   });
 
   test("remove is a no-op for nonexistent record", async () => {
-    const home = createDir("acolyte-distill-");
-    const store = createFileDistillStore(home);
+    const dir = createDir("acolyte-distill-");
+    const store = createStore(dir);
     await store.remove("dst_missing01", "sess_abc123");
     expect(await store.list("sess_abc123")).toHaveLength(0);
   });
 
-  test("ignores invalid JSON files", async () => {
-    const home = createDir("acolyte-distill-");
-    const store = createFileDistillStore(home);
+  test("write replaces existing record with same id", async () => {
+    const dir = createDir("acolyte-distill-");
+    const store = createStore(dir);
     const record: DistillRecord = {
-      id: "dst_valid001",
+      id: "dst_replace1",
       sessionId: "sess_abc123",
       tier: "observation",
-      content: "valid record",
+      content: "original",
       createdAt: "2026-03-04T12:00:00.000Z",
-      tokenEstimate: 3,
+      tokenEstimate: 1,
     };
     await store.write(record);
-
-    const { writeFileSync, mkdirSync } = await import("node:fs");
-    const { join } = await import("node:path");
-    const dir = join(home, ".acolyte", "distill", "sess_abc123");
-    mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, "dst_broken.json"), "not valid json", "utf8");
-
+    await store.write({ ...record, content: "updated" });
     const records = await store.list("sess_abc123");
     expect(records).toHaveLength(1);
-    expect(records[0]?.content).toBe("valid record");
+    expect(records[0]?.content).toBe("updated");
   });
 
   test("ignores unsafe session ids", async () => {
-    const home = createDir("acolyte-distill-");
-    const store = createFileDistillStore(home);
+    const dir = createDir("acolyte-distill-");
+    const store = createStore(dir);
     const records = await store.list("../escape");
     expect(records).toEqual([]);
 
@@ -153,28 +153,9 @@ describe("createFileDistillStore", () => {
     expect(stillEmpty).toEqual([]);
   });
 
-  test("write does not leave temp files behind", async () => {
-    const home = createDir("acolyte-distill-");
-    const store = createFileDistillStore(home);
-    const record: DistillRecord = {
-      id: "dst_temp001",
-      sessionId: "sess_abc123",
-      tier: "observation",
-      content: "temp test",
-      createdAt: "2026-03-04T12:00:00.000Z",
-      tokenEstimate: 2,
-    };
-    await store.write(record);
-    const { readdirSync } = await import("node:fs");
-    const { join } = await import("node:path");
-    const dir = join(home, ".acolyte", "distill", "sess_abc123");
-    const names = readdirSync(dir);
-    expect(names.some((name) => name.includes(".tmp-"))).toBe(false);
-  });
-
   test("supports resource-scoped distill keys", async () => {
-    const home = createDir("acolyte-distill-");
-    const store = createFileDistillStore(home);
+    const dir = createDir("acolyte-distill-");
+    const store = createStore(dir);
     const userRecord: DistillRecord = {
       id: "dst_user001",
       sessionId: "user_abc123",
@@ -195,5 +176,84 @@ describe("createFileDistillStore", () => {
     await store.write(projectRecord);
     expect((await store.list("user_abc123")).map((record) => record.content)).toEqual(["user fact"]);
     expect((await store.list("proj_abc123")).map((record) => record.content)).toEqual(["project fact"]);
+  });
+});
+
+describe("migrateFromFilesystem", () => {
+  test("migrates JSON files into SQLite store", async () => {
+    const home = createDir("acolyte-migrate-");
+    const scopeDir = join(home, ".acolyte", "distill", "sess_abc123");
+    mkdirSync(scopeDir, { recursive: true });
+
+    const record: DistillRecord = {
+      id: "dst_migr001",
+      sessionId: "sess_abc123",
+      tier: "observation",
+      content: "migrated fact",
+      createdAt: "2026-03-04T12:00:00.000Z",
+      tokenEstimate: 3,
+    };
+    writeFileSync(join(scopeDir, `${record.id}.json`), JSON.stringify(record), "utf8");
+
+    const store = createSqliteDistillStore(join(home, "test.db"));
+    const count = await migrateFromFilesystem(home, store);
+    expect(count).toBe(1);
+
+    const records = await store.list("sess_abc123");
+    expect(records).toHaveLength(1);
+    expect(records[0]?.content).toBe("migrated fact");
+
+    // Old directory should be renamed to distill.bak
+    const { existsSync } = await import("node:fs");
+    expect(existsSync(join(home, ".acolyte", "distill"))).toBe(false);
+    expect(existsSync(join(home, ".acolyte", "distill.bak"))).toBe(true);
+  });
+
+  test("returns 0 when no distill directory exists", async () => {
+    const home = createDir("acolyte-migrate-");
+    const store = createSqliteDistillStore(join(home, "test.db"));
+    const count = await migrateFromFilesystem(home, store);
+    expect(count).toBe(0);
+  });
+
+  test("skips invalid JSON files during migration", async () => {
+    const home = createDir("acolyte-migrate-");
+    const scopeDir = join(home, ".acolyte", "distill", "sess_abc123");
+    mkdirSync(scopeDir, { recursive: true });
+
+    writeFileSync(join(scopeDir, "dst_broken.json"), "not valid json", "utf8");
+
+    const validRecord: DistillRecord = {
+      id: "dst_valid001",
+      sessionId: "sess_abc123",
+      tier: "observation",
+      content: "valid record",
+      createdAt: "2026-03-04T12:00:00.000Z",
+      tokenEstimate: 3,
+    };
+    writeFileSync(join(scopeDir, `${validRecord.id}.json`), JSON.stringify(validRecord), "utf8");
+
+    const store = createSqliteDistillStore(join(home, "test.db"));
+    const count = await migrateFromFilesystem(home, store);
+    expect(count).toBe(1);
+
+    const records = await store.list("sess_abc123");
+    expect(records).toHaveLength(1);
+    expect(records[0]?.content).toBe("valid record");
+  });
+
+  test("renames distill dir even when all files are invalid", async () => {
+    const home = createDir("acolyte-migrate-");
+    const scopeDir = join(home, ".acolyte", "distill", "sess_abc123");
+    mkdirSync(scopeDir, { recursive: true });
+    writeFileSync(join(scopeDir, "dst_broken.json"), "not valid json", "utf8");
+
+    const store = createSqliteDistillStore(join(home, "test.db"));
+    const count = await migrateFromFilesystem(home, store);
+    expect(count).toBe(0);
+
+    const { existsSync } = await import("node:fs");
+    expect(existsSync(join(home, ".acolyte", "distill"))).toBe(false);
+    expect(existsSync(join(home, ".acolyte", "distill.bak"))).toBe(true);
   });
 });

--- a/src/memory-distill-store.ts
+++ b/src/memory-distill-store.ts
@@ -1,5 +1,6 @@
+import { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
-import { mkdir, readdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { readdir, readFile, rename } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { type DistillRecord, distillRecordSchema } from "./memory-contract";
@@ -8,56 +9,131 @@ export interface DistillStore {
   list(scopeKey: string): Promise<readonly DistillRecord[]>;
   write(record: DistillRecord): Promise<void>;
   remove(id: string, scopeKey: string): Promise<void>;
+  close(): void;
 }
 
-function safeDistillScopeKey(scopeKey: string): string | null {
+export function safeDistillScopeKey(scopeKey: string): string | null {
   return /^(sess|user|proj)_[a-z0-9_-]+$/.test(scopeKey) ? scopeKey : null;
 }
 
-function distillDir(homeDir: string, scopeKey: string): string | null {
-  const safeName = safeDistillScopeKey(scopeKey);
-  if (!safeName) return null;
-  return join(homeDir, ".acolyte", "distill", safeName);
+function initSchema(db: Database): void {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS distill_records (
+      id TEXT PRIMARY KEY,
+      scope_key TEXT NOT NULL,
+      tier TEXT NOT NULL,
+      content TEXT NOT NULL,
+      current_task TEXT,
+      next_step TEXT,
+      created_at TEXT NOT NULL,
+      token_estimate INTEGER NOT NULL
+    )
+  `);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_distill_scope ON distill_records(scope_key)`);
 }
 
-export function createFileDistillStore(homeDir = homedir()): DistillStore {
+type DistillRow = {
+  id: string;
+  scope_key: string;
+  tier: string;
+  content: string;
+  current_task: string | null;
+  next_step: string | null;
+  created_at: string;
+  token_estimate: number;
+};
+
+function rowToRecord(row: DistillRow): DistillRecord {
+  return {
+    id: row.id,
+    sessionId: row.scope_key,
+    tier: row.tier as DistillRecord["tier"],
+    content: row.content,
+    ...(row.current_task ? { currentTask: row.current_task } : {}),
+    ...(row.next_step ? { nextStep: row.next_step } : {}),
+    createdAt: row.created_at,
+    tokenEstimate: row.token_estimate,
+  };
+}
+
+export function createSqliteDistillStore(dbPath?: string): DistillStore {
+  const resolvedPath = dbPath ?? join(homedir(), ".acolyte", "memory.db");
+  const db = new Database(resolvedPath, { create: true });
+  db.run("PRAGMA journal_mode = WAL");
+  initSchema(db);
+
+  const listStmt = db.prepare<DistillRow, [string]>(
+    "SELECT * FROM distill_records WHERE scope_key = ? ORDER BY created_at ASC",
+  );
+  const writeStmt = db.prepare<void, [string, string, string, string, string | null, string | null, string, number]>(
+    `INSERT OR REPLACE INTO distill_records (id, scope_key, tier, content, current_task, next_step, created_at, token_estimate)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  );
+  const removeStmt = db.prepare<void, [string, string]>("DELETE FROM distill_records WHERE id = ? AND scope_key = ?");
+
   return {
     async list(scopeKey) {
-      const dir = distillDir(homeDir, scopeKey);
-      if (!dir) return [];
-      if (!existsSync(dir)) return [];
-      const names = await readdir(dir);
-      const records: DistillRecord[] = [];
-      for (const name of names) {
-        if (!name.endsWith(".json")) continue;
-        try {
-          const raw = await readFile(join(dir, name), "utf8");
-          const parsed = distillRecordSchema.safeParse(JSON.parse(raw));
-          if (parsed.success) records.push(parsed.data);
-        } catch {
-          // Ignore unreadable distill files.
-        }
-      }
-      records.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
-      return records;
-    },
-    async remove(id, scopeKey) {
-      const dir = distillDir(homeDir, scopeKey);
-      if (!dir) return;
-      await rm(join(dir, `${id}.json`), { force: true }).catch(() => {});
+      if (!safeDistillScopeKey(scopeKey)) return [];
+      return listStmt.all(scopeKey).map(rowToRecord);
     },
     async write(record) {
-      const dir = distillDir(homeDir, record.sessionId);
-      if (!dir) return;
-      await mkdir(dir, { recursive: true });
-      const targetPath = join(dir, `${record.id}.json`);
-      const tempPath = join(dir, `${record.id}.json.tmp-${process.pid}-${Date.now()}`);
-      try {
-        await writeFile(tempPath, JSON.stringify(record, null, 2), "utf8");
-        await rename(tempPath, targetPath);
-      } finally {
-        await rm(tempPath, { force: true }).catch(() => {});
-      }
+      if (!safeDistillScopeKey(record.sessionId)) return;
+      writeStmt.run(
+        record.id,
+        record.sessionId,
+        record.tier,
+        record.content,
+        record.currentTask ?? null,
+        record.nextStep ?? null,
+        record.createdAt,
+        record.tokenEstimate,
+      );
+    },
+    async remove(id, scopeKey) {
+      if (!safeDistillScopeKey(scopeKey)) return;
+      removeStmt.run(id, scopeKey);
+    },
+    close() {
+      db.close();
     },
   };
+}
+
+// TODO(cniska): Drop legacy distill migration at v1.0.0.
+export async function migrateFromFilesystem(homeDir: string, store: DistillStore): Promise<number> {
+  const distillDir = join(homeDir, ".acolyte", "distill");
+  if (!existsSync(distillDir)) return 0;
+
+  let migrated = 0;
+  const scopeDirs = await readdir(distillDir, { withFileTypes: true });
+  const records: DistillRecord[] = [];
+  for (const entry of scopeDirs) {
+    if (!entry.isDirectory()) continue;
+    const scopeKey = entry.name;
+    if (!safeDistillScopeKey(scopeKey)) continue;
+    const scopePath = join(distillDir, scopeKey);
+    const files = await readdir(scopePath);
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      try {
+        const raw = await readFile(join(scopePath, file), "utf8");
+        const parsed = distillRecordSchema.safeParse(JSON.parse(raw));
+        if (parsed.success) records.push(parsed.data);
+      } catch {
+        // Skip unreadable files.
+      }
+    }
+  }
+
+  for (const record of records) {
+    await store.write(record);
+    migrated += 1;
+  }
+
+  const backupPath = join(homeDir, ".acolyte", "distill.bak");
+  if (!existsSync(backupPath)) {
+    await rename(distillDir, backupPath);
+  }
+
+  return migrated;
 }

--- a/src/memory-distill-store.ts
+++ b/src/memory-distill-store.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync } from "node:fs";
 import { readdir, readFile, rename } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { log } from "./log";
 import { type DistillRecord, distillRecordSchema } from "./memory-contract";
 
 export interface DistillStore {
@@ -62,6 +63,7 @@ export function createSqliteDistillStore(dbPath?: string): DistillStore {
   const db = new Database(resolvedPath, { create: true });
   db.run("PRAGMA journal_mode = WAL");
   initSchema(db);
+  log.debug("memory.distill.store_opened", { path: resolvedPath });
 
   const listStmt = db.prepare<DistillRow, [string]>(
     "SELECT * FROM distill_records WHERE scope_key = ? ORDER BY created_at ASC",
@@ -136,5 +138,6 @@ export async function migrateFromFilesystem(homeDir: string, store: DistillStore
     await rename(distillDir, backupPath);
   }
 
+  log.info("memory.distill.migration_done", { migrated });
   return migrated;
 }

--- a/src/memory-distill-store.ts
+++ b/src/memory-distill-store.ts
@@ -1,8 +1,8 @@
 import { Database } from "bun:sqlite";
-import { existsSync } from "node:fs";
+import { existsSync, mkdirSync } from "node:fs";
 import { readdir, readFile, rename } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { type DistillRecord, distillRecordSchema } from "./memory-contract";
 
 export interface DistillStore {
@@ -58,6 +58,7 @@ function rowToRecord(row: DistillRow): DistillRecord {
 
 export function createSqliteDistillStore(dbPath?: string): DistillStore {
   const resolvedPath = dbPath ?? join(homedir(), ".acolyte", "memory.db");
+  mkdirSync(dirname(resolvedPath), { recursive: true });
   const db = new Database(resolvedPath, { create: true });
   db.run("PRAGMA journal_mode = WAL");
   initSchema(db);

--- a/src/memory-source-distill.test.ts
+++ b/src/memory-source-distill.test.ts
@@ -31,6 +31,7 @@ function createMockStore(
       const idx = records.findIndex((r) => r.id === id);
       if (idx >= 0) records.splice(idx, 1);
     },
+    close() {},
   };
 }
 

--- a/src/memory-source-distill.ts
+++ b/src/memory-source-distill.ts
@@ -2,6 +2,7 @@ import { homedir } from "node:os";
 import { estimateTokens } from "./agent-input";
 import { appConfig } from "./app-config";
 import { nowIso } from "./datetime";
+import { log } from "./log";
 import type { DistillRecord, MemoryCommitMetrics, MemorySource, MemorySourceEntry } from "./memory-contract";
 import { OBSERVER_PROMPT, REFLECTOR_PROMPT } from "./memory-distill-prompts";
 import { createSqliteDistillStore, type DistillStore, migrateFromFilesystem } from "./memory-distill-store";
@@ -21,7 +22,10 @@ let defaultStore: DistillStore | null = null;
 function getDefaultStore(): DistillStore {
   if (!defaultStore) {
     defaultStore = createSqliteDistillStore();
-    migrateFromFilesystem(homedir(), defaultStore).catch(() => {});
+    migrateFromFilesystem(homedir(), defaultStore).catch((error) => {
+      log.warn("memory.distill.migration_failed", { error: String(error) });
+    });
+    process.on("exit", () => defaultStore?.close());
   }
   return defaultStore;
 }

--- a/src/memory-source-distill.ts
+++ b/src/memory-source-distill.ts
@@ -272,6 +272,7 @@ async function commitDistillForKey(
     tokenEstimate: estimateTokens(observed),
   };
   await ds.write(observation);
+  log.debug("memory.distill.observation_written", { key, id: observation.id, tokens: observation.tokenEstimate });
 
   const entries = [...existingEntries, observation];
   const observations = entries.filter((e) => e.tier === "observation");
@@ -307,10 +308,12 @@ async function commitDistillForKey(
     tokenEstimate: estimateTokens(reflected),
   };
   await ds.write(reflection);
+  log.debug("memory.distill.reflection_written", { key, id: reflection.id, tokens: reflection.tokenEstimate });
 
   // GC: remove all prior observations and reflections now consolidated into the new reflection.
   const stale = [...observations, ...reflections];
   await Promise.all(stale.map((r) => ds.remove(r.id, key)));
+  log.debug("memory.distill.gc", { key, removed: stale.length });
 }
 
 export function createDistillMemorySource(
@@ -357,6 +360,9 @@ export function createDistillMemorySource(
       }
 
       const scoped = splitScopedObservation(observed);
+      if (scoped.droppedUntaggedCount > 0) {
+        log.debug("memory.distill.dropped_untagged", { key, count: scoped.droppedUntaggedCount });
+      }
       if (scoped.session) {
         await commitDistillForKey(ds, key, scoped.session, runner, config);
       }
@@ -369,6 +375,13 @@ export function createDistillMemorySource(
         const userKey = resolveDistillScopeKey("user", ctx);
         if (userKey) await commitDistillForKey(ds, userKey, scoped.user, runner, config);
       }
+      log.debug("memory.distill.commit_done", {
+        key,
+        session: scoped.sessionCount,
+        project: scoped.projectCount,
+        user: scoped.userCount,
+        dropped: scoped.droppedUntaggedCount,
+      });
       return {
         projectPromotedFacts: scoped.projectCount,
         userPromotedFacts: scoped.userCount,

--- a/src/memory-source-distill.ts
+++ b/src/memory-source-distill.ts
@@ -1,9 +1,10 @@
+import { homedir } from "node:os";
 import { estimateTokens } from "./agent-input";
 import { appConfig } from "./app-config";
 import { nowIso } from "./datetime";
 import type { DistillRecord, MemoryCommitMetrics, MemorySource, MemorySourceEntry } from "./memory-contract";
 import { OBSERVER_PROMPT, REFLECTOR_PROMPT } from "./memory-distill-prompts";
-import { createFileDistillStore, type DistillStore } from "./memory-distill-store";
+import { createSqliteDistillStore, type DistillStore, migrateFromFilesystem } from "./memory-distill-store";
 import { createModel } from "./model-factory";
 import { normalizeModel } from "./provider-config";
 import { defaultUserResourceId, parseResourceId, projectResourceIdFromWorkspace, type ResourceId } from "./resource-id";
@@ -18,7 +19,10 @@ export type DistillConfig = {
 
 let defaultStore: DistillStore | null = null;
 function getDefaultStore(): DistillStore {
-  if (!defaultStore) defaultStore = createFileDistillStore();
+  if (!defaultStore) {
+    defaultStore = createSqliteDistillStore();
+    migrateFromFilesystem(homedir(), defaultStore).catch(() => {});
+  }
   return defaultStore;
 }
 const REFLECTION_RETRY_LIMIT = 2;


### PR DESCRIPTION
## Summary

- replace `createFileDistillStore` with SQLite-backed `createSqliteDistillStore`
- add legacy filesystem migration with `distill.bak` rename
- add `close()` to `DistillStore` interface
- update `docs/memory.md` storage references

Fixes #37