### PR TITLE
feat(memory): semantic recall

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -224,7 +224,7 @@ How each agent retains knowledge across sessions.
 
 | Project | Approach |
 |---|---|
-| **Acolyte** | Context distillation to 3-tier persistent memory |
+| **Acolyte** | Context distillation to 3-tier persistent memory with semantic recall |
 | OpenHands | Microagent recall + condenser pipeline |
 | OpenClaw | Vector search via LanceDB |
 | Goose | Session search via MCP |
@@ -249,6 +249,8 @@ Memory tiers:
 - **Session**
 - **Project**
 - **User**
+
+At query time, entries are ranked by semantic similarity to the current task using provider embeddings and cosine similarity. Records without embeddings fall back to recency ordering.
 
 ## Context budgeting
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -51,6 +51,7 @@ Shipped, user-visible capabilities.
 - Context distillation with automatic observation and reflection.
 - Session-scoped distill memory.
 - SQLite-backed persistent storage for distill records.
+- Semantic recall with provider embeddings and cosine similarity ranking.
 
 ## Safety and control
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -73,6 +73,7 @@ The observation/reflection model is inspired by [Mastra's Observational Memory](
 - Aggressive old-turn compaction is driven by typed message metadata (`kind: tool_payload`), not regex heuristics.
 - Debug observability uses lifecycle-scoped events (`lifecycle.memory.load_*`, `lifecycle.memory.commit_*`) through standard debug channels.
 - Commit debug includes promotion counters (`project_promoted_facts`, `user_promoted_facts`, `session_scoped_facts`, `dropped_untagged_facts`).
+- Repeated malformed-tag drops emit `lifecycle.memory.quality_warning` with `malformed_reject_streak` after 3 consecutive commits with malformed tags.
 - Selection dedupes identical entry content to avoid wasting budget on repeats.
 - Normalization drops blank entries before selection.
 - Distill record writes use SQLite with WAL mode for atomic persistence.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -55,7 +55,7 @@ The observation/reflection model is inspired by [Mastra's Observational Memory](
   - Observation lines tagged `[user]` promote to user scope.
   - Session/continuation lines stay in session scope.
   - Untagged fact lines are dropped (strict tagged promotion, no fallback).
-  - Malformed bracket tags (for example `[proj]`) reject the entire session observation batch.
+  - Malformed bracket tags (for example `[proj]`) are silently dropped and logged.
 - Load strategy:
   - Latest reflection first
   - Then post-reflection observations (fresh delta, newest first)
@@ -72,9 +72,7 @@ The observation/reflection model is inspired by [Mastra's Observational Memory](
 - Agent input assembly applies deterministic rolling history fitting (newest-first, truncate-to-fit under remaining budget).
 - Aggressive old-turn compaction is driven by typed message metadata (`kind: tool_payload`), not regex heuristics.
 - Debug observability uses lifecycle-scoped events (`lifecycle.memory.load_*`, `lifecycle.memory.commit_*`) through standard debug channels.
-- Commit debug includes promotion counters (`project_promoted_facts`, `user_promoted_facts`, `session_scoped_facts`, `dropped_untagged_facts`, `malformed_tagged_facts`).
-- Repeated malformed-tag rejects emit `lifecycle.memory.quality_warning` with `malformed_reject_streak`.
-- Server runtime emits a dedicated `memory quality warning` log line for `lifecycle.memory.quality_warning` events.
+- Commit debug includes promotion counters (`project_promoted_facts`, `user_promoted_facts`, `session_scoped_facts`, `dropped_untagged_facts`).
 - Selection dedupes identical entry content to avoid wasting budget on repeats.
 - Normalization drops blank entries before selection.
 - Distill record writes use SQLite with WAL mode for atomic persistence.

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -78,11 +78,13 @@ The observation/reflection model is inspired by [Mastra's Observational Memory](
 - Selection dedupes identical entry content to avoid wasting budget on repeats.
 - Normalization drops blank entries before selection.
 - Distill record writes use SQLite with WAL mode for atomic persistence.
+- Semantic recall: distill records are embedded at write time using the provider embedding API. At query time, the user's message is embedded and entries are ranked by cosine similarity. Records without embeddings fall back to recency ordering. Continuation entries always rank first.
 
 ## Storage
 
 - Stored notes: `.acolyte/memory/{user|project}/*.md`
 - Distill records: `~/.acolyte/memory.db` (SQLite, keyed by `scope_key`: `sess_*`, `proj_*`, or `user_*`).
+- Embeddings: `distill_embeddings` table in `memory.db` (BLOB vectors, keyed by `record_id`).
 
 ## Extension seams
 
@@ -102,5 +104,6 @@ The observation/reflection model is inspired by [Mastra's Observational Memory](
 - `src/memory-source-distill.ts` — Distill memory source with observer and reflector agents.
 - `src/memory-source-stored.ts` — Stored markdown memory source.
 - `src/memory-distill-prompts.ts` — Observer and reflector prompt templates.
-- `src/memory-distill-store.ts` — SQLite-based distill record persistence with legacy filesystem migration.
+- `src/memory-distill-store.ts` — SQLite-based distill record and embedding persistence.
+- `src/memory-embedding.ts` — Provider embedding API wrapper and cosine similarity.
 - `src/memory-store.ts` — Memory store interface for list, add, and remove.

--- a/src/app-config.ts
+++ b/src/app-config.ts
@@ -37,6 +37,9 @@ export const appConfig = {
     budgetTokens: fileConfig.memoryBudgetTokens,
     sources: fileConfig.memorySources,
   },
+  embedding: {
+    model: fileConfig.embeddingModel,
+  },
   agent: {
     contextMaxTokens: fileConfig.contextMaxTokens,
     inputBudget: {

--- a/src/config-contract.ts
+++ b/src/config-contract.ts
@@ -79,6 +79,7 @@ export interface Config {
   maxAttachmentMessageTokens?: number;
   maxPinnedMessageTokens?: number;
   replyTimeoutMs?: number;
+  embeddingModel?: string;
 }
 
 export interface ResolvedConfig {
@@ -104,6 +105,7 @@ export interface ResolvedConfig {
   maxAttachmentMessageTokens: number;
   maxPinnedMessageTokens: number;
   replyTimeoutMs: number;
+  embeddingModel: string;
 }
 
 export const CONFIG_SET_SCHEMAS: Record<keyof Config, z.ZodTypeAny> = {
@@ -129,6 +131,7 @@ export const CONFIG_SET_SCHEMAS: Record<keyof Config, z.ZodTypeAny> = {
   maxAttachmentMessageTokens: parseIntegerSchema(100, MAX_ATTACHMENT_MESSAGE_TOKENS),
   maxPinnedMessageTokens: parseIntegerSchema(100, MAX_PINNED_MESSAGE_TOKENS),
   replyTimeoutMs: parseIntegerSchema(1_000, MAX_RUN_REPLY_TIMEOUT_MS),
+  embeddingModel: nonEmptyStringSchema,
 };
 
 export function toConfig(input: Record<string, unknown>): Config {
@@ -190,5 +193,6 @@ export function toConfig(input: Record<string, unknown>): Config {
       input.maxPinnedMessageTokens,
     ),
     replyTimeoutMs: parseField(parseIntegerSchema(1_000, MAX_RUN_REPLY_TIMEOUT_MS), input.replyTimeoutMs),
+    embeddingModel: parseField(nonEmptyStringSchema, input.embeddingModel),
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,7 @@ function createDefaultConfig() {
     maxAttachmentMessageTokens: 3_000,
     maxPinnedMessageTokens: 1_200,
     replyTimeoutMs: 180_000,
+    embeddingModel: "text-embedding-3-small",
   };
 }
 
@@ -152,6 +153,7 @@ function serializeToml(config: Config): string {
   if (typeof config.maxPinnedMessageTokens === "number")
     lines.push(`maxPinnedMessageTokens = ${config.maxPinnedMessageTokens}`);
   if (typeof config.replyTimeoutMs === "number") lines.push(`replyTimeoutMs = ${config.replyTimeoutMs}`);
+  if (config.embeddingModel) lines.push(`embeddingModel = ${JSON.stringify(config.embeddingModel)}`);
   return `${lines.join("\n")}${lines.length > 0 ? "\n" : ""}`;
 }
 
@@ -183,6 +185,7 @@ function resolveConfig(config: Config): ResolvedConfig {
     maxAttachmentMessageTokens: config.maxAttachmentMessageTokens ?? defaults.maxAttachmentMessageTokens,
     maxPinnedMessageTokens: config.maxPinnedMessageTokens ?? defaults.maxPinnedMessageTokens,
     replyTimeoutMs: config.replyTimeoutMs ?? defaults.replyTimeoutMs,
+    embeddingModel: config.embeddingModel ?? defaults.embeddingModel,
   };
 }
 

--- a/src/memory-contract.ts
+++ b/src/memory-contract.ts
@@ -24,11 +24,13 @@ export type MemoryLoadContext = {
   readonly sessionId?: string;
   readonly resourceId?: ResourceId;
   readonly workspace?: string;
+  readonly query?: string;
 };
 
 export type MemorySourceEntry = {
   readonly content: string;
   readonly isContinuation?: boolean;
+  readonly recordId?: string;
 };
 
 export type MemoryCommitContext = MemoryLoadContext & {

--- a/src/memory-distill-store.test.ts
+++ b/src/memory-distill-store.test.ts
@@ -179,6 +179,56 @@ describe("createSqliteDistillStore", () => {
   });
 });
 
+describe("embedding storage", () => {
+  test("writeEmbedding + getEmbedding round-trips", async () => {
+    const dir = createDir("acolyte-distill-");
+    const store = createStore(dir);
+    const embedding = Buffer.from(new Float32Array([0.1, 0.2, 0.3]).buffer);
+    store.writeEmbedding("dst_emb001", "sess_abc123", embedding);
+    const result = store.getEmbedding("dst_emb001");
+    expect(result).not.toBeNull();
+    if (!result) throw new Error("expected embedding");
+    const arr = new Float32Array(result.buffer, result.byteOffset, result.byteLength / 4);
+    expect(arr[0]).toBeCloseTo(0.1);
+    expect(arr[1]).toBeCloseTo(0.2);
+    expect(arr[2]).toBeCloseTo(0.3);
+  });
+
+  test("getEmbedding returns null for missing record", async () => {
+    const dir = createDir("acolyte-distill-");
+    const store = createStore(dir);
+    expect(store.getEmbedding("dst_missing")).toBeNull();
+  });
+
+  test("removeEmbedding deletes embedding", async () => {
+    const dir = createDir("acolyte-distill-");
+    const store = createStore(dir);
+    const embedding = Buffer.from(new Float32Array([1, 2, 3]).buffer);
+    store.writeEmbedding("dst_rm001", "sess_abc123", embedding);
+    expect(store.getEmbedding("dst_rm001")).not.toBeNull();
+    store.removeEmbedding("dst_rm001");
+    expect(store.getEmbedding("dst_rm001")).toBeNull();
+  });
+
+  test("remove record also removes embedding", async () => {
+    const dir = createDir("acolyte-distill-");
+    const store = createStore(dir);
+    const record: DistillRecord = {
+      id: "dst_cascade1",
+      sessionId: "sess_abc123",
+      tier: "observation",
+      content: "test",
+      createdAt: "2026-03-04T12:00:00.000Z",
+      tokenEstimate: 1,
+    };
+    await store.write(record);
+    store.writeEmbedding(record.id, "sess_abc123", Buffer.from(new Float32Array([1]).buffer));
+    expect(store.getEmbedding(record.id)).not.toBeNull();
+    await store.remove(record.id, "sess_abc123");
+    expect(store.getEmbedding(record.id)).toBeNull();
+  });
+});
+
 describe("migrateFromFilesystem", () => {
   test("migrates JSON files into SQLite store", async () => {
     const home = createDir("acolyte-migrate-");

--- a/src/memory-distill-store.ts
+++ b/src/memory-distill-store.ts
@@ -13,6 +13,7 @@ export interface DistillStore {
   writeEmbedding(recordId: string, scopeKey: string, embedding: Buffer): void;
   removeEmbedding(recordId: string): void;
   getEmbedding(recordId: string): Buffer | null;
+  getEmbeddings(recordIds: string[]): Map<string, Buffer>;
   close(): void;
 }
 
@@ -124,6 +125,16 @@ export function createSqliteDistillStore(dbPath?: string): DistillStore {
     getEmbedding(recordId) {
       const row = getEmbStmt.get(recordId);
       return row ? row.embedding : null;
+    },
+    getEmbeddings(recordIds) {
+      if (recordIds.length === 0) return new Map();
+      const placeholders = recordIds.map(() => "?").join(",");
+      const rows = db
+        .prepare<{ record_id: string; embedding: Buffer }, string[]>(
+          `SELECT record_id, embedding FROM distill_embeddings WHERE record_id IN (${placeholders})`,
+        )
+        .all(...recordIds);
+      return new Map(rows.map((row) => [row.record_id, row.embedding]));
     },
     close() {
       db.close();

--- a/src/memory-distill-store.ts
+++ b/src/memory-distill-store.ts
@@ -10,6 +10,9 @@ export interface DistillStore {
   list(scopeKey: string): Promise<readonly DistillRecord[]>;
   write(record: DistillRecord): Promise<void>;
   remove(id: string, scopeKey: string): Promise<void>;
+  writeEmbedding(recordId: string, scopeKey: string, embedding: Buffer): void;
+  removeEmbedding(recordId: string): void;
+  getEmbedding(recordId: string): Buffer | null;
   close(): void;
 }
 
@@ -31,6 +34,14 @@ function initSchema(db: Database): void {
     )
   `);
   db.run(`CREATE INDEX IF NOT EXISTS idx_distill_scope ON distill_records(scope_key)`);
+  db.run(`
+    CREATE TABLE IF NOT EXISTS distill_embeddings (
+      record_id TEXT PRIMARY KEY,
+      scope_key TEXT NOT NULL,
+      embedding BLOB NOT NULL
+    )
+  `);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_embedding_scope ON distill_embeddings(scope_key)`);
 }
 
 type DistillRow = {
@@ -73,6 +84,13 @@ export function createSqliteDistillStore(dbPath?: string): DistillStore {
      VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
   );
   const removeStmt = db.prepare<void, [string, string]>("DELETE FROM distill_records WHERE id = ? AND scope_key = ?");
+  const writeEmbStmt = db.prepare<void, [string, string, Buffer]>(
+    "INSERT OR REPLACE INTO distill_embeddings (record_id, scope_key, embedding) VALUES (?, ?, ?)",
+  );
+  const removeEmbStmt = db.prepare<void, [string]>("DELETE FROM distill_embeddings WHERE record_id = ?");
+  const getEmbStmt = db.prepare<{ embedding: Buffer }, [string]>(
+    "SELECT embedding FROM distill_embeddings WHERE record_id = ?",
+  );
 
   return {
     async list(scopeKey) {
@@ -95,6 +113,17 @@ export function createSqliteDistillStore(dbPath?: string): DistillStore {
     async remove(id, scopeKey) {
       if (!safeDistillScopeKey(scopeKey)) return;
       removeStmt.run(id, scopeKey);
+      removeEmbStmt.run(id);
+    },
+    writeEmbedding(recordId, scopeKey, embedding) {
+      writeEmbStmt.run(recordId, scopeKey, embedding);
+    },
+    removeEmbedding(recordId) {
+      removeEmbStmt.run(recordId);
+    },
+    getEmbedding(recordId) {
+      const row = getEmbStmt.get(recordId);
+      return row ? row.embedding : null;
     },
     close() {
       db.close();

--- a/src/memory-distill-store.ts
+++ b/src/memory-distill-store.ts
@@ -117,6 +117,7 @@ export function createSqliteDistillStore(dbPath?: string): DistillStore {
       removeEmbStmt.run(id);
     },
     writeEmbedding(recordId, scopeKey, embedding) {
+      if (!safeDistillScopeKey(scopeKey)) return;
       writeEmbStmt.run(recordId, scopeKey, embedding);
     },
     removeEmbedding(recordId) {

--- a/src/memory-embedding.test.ts
+++ b/src/memory-embedding.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { bufferToEmbedding, cosineSimilarity, embeddingToBuffer } from "./memory-embedding";
+
+describe("cosineSimilarity", () => {
+  test("identical vectors return 1", () => {
+    const a = new Float32Array([1, 0, 0]);
+    expect(cosineSimilarity(a, a)).toBeCloseTo(1);
+  });
+
+  test("orthogonal vectors return 0", () => {
+    const a = new Float32Array([1, 0, 0]);
+    const b = new Float32Array([0, 1, 0]);
+    expect(cosineSimilarity(a, b)).toBeCloseTo(0);
+  });
+
+  test("opposite vectors return -1", () => {
+    const a = new Float32Array([1, 0, 0]);
+    const b = new Float32Array([-1, 0, 0]);
+    expect(cosineSimilarity(a, b)).toBeCloseTo(-1);
+  });
+
+  test("similar vectors score higher than dissimilar", () => {
+    const query = new Float32Array([1, 0, 0, 0]);
+    const similar = new Float32Array([0.9, 0.1, 0, 0]);
+    const dissimilar = new Float32Array([0, 1, 0, 0]);
+    expect(cosineSimilarity(query, similar)).toBeGreaterThan(cosineSimilarity(query, dissimilar));
+  });
+
+  test("zero vectors return 0", () => {
+    const a = new Float32Array([0, 0, 0]);
+    const b = new Float32Array([1, 0, 0]);
+    expect(cosineSimilarity(a, b)).toBe(0);
+  });
+});
+
+describe("embedding serialization", () => {
+  test("round-trips through buffer", () => {
+    const original = new Float32Array([0.1, 0.2, 0.3, 0.4]);
+    const buf = embeddingToBuffer(original);
+    const restored = bufferToEmbedding(buf);
+    expect(restored.length).toBe(original.length);
+    for (let i = 0; i < original.length; i++) {
+      expect(restored[i]).toBeCloseTo(original[i]);
+    }
+  });
+});

--- a/src/memory-embedding.ts
+++ b/src/memory-embedding.ts
@@ -1,0 +1,69 @@
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { createOpenAI } from "@ai-sdk/openai";
+import { defaultCredentials } from "./agent-model";
+import { appConfig } from "./app-config";
+import { log } from "./log";
+import { providerFromModel } from "./provider-config";
+
+export function cosineSimilarity(a: Float32Array, b: Float32Array): number {
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  const denom = Math.sqrt(normA) * Math.sqrt(normB);
+  return denom === 0 ? 0 : dot / denom;
+}
+
+export function embeddingToBuffer(embedding: Float32Array): Buffer {
+  return Buffer.from(embedding.buffer, embedding.byteOffset, embedding.byteLength);
+}
+
+export function bufferToEmbedding(buf: Buffer): Float32Array {
+  return new Float32Array(buf.buffer, buf.byteOffset, buf.byteLength / 4);
+}
+
+function createEmbeddingModel(qualifiedModel: string) {
+  const creds = defaultCredentials();
+  const provider = providerFromModel(qualifiedModel);
+  const slash = qualifiedModel.indexOf("/");
+  const modelId = slash >= 0 ? qualifiedModel.slice(slash + 1) : qualifiedModel;
+  const providerCreds = creds[provider] ?? {};
+
+  switch (provider) {
+    case "openai": {
+      const openai = createOpenAI({
+        apiKey: providerCreds.apiKey,
+        ...(providerCreds.baseUrl ? { baseURL: providerCreds.baseUrl } : {}),
+      });
+      return openai.textEmbeddingModel(modelId);
+    }
+    case "google": {
+      const google = createGoogleGenerativeAI({
+        apiKey: providerCreds.apiKey,
+        ...(providerCreds.baseUrl ? { baseURL: providerCreds.baseUrl } : {}),
+      });
+      return google.textEmbeddingModel(modelId);
+    }
+    default:
+      return null;
+  }
+}
+
+export async function embedText(text: string): Promise<Float32Array | null> {
+  const modelId = appConfig.embedding.model;
+  const model = createEmbeddingModel(modelId);
+  if (!model) return null;
+  try {
+    const result = await model.doEmbed({ values: [text] });
+    const raw = result.embeddings[0];
+    if (!raw) return null;
+    return new Float32Array(raw);
+  } catch (error) {
+    log.warn("memory.embedding.failed", { model: modelId, error: String(error) });
+    return null;
+  }
+}

--- a/src/memory-embedding.ts
+++ b/src/memory-embedding.ts
@@ -53,9 +53,19 @@ function createEmbeddingModel(qualifiedModel: string) {
   }
 }
 
-export async function embedText(text: string): Promise<Float32Array | null> {
+let cachedModelId: string | null = null;
+let cachedModel: ReturnType<typeof createEmbeddingModel> = null;
+
+function getEmbeddingModel() {
   const modelId = appConfig.embedding.model;
-  const model = createEmbeddingModel(modelId);
+  if (cachedModelId === modelId && cachedModel) return cachedModel;
+  cachedModel = createEmbeddingModel(modelId);
+  cachedModelId = modelId;
+  return cachedModel;
+}
+
+export async function embedText(text: string): Promise<Float32Array | null> {
+  const model = getEmbeddingModel();
   if (!model) return null;
   try {
     const result = await model.doEmbed({ values: [text] });
@@ -63,7 +73,7 @@ export async function embedText(text: string): Promise<Float32Array | null> {
     if (!raw) return null;
     return new Float32Array(raw);
   } catch (error) {
-    log.warn("memory.embedding.failed", { model: modelId, error: String(error) });
+    log.warn("memory.embedding.failed", { model: appConfig.embedding.model, error: String(error) });
     return null;
   }
 }

--- a/src/memory-pipeline.test.ts
+++ b/src/memory-pipeline.test.ts
@@ -37,7 +37,7 @@ describe("memory pipeline", () => {
       {},
       10_000,
       normalizeMemoryEntries,
-      (entries) => ({
+      async (entries) => ({
         entries: [entries[entries.length - 1]],
         tokenEstimate: entries[entries.length - 1].tokenEstimate,
       }),
@@ -51,7 +51,7 @@ describe("memory pipeline", () => {
       {},
       10_000,
       async () => [{ sourceId: "custom", content: "normalized", tokenEstimate: 2 }],
-      selectMemoryEntries,
+      async (entries, budget) => selectMemoryEntries(entries, budget),
     );
     expect(result.entries.map((entry) => entry.content)).toEqual(["normalized"]);
     expect(result.entries.map((entry) => entry.sourceId)).toEqual(["custom"]);

--- a/src/memory-pipeline.ts
+++ b/src/memory-pipeline.ts
@@ -70,13 +70,13 @@ export function selectMemoryEntries(
   let selectedContinuation = false;
   for (const entry of prioritizedEntries) {
     if (used >= budgetTokens) break;
-    if (entry.isContinuation === true && selectedContinuation) continue;
+    if (entry.isContinuation && selectedContinuation) continue;
     const contentKey = normalizeContentKey(entry.content);
     if (seenContentKeys.has(contentKey)) continue;
     if (entry.tokenEstimate > budgetTokens - used) continue;
     selected.push(entry);
     seenContentKeys.add(contentKey);
-    if (entry.isContinuation === true) selectedContinuation = true;
+    if (entry.isContinuation) selectedContinuation = true;
     used += entry.tokenEstimate;
   }
   return { entries: selected, tokenEstimate: used };
@@ -153,7 +153,7 @@ function prioritizeContinuationEntries(entries: readonly MemoryPipelineEntry[]):
   const other: MemoryPipelineEntry[] = [];
   for (let index = entries.length - 1; index >= 0; index -= 1) {
     const entry = entries[index];
-    if (entry.isContinuation === true) continuation.push(entry);
+    if (entry.isContinuation) continuation.push(entry);
     else other.push(entry);
   }
   return [...continuation, ...other.reverse()];

--- a/src/memory-pipeline.ts
+++ b/src/memory-pipeline.ts
@@ -1,17 +1,21 @@
 import { estimateTokens } from "./agent-input";
 import type { MemoryCommitContext, MemoryCommitMetrics, MemoryLoadContext, MemorySource } from "./memory-contract";
+import type { DistillStore } from "./memory-distill-store";
+import { bufferToEmbedding, cosineSimilarity, embedText } from "./memory-embedding";
 
 export type MemoryPipelineEntry = {
   sourceId: string;
   content: string;
   tokenEstimate: number;
   isContinuation?: boolean;
+  recordId?: string;
 };
 
 export type MemorySelectionStrategy = (
   entries: readonly MemoryPipelineEntry[],
   budgetTokens: number,
-) => { entries: MemoryPipelineEntry[]; tokenEstimate: number };
+  ctx?: MemoryLoadContext,
+) => Promise<{ entries: MemoryPipelineEntry[]; tokenEstimate: number }>;
 
 export type MemoryNormalizeStrategy = (
   sources: readonly MemorySource[],
@@ -23,12 +27,12 @@ export async function runMemoryPipeline(
   ctx: MemoryLoadContext,
   budgetTokens: number,
   normalizeEntries: MemoryNormalizeStrategy = normalizeMemoryEntries,
-  selectEntries: MemorySelectionStrategy = selectMemoryEntries,
+  selectEntries: MemorySelectionStrategy = selectMemoryEntriesSemantic,
 ): Promise<{ entries: MemoryPipelineEntry[]; tokenEstimate: number }> {
   if (budgetTokens <= 0) return { entries: [], tokenEstimate: 0 };
 
   const entries = await normalizeEntries(sources, ctx);
-  return selectEntries(entries, budgetTokens);
+  return selectEntries(entries, budgetTokens, ctx);
 }
 
 export async function normalizeMemoryEntries(
@@ -46,6 +50,7 @@ export async function normalizeMemoryEntries(
         content,
         tokenEstimate: estimateTokens(content),
         isContinuation: entry.isContinuation,
+        recordId: entry.recordId,
       });
     }
   }
@@ -74,6 +79,70 @@ export function selectMemoryEntries(
     if (entry.isContinuation === true) selectedContinuation = true;
     used += entry.tokenEstimate;
   }
+  return { entries: selected, tokenEstimate: used };
+}
+
+let defaultStoreRef: DistillStore | null = null;
+
+export function setDefaultStoreForSelection(store: DistillStore | null): void {
+  defaultStoreRef = store;
+}
+
+export async function selectMemoryEntriesSemantic(
+  entries: readonly MemoryPipelineEntry[],
+  budgetTokens: number,
+  ctx?: MemoryLoadContext,
+): Promise<{ entries: MemoryPipelineEntry[]; tokenEstimate: number }> {
+  if (budgetTokens <= 0) return { entries: [], tokenEstimate: 0 };
+  if (!ctx?.query || !defaultStoreRef) return selectMemoryEntries(entries, budgetTokens);
+
+  const queryEmbedding = await embedText(ctx.query);
+  if (!queryEmbedding) return selectMemoryEntries(entries, budgetTokens);
+
+  const continuation: MemoryPipelineEntry[] = [];
+  const scorable: { entry: MemoryPipelineEntry; score: number }[] = [];
+
+  for (const entry of entries) {
+    if (entry.isContinuation) {
+      continuation.push(entry);
+      continue;
+    }
+    let score = 0;
+    if (entry.recordId) {
+      const buf = defaultStoreRef.getEmbedding(entry.recordId);
+      if (buf) {
+        score = cosineSimilarity(queryEmbedding, bufferToEmbedding(buf));
+      }
+    }
+    scorable.push({ entry, score });
+  }
+
+  scorable.sort((a, b) => b.score - a.score);
+
+  const selected: MemoryPipelineEntry[] = [];
+  const seenContentKeys = new Set<string>();
+  let used = 0;
+  let selectedContinuation = false;
+
+  for (const entry of continuation.reverse()) {
+    if (selectedContinuation) continue;
+    if (entry.tokenEstimate > budgetTokens - used) continue;
+    selected.push(entry);
+    seenContentKeys.add(normalizeContentKey(entry.content));
+    selectedContinuation = true;
+    used += entry.tokenEstimate;
+  }
+
+  for (const { entry } of scorable) {
+    if (used >= budgetTokens) break;
+    const contentKey = normalizeContentKey(entry.content);
+    if (seenContentKeys.has(contentKey)) continue;
+    if (entry.tokenEstimate > budgetTokens - used) continue;
+    selected.push(entry);
+    seenContentKeys.add(contentKey);
+    used += entry.tokenEstimate;
+  }
+
   return { entries: selected, tokenEstimate: used };
 }
 

--- a/src/memory-pipeline.ts
+++ b/src/memory-pipeline.ts
@@ -100,22 +100,24 @@ export async function selectMemoryEntriesSemantic(
   if (!queryEmbedding) return selectMemoryEntries(entries, budgetTokens);
 
   const continuation: MemoryPipelineEntry[] = [];
-  const scorable: { entry: MemoryPipelineEntry; score: number }[] = [];
+  const nonContinuation: MemoryPipelineEntry[] = [];
 
   for (const entry of entries) {
-    if (entry.isContinuation) {
-      continuation.push(entry);
-      continue;
-    }
+    if (entry.isContinuation) continuation.push(entry);
+    else nonContinuation.push(entry);
+  }
+
+  const recordIds = nonContinuation.map((e) => e.recordId).filter((id): id is string => id !== undefined);
+  const embeddingMap = defaultStoreRef.getEmbeddings(recordIds);
+
+  const scorable = nonContinuation.map((entry) => {
     let score = 0;
     if (entry.recordId) {
-      const buf = defaultStoreRef.getEmbedding(entry.recordId);
-      if (buf) {
-        score = cosineSimilarity(queryEmbedding, bufferToEmbedding(buf));
-      }
+      const buf = embeddingMap.get(entry.recordId);
+      if (buf) score = cosineSimilarity(queryEmbedding, bufferToEmbedding(buf));
     }
-    scorable.push({ entry, score });
-  }
+    return { entry, score };
+  });
 
   scorable.sort((a, b) => b.score - a.score);
 

--- a/src/memory-pipeline.ts
+++ b/src/memory-pipeline.ts
@@ -1,6 +1,5 @@
 import { estimateTokens } from "./agent-input";
 import type { MemoryCommitContext, MemoryCommitMetrics, MemoryLoadContext, MemorySource } from "./memory-contract";
-import type { DistillStore } from "./memory-distill-store";
 import { bufferToEmbedding, cosineSimilarity, embedText } from "./memory-embedding";
 
 export type MemoryPipelineEntry = {
@@ -9,6 +8,10 @@ export type MemoryPipelineEntry = {
   tokenEstimate: number;
   isContinuation?: boolean;
   recordId?: string;
+};
+
+export type EmbeddingLookup = {
+  getEmbeddings(recordIds: string[]): Map<string, Buffer>;
 };
 
 export type MemorySelectionStrategy = (
@@ -27,12 +30,13 @@ export async function runMemoryPipeline(
   ctx: MemoryLoadContext,
   budgetTokens: number,
   normalizeEntries: MemoryNormalizeStrategy = normalizeMemoryEntries,
-  selectEntries: MemorySelectionStrategy = selectMemoryEntriesSemantic,
+  selectEntries?: MemorySelectionStrategy,
 ): Promise<{ entries: MemoryPipelineEntry[]; tokenEstimate: number }> {
   if (budgetTokens <= 0) return { entries: [], tokenEstimate: 0 };
 
   const entries = await normalizeEntries(sources, ctx);
-  return selectEntries(entries, budgetTokens, ctx);
+  const select = selectEntries ?? (async (e, b) => selectMemoryEntries(e, b));
+  return select(entries, budgetTokens, ctx);
 }
 
 export async function normalizeMemoryEntries(
@@ -82,70 +86,62 @@ export function selectMemoryEntries(
   return { entries: selected, tokenEstimate: used };
 }
 
-let defaultStoreRef: DistillStore | null = null;
+export function createSemanticSelection(lookup: EmbeddingLookup): MemorySelectionStrategy {
+  return async (entries, budgetTokens, ctx) => {
+    if (budgetTokens <= 0) return { entries: [], tokenEstimate: 0 };
+    if (!ctx?.query) return selectMemoryEntries(entries, budgetTokens);
 
-export function setDefaultStoreForSelection(store: DistillStore | null): void {
-  defaultStoreRef = store;
-}
+    const queryEmbedding = await embedText(ctx.query);
+    if (!queryEmbedding) return selectMemoryEntries(entries, budgetTokens);
 
-export async function selectMemoryEntriesSemantic(
-  entries: readonly MemoryPipelineEntry[],
-  budgetTokens: number,
-  ctx?: MemoryLoadContext,
-): Promise<{ entries: MemoryPipelineEntry[]; tokenEstimate: number }> {
-  if (budgetTokens <= 0) return { entries: [], tokenEstimate: 0 };
-  if (!ctx?.query || !defaultStoreRef) return selectMemoryEntries(entries, budgetTokens);
+    const continuation: MemoryPipelineEntry[] = [];
+    const nonContinuation: MemoryPipelineEntry[] = [];
 
-  const queryEmbedding = await embedText(ctx.query);
-  if (!queryEmbedding) return selectMemoryEntries(entries, budgetTokens);
-
-  const continuation: MemoryPipelineEntry[] = [];
-  const nonContinuation: MemoryPipelineEntry[] = [];
-
-  for (const entry of entries) {
-    if (entry.isContinuation) continuation.push(entry);
-    else nonContinuation.push(entry);
-  }
-
-  const recordIds = nonContinuation.map((e) => e.recordId).filter((id): id is string => id !== undefined);
-  const embeddingMap = defaultStoreRef.getEmbeddings(recordIds);
-
-  const scorable = nonContinuation.map((entry) => {
-    let score = 0;
-    if (entry.recordId) {
-      const buf = embeddingMap.get(entry.recordId);
-      if (buf) score = cosineSimilarity(queryEmbedding, bufferToEmbedding(buf));
+    for (const entry of entries) {
+      if (entry.isContinuation) continuation.push(entry);
+      else nonContinuation.push(entry);
     }
-    return { entry, score };
-  });
 
-  scorable.sort((a, b) => b.score - a.score);
+    const recordIds = nonContinuation.map((e) => e.recordId).filter((id): id is string => id !== undefined);
+    const embeddingMap = lookup.getEmbeddings(recordIds);
 
-  const selected: MemoryPipelineEntry[] = [];
-  const seenContentKeys = new Set<string>();
-  let used = 0;
-  let selectedContinuation = false;
+    const scorable = nonContinuation.map((entry) => {
+      let score = 0;
+      if (entry.recordId) {
+        const buf = embeddingMap.get(entry.recordId);
+        if (buf) score = cosineSimilarity(queryEmbedding, bufferToEmbedding(buf));
+      }
+      return { entry, score };
+    });
 
-  for (const entry of continuation.reverse()) {
-    if (selectedContinuation) continue;
-    if (entry.tokenEstimate > budgetTokens - used) continue;
-    selected.push(entry);
-    seenContentKeys.add(normalizeContentKey(entry.content));
-    selectedContinuation = true;
-    used += entry.tokenEstimate;
-  }
+    scorable.sort((a, b) => b.score - a.score);
 
-  for (const { entry } of scorable) {
-    if (used >= budgetTokens) break;
-    const contentKey = normalizeContentKey(entry.content);
-    if (seenContentKeys.has(contentKey)) continue;
-    if (entry.tokenEstimate > budgetTokens - used) continue;
-    selected.push(entry);
-    seenContentKeys.add(contentKey);
-    used += entry.tokenEstimate;
-  }
+    const selected: MemoryPipelineEntry[] = [];
+    const seenContentKeys = new Set<string>();
+    let used = 0;
+    let selectedContinuation = false;
 
-  return { entries: selected, tokenEstimate: used };
+    for (const entry of continuation.reverse()) {
+      if (selectedContinuation) continue;
+      if (entry.tokenEstimate > budgetTokens - used) continue;
+      selected.push(entry);
+      seenContentKeys.add(normalizeContentKey(entry.content));
+      selectedContinuation = true;
+      used += entry.tokenEstimate;
+    }
+
+    for (const { entry } of scorable) {
+      if (used >= budgetTokens) break;
+      const contentKey = normalizeContentKey(entry.content);
+      if (seenContentKeys.has(contentKey)) continue;
+      if (entry.tokenEstimate > budgetTokens - used) continue;
+      selected.push(entry);
+      seenContentKeys.add(contentKey);
+      used += entry.tokenEstimate;
+    }
+
+    return { entries: selected, tokenEstimate: used };
+  };
 }
 
 function prioritizeContinuationEntries(entries: readonly MemoryPipelineEntry[]): MemoryPipelineEntry[] {

--- a/src/memory-policy.ts
+++ b/src/memory-policy.ts
@@ -1,0 +1,19 @@
+export type MemoryPolicy = {
+  /** Max retries when reflection output exceeds token budget. */
+  reflectionRetryLimit: number;
+  /** Number of recent messages passed to the observer agent. */
+  contextMessageWindow: number;
+  /** Emit quality warning after this many consecutive commits with malformed tags. */
+  malformedStreakWarningThreshold: number;
+};
+
+export const defaultMemoryPolicy: MemoryPolicy = {
+  reflectionRetryLimit: 2,
+  contextMessageWindow: 20,
+  malformedStreakWarningThreshold: 3,
+};
+
+export function resolveMemoryPolicy(override?: Partial<MemoryPolicy>): MemoryPolicy {
+  if (!override) return defaultMemoryPolicy;
+  return { ...defaultMemoryPolicy, ...override };
+}

--- a/src/memory-registry.test.ts
+++ b/src/memory-registry.test.ts
@@ -82,7 +82,7 @@ describe("memory registry", () => {
           contents.map((entry) => ({ sourceId: sources[index].id, content: entry.content, tokenEstimate: 1 })),
         );
       },
-      (entries) => ({ entries: [entries[1]], tokenEstimate: entries[1].tokenEstimate }),
+      async (entries) => ({ entries: [entries[1]], tokenEstimate: entries[1].tokenEstimate }),
     );
     const result = await registry.load({}, 10_000);
     expect(result.prompt).toContain("second");

--- a/src/memory-registry.ts
+++ b/src/memory-registry.ts
@@ -14,6 +14,7 @@ import {
   distillProjectMemorySource,
   distillUserMemorySource,
   extractLastLineValue,
+  getDefaultSelectionStrategy,
 } from "./memory-source-distill";
 import { storedMemorySource } from "./memory-source-stored";
 
@@ -100,7 +101,19 @@ export function createMemoryRegistry(
   };
 }
 
-const defaultMemoryRegistry = createMemoryRegistry();
+let defaultMemoryRegistry: MemoryRegistry | null = null;
 
-export const loadMemoryContext = defaultMemoryRegistry.load;
-export const commitMemorySources = defaultMemoryRegistry.commit;
+function getDefaultMemoryRegistry(): MemoryRegistry {
+  if (!defaultMemoryRegistry) {
+    defaultMemoryRegistry = createMemoryRegistry(
+      DEFAULT_MEMORY_SOURCES,
+      normalizeMemoryEntries,
+      getDefaultSelectionStrategy() ?? undefined,
+    );
+  }
+  return defaultMemoryRegistry;
+}
+
+export const loadMemoryContext: MemoryRegistry["load"] = (ctx, budgetTokens) =>
+  getDefaultMemoryRegistry().load(ctx, budgetTokens);
+export const commitMemorySources: MemoryRegistry["commit"] = (ctx) => getDefaultMemoryRegistry().commit(ctx);

--- a/src/memory-registry.ts
+++ b/src/memory-registry.ts
@@ -73,7 +73,7 @@ export function createMemoryRegistry(
     }[],
   ): { currentTask?: string; nextStep?: string } => {
     const continuationText = entries
-      .filter((entry) => entry.isContinuation === true)
+      .filter((entry) => entry.isContinuation)
       .map((entry) => entry.content)
       .join("\n");
     return {
@@ -90,7 +90,7 @@ export function createMemoryRegistry(
         prompt: formatMemoryContextPrompt(result.entries),
         tokenEstimate: result.tokenEstimate,
         entryCount: result.entries.length,
-        continuationSelected: result.entries.some((entry) => entry.isContinuation === true),
+        continuationSelected: result.entries.some((entry) => entry.isContinuation),
         continuation,
       };
     },

--- a/src/memory-registry.ts
+++ b/src/memory-registry.ts
@@ -8,7 +8,6 @@ import {
   normalizeMemoryEntries,
   runMemoryCommitPipeline,
   runMemoryPipeline,
-  selectMemoryEntries,
 } from "./memory-pipeline";
 import {
   distillMemorySource,
@@ -65,7 +64,7 @@ export const DEFAULT_MEMORY_SOURCES: readonly MemorySource[] = resolveMemorySour
 export function createMemoryRegistry(
   sources: readonly MemorySource[] = DEFAULT_MEMORY_SOURCES,
   normalizeEntries: MemoryNormalizeStrategy = normalizeMemoryEntries,
-  selectEntries: MemorySelectionStrategy = selectMemoryEntries,
+  selectEntries?: MemorySelectionStrategy,
 ): MemoryRegistry {
   const extractContinuation = (
     entries: readonly {

--- a/src/memory-source-distill.test.ts
+++ b/src/memory-source-distill.test.ts
@@ -36,6 +36,9 @@ function createMockStore(
     getEmbedding() {
       return null;
     },
+    getEmbeddings() {
+      return new Map();
+    },
     close() {},
   };
 }

--- a/src/memory-source-distill.test.ts
+++ b/src/memory-source-distill.test.ts
@@ -31,6 +31,11 @@ function createMockStore(
       const idx = records.findIndex((r) => r.id === id);
       if (idx >= 0) records.splice(idx, 1);
     },
+    writeEmbedding() {},
+    removeEmbedding() {},
+    getEmbedding() {
+      return null;
+    },
     close() {},
   };
 }

--- a/src/memory-source-distill.ts
+++ b/src/memory-source-distill.ts
@@ -63,6 +63,7 @@ function embedAndStore(ds: DistillStore, recordId: string, scopeKey: string, con
 const CHARS_PER_TOKEN_ESTIMATE = 4;
 const TEXT_SHRINK_RATIO = 0.9;
 const DISTILL_CONTEXT_MESSAGE_WINDOW = 20;
+const MALFORMED_STREAK_WARNING_THRESHOLD = 3;
 
 function clampToTokenEstimate(content: string, maxTokens: number): string {
   const text = content.trim();
@@ -354,6 +355,7 @@ export function createDistillMemorySource(
   const id = options.id ?? "distill_session";
   const loadScope = options.loadScope ?? "session";
   const commitScope = options.commitScope ?? "session";
+  let malformedRejectStreak = 0;
   return {
     id,
 
@@ -392,7 +394,13 @@ export function createDistillMemorySource(
         log.debug("memory.distill.dropped_untagged", { key, count: scoped.droppedUntaggedCount });
       }
       if (scoped.droppedMalformedCount > 0) {
+        malformedRejectStreak += 1;
         log.debug("memory.distill.dropped_malformed", { key, count: scoped.droppedMalformedCount });
+        if (malformedRejectStreak >= MALFORMED_STREAK_WARNING_THRESHOLD) {
+          log.warn("lifecycle.memory.quality_warning", { key, malformed_reject_streak: malformedRejectStreak });
+        }
+      } else {
+        malformedRejectStreak = 0;
       }
       if (scoped.session) {
         await commitDistillForKey(ds, key, scoped.session, runner, config);

--- a/src/memory-source-distill.ts
+++ b/src/memory-source-distill.ts
@@ -8,6 +8,7 @@ import { OBSERVER_PROMPT, REFLECTOR_PROMPT } from "./memory-distill-prompts";
 import { createSqliteDistillStore, type DistillStore, migrateFromFilesystem } from "./memory-distill-store";
 import { embeddingToBuffer, embedText } from "./memory-embedding";
 import { createSemanticSelection, type MemorySelectionStrategy } from "./memory-pipeline";
+import { defaultMemoryPolicy, type MemoryPolicy } from "./memory-policy";
 import { createModel } from "./model-factory";
 import { normalizeModel } from "./provider-config";
 import { defaultUserResourceId, parseResourceId, projectResourceIdFromWorkspace, type ResourceId } from "./resource-id";
@@ -39,7 +40,6 @@ export function getDefaultSelectionStrategy(): MemorySelectionStrategy | null {
   getDefaultStore();
   return defaultSelectionStrategy;
 }
-const REFLECTION_RETRY_LIMIT = 2;
 
 type DistillScope = "session" | "project" | "user";
 
@@ -48,6 +48,7 @@ type DistillSourceOptions = {
   loadScope?: DistillScope;
   commitScope?: DistillScope | "none";
   config?: DistillConfig;
+  policy?: MemoryPolicy;
 };
 
 function embedAndStore(ds: DistillStore, recordId: string, scopeKey: string, content: string): void {
@@ -62,8 +63,6 @@ function embedAndStore(ds: DistillStore, recordId: string, scopeKey: string, con
 
 const CHARS_PER_TOKEN_ESTIMATE = 4;
 const TEXT_SHRINK_RATIO = 0.9;
-const DISTILL_CONTEXT_MESSAGE_WINDOW = 20;
-const MALFORMED_STREAK_WARNING_THRESHOLD = 3;
 
 function clampToTokenEstimate(content: string, maxTokens: number): string {
   const text = content.trim();
@@ -284,6 +283,7 @@ async function commitDistillForKey(
   observed: string,
   runner: DistillRunner,
   config: DistillConfig,
+  policy: MemoryPolicy,
 ): Promise<void> {
   const existingEntries = await ds.list(key);
   const latestObservation = existingEntries.filter((e) => e.tier === "observation").slice(-1)[0];
@@ -314,7 +314,7 @@ async function commitDistillForKey(
 
   const allObservations = pendingObservations.map((o) => o.content).join("\n\n---\n\n");
   let reflected = "";
-  for (let attempt = 0; attempt <= REFLECTION_RETRY_LIMIT; attempt += 1) {
+  for (let attempt = 0; attempt <= policy.reflectionRetryLimit; attempt += 1) {
     const promptSuffix =
       attempt === 0
         ? ""
@@ -352,6 +352,7 @@ export function createDistillMemorySource(
 ): MemorySource {
   const ds = injectedStore ?? getDefaultStore();
   const config = options.config ?? defaultDistillConfig();
+  const policy = options.policy ?? defaultMemoryPolicy;
   const id = options.id ?? "distill_session";
   const loadScope = options.loadScope ?? "session";
   const commitScope = options.commitScope ?? "session";
@@ -371,7 +372,7 @@ export function createDistillMemorySource(
       if (!key) return;
       if (ctx.messages.length < config.messageThreshold) return;
 
-      const recentMessages = ctx.messages.slice(-DISTILL_CONTEXT_MESSAGE_WINDOW);
+      const recentMessages = ctx.messages.slice(-policy.contextMessageWindow);
       const distillInput = [...recentMessages, { role: "assistant", content: ctx.output }]
         .map((m) => `${m.role}: ${m.content}`)
         .join("\n\n");
@@ -379,7 +380,7 @@ export function createDistillMemorySource(
       const observed = clampToTokenEstimate(observedRaw, config.maxOutputTokens);
       if (!observed.trim()) return;
       if (commitScope !== "session") {
-        await commitDistillForKey(ds, key, observed, runner, config);
+        await commitDistillForKey(ds, key, observed, runner, config, policy);
         const observedFactCount = observed.split(/\r?\n/).filter((line) => line.trim()).length;
         return {
           projectPromotedFacts: commitScope === "project" ? observedFactCount : 0,
@@ -396,23 +397,23 @@ export function createDistillMemorySource(
       if (scoped.droppedMalformedCount > 0) {
         malformedRejectStreak += 1;
         log.debug("memory.distill.dropped_malformed", { key, count: scoped.droppedMalformedCount });
-        if (malformedRejectStreak >= MALFORMED_STREAK_WARNING_THRESHOLD) {
+        if (malformedRejectStreak >= policy.malformedStreakWarningThreshold) {
           log.warn("lifecycle.memory.quality_warning", { key, malformed_reject_streak: malformedRejectStreak });
         }
       } else {
         malformedRejectStreak = 0;
       }
       if (scoped.session) {
-        await commitDistillForKey(ds, key, scoped.session, runner, config);
+        await commitDistillForKey(ds, key, scoped.session, runner, config, policy);
       }
 
       if (scoped.project) {
         const projectKey = resolveDistillScopeKey("project", ctx);
-        if (projectKey) await commitDistillForKey(ds, projectKey, scoped.project, runner, config);
+        if (projectKey) await commitDistillForKey(ds, projectKey, scoped.project, runner, config, policy);
       }
       if (scoped.user) {
         const userKey = resolveDistillScopeKey("user", ctx);
-        if (userKey) await commitDistillForKey(ds, userKey, scoped.user, runner, config);
+        if (userKey) await commitDistillForKey(ds, userKey, scoped.user, runner, config, policy);
       }
       log.debug("memory.distill.commit_done", {
         key,

--- a/src/memory-source-distill.ts
+++ b/src/memory-source-distill.ts
@@ -48,7 +48,9 @@ function embedAndStore(ds: DistillStore, recordId: string, scopeKey: string, con
     .then((vec) => {
       if (vec) ds.writeEmbedding(recordId, scopeKey, embeddingToBuffer(vec));
     })
-    .catch(() => {});
+    .catch((error) => {
+      log.warn("memory.distill.embed_failed", { recordId, error: String(error) });
+    });
 }
 
 const CHARS_PER_TOKEN_ESTIMATE = 4;

--- a/src/memory-source-distill.ts
+++ b/src/memory-source-distill.ts
@@ -6,6 +6,8 @@ import { log } from "./log";
 import type { DistillRecord, MemoryCommitMetrics, MemorySource, MemorySourceEntry } from "./memory-contract";
 import { OBSERVER_PROMPT, REFLECTOR_PROMPT } from "./memory-distill-prompts";
 import { createSqliteDistillStore, type DistillStore, migrateFromFilesystem } from "./memory-distill-store";
+import { embeddingToBuffer, embedText } from "./memory-embedding";
+import { setDefaultStoreForSelection } from "./memory-pipeline";
 import { createModel } from "./model-factory";
 import { normalizeModel } from "./provider-config";
 import { defaultUserResourceId, parseResourceId, projectResourceIdFromWorkspace, type ResourceId } from "./resource-id";
@@ -22,6 +24,7 @@ let defaultStore: DistillStore | null = null;
 function getDefaultStore(): DistillStore {
   if (!defaultStore) {
     defaultStore = createSqliteDistillStore();
+    setDefaultStoreForSelection(defaultStore);
     migrateFromFilesystem(homedir(), defaultStore).catch((error) => {
       log.warn("memory.distill.migration_failed", { error: String(error) });
     });
@@ -39,6 +42,14 @@ type DistillSourceOptions = {
   commitScope?: DistillScope | "none";
   config?: DistillConfig;
 };
+
+function embedAndStore(ds: DistillStore, recordId: string, scopeKey: string, content: string): void {
+  embedText(content)
+    .then((vec) => {
+      if (vec) ds.writeEmbedding(recordId, scopeKey, embeddingToBuffer(vec));
+    })
+    .catch(() => {});
+}
 
 const CHARS_PER_TOKEN_ESTIMATE = 4;
 const TEXT_SHRINK_RATIO = 0.9;
@@ -229,12 +240,12 @@ async function loadEntriesForKey(ds: DistillStore, key: string): Promise<readonl
     const mostRecent = observationsSinceReflection[0] ?? latestReflection;
     const reflectionContent = stripContinuationLines(latestReflection.content);
     return [
-      ...(reflectionContent ? [{ content: reflectionContent }] : []),
-      ...observationsSinceReflection
-        .map((e) => stripContinuationLines(e.content))
-        .filter((content) => content.length > 0)
-        .map((content) => ({ content })),
-      ...continuationEntries(mostRecent).map((content) => ({ content, isContinuation: true })),
+      ...(reflectionContent ? [{ content: reflectionContent, recordId: latestReflection.id }] : []),
+      ...observationsSinceReflection.flatMap((e) => {
+        const content = stripContinuationLines(e.content);
+        return content.length > 0 ? [{ content, recordId: e.id }] : [];
+      }),
+      ...continuationEntries(mostRecent).map((content) => ({ content, isContinuation: true as const })),
     ];
   }
   const observationEntries = entries
@@ -243,11 +254,11 @@ async function loadEntriesForKey(ds: DistillStore, key: string): Promise<readonl
     .reverse();
   const mostRecent = observationEntries[0];
   return [
-    ...observationEntries
-      .map((e) => stripContinuationLines(e.content))
-      .filter((content) => content.length > 0)
-      .map((content) => ({ content })),
-    ...continuationEntries(mostRecent).map((content) => ({ content, isContinuation: true })),
+    ...observationEntries.flatMap((e) => {
+      const content = stripContinuationLines(e.content);
+      return content.length > 0 ? [{ content, recordId: e.id }] : [];
+    }),
+    ...continuationEntries(mostRecent).map((content) => ({ content, isContinuation: true as const })),
   ];
 }
 
@@ -272,6 +283,7 @@ async function commitDistillForKey(
     tokenEstimate: estimateTokens(observed),
   };
   await ds.write(observation);
+  embedAndStore(ds, observation.id, key, observed);
   log.debug("memory.distill.observation_written", { key, id: observation.id, tokens: observation.tokenEstimate });
 
   const entries = [...existingEntries, observation];
@@ -308,6 +320,7 @@ async function commitDistillForKey(
     tokenEstimate: estimateTokens(reflected),
   };
   await ds.write(reflection);
+  embedAndStore(ds, reflection.id, key, reflected);
   log.debug("memory.distill.reflection_written", { key, id: reflection.id, tokens: reflection.tokenEstimate });
 
   // GC: remove all prior observations and reflections now consolidated into the new reflection.

--- a/src/memory-source-distill.ts
+++ b/src/memory-source-distill.ts
@@ -7,7 +7,7 @@ import type { DistillRecord, MemoryCommitMetrics, MemorySource, MemorySourceEntr
 import { OBSERVER_PROMPT, REFLECTOR_PROMPT } from "./memory-distill-prompts";
 import { createSqliteDistillStore, type DistillStore, migrateFromFilesystem } from "./memory-distill-store";
 import { embeddingToBuffer, embedText } from "./memory-embedding";
-import { setDefaultStoreForSelection } from "./memory-pipeline";
+import { createSemanticSelection, type MemorySelectionStrategy } from "./memory-pipeline";
 import { createModel } from "./model-factory";
 import { normalizeModel } from "./provider-config";
 import { defaultUserResourceId, parseResourceId, projectResourceIdFromWorkspace, type ResourceId } from "./resource-id";
@@ -21,16 +21,23 @@ export type DistillConfig = {
 };
 
 let defaultStore: DistillStore | null = null;
+let defaultSelectionStrategy: MemorySelectionStrategy | null = null;
+
 function getDefaultStore(): DistillStore {
   if (!defaultStore) {
     defaultStore = createSqliteDistillStore();
-    setDefaultStoreForSelection(defaultStore);
+    defaultSelectionStrategy = createSemanticSelection(defaultStore);
     migrateFromFilesystem(homedir(), defaultStore).catch((error) => {
       log.warn("memory.distill.migration_failed", { error: String(error) });
     });
     process.on("exit", () => defaultStore?.close());
   }
   return defaultStore;
+}
+
+export function getDefaultSelectionStrategy(): MemorySelectionStrategy | null {
+  getDefaultStore();
+  return defaultSelectionStrategy;
 }
 const REFLECTION_RETRY_LIMIT = 2;
 

--- a/src/memory-source-distill.ts
+++ b/src/memory-source-distill.ts
@@ -137,6 +137,7 @@ function splitScopedObservation(observed: string): {
   projectCount: number;
   userCount: number;
   droppedUntaggedCount: number;
+  droppedMalformedCount: number;
 } {
   const lines = observed
     .split(/\r?\n/)
@@ -146,13 +147,17 @@ function splitScopedObservation(observed: string): {
   const projectLines: string[] = [];
   const userLines: string[] = [];
   let droppedUntaggedCount = 0;
+  let droppedMalformedCount = 0;
   for (const line of lines) {
     if (isContinuationLine(line)) {
       sessionLines.push(line);
       continue;
     }
     const tagged = stripScopeTag(line);
-    if (!tagged.scope && hasBracketPrefix(line)) continue;
+    if (!tagged.scope && hasBracketPrefix(line)) {
+      droppedMalformedCount += 1;
+      continue;
+    }
     if (!tagged.content) continue;
     // Continuation state is always session-scoped, regardless of any tag prefix.
     if (isContinuationLine(tagged.content)) {
@@ -183,6 +188,7 @@ function splitScopedObservation(observed: string): {
     projectCount: projectLines.length,
     userCount: userLines.length,
     droppedUntaggedCount,
+    droppedMalformedCount,
   };
 }
 
@@ -377,6 +383,9 @@ export function createDistillMemorySource(
       const scoped = splitScopedObservation(observed);
       if (scoped.droppedUntaggedCount > 0) {
         log.debug("memory.distill.dropped_untagged", { key, count: scoped.droppedUntaggedCount });
+      }
+      if (scoped.droppedMalformedCount > 0) {
+        log.debug("memory.distill.dropped_malformed", { key, count: scoped.droppedMalformedCount });
       }
       if (scoped.session) {
         await commitDistillForKey(ds, key, scoped.session, runner, config);

--- a/src/server-chat-runtime.ts
+++ b/src/server-chat-runtime.ts
@@ -185,6 +185,7 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
       sessionId: chatRequest.sessionId,
       resourceId: canonicalResourceId,
       workspace: workspaceResolution.workspacePath,
+      query: chatRequest.message,
       useMemory: chatRequest.useMemory !== false,
       onDebug: (event, fields) => {
         log.info("agent debug", {

--- a/src/soul.ts
+++ b/src/soul.ts
@@ -46,6 +46,7 @@ type CreateSoulPromptOptions = {
   sessionId?: string;
   resourceId?: ResourceId;
   workspace?: string;
+  query?: string;
   useMemory?: boolean;
   memoryBudgetTokens?: number;
   onDebug?: (event: string, fields?: Record<string, unknown>) => void;
@@ -78,7 +79,12 @@ export async function createSoulPrompt(options: CreateSoulPromptOptions = {}): P
     return { prompt: base, memoryTokens: 0 };
   }
   const memoryContext = await loadMemoryContext(
-    { sessionId: options.sessionId, resourceId: options.resourceId, workspace: options.workspace },
+    {
+      sessionId: options.sessionId,
+      resourceId: options.resourceId,
+      workspace: options.workspace,
+      query: options.query,
+    },
     budgetTokens,
   );
   const memoryPrompt = memoryContext.prompt;


### PR DESCRIPTION
## Summary

- embed distill records at write time using provider embedding API
- store embeddings as BLOBs in SQLite alongside distill records
- rank memory entries by cosine similarity at query time
- thread user message as query through soul prompt to selection pipeline
- fall back to recency ordering for records without embeddings
- add embeddingModel config field (default: text-embedding-3-small)
- batch embedding lookups with single SQL query
- cache embedding model instance across calls
- no new dependencies

Fixes #12