### PR TITLE
feat(tools): persist tool cache with SQLite

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -31,7 +31,7 @@ Shipped, user-visible capabilities.
 - Tool-guarded execution for safer autonomous runs.
 - Streaming progress output for tool activity with real-time token usage.
 - Proactive token budgeting via tiktoken with system prompt reservation and priority-based allocation.
-- Per-task LRU result cache for read-only and search tools.
+- Two-tier result cache for read-only and search tools with SQLite-backed cross-task persistence.
 
 ## Tools
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -48,7 +48,7 @@ Naming conventions and core terms used across Acolyte code and docs.
 - **Step Budget**: guard that enforces per-cycle and total limits on tool calls to prevent runaway loops.
 - **Task**: lifecycle work request flowing through accept/queue/run/terminal states.
 - **Task Queue**: runtime queue policy/mechanism that orders accepted tasks and enforces capacity/cancellation boundaries.
-- **Tool Cache**: per-task LRU cache for read-only and search tool results. Invalidated on writes; shell commands clear the entire cache.
+- **Tool Cache**: two-tier cache for read-only and search tool results. L1 is an in-memory LRU per task; L2 is SQLite-backed persistence across tasks within a session. Invalidated on writes; shell commands clear both tiers.
 - **Tool Recovery**: structured recovery payload attached to a tool failure when the tool knows the corrective action. Carries `tool`, `kind`, `summary`, and `instruction`, and may include next-step hints like `nextTool` or `targetPaths`, so lifecycle can regenerate with targeted recovery guidance instead of host-side string matching.
 - **Toolkit**: grouped domain tools exposed through adapters/composition.
 - **Verify Cycle**: post-write verification sequence that runs when verification is enabled for the request scope; the evaluator transitions to verify mode, performs the lightest sufficient scoped verification or review, and re-generates on failure.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,38 +6,26 @@ One terminal-first AI coding agent for day-to-day development across projects an
 Opinionated for the 80% default workflow, with stable extension points for customization.
 Built for safe autonomous execution of bounded tasks with the developer in control.
 
-## What shipped at launch
+## Shipped
 
-Acolyte v0 ships with these capabilities:
-
-- **Foundations** — `bun run verify` runs lint, typecheck, and tests; CI passes on every commit
-- **Core UX** — setup, diagnostics, per-tool permissions, error recovery
-- **Execution engine** — 5-phase lifecycle (resolve → prepare → generate → evaluate → finalize) with streaming tool calls
-- **Reliability** — anti-loop guards, step budgets, actionable diagnostics, automatic verify cycles
-- **Autonomous execution** — bounded coding tasks end-to-end: edit, verify, recover
-- **Memory** — context distillation across session/project/user tiers, proactive token budgeting, rolling history pruning
-- **Product polish** — typed RPC protocol, task-centric execution, skill parity, visual regression coverage
-- **Extensibility** — interface-first boundaries for lifecycle, tools, guards, memory, and transport
-- **OSS readiness** — docs, license, CI/CD, security baseline, localization, configurable locale
+- 5-phase lifecycle with streaming tool calls, guards, and automatic verify cycles
+- Context distillation with 3-tier persistent memory (session/project/user)
+- Semantic recall with provider embeddings and cosine similarity ranking
+- SQLite-backed storage for distill records, embeddings, and lifecycle traces
+- AST-aware structural editing via ast-grep
+- Custom React terminal renderer with single input pipeline
+- Typed RPC protocol with task state machine
+- Lifecycle observability via `acolyte trace`
+- Skills system with declarative SKILL.md standard
+- Multi-provider support (OpenAI, Anthropic, Google)
 
 ## What's next
 
