### PR TITLE
feat(lifecycle): wait for user input on blocked signal

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -12,7 +12,7 @@ resolve → prepare → generate → evaluate → finalize
 - **prepare**: build base agent input, tools, session context, and policy state
 - **generate**: run model + tool loop for one attempt; the model may also emit a lifecycle signal (`done`, `no_op`, `blocked`) alongside its final text
 - **evaluate**: accept a valid lifecycle signal or apply evaluators and choose `done` or bounded regeneration
-- **finalize**: emit final response and lifecycle summary events
+- **finalize**: emit final response and lifecycle summary events; a `blocked` signal maps to `ChatResponseState = "awaiting-input"`, signaling the TUI to show a waiting indicator until the user replies
 
 ## Regeneration model
 

--- a/src/agent-instructions.ts
+++ b/src/agent-instructions.ts
@@ -17,7 +17,7 @@ const BASE_INSTRUCTIONS = [
   "Never summarize, recap, or list what you did. The user can see your actions directly.",
   "Make reasonable assumptions to keep momentum; ask only when blocked by ambiguity or risk.",
   "When lint or format checks fail, run the project auto-fix command (if available) before attempting manual repairs.",
-  "When the task is complete, already needs no changes, or you are blocked, end the final response with exactly one control line on its own line: `@signal done`, `@signal no_op`, or `@signal blocked`.",
+  "When the task is complete or needs no changes, end the final response with `@signal done` or `@signal no_op` on its own line. When you cannot proceed without information only the user can provide, use `@signal blocked` — this stops execution; the user must reply before work continues. On the next line, write a concise message stating: what is missing, why it is needed, and what you will do once you have the answer.",
 ];
 
 export function createModeInstructions(mode: AgentMode, workspace?: string): string {

--- a/src/api.ts
+++ b/src/api.ts
@@ -30,7 +30,8 @@ export interface ChatRequest {
   readonly workspace?: string;
 }
 
-export type ChatResponseState = "done" | "awaiting-input";
+export const chatResponseStateSchema = z.enum(["done", "awaiting-input"]);
+export type ChatResponseState = z.infer<typeof chatResponseStateSchema>;
 
 export interface ChatResponse {
   state: ChatResponseState;

--- a/src/api.ts
+++ b/src/api.ts
@@ -30,7 +30,10 @@ export interface ChatRequest {
   readonly workspace?: string;
 }
 
+export type ChatResponseState = "done" | "awaiting-input";
+
 export interface ChatResponse {
+  state: ChatResponseState;
   output: string;
   model: string;
   usage?: TokenUsage;

--- a/src/chat-message-handler-stream.int.test.ts
+++ b/src/chat-message-handler-stream.int.test.ts
@@ -23,7 +23,7 @@ describe("chat message handler stream behavior", () => {
             toolName: "run-command",
             content: { kind: "tool-header", labelKey: "tool.label.run", detail: "echo hi" },
           });
-          return { model: "gpt-5-mini", output: "done" };
+          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
         },
         status: async () => ({}),
       }),
@@ -44,6 +44,7 @@ describe("chat message handler stream behavior", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         reply: async () => ({
+          state: "done" as const,
           model: "gpt-5-mini",
           output: "done",
           toolCalls: ["run-command"],
@@ -75,7 +76,7 @@ describe("chat message handler stream behavior", () => {
             toolName: "search-files",
             isError: false,
           });
-          return { model: "gpt-5-mini", output: "No matches found." };
+          return { state: "done" as const, model: "gpt-5-mini", output: "No matches found." };
         },
       }),
     });
@@ -138,7 +139,7 @@ describe("chat message handler stream behavior", () => {
         reply: async () => {
           calls += 1;
           if (calls === 1) throw new Error("Remote server stream timed out after 120000ms");
-          return { model: "gpt-5-mini", output: "ok" };
+          return { state: "done" as const, model: "gpt-5-mini", output: "ok" };
         },
       }),
     });