-Priorities for the near term, roughly ordered.
+Tracked in [GitHub Issues](https://github.com/cniska/acolyte/issues). Key priorities:
 
-1. **Memory hardening** — evals for repeated instruction failures, hallucination checks, semantic recall via vector search
-2. **Chat correctness** — end-to-end regression checks, cross-session memory continuity, edge case coverage
-3. **Codebase polish** — audit/cleanup pass, `.gitignore`-based file discovery, config-driven permissions
-4. **Early adopter feedback** — day-one value on real projects, usability fixes from first users
-5. **Cloud sync** — shared storage services (memory, sessions), auth, local-first fallback
-
-## Further out
-
-- **Memory scalability** — progressive compaction for ultra-long sessions, storage backends beyond filesystem
-- **Autonomy track** — bounded-task soak testing, failure explainability, stable protocol baseline
-- **Long-run tasks** — background task IDs, detach/attach flow, task lifecycle RPC methods
-- **Session workflows** — branching and session-tree navigation for isolated sub-tasks
-- **Safety controls** — stronger tool policy, opt-in guard/evaluator policy controls
-- **Tooling fidelity** — structured progress payloads, output truncation with on-demand full, output collapsing
-- **Extension surface** — runtime hooks, agent-authored skills, slash command extensions
-- **Embedding surface** — SDK-first local in-process API alongside CLI/RPC
-- **Plan mode** — automatic planning phase from request intent, read-only tool set, lifecycle-driven plan→work transition
+- **Structured log format** — JSON log output for daemon (#34)
+- **Logs command** — CLI access to daemon logs (#32)
+- **Tool cache persistence** — SQLite-backed cross-task tool cache (#38)
+- **Trace event subscription** — real-time trace events over RPC (#45)
+- **Plan mode** — lifecycle-driven planning phase with read-only tool set (#14)
+- **Required-input handoff** — structured model-to-user handoff for decisions (#17)

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -32,12 +32,12 @@ Entries in `IGNORED_DIRS` take precedence and cannot be re-included by gitignore
 
 ## Tool result cache
 
-Read-only and search tools (`read-file`, `find-files`, `search-files`, `scan-code`) are cached per-task. Identical calls return the cached result without re-executing.
+Read-only and search tools (`read-file`, `find-files`, `search-files`, `scan-code`) are cached. Identical calls return the cached result without re-executing.
 
 - **Key**: deterministic `toolName:stableJSON(args)` — object keys sorted for stability
 - **Invalidation**: write tools (`edit-file`, `create-file`, `delete-file`) evict entries with overlapping paths; `run-command` clears the entire cache
-- **Scope**: one cache per task, discarded when the task ends
-- **Eviction**: LRU (least recently used) with a default cap of 256 entries
+- **L1 (in-memory)**: per-task LRU with a default cap of 256 entries, discarded when the task ends
+- **L2 (SQLite)**: persists path-tracked entries (`read-file`, `scan-code`) across tasks within a session in `~/.acolyte/tool.db`, cleared on session switch
 
 This reduces redundant I/O and avoids re-sending identical tool results to the model.
 

--- a/src/lifecycle-prepare.ts
+++ b/src/lifecycle-prepare.ts
@@ -21,6 +21,7 @@ export function phasePrepare(input: PhasePrepareInput): PhasePrepareResult {
     workspace: input.workspace,
     onOutput: input.onOutput,
     taskId: input.taskId,
+    sessionId: input.request.sessionId,
   });
   const toolTokens = estimateToolTokens(tools);
   const requestInput = createAgentInput(input.request, { systemPromptTokens, toolTokens });

--- a/src/memory-distill-store.test.ts
+++ b/src/memory-distill-store.test.ts
@@ -3,26 +3,24 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { DistillRecord } from "./memory-contract";
 import { createSqliteDistillStore, migrateFromFilesystem } from "./memory-distill-store";
-import { tempDir } from "./test-utils";
+import { tempDb, tempDir } from "./test-utils";
 
+const { create: createStore, cleanup: cleanupStores } = tempDb("acolyte-distill-", createSqliteDistillStore);
 const { createDir, cleanupDirs } = tempDir();
-afterEach(cleanupDirs);
-
-function createStore(dir: string) {
-  return createSqliteDistillStore(join(dir, "test.db"));
-}
+afterEach(() => {
+  cleanupStores();
+  cleanupDirs();
+});
 
 describe("createSqliteDistillStore", () => {
   test("list returns empty for nonexistent session", async () => {
-    const dir = createDir("acolyte-distill-");
-    const store = createStore(dir);
+    const store = createStore();
     const records = await store.list("sess_nonexistent");
     expect(records).toEqual([]);
   });
 
   test("write + list round-trips a record", async () => {
-    const dir = createDir("acolyte-distill-");
-    const store = createStore(dir);
+    const store = createStore();
     const record: DistillRecord = {
       id: "dst_test001",
       sessionId: "sess_abc123",
@@ -38,8 +36,7 @@ describe("createSqliteDistillStore", () => {
   });
 
   test("list returns records sorted chronologically", async () => {
-    const dir = createDir("acolyte-distill-");
-    const store = createStore(dir);
+    const store = createStore();
     const older: DistillRecord = {
       id: "dst_older001",
       sessionId: "sess_abc123",
@@ -64,8 +61,7 @@ describe("createSqliteDistillStore", () => {
   });
 
   test("list isolates sessions", async () => {
-    const dir = createDir("acolyte-distill-");
-    const store = createStore(dir);
+    const store = createStore();
     const record1: DistillRecord = {
       id: "dst_sess1rec",
       sessionId: "sess_session1",
@@ -93,8 +89,7 @@ describe("createSqliteDistillStore", () => {
   });
 
   test("remove deletes a record by id and scope key", async () => {
-    const dir = createDir("acolyte-distill-");
-    const store = createStore(dir);
+    const store = createStore();
     const record: DistillRecord = {
       id: "dst_rmtest01",
       sessionId: "sess_abc123",
@@ -110,15 +105,13 @@ describe("createSqliteDistillStore", () => {
   });
 
   test("remove is a no-op for nonexistent record", async () => {
-    const dir = createDir("acolyte-distill-");
-    const store = createStore(dir);
+    const store = createStore();
     await store.remove("dst_missing01", "sess_abc123");
     expect(await store.list("sess_abc123")).toHaveLength(0);
   });
 
   test("write replaces existing record with same id", async () => {
-    const dir = createDir("acolyte-distill-");
-    const store = createStore(dir);
+    const store = createStore();
     const record: DistillRecord = {
       id: "dst_replace1",
       sessionId: "sess_abc123",
@@ -135,8 +128,7 @@ describe("createSqliteDistillStore", () => {
   });
 
   test("ignores unsafe session ids", async () => {
-    const dir = createDir("acolyte-distill-");
-    const store = createStore(dir);
+    const store = createStore();
     const records = await store.list("../escape");
     expect(records).toEqual([]);
 
@@ -154,8 +146,7 @@ describe("createSqliteDistillStore", () => {
   });
 
   test("supports resource-scoped distill keys", async () => {
-    const dir = createDir("acolyte-distill-");
-    const store = createStore(dir);
+    const store = createStore();
     const userRecord: DistillRecord = {
       id: "dst_user001",
       sessionId: "user_abc123",
@@ -181,8 +172,7 @@ describe("createSqliteDistillStore", () => {
 
 describe("embedding storage", () => {
   test("writeEmbedding + getEmbedding round-trips", async () => {
-    const dir = createDir("acolyte-distill-");
-    const store = createStore(dir);
+    const store = createStore();
     const embedding = Buffer.from(new Float32Array([0.1, 0.2, 0.3]).buffer);
     store.writeEmbedding("dst_emb001", "sess_abc123", embedding);
     const result = store.getEmbedding("dst_emb001");
@@ -195,14 +185,12 @@ describe("embedding storage", () => {
   });
 
   test("getEmbedding returns null for missing record", async () => {
-    const dir = createDir("acolyte-distill-");
-    const store = createStore(dir);
+    const store = createStore();
     expect(store.getEmbedding("dst_missing")).toBeNull();
   });
 
   test("removeEmbedding deletes embedding", async () => {
-    const dir = createDir("acolyte-distill-");
-    const store = createStore(dir);
+    const store = createStore();
     const embedding = Buffer.from(new Float32Array([1, 2, 3]).buffer);
     store.writeEmbedding("dst_rm001", "sess_abc123", embedding);
     expect(store.getEmbedding("dst_rm001")).not.toBeNull();
@@ -211,8 +199,7 @@ describe("embedding storage", () => {
   });
 
   test("remove record also removes embedding", async () => {
-    const dir = createDir("acolyte-distill-");
-    const store = createStore(dir);
+    const store = createStore();
     const record: DistillRecord = {
       id: "dst_cascade1",
       sessionId: "sess_abc123",

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -37,6 +37,26 @@ export async function createTempDir(prefix: string): Promise<string> {
   return mkdtemp(join(tmpdir(), prefix));
 }
 
+export function tempDb<T extends { close(): void }>(
+  prefix: string,
+  factory: (dbPath: string) => T,
+): { create: () => T; cleanup: () => void } {
+  const { createDir, cleanupDirs } = tempDir();
+  const stores: T[] = [];
+  return {
+    create() {
+      const dir = createDir(prefix);
+      const store = factory(join(dir, "test.db"));
+      stores.push(store);
+      return store;
+    },
+    cleanup() {
+      for (const store of stores.splice(0, stores.length)) store.close();
+      cleanupDirs();
+    },
+  };
+}
+
 export function testUuid(): string {
   return Bun.randomUUIDv7();
 }

--- a/src/tool-cache-store.test.ts
+++ b/src/tool-cache-store.test.ts
@@ -1,48 +1,31 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { join } from "node:path";
-import { tempDir } from "./test-utils";
-import { createToolCacheStore, type ToolCacheStore } from "./tool-cache-store";
+import { tempDb } from "./test-utils";
+import { createToolCacheStore } from "./tool-cache-store";
 
-const { createDir, cleanupDirs } = tempDir();
-
-const stores: ToolCacheStore[] = [];
-afterEach(() => {
-  for (const store of stores) store.close();
-  stores.length = 0;
-  cleanupDirs();
-});
-
-function createStore(dir: string) {
-  const store = createToolCacheStore(join(dir, "test.db"));
-  stores.push(store);
-  return store;
-}
+const { create, cleanup } = tempDb("acolyte-cache-", createToolCacheStore);
+afterEach(cleanup);
 
 describe("createToolCacheStore", () => {
   test("get returns null for missing key", () => {
-    const dir = createDir("acolyte-cache-");
-    const store = createStore(dir);
+    const store = create();
     expect(store.get("missing")).toBeNull();
   });
 
   test("set + get round-trips", () => {
-    const dir = createDir("acolyte-cache-");
-    const store = createStore(dir);
+    const store = create();
     store.set("key1", '{"result":"hello"}', ["/src/a.ts"]);
     expect(store.get("key1")).toBe('{"result":"hello"}');
   });
 
   test("set replaces existing entry", () => {
-    const dir = createDir("acolyte-cache-");
-    const store = createStore(dir);
+    const store = create();
     store.set("key1", "v1", []);
     store.set("key1", "v2", []);
     expect(store.get("key1")).toBe("v2");
   });
 
   test("invalidateByPath removes entries with matching paths", () => {
-    const dir = createDir("acolyte-cache-");
-    const store = createStore(dir);
+    const store = create();
     store.set("key1", "v1", ["/src/a.ts"]);
     store.set("key2", "v2", ["/src/b.ts"]);
     store.set("key3", "v3", ["/src/a.ts", "/src/c.ts"]);
@@ -54,16 +37,14 @@ describe("createToolCacheStore", () => {
   });
 
   test("invalidateByPath with empty paths returns 0", () => {
-    const dir = createDir("acolyte-cache-");
-    const store = createStore(dir);
+    const store = create();
     store.set("key1", "v1", ["/src/a.ts"]);
     expect(store.invalidateByPath([])).toBe(0);
     expect(store.get("key1")).toBe("v1");
   });
 
   test("clear removes all entries", () => {
-    const dir = createDir("acolyte-cache-");
-    const store = createStore(dir);
+    const store = create();
     store.set("key1", "v1", ["/src/a.ts"]);
     store.set("key2", "v2", ["/src/b.ts"]);
     store.clear();

--- a/src/tool-cache-store.test.ts
+++ b/src/tool-cache-store.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { tempDir } from "./test-utils";
+import { createToolCacheStore, type ToolCacheStore } from "./tool-cache-store";
+
+const { createDir, cleanupDirs } = tempDir();
+
+const stores: ToolCacheStore[] = [];
+afterEach(() => {
+  for (const store of stores) store.close();
+  stores.length = 0;
+  cleanupDirs();
+});
+
+function createStore(dir: string) {
+  const store = createToolCacheStore(join(dir, "test.db"));
+  stores.push(store);
+  return store;
+}
+
+describe("createToolCacheStore", () => {
+  test("get returns null for missing key", () => {
+    const dir = createDir("acolyte-cache-");
+    const store = createStore(dir);
+    expect(store.get("missing")).toBeNull();
+  });
+
+  test("set + get round-trips", () => {
+    const dir = createDir("acolyte-cache-");
+    const store = createStore(dir);
+    store.set("key1", '{"result":"hello"}', ["/src/a.ts"]);
+    expect(store.get("key1")).toBe('{"result":"hello"}');
+  });
+
+  test("set replaces existing entry", () => {
+    const dir = createDir("acolyte-cache-");
+    const store = createStore(dir);
+    store.set("key1", "v1", []);
+    store.set("key1", "v2", []);
+    expect(store.get("key1")).toBe("v2");
+  });
+
+  test("invalidateByPath removes entries with matching paths", () => {
+    const dir = createDir("acolyte-cache-");
+    const store = createStore(dir);
+    store.set("key1", "v1", ["/src/a.ts"]);
+    store.set("key2", "v2", ["/src/b.ts"]);
+    store.set("key3", "v3", ["/src/a.ts", "/src/c.ts"]);
+    const removed = store.invalidateByPath(["/src/a.ts"]);
+    expect(removed).toBe(2);
+    expect(store.get("key1")).toBeNull();
+    expect(store.get("key2")).toBe("v2");
+    expect(store.get("key3")).toBeNull();
+  });
+
+  test("invalidateByPath with empty paths returns 0", () => {
+    const dir = createDir("acolyte-cache-");
+    const store = createStore(dir);
+    store.set("key1", "v1", ["/src/a.ts"]);
+    expect(store.invalidateByPath([])).toBe(0);
+    expect(store.get("key1")).toBe("v1");
+  });
+
+  test("clear removes all entries", () => {
+    const dir = createDir("acolyte-cache-");
+    const store = createStore(dir);
+    store.set("key1", "v1", ["/src/a.ts"]);
+    store.set("key2", "v2", ["/src/b.ts"]);
+    store.clear();
+    expect(store.get("key1")).toBeNull();
+    expect(store.get("key2")).toBeNull();
+  });
+});

--- a/src/tool-cache-store.ts
+++ b/src/tool-cache-store.ts
@@ -1,0 +1,97 @@
+import { Database } from "bun:sqlite";
+import { mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { log } from "./log";
+
+export interface ToolCacheStore {
+  get(key: string): string | null;
+  set(key: string, value: string, paths: string[]): void;
+  invalidateByPath(paths: string[]): number;
+  clear(): void;
+  close(): void;
+}
+
+function initSchema(db: Database): void {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS tool_cache (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    )
+  `);
+  db.run(`
+    CREATE TABLE IF NOT EXISTS tool_cache_paths (
+      key TEXT NOT NULL,
+      path TEXT NOT NULL,
+      PRIMARY KEY (key, path)
+    )
+  `);
+  db.run(`CREATE INDEX IF NOT EXISTS idx_cache_path ON tool_cache_paths(path)`);
+}
+
+export function createToolCacheStore(dbPath?: string): ToolCacheStore {
+  const resolvedPath = dbPath ?? join(homedir(), ".acolyte", "tool.db");
+  mkdirSync(dirname(resolvedPath), { recursive: true });
+  const db = new Database(resolvedPath, { create: true });
+  db.run("PRAGMA journal_mode = WAL");
+  initSchema(db);
+  log.debug("tool.cache.store_opened", { path: resolvedPath });
+
+  const getStmt = db.prepare<{ value: string }, [string]>("SELECT value FROM tool_cache WHERE key = ?");
+  const setStmt = db.prepare<void, [string, string]>("INSERT OR REPLACE INTO tool_cache (key, value) VALUES (?, ?)");
+  const setPathStmt = db.prepare<void, [string, string]>(
+    "INSERT OR IGNORE INTO tool_cache_paths (key, path) VALUES (?, ?)",
+  );
+  const deleteStmt = db.prepare<void, [string]>("DELETE FROM tool_cache WHERE key = ?");
+  const deletePathsStmt = db.prepare<void, [string]>("DELETE FROM tool_cache_paths WHERE key = ?");
+
+  return {
+    get(key) {
+      const row = getStmt.get(key);
+      return row ? row.value : null;
+    },
+    set(key, value, paths) {
+      setStmt.run(key, value);
+      deletePathsStmt.run(key);
+      for (const path of paths) {
+        setPathStmt.run(key, path);
+      }
+    },
+    invalidateByPath(paths) {
+      if (paths.length === 0) return 0;
+      const placeholders = paths.map(() => "?").join(",");
+      const keys = db
+        .prepare<{ key: string }, string[]>(`SELECT DISTINCT key FROM tool_cache_paths WHERE path IN (${placeholders})`)
+        .all(...paths);
+      for (const { key } of keys) {
+        deleteStmt.run(key);
+        deletePathsStmt.run(key);
+      }
+      return keys.length;
+    },
+    clear() {
+      db.run("DELETE FROM tool_cache");
+      db.run("DELETE FROM tool_cache_paths");
+    },
+    close() {
+      db.close();
+    },
+  };
+}
+
+let defaultStore: ToolCacheStore | null = null;
+let lastSessionId: string | null = null;
+
+export function getDefaultToolCacheStore(sessionId?: string): ToolCacheStore {
+  if (!defaultStore) {
+    defaultStore = createToolCacheStore();
+    process.on("exit", () => defaultStore?.close());
+  }
+  if (sessionId && lastSessionId && sessionId !== lastSessionId) {
+    defaultStore.clear();
+    log.debug("tool.cache.session_switch", { from: lastSessionId, to: sessionId });
+  }
+  if (sessionId) lastSessionId = sessionId;
+  return defaultStore;
+}

--- a/src/tool-cache.test.ts
+++ b/src/tool-cache.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { tempDb } from "./test-utils";
 import { createToolCache } from "./tool-cache";
+import { createToolCacheStore } from "./tool-cache-store";
 
 const CACHEABLE = new Set(["read-file", "find-files", "search-files", "scan-code"]);
+const { create: createStore, cleanup } = tempDb("acolyte-cache-l2-", createToolCacheStore);
+afterEach(cleanup);
 
 describe("tool-cache", () => {
   test("isCacheable returns true for read/search tools", () => {
@@ -206,5 +210,61 @@ describe("tool-cache", () => {
     expect(stats.hits).toBe(2);
     expect(stats.invalidations).toBe(1);
     expect(stats.size).toBe(0);
+  });
+});
+
+describe("L2 SQLite integration", () => {
+  test("L1 miss falls back to L2 hit", () => {
+    const store = createStore();
+    const cache1 = createToolCache(CACHEABLE, 256, store);
+    cache1.set("read-file", { paths: [{ path: "/a.ts" }] }, { result: "content-a" });
+
+    // New L1 cache, same L2 store — simulates a new task
+    const cache2 = createToolCache(CACHEABLE, 256, store);
+    const entry = cache2.get("read-file", { paths: [{ path: "/a.ts" }] });
+    expect(entry).toBeDefined();
+    expect(entry?.result).toBe("content-a");
+  });
+
+  test("pathless entries are not persisted to L2", () => {
+    const store = createStore();
+    const cache1 = createToolCache(CACHEABLE, 256, store);
+    cache1.set("search-files", { patterns: ["foo"] }, { result: "found" });
+
+    const cache2 = createToolCache(CACHEABLE, 256, store);
+    expect(cache2.get("search-files", { patterns: ["foo"] })).toBeUndefined();
+  });
+
+  test("write invalidation propagates to L2", () => {
+    const store = createStore();
+    const cache1 = createToolCache(CACHEABLE, 256, store);
+    cache1.set("read-file", { paths: [{ path: "/a.ts" }] }, { result: "old" });
+
+    cache1.invalidateForWrite("edit-file", { path: "/a.ts" });
+
+    const cache2 = createToolCache(CACHEABLE, 256, store);
+    expect(cache2.get("read-file", { paths: [{ path: "/a.ts" }] })).toBeUndefined();
+  });
+
+  test("run-command clears L2", () => {
+    const store = createStore();
+    const cache1 = createToolCache(CACHEABLE, 256, store);
+    cache1.set("read-file", { paths: [{ path: "/a.ts" }] }, { result: "content" });
+
+    cache1.invalidateForWrite("run-command", {});
+
+    const cache2 = createToolCache(CACHEABLE, 256, store);
+    expect(cache2.get("read-file", { paths: [{ path: "/a.ts" }] })).toBeUndefined();
+  });
+
+  test("clear propagates to L2", () => {
+    const store = createStore();
+    const cache1 = createToolCache(CACHEABLE, 256, store);
+    cache1.set("read-file", { paths: [{ path: "/a.ts" }] }, { result: "content" });
+
+    cache1.clear();
+
+    const cache2 = createToolCache(CACHEABLE, 256, store);
+    expect(cache2.get("read-file", { paths: [{ path: "/a.ts" }] })).toBeUndefined();
   });
 });

--- a/src/tool-cache.ts
+++ b/src/tool-cache.ts
@@ -1,4 +1,5 @@
 import { extractReadPaths, normalizePath } from "./tool-arg-paths";
+import type { ToolCacheStore } from "./tool-cache-store";
 import type { ToolCache, ToolCacheEntry } from "./tool-contract";
 
 function stableKey(toolName: string, args: Record<string, unknown>): string {
@@ -37,7 +38,11 @@ function extractCachedPaths(toolName: string, args: Record<string, unknown>): st
 
 const DEFAULT_MAX_ENTRIES = 256;
 
-export function createToolCache(cacheableTools: ReadonlySet<string>, maxEntries = DEFAULT_MAX_ENTRIES): ToolCache {
+export function createToolCache(
+  cacheableTools: ReadonlySet<string>,
+  maxEntries = DEFAULT_MAX_ENTRIES,
+  store?: ToolCacheStore,
+): ToolCache {
   const cache = new Map<string, ToolCacheEntry>();
   const keyPaths = new Map<string, string[]>();
   let hits = 0;
@@ -54,20 +59,44 @@ export function createToolCache(cacheableTools: ReadonlySet<string>, maxEntries 
     }
   }
 
+  function deserialize(raw: string): ToolCacheEntry | undefined {
+    try {
+      return JSON.parse(raw) as ToolCacheEntry;
+    } catch {
+      return undefined;
+    }
+  }
+
   return {
     isCacheable: (toolName: string) => cacheableTools.has(toolName),
 
     get(toolName, args) {
       if (!cacheableTools.has(toolName)) return undefined;
       const key = stableKey(toolName, args);
+
+      // L1: in-memory
       const entry = cache.get(key);
       if (entry) {
-        // Move to end for LRU ordering
         cache.delete(key);
         cache.set(key, entry);
         hits += 1;
         return entry;
       }
+
+      // L2: SQLite store
+      if (store) {
+        const raw = store.get(key);
+        if (raw) {
+          const restored = deserialize(raw);
+          if (restored) {
+            if (cache.size >= maxEntries) evictOldest();
+            cache.set(key, restored);
+            hits += 1;
+            return restored;
+          }
+        }
+      }
+
       misses += 1;
       return undefined;
     },
@@ -84,6 +113,17 @@ export function createToolCache(cacheableTools: ReadonlySet<string>, maxEntries 
       cache.set(key, entry);
       const paths = extractCachedPaths(toolName, args);
       if (paths.length > 0) keyPaths.set(key, paths);
+
+      // Persist to L2 only for entries with tracked paths.
+      // Pathless entries (search/find) are L1-only since they can't be
+      // invalidated by targeted writes in L2.
+      if (store && paths.length > 0) {
+        try {
+          store.set(key, JSON.stringify(entry), paths);
+        } catch {
+          // Non-fatal — L1 cache still works.
+        }
+      }
     },
 
     populateSubEntries(toolName, args, result) {
@@ -91,10 +131,8 @@ export function createToolCache(cacheableTools: ReadonlySet<string>, maxEntries 
       const paths = args.paths;
       if (!Array.isArray(paths) || paths.length < 2) return;
       if (typeof result !== "string") return;
-      // readSnippets joins sections with "\n\n", each starting with "File: /abs/path"
       const sections = result.split("\n\nFile: ");
       if (sections.length < 2) return;
-      // First section already starts with "File: ", rest had it stripped by split
       const normalized = [sections[0], ...sections.slice(1).map((s) => `File: ${s}`)];
       for (let i = 0; i < normalized.length && i < paths.length; i++) {
         const entry = paths[i];
@@ -106,7 +144,6 @@ export function createToolCache(cacheableTools: ReadonlySet<string>, maxEntries 
         if (pathEntry.start !== undefined) subArg.start = pathEntry.start;
         if (pathEntry.end !== undefined) subArg.end = pathEntry.end;
         this.set(toolName, { paths: [subArg] }, { result: normalized[i] });
-        // Also store under rangeless key so future reads of the same file hit cache.
         if (pathEntry.start !== undefined || pathEntry.end !== undefined) {
           const rangelessKey = stableKey(toolName, { paths: [{ path: p }] });
           if (!cache.has(rangelessKey)) {
@@ -122,6 +159,7 @@ export function createToolCache(cacheableTools: ReadonlySet<string>, maxEntries 
         cache.clear();
         keyPaths.clear();
         invalidations += removed;
+        store?.clear();
         return;
       }
       const writtenPaths = extractWrittenPaths(toolName, args);
@@ -134,6 +172,7 @@ export function createToolCache(cacheableTools: ReadonlySet<string>, maxEntries 
             invalidations += 1;
           }
         }
+        store?.invalidateByPath(writtenPaths);
       }
       // Evict entries without tracked paths (search/find) since they may reference written files
       const toEvict: string[] = [];
@@ -149,6 +188,7 @@ export function createToolCache(cacheableTools: ReadonlySet<string>, maxEntries 
     clear() {
       cache.clear();
       keyPaths.clear();
+      store?.clear();
     },
 
     stats() {

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -6,6 +6,7 @@ import { createFileToolkit } from "./file-toolkit";
 import { createGitToolkit } from "./git-toolkit";
 import { createShellToolkit } from "./shell-toolkit";
 import { createToolCache } from "./tool-cache";
+import { getDefaultToolCacheStore } from "./tool-cache-store";
 import type { ToolCategory, ToolDefinition, ToolkitDeps, ToolkitInput, ToolPermission } from "./tool-contract";
 import { createSessionContext, type SessionContext } from "./tool-guards";
 import type { ToolOutputListener } from "./tool-output-format";
@@ -117,13 +118,18 @@ export const READ_TOOL_SET = new Set<string>(READ_TOOLS);
 export const SEARCH_TOOL_SET = new Set<string>(SEARCH_TOOLS);
 export const DISCOVERY_TOOL_SET = new Set<string>(DISCOVERY_TOOLS);
 
-export function toolsForAgent(options?: { workspace?: string; onOutput?: ToolOutputListener; taskId?: string }): {
+export function toolsForAgent(options?: {
+  workspace?: string;
+  onOutput?: ToolOutputListener;
+  taskId?: string;
+  sessionId?: string;
+}): {
   tools: Toolset;
   session: SessionContext;
 } {
   const workspace = options?.workspace ?? resolve(process.cwd());
   const session = createSessionContext(options?.taskId, WRITE_TOOL_SET);
-  session.cache = createToolCache(DISCOVERY_TOOL_SET);
+  session.cache = createToolCache(DISCOVERY_TOOL_SET, undefined, getDefaultToolCacheStore(options?.sessionId));
   return {
     tools: collectTools(workspace, session, options?.onOutput) as unknown as Toolset,
     session,

--- a/src/trace-store.test.ts
+++ b/src/trace-store.test.ts
@@ -1,15 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { join } from "node:path";
-import { tempDir } from "./test-utils";
-import type { TraceEntry } from "./trace-store";
-import { createTraceStore } from "./trace-store";
+import { tempDb } from "./test-utils";
+import { createTraceStore, type TraceEntry } from "./trace-store";
 
-const { createDir, cleanupDirs } = tempDir();
-afterEach(cleanupDirs);
-
-function createStore(dir: string) {
-  return createTraceStore(join(dir, "test-trace.db"));
-}
+const { create: createStore, cleanup } = tempDb("acolyte-trace-", createTraceStore);
+afterEach(cleanup);
 
 function entry(overrides: Partial<TraceEntry> = {}): TraceEntry {
   return {
@@ -26,8 +20,7 @@ function entry(overrides: Partial<TraceEntry> = {}): TraceEntry {
 
 describe("createTraceStore", () => {
   test("write + listByTaskId round-trips an entry", () => {
-    const dir = createDir("acolyte-trace-");
-    const store = createStore(dir);
+    const store = createStore();
     store.write(entry());
     const lines = store.listByTaskId("task_1");
     expect(lines).toHaveLength(1);
@@ -37,19 +30,15 @@ describe("createTraceStore", () => {
     expect(lines[0]?.fields.event).toBe("lifecycle.start");
     expect(lines[0]?.fields.model).toBe("gpt-5-mini");
     expect(lines[0]?.fields.mode).toBe("work");
-    store.close();
   });
 
   test("listByTaskId returns empty for unknown task", () => {
-    const dir = createDir("acolyte-trace-");
-    const store = createStore(dir);
+    const store = createStore();
     expect(store.listByTaskId("task_missing")).toEqual([]);
-    store.close();
   });
 
   test("listByTaskId isolates tasks", () => {
-    const dir = createDir("acolyte-trace-");
-    const store = createStore(dir);
+    const store = createStore();
     store.write(entry({ taskId: "task_a", event: "lifecycle.start" }));
     store.write(entry({ taskId: "task_b", event: "lifecycle.summary" }));
     const a = store.listByTaskId("task_a");
@@ -58,12 +47,10 @@ describe("createTraceStore", () => {
     expect(a[0]?.fields.event).toBe("lifecycle.start");
     expect(b).toHaveLength(1);
     expect(b[0]?.fields.event).toBe("lifecycle.summary");
-    store.close();
   });
 
   test("listByTaskId preserves insertion order", () => {
-    const dir = createDir("acolyte-trace-");
-    const store = createStore(dir);
+    const store = createStore();
     store.write(entry({ timestamp: "2026-03-20T10:00:00.000Z", event: "lifecycle.start" }));
     store.write(entry({ timestamp: "2026-03-20T10:00:01.000Z", event: "lifecycle.generate.start" }));
     store.write(entry({ timestamp: "2026-03-20T10:00:02.000Z", event: "lifecycle.summary" }));
@@ -72,44 +59,36 @@ describe("createTraceStore", () => {
     expect(lines[0]?.fields.event).toBe("lifecycle.start");
     expect(lines[1]?.fields.event).toBe("lifecycle.generate.start");
     expect(lines[2]?.fields.event).toBe("lifecycle.summary");
-    store.close();
   });
 
   test("listTasks returns tasks ordered newest first", () => {
-    const dir = createDir("acolyte-trace-");
-    const store = createStore(dir);
+    const store = createStore();
     store.write(entry({ taskId: "task_old", timestamp: "2026-03-20T09:00:00.000Z" }));
     store.write(entry({ taskId: "task_new", timestamp: "2026-03-20T10:00:00.000Z" }));
     const tasks = store.listTasks(10);
     expect(tasks).toHaveLength(2);
     expect(tasks[0]?.taskId).toBe("task_new");
     expect(tasks[1]?.taskId).toBe("task_old");
-    store.close();
   });
 
   test("listTasks respects limit", () => {
-    const dir = createDir("acolyte-trace-");
-    const store = createStore(dir);
+    const store = createStore();
     for (let i = 0; i < 5; i++) {
       store.write(entry({ taskId: `task_${i}`, timestamp: `2026-03-20T10:0${i}:00.000Z` }));
     }
     const tasks = store.listTasks(3);
     expect(tasks).toHaveLength(3);
-    store.close();
   });
 
   test("listTasks extracts model from lifecycle.start fields", () => {
-    const dir = createDir("acolyte-trace-");
-    const store = createStore(dir);
+    const store = createStore();
     store.write(entry({ taskId: "task_m", event: "lifecycle.start", fields: { model: "gpt-5", mode: "work" } }));
     const tasks = store.listTasks(10);
     expect(tasks[0]?.model).toBe("gpt-5");
-    store.close();
   });
 
   test("listTasks detects hasError from lifecycle.summary", () => {
-    const dir = createDir("acolyte-trace-");
-    const store = createStore(dir);
+    const store = createStore();
     store.write(entry({ taskId: "task_err", event: "lifecycle.start" }));
     store.write(
       entry({
@@ -121,12 +100,10 @@ describe("createTraceStore", () => {
     );
     const tasks = store.listTasks(10);
     expect(tasks[0]?.hasError).toBe(true);
-    store.close();
   });
 
   test("listTasks returns hasError false when no error", () => {
-    const dir = createDir("acolyte-trace-");
-    const store = createStore(dir);
+    const store = createStore();
     store.write(entry({ taskId: "task_ok", event: "lifecycle.start" }));
     store.write(
       entry({
@@ -138,15 +115,12 @@ describe("createTraceStore", () => {
     );
     const tasks = store.listTasks(10);
     expect(tasks[0]?.hasError).toBe(false);
-    store.close();
   });
 
   test("raw field is empty string for SQLite-sourced lines", () => {
-    const dir = createDir("acolyte-trace-");
-    const store = createStore(dir);
+    const store = createStore();
     store.write(entry());
     const lines = store.listByTaskId("task_1");
     expect(lines[0]?.raw).toBe("");
-    store.close();
   });
 });


### PR DESCRIPTION
## Summary

- add SQLite L2 store for tool cache in ~/.acolyte/tool.db
- persist path-tracked entries (read-file, scan-code) across tasks
- pathless entries (search/find) stay in-memory only
- clear store on session switch
- update tooling, glossary, and features docs

Fixes #38