@@ -264,6 +265,7 @@ describe("chat message handler stream behavior", () => {
           { type: "text-delta", text: "This is a long streamed answer that should not be truncated at finalize." },
         ],
         reply: async () => ({
+          state: "done" as const,
           model: "gpt-5-mini",
           output: finalOutput,
         }),
@@ -293,6 +295,7 @@ describe("chat message handler stream behavior", () => {
           },
         ],
         reply: async () => ({
+          state: "done" as const,
           model: "gpt-5-mini",
           output: "done",
         }),
@@ -334,6 +337,7 @@ describe("chat message handler stream behavior", () => {
           },
         ],
         reply: async () => ({
+          state: "done" as const,
           model: "gpt-5-mini",
           output: "done",
         }),
@@ -355,8 +359,8 @@ describe("chat message handler stream behavior", () => {
 
   test("does not merge tool rows across separate user turns", async () => {
     const replies = [
-      { model: "gpt-5-mini", output: "first done" },
-      { model: "gpt-5-mini", output: "second done" },
+      { state: "done" as const, model: "gpt-5-mini", output: "first done" },
+      { state: "done" as const, model: "gpt-5-mini", output: "second done" },
     ];
     const eventsByTurn: StreamEvent[][] = [
       [
@@ -400,7 +404,7 @@ describe("chat message handler stream behavior", () => {
           for (const event of events) {
             options.onEvent(event);
           }
-          return replies[turn] ?? { model: "gpt-5-mini", output: "done" };
+          return replies[turn] ?? { state: "done" as const, model: "gpt-5-mini", output: "done" };
         },
       }),
     });
@@ -422,6 +426,7 @@ describe("chat message handler stream behavior", () => {
       client: createClient({
         status: async () => ({}),
         reply: async () => ({
+          state: "done" as const,
           model: "gpt-5-mini",
           output: "done",
           usage: {
@@ -460,7 +465,7 @@ describe("chat message handler stream behavior", () => {
         replyCount += 1;
         options.onEvent({ type: "status", state: { kind: "running", mode: "work" } });
         options.onEvent({ type: "text-delta", text: `delta-${replyCount}` });
-        return { model: "gpt-5-mini", output: `reply-${replyCount}` };
+        return { state: "done" as const, model: "gpt-5-mini", output: `reply-${replyCount}` };
       },
     });
 
@@ -556,7 +561,7 @@ describe("chat message handler stream behavior", () => {
             toolCallId: "call_1",
             toolName: "run-command",
           });
-          return { model: "gpt-5-mini", output: "I will run the command." };
+          return { state: "done" as const, model: "gpt-5-mini", output: "I will run the command." };
         },
         status: async () => ({}),
       }),
@@ -611,7 +616,7 @@ describe("chat message handler stream behavior", () => {
             toolCallId: "call_B",
             toolName: "edit-code",
           });
-          return { model: "gpt-5-mini", output: "done" };
+          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
         },
         status: async () => ({}),
       }),

--- a/src/chat-message-handler.int.test.ts
+++ b/src/chat-message-handler.int.test.ts
@@ -145,7 +145,7 @@ describe("chat message handler guards", () => {
       client: createClient({
         reply: async (input) => {
           requestedModel = input.model;
-          return { model: input.model, output: "ok" };
+          return { state: "done" as const, model: input.model, output: "ok" };
         },
       }),
     });
@@ -157,12 +157,13 @@ describe("chat message handler guards", () => {
 
   test("keeps create-edit-delete tool output visible across submits", async () => {
     const replies = [
-      { model: "gpt-5-mini", output: "Created sum.rs." },
+      { state: "done" as const, model: "gpt-5-mini", output: "Created sum.rs." },
       {
+        state: "done" as const,
         model: "gpt-5-mini",
         output: "Updated sum.rs for three args.",
       },
-      { model: "gpt-5-mini", output: "Removed sum.rs." },
+      { state: "done" as const, model: "gpt-5-mini", output: "Removed sum.rs." },
     ];
     const eventsByTurn: StreamEvent[][] = [
       [
@@ -215,7 +216,7 @@ describe("chat message handler guards", () => {
           for (const event of events) {
             options.onEvent(event);
           }
-          return replies[turn] ?? { model: "gpt-5-mini", output: "done" };
+          return replies[turn] ?? { state: "done" as const, model: "gpt-5-mini", output: "done" };
         },
       }),
     });
@@ -358,7 +359,7 @@ describe("chat message handler guards", () => {
               options?.signal?.addEventListener("abort", abort, { once: true });
             });
           }
-          return { model: "gpt-5-mini", output: "Second answer." };
+          return { state: "done" as const, model: "gpt-5-mini", output: "Second answer." };
         },
         status: async () => ({}),
       }),
@@ -424,7 +425,7 @@ describe("chat message handler guards", () => {
       client: createClient({
         reply: async () => {
           replyCalls += 1;
-          return { model: "gpt-5-mini", output: "ok" };
+          return { state: "done" as const, model: "gpt-5-mini", output: "ok" };
         },
         status: async () => ({}),
       }),
@@ -482,7 +483,7 @@ describe("chat message handler guards", () => {
         client: createClient({
           reply: async () => {
             replyCalls += 1;
-            return { model: "gpt-5-mini", output: "ok" };
+            return { state: "done" as const, model: "gpt-5-mini", output: "ok" };
           },
           status: async () => ({}),
         }),

--- a/src/chat-turn.test.ts
+++ b/src/chat-turn.test.ts
@@ -44,6 +44,7 @@ describe("chat turn helpers", () => {
     const turn = await runAssistantTurn({
       client: {
         replyStream: async () => ({
+          state: "done" as const,
           model: "gpt-5-mini",
           output: "done",
         }),
@@ -72,6 +73,7 @@ describe("chat turn helpers", () => {
     const turn = await runAssistantTurn({
       client: {
         replyStream: async () => ({
+          state: "done" as const,
           model: "gpt-5-mini",
           output: "done",
           toolCalls: ["read-file"],

--- a/src/chat-turn.ts
+++ b/src/chat-turn.ts
@@ -124,16 +124,20 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
 
     modelCalls: reply.modelCalls,
   };
-  const durationMs = Date.now() - params.pendingStartedAt;
-  if (durationMs >= 300) {
-    const duration = formatDuration(durationMs);
-    const toolCount = reply.toolCalls?.length ?? 0;
-    const totalTokens = tokenEntry.usage.totalTokens;
-    const details: string[] = [];
-    if (toolCount > 0) details.push(t("unit.tool", { count: toolCount }));
-    if (totalTokens > 0) details.push(formatTokenCount(totalTokens));
-    const suffix = details.length > 0 ? ` (${details.join(" · ")})` : "";
-    rows.push(createRow("status", t("chat.worked", { duration, suffix }), { marker: palette.success, dim: true }));
+  if (reply.state === "awaiting-input") {
+    rows.push(createRow("status", t("chat.awaiting_input"), { marker: palette.brand, dim: true }));
+  } else {
+    const durationMs = Date.now() - params.pendingStartedAt;
+    if (durationMs >= 300) {
+      const duration = formatDuration(durationMs);
+      const toolCount = reply.toolCalls?.length ?? 0;
+      const totalTokens = tokenEntry.usage.totalTokens;
+      const details: string[] = [];
+      if (toolCount > 0) details.push(t("unit.tool", { count: toolCount }));
+      if (totalTokens > 0) details.push(formatTokenCount(totalTokens));
+      const suffix = details.length > 0 ? ` (${details.join(" · ")})` : "";
+      rows.push(createRow("status", t("chat.worked", { duration, suffix }), { marker: palette.success, dim: true }));
+    }
   }
 
   return {

--- a/src/cli-prompt.test.ts
+++ b/src/cli-prompt.test.ts
@@ -24,7 +24,12 @@ describe("cli-prompt", () => {
       tokenUsage: [],
     };
     const client: Client = {
-      replyStream: async () => ({ output: "done", model: "gpt-5-mini", toolCalls: ["read-file"] }),
+      replyStream: async () => ({
+        state: "done" as const,
+        output: "done",
+        model: "gpt-5-mini",
+        toolCalls: ["read-file"],
+      }),
       status: async () => ({}),
       taskStatus: async () => null,
     };

--- a/src/client-contract.ts
+++ b/src/client-contract.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { agentModeSchema } from "./agent-contract";
-import type { ChatRequest, ChatResponse } from "./api";
+import { type ChatRequest, type ChatResponse, chatResponseStateSchema } from "./api";
 import { invariant } from "./assert";
 import { rpcServerMessageSchema } from "./rpc-protocol";
 import type { StatusFields } from "./status-contract";
@@ -245,7 +245,7 @@ export function parseChatResponse(payload: unknown): ChatResponse | null {
             messageTokens: (json.promptBreakdown as { messageTokens: number }).messageTokens,
           }
         : undefined,
-    state: json.state === "awaiting-input" ? "awaiting-input" : "done",
+    state: chatResponseStateSchema.catch("done").parse(json.state),
     error: typeof json.error === "string" ? json.error : undefined,
   };
 }

--- a/src/client-contract.ts
+++ b/src/client-contract.ts
@@ -245,6 +245,7 @@ export function parseChatResponse(payload: unknown): ChatResponse | null {
             messageTokens: (json.promptBreakdown as { messageTokens: number }).messageTokens,
           }
         : undefined,
+    state: json.state === "awaiting-input" ? "awaiting-input" : "done",
     error: typeof json.error === "string" ? json.error : undefined,
   };
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -113,6 +113,7 @@ export const EN_MESSAGES = {
   "chat.usage.metric.total": "Total",
   "chat.usage.none": "No usage data yet. Send a prompt first.",
   "chat.unresolved_path": "No file or folder found: @{path}",
+  "chat.awaiting_input": "Waiting for your reply",
   "chat.worked": "Worked {duration}{suffix}",
   "chat.write.confirm.required": "Write request needs confirmation in read mode.",
   "cli.config.api_key_unsupported": "Config apiKey is not supported. Use ACOLYTE_API_KEY in .env instead.",

--- a/src/lifecycle-finalize.test.ts
+++ b/src/lifecycle-finalize.test.ts
@@ -150,4 +150,21 @@ describe("phaseFinalize", () => {
       messageTokens: 34,
     });
   });
+
+  test("sets state to awaiting-input when signal is blocked", () => {
+    const ctx = createRunContext({
+      result: { text: "Which environment should I deploy to?", toolCalls: [], signal: "blocked" },
+    });
+    const response = phaseFinalize(ctx);
+    expect(response.state).toBe("awaiting-input");
+    expect(response.output).toBe("Which environment should I deploy to?");
+  });
+
+  test("sets state to done when signal is done", () => {
+    const ctx = createRunContext({
+      result: { text: "Done.", toolCalls: [], signal: "done" },
+    });
+    const response = phaseFinalize(ctx);
+    expect(response.state).toBe("done");
+  });
 });

--- a/src/lifecycle-finalize.ts
+++ b/src/lifecycle-finalize.ts
@@ -73,6 +73,7 @@ export function phaseFinalize(ctx: RunContext): ChatResponse {
   });
 
   return {
+    state: ctx.result?.signal === "blocked" ? "awaiting-input" : "done",
     model: ctx.model,
     output,
     ...(ctx.currentError ? { error: ctx.currentError.message } : {}),

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -36,6 +36,7 @@ const phaseEvaluate = mock(
 
 const phaseFinalize = mock(
   (ctx: { result?: { text: string } }): ChatResponse => ({
+    state: "done",
     model: "gpt-5-mini",
     output: ctx.result?.text ?? "",
   }),
@@ -86,7 +87,7 @@ describe("runLifecycle", () => {
     expect(phaseGenerate).toHaveBeenCalledTimes(1);
     expect(phaseEvaluate).toHaveBeenCalledTimes(1);
     expect(phaseFinalize).toHaveBeenCalledTimes(1);
-    expect(response).toEqual({ model: "gpt-5-mini", output: "Generated output" });
+    expect(response).toEqual({ state: "done", model: "gpt-5-mini", output: "Generated output" });
   });
 });
 

--- a/src/server-http.test.ts
+++ b/src/server-http.test.ts
@@ -13,7 +13,7 @@ function createTestDeps(overrides: Partial<Parameters<typeof createServerFetchHa
       return typeof candidate.message === "string";
     },
     runChatRequest: async (_chatRequest: ChatRequest, handlers: RunChatHandlers) => {
-      handlers.onDone({ output: "ok", model: "gpt-5-mini" });
+      handlers.onDone({ state: "done", output: "ok", model: "gpt-5-mini" });
     },
     serverError: (_message: string, _error: unknown, _details: Record<string, unknown>, status = 500) =>
       new Response("server error", { status }),
@@ -65,7 +65,7 @@ describe("server-http auth coverage", () => {
         hasValidAuth: () => false,
         runChatRequest: async (_chatRequest: ChatRequest, handlers: RunChatHandlers) => {
           runCalls += 1;
-          handlers.onDone({ output: "ok", model: "gpt-5-mini" });
+          handlers.onDone({ state: "done", output: "ok", model: "gpt-5-mini" });
         },
       }),
     );

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -247,6 +247,7 @@ export function createClient(overrides?: {
     (async () => ({
       model: "gpt-5-mini",
       output: "ok",
+      state: "done" as const,
     }));
   const replyStream =
     overrides?.replyStream ??


### PR DESCRIPTION
## Summary

- add `ChatResponseState` Zod schema (`done` | `awaiting-input`) to `ChatResponse`
- map `@signal blocked` to `awaiting-input` state in `phaseFinalize`
- parse and forward `state` in `parseChatResponse` with safe default
- show "Waiting for your reply" status row in TUI when agent is blocked
- clarify `@signal blocked` agent instruction to describe what to include
- document `blocked` → `awaiting-input` mapping in lifecycle docs

Fixes #17