### PR TITLE
feat: add task checklist

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,7 +66,7 @@ lifecycle → guard → cache → toolkit → registry
 
 - **guard:** pre-execution safety/redundancy checks and post-execution call recording
 - **cache:** per-task reuse layer for read-only and search tool results
-- **toolkit:** domain tool definitions with guarded execution (`file-toolkit`, `code-toolkit`, `git-toolkit`, `shell-toolkit`, `web-toolkit`)
+- **toolkit:** domain tool definitions with guarded execution (`file-toolkit`, `code-toolkit`, `git-toolkit`, `shell-toolkit`, `web-toolkit`, `checklist-toolkit`)
 - **registry:** toolkit registration, permission filtering, and agent-facing tool surface
 - **details:** see [Tooling](./tooling.md)
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -36,6 +36,7 @@ Shipped, user-visible capabilities.
 - automatic formatting of edited files via detected formatter
 - automatic linting of edited files via detected linter
 - deterministic verify command execution from detected project configuration
+- inline task checklist for multi-step tasks, pinned between transcript and input
 
 ## Tools
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -21,6 +21,7 @@ Naming conventions and core terms used across Acolyte code and docs.
 | Term | Definition |
 |---|---|
 | Base Agent Input | Immutable prompt input created during `prepare` and used as the base for each generation attempt |
+| Checklist | Inline progress display for multi-step tasks, rendered between transcript and input. The agent creates and updates items via the `update-checklist` tool |
 | Context Budgeting | Proactive token allocation via tiktoken — system prompt reserved first, remaining space filled by priority (memory → attachments → history → tool payloads) |
 | Continuation State | Persisted "Current task" and "Next step" cues carried into later turns |
 | Distill | Automatic memory source family that extracts and consolidates knowledge into records (project/user/session scope variants) |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -21,7 +21,7 @@ Naming conventions and core terms used across Acolyte code and docs.
 | Term | Definition |
 |---|---|
 | Base Agent Input | Immutable prompt input created during `prepare` and used as the base for each generation attempt |
-| Checklist | Inline progress display for multi-step tasks, rendered between transcript and input. The agent creates and updates items via the `update-checklist` tool |
+| Checklist | Inline progress display for multi-step tasks, rendered between transcript and input. The agent defines steps via `create-checklist` and marks progress via `update-checklist` |
 | Context Budgeting | Proactive token allocation via tiktoken — system prompt reserved first, remaining space filled by priority (memory → attachments → history → tool payloads) |
 | Continuation State | Persisted "Current task" and "Next step" cues carried into later turns |
 | Distill | Automatic memory source family that extracts and consolidates knowledge into records (project/user/session scope variants) |

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -9,7 +9,7 @@ lifecycle → guard → cache → toolkit → registry
 ## Layers
 
 - **guard**: pre-execution checks and post-execution call recording
-- **toolkit**: domain tool definitions (`file-toolkit`, `code-toolkit`, `git-toolkit`, `shell-toolkit`, `web-toolkit`)
+- **toolkit**: domain tool definitions (`file-toolkit`, `code-toolkit`, `git-toolkit`, `shell-toolkit`, `web-toolkit`, `checklist-toolkit`)
 - **registry**: permission filtering and agent-facing tool surface
 
 ## Guarded execution

--- a/src/agent-modes.ts
+++ b/src/agent-modes.ts
@@ -46,7 +46,7 @@ export const agentModes: Record<AgentMode, AgentModeDefinition> = {
       "Do not run verify, test, or build commands — the lifecycle handles format, lint, and verify automatically after your edits.",
       "Do not signal done until the requested behavior is actually implemented. Updating help text, comments, or tests alone is not completing the task — the functional change must be in place.",
       "After the last tool call, use the lifecycle signal format from the base instructions and keep the user-facing outcome to one sentence.",
-      "For multi-step tasks (3+ distinct steps), use `update-checklist` at the start to show the user a progress checklist. Update item statuses as you complete each step.",
+      "For multi-step tasks (3+ distinct steps), use `set-checklist` at the start to define a progress checklist. Use `update-checklist` to mark items as you complete each step.",
     ],
   },
   verify: {

--- a/src/agent-modes.ts
+++ b/src/agent-modes.ts
@@ -46,6 +46,7 @@ export const agentModes: Record<AgentMode, AgentModeDefinition> = {
       "Do not run verify, test, or build commands — the lifecycle handles format, lint, and verify automatically after your edits.",
       "Do not signal done until the requested behavior is actually implemented. Updating help text, comments, or tests alone is not completing the task — the functional change must be in place.",
       "After the last tool call, use the lifecycle signal format from the base instructions and keep the user-facing outcome to one sentence.",
+      "For multi-step tasks (3+ distinct steps), use `update-checklist` at the start to show the user a progress checklist. Update item statuses as you complete each step.",
     ],
   },
   verify: {

--- a/src/agent-modes.ts
+++ b/src/agent-modes.ts
@@ -46,7 +46,7 @@ export const agentModes: Record<AgentMode, AgentModeDefinition> = {
       "Do not run verify, test, or build commands — the lifecycle handles format, lint, and verify automatically after your edits.",
       "Do not signal done until the requested behavior is actually implemented. Updating help text, comments, or tests alone is not completing the task — the functional change must be in place.",
       "After the last tool call, use the lifecycle signal format from the base instructions and keep the user-facing outcome to one sentence.",
-      "For multi-step tasks (3+ distinct steps), use `set-checklist` at the start to define a progress checklist. Use `update-checklist` to mark items as you complete each step.",
+      "For multi-step tasks (3+ distinct steps), use `create-checklist` at the start to define a progress checklist. Use `update-checklist` to mark items as you complete each step.",
     ],
   },
   verify: {

--- a/src/chat-app.tsx
+++ b/src/chat-app.tsx
@@ -1,9 +1,10 @@
+import { ChatChecklist } from "./chat-checklist";
 import { isChecklistOutput } from "./chat-contract";
 import { ChatHeader } from "./chat-header";
 import { ChatInputPanel } from "./chat-input-panel";
 import { isHeaderItem } from "./chat-promotion";
 import { type ChatAppProps, useChatState } from "./chat-state";
-import { ChatChecklist, ChatTranscript, ChatTranscriptRow } from "./chat-transcript";
+import { ChatTranscript, ChatTranscriptRow } from "./chat-transcript";
 import { palette } from "./palette";
 import { Box, render, Static, Text, useApp } from "./tui";
 import { DEFAULT_COLUMNS } from "./tui/styles";

--- a/src/chat-app.tsx
+++ b/src/chat-app.tsx
@@ -1,4 +1,5 @@
 import { ChatChecklist } from "./chat-checklist";
+import type { ChatRow } from "./chat-contract";
 import { isChecklistOutput } from "./chat-contract";
 import { ChatHeader } from "./chat-header";
 import { ChatInputPanel } from "./chat-input-panel";
@@ -13,8 +14,11 @@ function ChatApp(props: ChatAppProps) {
   const { exit } = useApp();
   const state = useChatState(props, exit);
 
-  const transcriptRows = state.rows.filter((row) => !isChecklistOutput(row.content));
-  const checklistRows = state.rows.filter((row) => isChecklistOutput(row.content));
+  const transcriptRows: ChatRow[] = [];
+  const checklistRows: ChatRow[] = [];
+  for (const row of state.rows) {
+    (isChecklistOutput(row.content) ? checklistRows : transcriptRows).push(row);
+  }
 
   return (
     <Box flexDirection="column">

--- a/src/chat-app.tsx
+++ b/src/chat-app.tsx
@@ -1,8 +1,9 @@
+import { isChecklistOutput } from "./chat-contract";
 import { ChatHeader } from "./chat-header";
 import { ChatInputPanel } from "./chat-input-panel";
 import { isHeaderItem } from "./chat-promotion";
 import { type ChatAppProps, useChatState } from "./chat-state";
-import { ChatTranscript, ChatTranscriptRow } from "./chat-transcript";
+import { ChatChecklist, ChatTranscript, ChatTranscriptRow } from "./chat-transcript";
 import { palette } from "./palette";
 import { Box, render, Static, Text, useApp } from "./tui";
 import { DEFAULT_COLUMNS } from "./tui/styles";
@@ -10,6 +11,9 @@ import { DEFAULT_COLUMNS } from "./tui/styles";
 function ChatApp(props: ChatAppProps) {
   const { exit } = useApp();
   const state = useChatState(props, exit);
+
+  const transcriptRows = state.rows.filter((row) => !isChecklistOutput(row.content));
+  const checklistRows = state.rows.filter((row) => isChecklistOutput(row.content));
 
   return (
     <Box flexDirection="column">
@@ -39,13 +43,14 @@ function ChatApp(props: ChatAppProps) {
         }}
       </Static>
       <ChatTranscript
-        rows={state.rows}
+        rows={transcriptRows}
         pendingState={state.pendingState}
         pendingFrame={state.pendingFrame}
         pendingStartedAt={state.pendingStartedAt}
         queuedMessages={state.queuedMessages}
         runningUsage={state.runningUsage}
       />
+      <ChatChecklist rows={checklistRows} />
 
       <Text> </Text>
       <ChatInputPanel

--- a/src/chat-checklist.tsx
+++ b/src/chat-checklist.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import type { ChatRow } from "./chat-contract";
 import { isChecklistOutput } from "./chat-contract";
 import { type ChecklistOutput, checklistMarker, checklistProgress } from "./checklist-contract";
-import { palette } from "./palette";
 import { Box, Text } from "./tui";
 import { DEFAULT_COLUMNS } from "./tui/styles";
 
@@ -37,7 +36,7 @@ export function ChatChecklist({ rows }: ChatChecklistProps): React.ReactNode {
           <Text> </Text>
           <Box>
             <Box width={2}>
-              <Text color={palette.brand}>{"• "}</Text>
+              <Text>{"  "}</Text>
             </Box>
             <Box width={contentWidth}>
               {isChecklistOutput(row.content) ? <Text>{renderChecklist(row.content)}</Text> : null}

--- a/src/chat-checklist.tsx
+++ b/src/chat-checklist.tsx
@@ -34,13 +34,8 @@ export function ChatChecklist({ rows }: ChatChecklistProps): React.ReactNode {
       {rows.map((row) => (
         <React.Fragment key={row.id}>
           <Text> </Text>
-          <Box>
-            <Box width={2}>
-              <Text>{"  "}</Text>
-            </Box>
-            <Box width={contentWidth}>
-              {isChecklistOutput(row.content) ? <Text>{renderChecklist(row.content)}</Text> : null}
-            </Box>
+          <Box width={contentWidth}>
+            {isChecklistOutput(row.content) ? <Text>{renderChecklist(row.content)}</Text> : null}
           </Box>
         </React.Fragment>
       ))}

--- a/src/chat-checklist.tsx
+++ b/src/chat-checklist.tsx
@@ -1,7 +1,8 @@
 import React from "react";
 import type { ChatRow } from "./chat-contract";
 import { isChecklistOutput } from "./chat-contract";
-import { type ChecklistOutput, formatChecklist } from "./checklist-contract";
+import type { ChecklistOutput } from "./checklist-contract";
+import { formatChecklist } from "./checklist-format";
 import { Box, Text } from "./tui";
 import { DEFAULT_COLUMNS } from "./tui/styles";
 

--- a/src/chat-checklist.tsx
+++ b/src/chat-checklist.tsx
@@ -14,7 +14,7 @@ function renderChecklist(output: ChecklistOutput): React.ReactNode {
       {items.map((item) => (
         <React.Fragment key={item.id}>
           {"\n"}
-          <Text dimColor>{`  ${item.text}`}</Text>
+          <Text dimColor>{`  ${item.marker} ${item.label}`}</Text>
         </React.Fragment>
       ))}
     </>

--- a/src/chat-checklist.tsx
+++ b/src/chat-checklist.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import type { ChatRow } from "./chat-contract";
+import { isChecklistOutput } from "./chat-contract";
+import { type ChecklistOutput, checklistMarker, checklistProgress } from "./checklist-contract";
+import { palette } from "./palette";
+import { Box, Text } from "./tui";
+import { DEFAULT_COLUMNS } from "./tui/styles";
+
+function renderChecklist(output: ChecklistOutput): React.ReactNode {
+  const sorted = [...output.items].sort((a, b) => a.order - b.order);
+  const { done, total } = checklistProgress(sorted);
+  return (
+    <>
+      <Text bold>{`${output.groupTitle} (${done}/${total})`}</Text>
+      {sorted.map((item) => (
+        <React.Fragment key={item.id}>
+          {"\n"}
+          <Text dimColor>{`  ${checklistMarker(item.status)} ${item.label}`}</Text>
+        </React.Fragment>
+      ))}
+    </>
+  );
+}
+
+type ChatChecklistProps = {
+  rows: ChatRow[];
+};
+
+export function ChatChecklist({ rows }: ChatChecklistProps): React.ReactNode {
+  if (rows.length === 0) return null;
+  const columns = process.stdout.columns ?? DEFAULT_COLUMNS;
+  const contentWidth = Math.max(24, columns - 2);
+  return (
+    <>
+      {rows.map((row) => (
+        <React.Fragment key={row.id}>
+          <Text> </Text>
+          <Box>
+            <Box width={2}>
+              <Text color={palette.brand}>{"• "}</Text>
+            </Box>
+            <Box width={contentWidth}>
+              {isChecklistOutput(row.content) ? <Text>{renderChecklist(row.content)}</Text> : null}
+            </Box>
+          </Box>
+        </React.Fragment>
+      ))}
+    </>
+  );
+}

--- a/src/chat-checklist.tsx
+++ b/src/chat-checklist.tsx
@@ -1,20 +1,19 @@
 import React from "react";
 import type { ChatRow } from "./chat-contract";
 import { isChecklistOutput } from "./chat-contract";
-import { type ChecklistOutput, checklistMarker, checklistProgress } from "./checklist-contract";
+import { type ChecklistOutput, formatChecklist } from "./checklist-contract";
 import { Box, Text } from "./tui";
 import { DEFAULT_COLUMNS } from "./tui/styles";
 
 function renderChecklist(output: ChecklistOutput): React.ReactNode {
-  const sorted = [...output.items].sort((a, b) => a.order - b.order);
-  const { done, total } = checklistProgress(sorted);
+  const { header, lines } = formatChecklist(output);
   return (
     <>
-      <Text bold>{`${output.groupTitle} (${done}/${total})`}</Text>
-      {sorted.map((item) => (
-        <React.Fragment key={item.id}>
+      <Text bold>{header}</Text>
+      {lines.map((line) => (
+        <React.Fragment key={line}>
           {"\n"}
-          <Text dimColor>{`  ${checklistMarker(item.status)} ${item.label}`}</Text>
+          <Text dimColor>{`  ${line}`}</Text>
         </React.Fragment>
       ))}
     </>

--- a/src/chat-checklist.tsx
+++ b/src/chat-checklist.tsx
@@ -7,14 +7,14 @@ import { Box, Text } from "./tui";
 import { DEFAULT_COLUMNS } from "./tui/styles";
 
 function renderChecklist(output: ChecklistOutput): React.ReactNode {
-  const { header, lines } = formatChecklist(output);
+  const { header, items } = formatChecklist(output);
   return (
     <>
       <Text bold>{header}</Text>
-      {lines.map((line) => (
-        <React.Fragment key={line}>
+      {items.map((item) => (
+        <React.Fragment key={item.id}>
           {"\n"}
-          <Text dimColor>{`  ${line}`}</Text>
+          <Text dimColor>{`  ${item.text}`}</Text>
         </React.Fragment>
       ))}
     </>

--- a/src/chat-contract.ts
+++ b/src/chat-contract.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { checklistOutputSchema } from "./checklist-contract";
 import { isoDateTimeSchema } from "./datetime";
 import { domainIdSchema } from "./id-contract";
 import { createId } from "./short-id";
@@ -48,7 +49,7 @@ export const commandOutputSchema = z.object({
 
 export type CommandOutput = z.infer<typeof commandOutputSchema>;
 
-const chatRowContentSchema = z.union([z.string(), toolOutputSchema, commandOutputSchema]);
+const chatRowContentSchema = z.union([z.string(), toolOutputSchema, commandOutputSchema, checklistOutputSchema]);
 
 export type ChatRowContent = z.infer<typeof chatRowContentSchema>;
 
@@ -71,4 +72,10 @@ export function isToolOutput(content: ChatRowContent | undefined): content is To
 
 export function isCommandOutput(content: ChatRowContent | undefined): content is CommandOutput {
   return typeof content === "object" && "header" in content;
+}
+
+export function isChecklistOutput(
+  content: ChatRowContent | undefined,
+): content is z.infer<typeof checklistOutputSchema> {
+  return typeof content === "object" && "groupId" in content;
 }

--- a/src/chat-message-handler-stream.ts
+++ b/src/chat-message-handler-stream.ts
@@ -150,7 +150,11 @@ export function createMessageStreamState(input: {
 
     finalize: () => {
       sealAssistantRow();
+      const checklistIds = new Set(checklistRowIdByGroupId.values());
       checklistRowIdByGroupId.clear();
+      if (checklistIds.size > 0) {
+        input.setRows((current) => current.filter((row) => !checklistIds.has(row.id)));
+      }
       const ids = [...assistantRowIds];
       assistantRowIds.length = 0;
       return ids;
@@ -158,14 +162,15 @@ export function createMessageStreamState(input: {
 
     dispose: () => {
       cancelFlushTimer();
+      const checklistIds = new Set(checklistRowIdByGroupId.values());
       checklistRowIdByGroupId.clear();
       const idsToRemove = [...assistantRowIds];
       if (activeRowId && !idsToRemove.includes(activeRowId)) idsToRemove.push(activeRowId);
       activeRowId = null;
       activeContent = "";
       assistantRowIds.length = 0;
-      if (idsToRemove.length > 0) {
-        const removeSet = new Set(idsToRemove);
+      const removeSet = new Set([...idsToRemove, ...checklistIds]);
+      if (removeSet.size > 0) {
         input.setRows((current) => current.filter((row) => !removeSet.has(row.id)));
       }
     },

--- a/src/chat-message-handler-stream.ts
+++ b/src/chat-message-handler-stream.ts
@@ -150,6 +150,7 @@ export function createMessageStreamState(input: {
 
     finalize: () => {
       sealAssistantRow();
+      checklistRowIdByGroupId.clear();
       const ids = [...assistantRowIds];
       assistantRowIds.length = 0;
       return ids;
@@ -157,6 +158,7 @@ export function createMessageStreamState(input: {
 
     dispose: () => {
       cancelFlushTimer();
+      checklistRowIdByGroupId.clear();
       const idsToRemove = [...assistantRowIds];
       if (activeRowId && !idsToRemove.includes(activeRowId)) idsToRemove.push(activeRowId);
       activeRowId = null;

--- a/src/chat-message-handler-stream.ts
+++ b/src/chat-message-handler-stream.ts
@@ -1,4 +1,5 @@
 import { type ChatRow, createRow } from "./chat-contract";
+import type { ChecklistItem } from "./checklist-contract";
 import { LIFECYCLE_ERROR_CODES } from "./error-contract";
 import { palette } from "./palette";
 import { createId } from "./short-id";
@@ -14,6 +15,7 @@ export type MessageStreamState = {
     errorCode?: string;
     error?: { category?: string; [key: string]: unknown };
   }) => void;
+  onChecklist: (entry: { groupId: string; groupTitle: string; items: ChecklistItem[] }) => void;
   onProgressError: (error: string) => void;
   streamedAssistantText: () => string;
   /** Flush remaining content and return IDs of all streaming assistant rows (for replacement by final turn rows). */
@@ -36,6 +38,9 @@ export function createMessageStreamState(input: {
   // --- tool output state ---
   const toolRowIdByCallId = new Map<string, string>();
   const toolOutput = createToolOutputState();
+
+  // --- checklist state ---
+  const checklistRowIdByGroupId = new Map<string, string>();
 
   function cancelFlushTimer(): void {
     if (flushTimer) {
@@ -118,6 +123,19 @@ export function createMessageStreamState(input: {
       input.setRows((current) =>
         current.map((row) => (row.id === rowId ? { ...row, style: { ...row.style, marker: markerColor } } : row)),
       );
+    },
+
+    onChecklist: (entry) => {
+      const content = { groupId: entry.groupId, groupTitle: entry.groupTitle, items: entry.items };
+      const existingRowId = checklistRowIdByGroupId.get(entry.groupId);
+      if (!existingRowId) {
+        sealAssistantRow();
+        const rowId = `row_${createId()}`;
+        checklistRowIdByGroupId.set(entry.groupId, rowId);
+        input.setRows((current) => [...current, { id: rowId, kind: "task" as const, content }]);
+        return;
+      }
+      input.setRows((current) => current.map((row) => (row.id === existingRowId ? { ...row, content } : row)));
     },
 
     onProgressError: (error) => {

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -127,6 +127,9 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
             case "tool-result":
               streamState.onToolResult(event);
               break;
+            case "checklist":
+              streamState.onChecklist(event);
+              break;
             case "error":
               streamState.onProgressError(event.errorMessage);
               break;

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -340,3 +340,30 @@ export function ChatTranscript(props: ChatTranscriptProps): React.ReactNode {
     </>
   );
 }
+
+type ChatChecklistProps = {
+  rows: ChatRow[];
+};
+
+export function ChatChecklist({ rows }: ChatChecklistProps): React.ReactNode {
+  if (rows.length === 0) return null;
+  const columns = process.stdout.columns ?? DEFAULT_COLUMNS;
+  const contentWidth = Math.max(24, columns - 2);
+  return (
+    <>
+      {rows.map((row) => (
+        <React.Fragment key={row.id}>
+          <Text> </Text>
+          <Box>
+            <Box width={2}>
+              <Text color={palette.brand}>{"• "}</Text>
+            </Box>
+            <Box width={contentWidth}>
+              {isChecklistOutput(row.content) ? <Text>{renderChecklist(row.content)}</Text> : null}
+            </Box>
+          </Box>
+        </React.Fragment>
+      ))}
+    </>
+  );
+}

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -2,10 +2,9 @@ import React from "react";
 import type { AgentMode } from "./agent-contract";
 import { renderAssistantContent } from "./chat-content-render";
 import type { ChatRow, CommandOutput } from "./chat-contract";
-import { isChecklistOutput, isCommandOutput, isToolOutput } from "./chat-contract";
+import { isCommandOutput, isToolOutput } from "./chat-contract";
 import { commandOutputColWidth, formatTokenCount } from "./chat-format";
 import { ShimmerText } from "./chat-shimmer";
-import { type ChecklistOutput, checklistMarker, checklistProgress } from "./checklist-contract";
 import type { PendingState } from "./client-contract";
 import { t, tDynamic } from "./i18n";
 import { palette } from "./palette";
@@ -199,22 +198,6 @@ function renderToolOutput(parts: ToolOutputPart[], toolContentWidth: number): Re
   );
 }
 
-function renderChecklist(output: ChecklistOutput): React.ReactNode {
-  const sorted = [...output.items].sort((a, b) => a.order - b.order);
-  const { done, total } = checklistProgress(sorted);
-  return (
-    <>
-      <Text bold>{`${output.groupTitle} (${done}/${total})`}</Text>
-      {sorted.map((item) => (
-        <React.Fragment key={item.id}>
-          {"\n"}
-          <Text dimColor>{`  ${checklistMarker(item.status)} ${item.label}`}</Text>
-        </React.Fragment>
-      ))}
-    </>
-  );
-}
-
 type ChatTranscriptRowProps = {
   row: ChatRow;
   contentWidth: number;
@@ -232,21 +215,19 @@ export function ChatTranscriptRow({ row, contentWidth, toolContentWidth }: ChatT
         <Text color={markerColor}>{marker}</Text>
       </Box>
       <Box width={row.kind === "tool" ? toolContentWidth : contentWidth}>
-        {isChecklistOutput(row.content) ? (
-          <Text>{renderChecklist(row.content)}</Text>
-        ) : isToolOutput(row.content) ? (
+        {isToolOutput(row.content) ? (
           <Text>{renderToolOutput(row.content.parts, toolContentWidth)}</Text>
         ) : isCommandOutput(row.content) ? (
           <Text>{renderCommandOutput(row.content)}</Text>
-        ) : row.kind === "assistant" ? (
+        ) : row.kind === "assistant" && typeof row.content === "string" ? (
           <Text dimColor={dim} color={textColor}>
             {renderAssistantContent(row.content, contentWidth)}
           </Text>
-        ) : (
+        ) : typeof row.content === "string" ? (
           <Text dimColor={dim} color={textColor}>
             {row.content}
           </Text>
-        )}
+        ) : null}
       </Box>
     </Box>
   );
@@ -337,33 +318,6 @@ export function ChatTranscript(props: ChatTranscriptProps): React.ReactNode {
           ))}
         </>
       ) : null}
-    </>
-  );
-}
-
-type ChatChecklistProps = {
-  rows: ChatRow[];
-};
-
-export function ChatChecklist({ rows }: ChatChecklistProps): React.ReactNode {
-  if (rows.length === 0) return null;
-  const columns = process.stdout.columns ?? DEFAULT_COLUMNS;
-  const contentWidth = Math.max(24, columns - 2);
-  return (
-    <>
-      {rows.map((row) => (
-        <React.Fragment key={row.id}>
-          <Text> </Text>
-          <Box>
-            <Box width={2}>
-              <Text color={palette.brand}>{"• "}</Text>
-            </Box>
-            <Box width={contentWidth}>
-              {isChecklistOutput(row.content) ? <Text>{renderChecklist(row.content)}</Text> : null}
-            </Box>
-          </Box>
-        </React.Fragment>
-      ))}
     </>
   );
 }

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -2,9 +2,10 @@ import React from "react";
 import type { AgentMode } from "./agent-contract";
 import { renderAssistantContent } from "./chat-content-render";
 import type { ChatRow, CommandOutput } from "./chat-contract";
-import { isCommandOutput, isToolOutput } from "./chat-contract";
+import { isChecklistOutput, isCommandOutput, isToolOutput } from "./chat-contract";
 import { commandOutputColWidth, formatTokenCount } from "./chat-format";
 import { ShimmerText } from "./chat-shimmer";
+import { type ChecklistOutput, checklistMarker, checklistProgress } from "./checklist-contract";
 import type { PendingState } from "./client-contract";
 import { t, tDynamic } from "./i18n";
 import { palette } from "./palette";
@@ -198,6 +199,22 @@ function renderToolOutput(parts: ToolOutputPart[], toolContentWidth: number): Re
   );
 }
 
+function renderChecklist(output: ChecklistOutput): React.ReactNode {
+  const sorted = [...output.items].sort((a, b) => a.order - b.order);
+  const { done, total } = checklistProgress(sorted);
+  return (
+    <>
+      <Text bold>{`${output.groupTitle} (${done}/${total})`}</Text>
+      {sorted.map((item) => (
+        <React.Fragment key={item.id}>
+          {"\n"}
+          <Text dimColor>{`  ${checklistMarker(item.status)} ${item.label}`}</Text>
+        </React.Fragment>
+      ))}
+    </>
+  );
+}
+
 type ChatTranscriptRowProps = {
   row: ChatRow;
   contentWidth: number;
@@ -215,7 +232,9 @@ export function ChatTranscriptRow({ row, contentWidth, toolContentWidth }: ChatT
         <Text color={markerColor}>{marker}</Text>
       </Box>
       <Box width={row.kind === "tool" ? toolContentWidth : contentWidth}>
-        {isToolOutput(row.content) ? (
+        {isChecklistOutput(row.content) ? (
+          <Text>{renderChecklist(row.content)}</Text>
+        ) : isToolOutput(row.content) ? (
           <Text>{renderToolOutput(row.content.parts, toolContentWidth)}</Text>
         ) : isCommandOutput(row.content) ? (
           <Text>{renderCommandOutput(row.content)}</Text>

--- a/src/checklist-contract.test.ts
+++ b/src/checklist-contract.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { checklistMarker, checklistProgress, formatChecklist } from "./checklist-contract";
+
+describe("checklistMarker", () => {
+  test("returns correct markers", () => {
+    expect(checklistMarker("pending")).toBe("○");
+    expect(checklistMarker("in_progress")).toBe("◐");
+    expect(checklistMarker("done")).toBe("●");
+    expect(checklistMarker("failed")).toBe("◉");
+  });
+});
+
+describe("checklistProgress", () => {
+  test("counts done items", () => {
+    expect(
+      checklistProgress([
+        { id: "1", label: "a", status: "done", order: 0 },
+        { id: "2", label: "b", status: "in_progress", order: 1 },
+        { id: "3", label: "c", status: "pending", order: 2 },
+      ]),
+    ).toEqual({ done: 1, total: 3 });
+  });
+
+  test("handles all done", () => {
+    expect(
+      checklistProgress([
+        { id: "1", label: "a", status: "done", order: 0 },
+        { id: "2", label: "b", status: "done", order: 1 },
+      ]),
+    ).toEqual({ done: 2, total: 2 });
+  });
+
+  test("failed items do not count as done", () => {
+    expect(
+      checklistProgress([
+        { id: "1", label: "a", status: "done", order: 0 },
+        { id: "2", label: "b", status: "failed", order: 1 },
+      ]),
+    ).toEqual({ done: 1, total: 2 });
+  });
+
+  test("handles empty list", () => {
+    expect(checklistProgress([])).toEqual({ done: 0, total: 0 });
+  });
+});
+
+describe("formatChecklist", () => {
+  test("returns header with progress and sorted lines", () => {
+    const result = formatChecklist({
+      groupId: "g1",
+      groupTitle: "Build",
+      items: [
+        { id: "s2", label: "test", status: "in_progress", order: 1 },
+        { id: "s1", label: "lint", status: "done", order: 0 },
+        { id: "s3", label: "deploy", status: "pending", order: 2 },
+      ],
+    });
+    expect(result.header).toBe("Build (1/3)");
+    expect(result.lines).toEqual(["● lint", "◐ test", "○ deploy"]);
+  });
+
+  test("handles single item", () => {
+    const result = formatChecklist({
+      groupId: "g1",
+      groupTitle: "Quick",
+      items: [{ id: "s1", label: "do it", status: "pending", order: 0 }],
+    });
+    expect(result.header).toBe("Quick (0/1)");
+    expect(result.lines).toEqual(["○ do it"]);
+  });
+});

--- a/src/checklist-contract.test.ts
+++ b/src/checklist-contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { checklistMarker, checklistProgress, formatChecklist } from "./checklist-contract";
+import { checklistMarker, checklistProgress } from "./checklist-contract";
 
 describe("checklistMarker", () => {
   test("returns correct markers", () => {
@@ -41,31 +41,5 @@ describe("checklistProgress", () => {
 
   test("handles empty list", () => {
     expect(checklistProgress([])).toEqual({ done: 0, total: 0 });
-  });
-});
-
-describe("formatChecklist", () => {
-  test("returns header with progress and sorted lines", () => {
-    const result = formatChecklist({
-      groupId: "g1",
-      groupTitle: "Build",
-      items: [
-        { id: "s2", label: "test", status: "in_progress", order: 1 },
-        { id: "s1", label: "lint", status: "done", order: 0 },
-        { id: "s3", label: "deploy", status: "pending", order: 2 },
-      ],
-    });
-    expect(result.header).toBe("Build (1/3)");
-    expect(result.lines).toEqual(["● lint", "◐ test", "○ deploy"]);
-  });
-
-  test("handles single item", () => {
-    const result = formatChecklist({
-      groupId: "g1",
-      groupTitle: "Quick",
-      items: [{ id: "s1", label: "do it", status: "pending", order: 0 }],
-    });
-    expect(result.header).toBe("Quick (0/1)");
-    expect(result.lines).toEqual(["○ do it"]);
   });
 });

--- a/src/checklist-contract.ts
+++ b/src/checklist-contract.ts
@@ -37,3 +37,12 @@ export function checklistProgress(items: ChecklistItem[]): { done: number; total
     total: items.length,
   };
 }
+
+export function formatChecklist(output: ChecklistOutput): { header: string; lines: string[] } {
+  const sorted = [...output.items].sort((a, b) => a.order - b.order);
+  const { done, total } = checklistProgress(sorted);
+  return {
+    header: `${output.groupTitle} (${done}/${total})`,
+    lines: sorted.map((item) => `${checklistMarker(item.status)} ${item.label}`),
+  };
+}

--- a/src/checklist-contract.ts
+++ b/src/checklist-contract.ts
@@ -1,0 +1,39 @@
+import { z } from "zod";
+
+export const checklistItemStatusSchema = z.enum(["pending", "in_progress", "done", "failed"]);
+export type ChecklistItemStatus = z.infer<typeof checklistItemStatusSchema>;
+
+export const checklistItemSchema = z.object({
+  id: z.string().min(1),
+  label: z.string().min(1),
+  status: checklistItemStatusSchema,
+  order: z.number().int().nonnegative(),
+});
+
+export type ChecklistItem = z.infer<typeof checklistItemSchema>;
+
+export const checklistOutputSchema = z.object({
+  groupId: z.string().min(1),
+  groupTitle: z.string().min(1),
+  items: z.array(checklistItemSchema),
+});
+
+export type ChecklistOutput = z.infer<typeof checklistOutputSchema>;
+
+const STATUS_MARKERS: Record<ChecklistItemStatus, string> = {
+  pending: "\u25CB",
+  in_progress: "\u25D0",
+  done: "\u25CF",
+  failed: "\u25C9",
+};
+
+export function checklistMarker(status: ChecklistItemStatus): string {
+  return STATUS_MARKERS[status];
+}
+
+export function checklistProgress(items: ChecklistItem[]): { done: number; total: number } {
+  return {
+    done: items.filter((item) => item.status === "done").length,
+    total: items.length,
+  };
+}

--- a/src/checklist-contract.ts
+++ b/src/checklist-contract.ts
@@ -21,10 +21,10 @@ export const checklistOutputSchema = z.object({
 export type ChecklistOutput = z.infer<typeof checklistOutputSchema>;
 
 const STATUS_MARKERS: Record<ChecklistItemStatus, string> = {
-  pending: "\u25CB",
-  in_progress: "\u25D0",
-  done: "\u25CF",
-  failed: "\u25C9",
+  pending: "○",
+  in_progress: "◐",
+  done: "●",
+  failed: "◉",
 };
 
 export function checklistMarker(status: ChecklistItemStatus): string {

--- a/src/checklist-contract.ts
+++ b/src/checklist-contract.ts
@@ -37,12 +37,3 @@ export function checklistProgress(items: ChecklistItem[]): { done: number; total
     total: items.length,
   };
 }
-
-export function formatChecklist(output: ChecklistOutput): { header: string; lines: string[] } {
-  const sorted = [...output.items].sort((a, b) => a.order - b.order);
-  const { done, total } = checklistProgress(sorted);
-  return {
-    header: `${output.groupTitle} (${done}/${total})`,
-    lines: sorted.map((item) => `${checklistMarker(item.status)} ${item.label}`),
-  };
-}

--- a/src/checklist-format.test.ts
+++ b/src/checklist-format.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { formatChecklist } from "./checklist-format";
+
+describe("formatChecklist", () => {
+  test("returns header with progress and sorted lines", () => {
+    const result = formatChecklist({
+      groupId: "g1",
+      groupTitle: "Build",
+      items: [
+        { id: "s2", label: "test", status: "in_progress", order: 1 },
+        { id: "s1", label: "lint", status: "done", order: 0 },
+        { id: "s3", label: "deploy", status: "pending", order: 2 },
+      ],
+    });
+    expect(result.header).toBe("Build (1/3)");
+    expect(result.lines).toEqual(["● lint", "◐ test", "○ deploy"]);
+  });
+
+  test("handles single item", () => {
+    const result = formatChecklist({
+      groupId: "g1",
+      groupTitle: "Quick",
+      items: [{ id: "s1", label: "do it", status: "pending", order: 0 }],
+    });
+    expect(result.header).toBe("Quick (0/1)");
+    expect(result.lines).toEqual(["○ do it"]);
+  });
+});

--- a/src/checklist-format.test.ts
+++ b/src/checklist-format.test.ts
@@ -14,9 +14,9 @@ describe("formatChecklist", () => {
     });
     expect(result.header).toBe("Build (1/3)");
     expect(result.items).toEqual([
-      { id: "s1", text: "● lint" },
-      { id: "s2", text: "◐ test" },
-      { id: "s3", text: "○ deploy" },
+      { id: "s1", marker: "●", label: "lint" },
+      { id: "s2", marker: "◐", label: "test" },
+      { id: "s3", marker: "○", label: "deploy" },
     ]);
   });
 
@@ -27,6 +27,6 @@ describe("formatChecklist", () => {
       items: [{ id: "s1", label: "do it", status: "pending", order: 0 }],
     });
     expect(result.header).toBe("Quick (0/1)");
-    expect(result.items).toEqual([{ id: "s1", text: "○ do it" }]);
+    expect(result.items).toEqual([{ id: "s1", marker: "○", label: "do it" }]);
   });
 });

--- a/src/checklist-format.test.ts
+++ b/src/checklist-format.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { formatChecklist } from "./checklist-format";
 
 describe("formatChecklist", () => {
-  test("returns header with progress and sorted lines", () => {
+  test("returns header with progress and sorted items", () => {
     const result = formatChecklist({
       groupId: "g1",
       groupTitle: "Build",
@@ -13,7 +13,11 @@ describe("formatChecklist", () => {
       ],
     });
     expect(result.header).toBe("Build (1/3)");
-    expect(result.lines).toEqual(["● lint", "◐ test", "○ deploy"]);
+    expect(result.items).toEqual([
+      { id: "s1", text: "● lint" },
+      { id: "s2", text: "◐ test" },
+      { id: "s3", text: "○ deploy" },
+    ]);
   });
 
   test("handles single item", () => {
@@ -23,6 +27,6 @@ describe("formatChecklist", () => {
       items: [{ id: "s1", label: "do it", status: "pending", order: 0 }],
     });
     expect(result.header).toBe("Quick (0/1)");
-    expect(result.lines).toEqual(["○ do it"]);
+    expect(result.items).toEqual([{ id: "s1", text: "○ do it" }]);
   });
 });

--- a/src/checklist-format.ts
+++ b/src/checklist-format.ts
@@ -1,0 +1,10 @@
+import { type ChecklistOutput, checklistMarker, checklistProgress } from "./checklist-contract";
+
+export function formatChecklist(output: ChecklistOutput): { header: string; lines: string[] } {
+  const sorted = [...output.items].sort((a, b) => a.order - b.order);
+  const { done, total } = checklistProgress(sorted);
+  return {
+    header: `${output.groupTitle} (${done}/${total})`,
+    lines: sorted.map((item) => `${checklistMarker(item.status)} ${item.label}`),
+  };
+}

--- a/src/checklist-format.ts
+++ b/src/checklist-format.ts
@@ -1,10 +1,12 @@
 import { type ChecklistOutput, checklistMarker, checklistProgress } from "./checklist-contract";
 
-export function formatChecklist(output: ChecklistOutput): { header: string; lines: string[] } {
+export type FormattedChecklistItem = { id: string; text: string };
+
+export function formatChecklist(output: ChecklistOutput): { header: string; items: FormattedChecklistItem[] } {
   const sorted = [...output.items].sort((a, b) => a.order - b.order);
   const { done, total } = checklistProgress(sorted);
   return {
     header: `${output.groupTitle} (${done}/${total})`,
-    lines: sorted.map((item) => `${checklistMarker(item.status)} ${item.label}`),
+    items: sorted.map((item) => ({ id: item.id, text: `${checklistMarker(item.status)} ${item.label}` })),
   };
 }

--- a/src/checklist-format.ts
+++ b/src/checklist-format.ts
@@ -1,12 +1,12 @@
 import { type ChecklistOutput, checklistMarker, checklistProgress } from "./checklist-contract";
 
-export type FormattedChecklistItem = { id: string; text: string };
+export type FormattedChecklistItem = { id: string; marker: string; label: string };
 
 export function formatChecklist(output: ChecklistOutput): { header: string; items: FormattedChecklistItem[] } {
   const sorted = [...output.items].sort((a, b) => a.order - b.order);
   const { done, total } = checklistProgress(sorted);
   return {
     header: `${output.groupTitle} (${done}/${total})`,
-    items: sorted.map((item) => ({ id: item.id, text: `${checklistMarker(item.status)} ${item.label}` })),
+    items: sorted.map((item) => ({ id: item.id, marker: checklistMarker(item.status), label: item.label })),
   };
 }

--- a/src/checklist-toolkit.ts
+++ b/src/checklist-toolkit.ts
@@ -1,0 +1,74 @@
+import { z } from "zod";
+import { checklistItemStatusSchema } from "./checklist-contract";
+import type { ToolkitDeps, ToolkitInput } from "./tool-contract";
+import { createTool } from "./tool-contract";
+import { runTool } from "./tool-execution";
+
+const updateChecklistInputSchema = z.object({
+  groupId: z.string().min(1).describe("Unique identifier for the checklist group."),
+  groupTitle: z.string().min(1).describe("Title displayed as the checklist header."),
+  items: z
+    .array(
+      z.object({
+        id: z.string().min(1).describe("Unique item identifier within this group."),
+        label: z.string().min(1).describe("Short description of the step."),
+        status: checklistItemStatusSchema.describe("Current status of this item."),
+        order: z.number().int().nonnegative().describe("Display position (0-based)."),
+      }),
+    )
+    .min(1)
+    .describe("Full list of checklist items. Always send the complete list, not a partial update."),
+});
+
+const updateChecklistOutputSchema = z.object({
+  kind: z.literal("update-checklist"),
+  groupId: z.string(),
+  itemCount: z.number(),
+});
+
+function createUpdateChecklistTool(_deps: ToolkitDeps, input: ToolkitInput) {
+  return createTool({
+    id: "update-checklist",
+    labelKey: "tool.label.update_checklist",
+    category: "write",
+    permissions: ["write"],
+    description:
+      "Create or update an inline task checklist visible to the user. Send the full item list each time — items not included are removed.",
+    instruction:
+      "Use `update-checklist` at the start of multi-step tasks to show the user a progress checklist. Create the checklist with all items as pending, then update individual item statuses as you work. Always send the complete item list.",
+    inputSchema: updateChecklistInputSchema,
+    outputSchema: updateChecklistOutputSchema,
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "update-checklist", toolCallId, toolInput, async (callId) => {
+        input.onOutput({
+          toolName: "update-checklist",
+          content: { kind: "tool-header", labelKey: "tool.label.update_checklist", detail: toolInput.groupTitle },
+          toolCallId: callId,
+        });
+
+        input.onChecklist({
+          groupId: toolInput.groupId,
+          groupTitle: toolInput.groupTitle,
+          items: toolInput.items.map((item) => ({
+            id: item.id,
+            label: item.label,
+            status: item.status,
+            order: item.order,
+          })),
+        });
+
+        return {
+          kind: "update-checklist" as const,
+          groupId: toolInput.groupId,
+          itemCount: toolInput.items.length,
+        };
+      });
+    },
+  });
+}
+
+export function createChecklistToolkit(deps: ToolkitDeps, input: ToolkitInput) {
+  return {
+    updateChecklist: createUpdateChecklistTool(deps, input),
+  };
+}

--- a/src/checklist-toolkit.ts
+++ b/src/checklist-toolkit.ts
@@ -44,9 +44,8 @@ function createSetChecklistTool(
 ) {
   return createTool({
     id: "set-checklist",
-    labelKey: "tool.label.set_checklist",
-    category: "read",
-    permissions: ["read"],
+    category: "meta",
+    permissions: [],
     description: "Create an inline task checklist visible to the user. All items start as pending.",
     instruction:
       "Use `set-checklist` once at the start of multi-step tasks to show the user a progress checklist. Define all steps upfront. Use `update-checklist` to change item statuses as you work.",
@@ -75,9 +74,8 @@ function createUpdateChecklistTool(
 ) {
   return createTool({
     id: "update-checklist",
-    labelKey: "tool.label.update_checklist",
-    category: "read",
-    permissions: ["read"],
+    category: "meta",
+    permissions: [],
     description: "Update the status of a single checklist item.",
     instruction:
       "Use `update-checklist` to mark a checklist item as `in_progress`, `done`, or `failed`. Requires a prior `set-checklist` call for the same groupId.",

--- a/src/checklist-toolkit.ts
+++ b/src/checklist-toolkit.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
-import { checklistItemStatusSchema } from "./checklist-contract";
+import { type ChecklistItem, checklistItemStatusSchema } from "./checklist-contract";
 import type { ToolkitDeps, ToolkitInput } from "./tool-contract";
 import { createTool } from "./tool-contract";
 import { runTool } from "./tool-execution";
 
-const updateChecklistInputSchema = z.object({
+const setChecklistInputSchema = z.object({
   groupId: z.string().min(1),
   groupTitle: z.string().min(1),
   items: z
@@ -12,48 +12,90 @@ const updateChecklistInputSchema = z.object({
       z.object({
         id: z.string().min(1),
         label: z.string().min(1),
-        status: checklistItemStatusSchema,
         order: z.number().int().nonnegative(),
       }),
     )
     .min(1),
 });
 
-const updateChecklistOutputSchema = z.object({
-  kind: z.literal("update-checklist"),
+const setChecklistOutputSchema = z.object({
+  kind: z.literal("set-checklist"),
   groupId: z.string(),
   itemCount: z.number(),
 });
 
-function createUpdateChecklistTool(_deps: ToolkitDeps, input: ToolkitInput) {
+const updateChecklistInputSchema = z.object({
+  groupId: z.string().min(1),
+  itemId: z.string().min(1),
+  status: checklistItemStatusSchema,
+});
+
+const updateChecklistOutputSchema = z.object({
+  kind: z.literal("update-checklist"),
+  groupId: z.string(),
+  itemId: z.string(),
+  status: checklistItemStatusSchema,
+});
+
+function createSetChecklistTool(
+  _deps: ToolkitDeps,
+  input: ToolkitInput,
+  state: Map<string, { title: string; items: ChecklistItem[] }>,
+) {
+  return createTool({
+    id: "set-checklist",
+    labelKey: "tool.label.set_checklist",
+    category: "read",
+    permissions: ["read"],
+    description: "Create an inline task checklist visible to the user. All items start as pending.",
+    instruction:
+      "Use `set-checklist` once at the start of multi-step tasks to show the user a progress checklist. Define all steps upfront. Use `update-checklist` to change item statuses as you work.",
+    inputSchema: setChecklistInputSchema,
+    outputSchema: setChecklistOutputSchema,
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "set-checklist", toolCallId, toolInput, async () => {
+        const items: ChecklistItem[] = toolInput.items.map((item) => ({
+          id: item.id,
+          label: item.label,
+          status: "pending",
+          order: item.order,
+        }));
+        state.set(toolInput.groupId, { title: toolInput.groupTitle, items });
+        input.onChecklist({ groupId: toolInput.groupId, groupTitle: toolInput.groupTitle, items });
+        return { kind: "set-checklist" as const, groupId: toolInput.groupId, itemCount: items.length };
+      });
+    },
+  });
+}
+
+function createUpdateChecklistTool(
+  _deps: ToolkitDeps,
+  input: ToolkitInput,
+  state: Map<string, { title: string; items: ChecklistItem[] }>,
+) {
   return createTool({
     id: "update-checklist",
     labelKey: "tool.label.update_checklist",
     category: "read",
     permissions: ["read"],
-    description:
-      "Create or update an inline task checklist visible to the user. Send the full item list each time — items not included are removed.",
+    description: "Update the status of a single checklist item.",
     instruction:
-      "Use `update-checklist` at the start of multi-step tasks to show the user a progress checklist. Create the checklist with all items as pending, then update individual item statuses as you work. Always send the complete item list.",
+      "Use `update-checklist` to mark a checklist item as `in_progress`, `done`, or `failed`. Requires a prior `set-checklist` call for the same groupId.",
     inputSchema: updateChecklistInputSchema,
     outputSchema: updateChecklistOutputSchema,
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "update-checklist", toolCallId, toolInput, async () => {
-        input.onChecklist({
-          groupId: toolInput.groupId,
-          groupTitle: toolInput.groupTitle,
-          items: toolInput.items.map((item) => ({
-            id: item.id,
-            label: item.label,
-            status: item.status,
-            order: item.order,
-          })),
-        });
-
+        const group = state.get(toolInput.groupId);
+        if (!group) throw new Error(`No checklist found for groupId "${toolInput.groupId}"`);
+        const item = group.items.find((i) => i.id === toolInput.itemId);
+        if (!item) throw new Error(`No item "${toolInput.itemId}" in checklist "${toolInput.groupId}"`);
+        item.status = toolInput.status;
+        input.onChecklist({ groupId: toolInput.groupId, groupTitle: group.title, items: group.items });
         return {
           kind: "update-checklist" as const,
           groupId: toolInput.groupId,
-          itemCount: toolInput.items.length,
+          itemId: toolInput.itemId,
+          status: toolInput.status,
         };
       });
     },
@@ -61,7 +103,9 @@ function createUpdateChecklistTool(_deps: ToolkitDeps, input: ToolkitInput) {
 }
 
 export function createChecklistToolkit(deps: ToolkitDeps, input: ToolkitInput) {
+  const state = new Map<string, { title: string; items: ChecklistItem[] }>();
   return {
-    updateChecklist: createUpdateChecklistTool(deps, input),
+    setChecklist: createSetChecklistTool(deps, input, state),
+    updateChecklist: createUpdateChecklistTool(deps, input, state),
   };
 }

--- a/src/checklist-toolkit.ts
+++ b/src/checklist-toolkit.ts
@@ -30,8 +30,8 @@ function createUpdateChecklistTool(_deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "update-checklist",
     labelKey: "tool.label.update_checklist",
-    category: "write",
-    permissions: ["write"],
+    category: "read",
+    permissions: ["read"],
     description:
       "Create or update an inline task checklist visible to the user. Send the full item list each time — items not included are removed.",
     instruction:

--- a/src/checklist-toolkit.ts
+++ b/src/checklist-toolkit.ts
@@ -4,7 +4,7 @@ import type { ToolkitDeps, ToolkitInput } from "./tool-contract";
 import { createTool } from "./tool-contract";
 import { runTool } from "./tool-execution";
 
-const setChecklistInputSchema = z.object({
+const createChecklistInputSchema = z.object({
   groupId: z.string().min(1),
   groupTitle: z.string().min(1),
   items: z
@@ -18,8 +18,8 @@ const setChecklistInputSchema = z.object({
     .min(1),
 });
 
-const setChecklistOutputSchema = z.object({
-  kind: z.literal("set-checklist"),
+const createChecklistOutputSchema = z.object({
+  kind: z.literal("create-checklist"),
   groupId: z.string(),
   itemCount: z.number(),
 });
@@ -37,22 +37,22 @@ const updateChecklistOutputSchema = z.object({
   status: checklistItemStatusSchema,
 });
 
-function createSetChecklistTool(
+function createCreateChecklistTool(
   _deps: ToolkitDeps,
   input: ToolkitInput,
   state: Map<string, { title: string; items: ChecklistItem[] }>,
 ) {
   return createTool({
-    id: "set-checklist",
+    id: "create-checklist",
     category: "meta",
     permissions: [],
     description: "Create an inline task checklist visible to the user. All items start as pending.",
     instruction:
-      "Use `set-checklist` once at the start of multi-step tasks to show the user a progress checklist. Define all steps upfront. Use `update-checklist` to change item statuses as you work.",
-    inputSchema: setChecklistInputSchema,
-    outputSchema: setChecklistOutputSchema,
+      "Use `create-checklist` once at the start of multi-step tasks to show the user a progress checklist. Define all steps upfront. Use `update-checklist` to change item statuses as you work.",
+    inputSchema: createChecklistInputSchema,
+    outputSchema: createChecklistOutputSchema,
     execute: async (toolInput, toolCallId) => {
-      return runTool(input.session, "set-checklist", toolCallId, toolInput, async () => {
+      return runTool(input.session, "create-checklist", toolCallId, toolInput, async () => {
         const items: ChecklistItem[] = toolInput.items.map((item) => ({
           id: item.id,
           label: item.label,
@@ -61,7 +61,7 @@ function createSetChecklistTool(
         }));
         state.set(toolInput.groupId, { title: toolInput.groupTitle, items });
         input.onChecklist({ groupId: toolInput.groupId, groupTitle: toolInput.groupTitle, items });
-        return { kind: "set-checklist" as const, groupId: toolInput.groupId, itemCount: items.length };
+        return { kind: "create-checklist" as const, groupId: toolInput.groupId, itemCount: items.length };
       });
     },
   });
@@ -78,7 +78,7 @@ function createUpdateChecklistTool(
     permissions: [],
     description: "Update the status of a single checklist item.",
     instruction:
-      "Use `update-checklist` to mark a checklist item as `in_progress`, `done`, or `failed`. Requires a prior `set-checklist` call for the same groupId.",
+      "Use `update-checklist` to mark a checklist item as `in_progress`, `done`, or `failed`. Requires a prior `create-checklist` call for the same groupId.",
     inputSchema: updateChecklistInputSchema,
     outputSchema: updateChecklistOutputSchema,
     execute: async (toolInput, toolCallId) => {
@@ -103,7 +103,7 @@ function createUpdateChecklistTool(
 export function createChecklistToolkit(deps: ToolkitDeps, input: ToolkitInput) {
   const state = new Map<string, { title: string; items: ChecklistItem[] }>();
   return {
-    setChecklist: createSetChecklistTool(deps, input, state),
+    createChecklist: createCreateChecklistTool(deps, input, state),
     updateChecklist: createUpdateChecklistTool(deps, input, state),
   };
 }

--- a/src/checklist-toolkit.ts
+++ b/src/checklist-toolkit.ts
@@ -85,10 +85,12 @@ function createUpdateChecklistTool(
       return runTool(input.session, "update-checklist", toolCallId, toolInput, async () => {
         const group = state.get(toolInput.groupId);
         if (!group) throw new Error(`No checklist found for groupId "${toolInput.groupId}"`);
-        const item = group.items.find((i) => i.id === toolInput.itemId);
-        if (!item) throw new Error(`No item "${toolInput.itemId}" in checklist "${toolInput.groupId}"`);
-        item.status = toolInput.status;
-        input.onChecklist({ groupId: toolInput.groupId, groupTitle: group.title, items: group.items });
+        if (!group.items.some((i) => i.id === toolInput.itemId)) {
+          throw new Error(`No item "${toolInput.itemId}" in checklist "${toolInput.groupId}"`);
+        }
+        const items = group.items.map((i) => (i.id === toolInput.itemId ? { ...i, status: toolInput.status } : i));
+        state.set(toolInput.groupId, { ...group, items });
+        input.onChecklist({ groupId: toolInput.groupId, groupTitle: group.title, items });
         return {
           kind: "update-checklist" as const,
           groupId: toolInput.groupId,

--- a/src/checklist-toolkit.ts
+++ b/src/checklist-toolkit.ts
@@ -39,13 +39,7 @@ function createUpdateChecklistTool(_deps: ToolkitDeps, input: ToolkitInput) {
     inputSchema: updateChecklistInputSchema,
     outputSchema: updateChecklistOutputSchema,
     execute: async (toolInput, toolCallId) => {
-      return runTool(input.session, "update-checklist", toolCallId, toolInput, async (callId) => {
-        input.onOutput({
-          toolName: "update-checklist",
-          content: { kind: "tool-header", labelKey: "tool.label.update_checklist", detail: toolInput.groupTitle },
-          toolCallId: callId,
-        });
-
+      return runTool(input.session, "update-checklist", toolCallId, toolInput, async () => {
         input.onChecklist({
           groupId: toolInput.groupId,
           groupTitle: toolInput.groupTitle,

--- a/src/checklist-toolkit.ts
+++ b/src/checklist-toolkit.ts
@@ -5,19 +5,18 @@ import { createTool } from "./tool-contract";
 import { runTool } from "./tool-execution";
 
 const updateChecklistInputSchema = z.object({
-  groupId: z.string().min(1).describe("Unique identifier for the checklist group."),
-  groupTitle: z.string().min(1).describe("Title displayed as the checklist header."),
+  groupId: z.string().min(1),
+  groupTitle: z.string().min(1),
   items: z
     .array(
       z.object({
-        id: z.string().min(1).describe("Unique item identifier within this group."),
-        label: z.string().min(1).describe("Short description of the step."),
-        status: checklistItemStatusSchema.describe("Current status of this item."),
-        order: z.number().int().nonnegative().describe("Display position (0-based)."),
+        id: z.string().min(1),
+        label: z.string().min(1),
+        status: checklistItemStatusSchema,
+        order: z.number().int().nonnegative(),
       }),
     )
-    .min(1)
-    .describe("Full list of checklist items. Always send the complete list, not a partial update."),
+    .min(1),
 });
 
 const updateChecklistOutputSchema = z.object({

--- a/src/checklist.int.test.ts
+++ b/src/checklist.int.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, test } from "bun:test";
+import { isChecklistOutput } from "./chat-contract";
+import type { ChecklistOutput } from "./checklist-contract";
+import { createClient, createMessageHandlerHarness } from "./test-utils";
+
+describe("checklist integration", () => {
+  test("checklist event creates a task row with correct content", async () => {
+    const { handleMessage, rows } = createMessageHandlerHarness({
+      client: createClient({
+        status: async () => ({}),
+        replyStream: async (_input, options) => {
+          options.onEvent({ type: "status", state: { kind: "running", mode: "work" } });
+          options.onEvent({
+            type: "checklist",
+            groupId: "grp_1",
+            groupTitle: "Refactoring auth module",
+            items: [
+              { id: "item_1", label: "read existing auth implementation", status: "done", order: 0 },
+              { id: "item_2", label: "extract token validation", status: "in_progress", order: 1 },
+              { id: "item_3", label: "add unit tests", status: "pending", order: 2 },
+            ],
+          });
+          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+        },
+      }),
+    });
+
+    await handleMessage("refactor auth");
+
+    const taskRows = rows.filter((row) => row.kind === "task" && isChecklistOutput(row.content));
+    expect(taskRows).toHaveLength(1);
+
+    const content = taskRows[0]?.content as ChecklistOutput;
+    expect(content.groupId).toBe("grp_1");
+    expect(content.groupTitle).toBe("Refactoring auth module");
+    expect(content.items).toHaveLength(3);
+    expect(content.items[0]?.status).toBe("done");
+    expect(content.items[1]?.status).toBe("in_progress");
+    expect(content.items[2]?.status).toBe("pending");
+  });
+
+  test("subsequent checklist events update the same row in place", async () => {
+    const { handleMessage, rows } = createMessageHandlerHarness({
+      client: createClient({
+        status: async () => ({}),
+        replyStream: async (_input, options) => {
+          options.onEvent({ type: "status", state: { kind: "running", mode: "work" } });
+
+          // Initial checklist
+          options.onEvent({
+            type: "checklist",
+            groupId: "grp_1",
+            groupTitle: "Build pipeline",
+            items: [
+              { id: "s1", label: "lint", status: "pending", order: 0 },
+              { id: "s2", label: "test", status: "pending", order: 1 },
+            ],
+          });
+
+          // Update: first item done, second in progress
+          options.onEvent({
+            type: "checklist",
+            groupId: "grp_1",
+            groupTitle: "Build pipeline",
+            items: [
+              { id: "s1", label: "lint", status: "done", order: 0 },
+              { id: "s2", label: "test", status: "in_progress", order: 1 },
+            ],
+          });
+
+          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+        },
+      }),
+    });
+
+    await handleMessage("run pipeline");
+
+    // Should have exactly one task row (updated in place, not two)
+    const taskRows = rows.filter((row) => row.kind === "task" && isChecklistOutput(row.content));
+    expect(taskRows).toHaveLength(1);
+
+    const content = taskRows[0]?.content as ChecklistOutput;
+    expect(content.items[0]?.status).toBe("done");
+    expect(content.items[1]?.status).toBe("in_progress");
+  });
+
+  test("different group IDs produce separate checklist rows", async () => {
+    const { handleMessage, rows } = createMessageHandlerHarness({
+      client: createClient({
+        status: async () => ({}),
+        replyStream: async (_input, options) => {
+          options.onEvent({ type: "status", state: { kind: "running", mode: "work" } });
+          options.onEvent({
+            type: "checklist",
+            groupId: "grp_a",
+            groupTitle: "Phase A",
+            items: [{ id: "a1", label: "step A1", status: "pending", order: 0 }],
+          });
+          options.onEvent({
+            type: "checklist",
+            groupId: "grp_b",
+            groupTitle: "Phase B",
+            items: [{ id: "b1", label: "step B1", status: "pending", order: 0 }],
+          });
+          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+        },
+      }),
+    });
+
+    await handleMessage("multi-phase");
+
+    const taskRows = rows.filter((row) => row.kind === "task" && isChecklistOutput(row.content));
+    expect(taskRows).toHaveLength(2);
+    expect((taskRows[0]?.content as ChecklistOutput).groupId).toBe("grp_a");
+    expect((taskRows[1]?.content as ChecklistOutput).groupId).toBe("grp_b");
+  });
+
+  test("checklist row appears before subsequent assistant text", async () => {
+    const { handleMessage, rows } = createMessageHandlerHarness({
+      client: createClient({
+        status: async () => ({}),
+        replyStream: async (_input, options) => {
+          options.onEvent({ type: "status", state: { kind: "running", mode: "work" } });
+          options.onEvent({
+            type: "checklist",
+            groupId: "grp_1",
+            groupTitle: "Steps",
+            items: [{ id: "s1", label: "do thing", status: "pending", order: 0 }],
+          });
+          options.onEvent({ type: "text-delta", text: "Working on it." });
+          return { state: "done" as const, model: "gpt-5-mini", output: "Working on it." };
+        },
+      }),
+    });
+
+    await handleMessage("go");
+
+    const taskIndex = rows.findIndex((row) => row.kind === "task" && isChecklistOutput(row.content));
+    const assistantIndex = rows.findIndex((row) => row.kind === "assistant");
+    expect(taskIndex).toBeGreaterThanOrEqual(0);
+    expect(assistantIndex).toBeGreaterThanOrEqual(0);
+    expect(taskIndex).toBeLessThan(assistantIndex);
+  });
+
+  test("checklist events do not break tool output rows", async () => {
+    const { handleMessage, rows } = createMessageHandlerHarness({
+      client: createClient({
+        status: async () => ({}),
+        replyStream: async (_input, options) => {
+          options.onEvent({ type: "status", state: { kind: "running", mode: "work" } });
+          options.onEvent({
+            type: "checklist",
+            groupId: "grp_1",
+            groupTitle: "Steps",
+            items: [{ id: "s1", label: "edit file", status: "in_progress", order: 0 }],
+          });
+          options.onEvent({
+            type: "tool-call",
+            toolCallId: "call_1",
+            toolName: "edit-file",
+            args: { path: "a.ts" },
+          });
+          options.onEvent({
+            type: "tool-output",
+            toolCallId: "call_1",
+            toolName: "edit-file",
+            content: { kind: "tool-header", labelKey: "tool.label.edit", detail: "a.ts" },
+          });
+          options.onEvent({
+            type: "tool-result",
+            toolCallId: "call_1",
+            toolName: "edit-file",
+          });
+          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+        },
+      }),
+    });
+
+    await handleMessage("edit something");
+
+    const taskRows = rows.filter((row) => row.kind === "task" && isChecklistOutput(row.content));
+    const toolRows = rows.filter((row) => row.kind === "tool");
+    expect(taskRows).toHaveLength(1);
+    expect(toolRows).toHaveLength(1);
+  });
+});

--- a/src/checklist.int.test.ts
+++ b/src/checklist.int.test.ts
@@ -17,8 +17,8 @@ describe("checklist integration", () => {
             groupId: "grp_1",
             groupTitle: "Refactoring auth module",
             items: [
-              { id: "item_1", label: "read existing auth implementation", status: "done", order: 0 },
-              { id: "item_2", label: "extract token validation", status: "in_progress", order: 1 },
+              { id: "item_1", label: "read existing auth implementation", status: "pending", order: 0 },
+              { id: "item_2", label: "extract token validation", status: "pending", order: 1 },
               { id: "item_3", label: "add unit tests", status: "pending", order: 2 },
             ],
           });
@@ -37,9 +37,7 @@ describe("checklist integration", () => {
     expect(content.groupId).toBe("grp_1");
     expect(content.groupTitle).toBe("Refactoring auth module");
     expect(content.items).toHaveLength(3);
-    expect(content.items[0]?.status).toBe("done");
-    expect(content.items[1]?.status).toBe("in_progress");
-    expect(content.items[2]?.status).toBe("pending");
+    expect(content.items.every((item) => item.status === "pending")).toBe(true);
   });
 
   test("subsequent checklist events update the same row in place", async () => {
@@ -49,6 +47,7 @@ describe("checklist integration", () => {
         status: async () => ({}),
         replyStream: async (_input, options) => {
           options.onEvent({ type: "status", state: { kind: "running", mode: "work" } });
+          // set-checklist creates with all pending
           options.onEvent({
             type: "checklist",
             groupId: "grp_1",
@@ -58,6 +57,7 @@ describe("checklist integration", () => {
               { id: "s2", label: "test", status: "pending", order: 1 },
             ],
           });
+          // update-checklist updates individual items
           options.onEvent({
             type: "checklist",
             groupId: "grp_1",

--- a/src/checklist.int.test.ts
+++ b/src/checklist.int.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
+import type { ChatRow } from "./chat-contract";
 import { isChecklistOutput } from "./chat-contract";
 import type { ChecklistOutput } from "./checklist-contract";
 import { createClient, createMessageHandlerHarness } from "./test-utils";
 
 describe("checklist integration", () => {
   test("checklist event creates a task row with correct content", async () => {
+    let snapshot: ChatRow[] = [];
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
@@ -20,6 +22,7 @@ describe("checklist integration", () => {
               { id: "item_3", label: "add unit tests", status: "pending", order: 2 },
             ],
           });
+          snapshot = [...rows];
           return { state: "done" as const, model: "gpt-5-mini", output: "done" };
         },
       }),
@@ -27,7 +30,7 @@ describe("checklist integration", () => {
 
     await handleMessage("refactor auth");
 
-    const taskRows = rows.filter((row) => row.kind === "task" && isChecklistOutput(row.content));
+    const taskRows = snapshot.filter((row) => row.kind === "task" && isChecklistOutput(row.content));
     expect(taskRows).toHaveLength(1);
 
     const content = taskRows[0]?.content as ChecklistOutput;
@@ -40,13 +43,12 @@ describe("checklist integration", () => {
   });
 
   test("subsequent checklist events update the same row in place", async () => {
+    let snapshot: ChatRow[] = [];
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
         replyStream: async (_input, options) => {
           options.onEvent({ type: "status", state: { kind: "running", mode: "work" } });
-
-          // Initial checklist
           options.onEvent({
             type: "checklist",
             groupId: "grp_1",
@@ -56,8 +58,6 @@ describe("checklist integration", () => {
               { id: "s2", label: "test", status: "pending", order: 1 },
             ],
           });
-
-          // Update: first item done, second in progress
           options.onEvent({
             type: "checklist",
             groupId: "grp_1",
@@ -67,7 +67,7 @@ describe("checklist integration", () => {
               { id: "s2", label: "test", status: "in_progress", order: 1 },
             ],
           });
-
+          snapshot = [...rows];
           return { state: "done" as const, model: "gpt-5-mini", output: "done" };
         },
       }),
@@ -75,8 +75,7 @@ describe("checklist integration", () => {
 
     await handleMessage("run pipeline");
 
-    // Should have exactly one task row (updated in place, not two)
-    const taskRows = rows.filter((row) => row.kind === "task" && isChecklistOutput(row.content));
+    const taskRows = snapshot.filter((row) => row.kind === "task" && isChecklistOutput(row.content));
     expect(taskRows).toHaveLength(1);
 
     const content = taskRows[0]?.content as ChecklistOutput;
@@ -85,6 +84,7 @@ describe("checklist integration", () => {
   });
 
   test("different group IDs produce separate checklist rows", async () => {
+    let snapshot: ChatRow[] = [];
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
@@ -102,6 +102,7 @@ describe("checklist integration", () => {
             groupTitle: "Phase B",
             items: [{ id: "b1", label: "step B1", status: "pending", order: 0 }],
           });
+          snapshot = [...rows];
           return { state: "done" as const, model: "gpt-5-mini", output: "done" };
         },
       }),
@@ -109,13 +110,14 @@ describe("checklist integration", () => {
 
     await handleMessage("multi-phase");
 
-    const taskRows = rows.filter((row) => row.kind === "task" && isChecklistOutput(row.content));
+    const taskRows = snapshot.filter((row) => row.kind === "task" && isChecklistOutput(row.content));
     expect(taskRows).toHaveLength(2);
     expect((taskRows[0]?.content as ChecklistOutput).groupId).toBe("grp_a");
     expect((taskRows[1]?.content as ChecklistOutput).groupId).toBe("grp_b");
   });
 
-  test("checklist row appears before subsequent assistant text", async () => {
+  test("checklist row appears before subsequent tool rows", async () => {
+    let snapshot: ChatRow[] = [];
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
@@ -127,22 +129,35 @@ describe("checklist integration", () => {
             groupTitle: "Steps",
             items: [{ id: "s1", label: "do thing", status: "pending", order: 0 }],
           });
-          options.onEvent({ type: "text-delta", text: "Working on it." });
-          return { state: "done" as const, model: "gpt-5-mini", output: "Working on it." };
+          options.onEvent({
+            type: "tool-call",
+            toolCallId: "call_1",
+            toolName: "read-file",
+            args: { path: "a.ts" },
+          });
+          options.onEvent({
+            type: "tool-output",
+            toolCallId: "call_1",
+            toolName: "read-file",
+            content: { kind: "tool-header", labelKey: "tool.label.read", detail: "a.ts" },
+          });
+          snapshot = [...rows];
+          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
         },
       }),
     });
 
     await handleMessage("go");
 
-    const taskIndex = rows.findIndex((row) => row.kind === "task" && isChecklistOutput(row.content));
-    const assistantIndex = rows.findIndex((row) => row.kind === "assistant");
+    const taskIndex = snapshot.findIndex((row) => row.kind === "task" && isChecklistOutput(row.content));
+    const toolIndex = snapshot.findIndex((row) => row.kind === "tool");
     expect(taskIndex).toBeGreaterThanOrEqual(0);
-    expect(assistantIndex).toBeGreaterThanOrEqual(0);
-    expect(taskIndex).toBeLessThan(assistantIndex);
+    expect(toolIndex).toBeGreaterThanOrEqual(0);
+    expect(taskIndex).toBeLessThan(toolIndex);
   });
 
   test("checklist events do not break tool output rows", async () => {
+    let snapshot: ChatRow[] = [];
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
@@ -171,6 +186,7 @@ describe("checklist integration", () => {
             toolCallId: "call_1",
             toolName: "edit-file",
           });
+          snapshot = [...rows];
           return { state: "done" as const, model: "gpt-5-mini", output: "done" };
         },
       }),
@@ -178,9 +194,55 @@ describe("checklist integration", () => {
 
     await handleMessage("edit something");
 
-    const taskRows = rows.filter((row) => row.kind === "task" && isChecklistOutput(row.content));
-    const toolRows = rows.filter((row) => row.kind === "tool");
+    const taskRows = snapshot.filter((row) => row.kind === "task" && isChecklistOutput(row.content));
+    const toolRows = snapshot.filter((row) => row.kind === "tool");
     expect(taskRows).toHaveLength(1);
     expect(toolRows).toHaveLength(1);
+  });
+
+  test("checklist rows are removed after turn completes", async () => {
+    const { handleMessage, rows } = createMessageHandlerHarness({
+      client: createClient({
+        status: async () => ({}),
+        replyStream: async (_input, options) => {
+          options.onEvent({ type: "status", state: { kind: "running", mode: "work" } });
+          options.onEvent({
+            type: "checklist",
+            groupId: "grp_1",
+            groupTitle: "Steps",
+            items: [{ id: "s1", label: "do thing", status: "done", order: 0 }],
+          });
+          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+        },
+      }),
+    });
+
+    await handleMessage("go");
+
+    const checklistRows = rows.filter((row) => row.kind === "task" && isChecklistOutput(row.content));
+    expect(checklistRows).toHaveLength(0);
+  });
+
+  test("checklist rows are removed on abort", async () => {
+    const { handleMessage, rows } = createMessageHandlerHarness({
+      client: createClient({
+        status: async () => ({}),
+        replyStream: async (_input, options) => {
+          options.onEvent({ type: "status", state: { kind: "running", mode: "work" } });
+          options.onEvent({
+            type: "checklist",
+            groupId: "grp_1",
+            groupTitle: "Steps",
+            items: [{ id: "s1", label: "do thing", status: "in_progress", order: 0 }],
+          });
+          throw Object.assign(new Error("aborted"), { name: "AbortError" });
+        },
+      }),
+    });
+
+    await handleMessage("go");
+
+    const checklistRows = rows.filter((row) => row.kind === "task" && isChecklistOutput(row.content));
+    expect(checklistRows).toHaveLength(0);
   });
 });

--- a/src/checklist.tui.test.tsx
+++ b/src/checklist.tui.test.tsx
@@ -29,15 +29,12 @@ describe("checklist TUI rendering", () => {
         },
       ]),
     ).toBe(
-      dedent(
-        `
-          Build pipeline (1/3)
-            ● lint
-            ◐ test
-            ○ deploy
-        `,
-        2,
-      ),
+      dedent`
+        Build pipeline (1/3)
+          ● lint
+          ◐ test
+          ○ deploy
+      `,
     );
   });
 
@@ -56,16 +53,13 @@ describe("checklist TUI rendering", () => {
         },
       ]),
     ).toBe(
-      dedent(
-        `
-          Steps (1/4)
-            ● done step
-            ◐ active step
-            ○ waiting step
-            ◉ broken step
-        `,
-        2,
-      ),
+      dedent`
+        Steps (1/4)
+          ● done step
+          ◐ active step
+          ○ waiting step
+          ◉ broken step
+      `,
     );
   });
 
@@ -83,15 +77,12 @@ describe("checklist TUI rendering", () => {
         },
       ]),
     ).toBe(
-      dedent(
-        `
-          Steps (1/3)
-            ● first
-            ◐ second
-            ○ third
-        `,
-        2,
-      ),
+      dedent`
+        Steps (1/3)
+          ● first
+          ◐ second
+          ○ third
+      `,
     );
   });
 
@@ -114,16 +105,13 @@ describe("checklist TUI rendering", () => {
         },
       ]),
     ).toBe(
-      dedent(
-        `
-          Phase A (1/1)
-            ● step A
+      dedent`
+        Phase A (1/1)
+          ● step A
 
-          Phase B (0/1)
-            ○ step B
-        `,
-        2,
-      ),
+        Phase B (0/1)
+          ○ step B
+      `,
     );
   });
 
@@ -140,14 +128,11 @@ describe("checklist TUI rendering", () => {
         },
       ]),
     ).toBe(
-      dedent(
-        `
-          Done (2/2)
-            ● a
-            ● b
-        `,
-        2,
-      ),
+      dedent`
+        Done (2/2)
+          ● a
+          ● b
+      `,
     );
   });
 });

--- a/src/checklist.tui.test.tsx
+++ b/src/checklist.tui.test.tsx
@@ -29,12 +29,15 @@ describe("checklist TUI rendering", () => {
         },
       ]),
     ).toBe(
-      dedent`
-        • Build pipeline (1/3)
+      dedent(
+        `
+          Build pipeline (1/3)
             ● lint
             ◐ test
             ○ deploy
-      `,
+        `,
+        2,
+      ),
     );
   });
 
@@ -53,13 +56,16 @@ describe("checklist TUI rendering", () => {
         },
       ]),
     ).toBe(
-      dedent`
-        • Steps (1/4)
+      dedent(
+        `
+          Steps (1/4)
             ● done step
             ◐ active step
             ○ waiting step
             ◉ broken step
-      `,
+        `,
+        2,
+      ),
     );
   });
 
@@ -77,12 +83,15 @@ describe("checklist TUI rendering", () => {
         },
       ]),
     ).toBe(
-      dedent`
-        • Steps (1/3)
+      dedent(
+        `
+          Steps (1/3)
             ● first
             ◐ second
             ○ third
-      `,
+        `,
+        2,
+      ),
     );
   });
 
@@ -105,13 +114,16 @@ describe("checklist TUI rendering", () => {
         },
       ]),
     ).toBe(
-      dedent`
-        • Phase A (1/1)
+      dedent(
+        `
+          Phase A (1/1)
             ● step A
 
-        • Phase B (0/1)
+          Phase B (0/1)
             ○ step B
-      `,
+        `,
+        2,
+      ),
     );
   });
 
@@ -128,11 +140,14 @@ describe("checklist TUI rendering", () => {
         },
       ]),
     ).toBe(
-      dedent`
-        • Done (2/2)
+      dedent(
+        `
+          Done (2/2)
             ● a
             ● b
-      `,
+        `,
+        2,
+      ),
     );
   });
 });

--- a/src/checklist.tui.test.tsx
+++ b/src/checklist.tui.test.tsx
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import { ChatChecklist } from "./chat-checklist";
+import type { ChatRow } from "./chat-contract";
+import type { ChecklistOutput } from "./checklist-contract";
+import { dedent } from "./test-utils";
+import { renderPlain } from "./tui-test-utils";
+
+function renderChecklist(checklists: ChecklistOutput[]): string {
+  const rows: ChatRow[] = checklists.map((content, i) => ({
+    id: `row_${i}`,
+    kind: "task",
+    content,
+  }));
+  return renderPlain(<ChatChecklist rows={rows} />, 96);
+}
+
+describe("checklist TUI rendering", () => {
+  test("renders header with progress and status markers", () => {
+    expect(
+      renderChecklist([
+        {
+          groupId: "g1",
+          groupTitle: "Build pipeline",
+          items: [
+            { id: "s1", label: "lint", status: "done", order: 0 },
+            { id: "s2", label: "test", status: "in_progress", order: 1 },
+            { id: "s3", label: "deploy", status: "pending", order: 2 },
+          ],
+        },
+      ]),
+    ).toBe(
+      dedent`
+        • Build pipeline (1/3)
+            ● lint
+            ◐ test
+            ○ deploy
+      `,
+    );
+  });
+
+  test("renders all status marker variants", () => {
+    expect(
+      renderChecklist([
+        {
+          groupId: "g1",
+          groupTitle: "Steps",
+          items: [
+            { id: "s1", label: "done step", status: "done", order: 0 },
+            { id: "s2", label: "active step", status: "in_progress", order: 1 },
+            { id: "s3", label: "waiting step", status: "pending", order: 2 },
+            { id: "s4", label: "broken step", status: "failed", order: 3 },
+          ],
+        },
+      ]),
+    ).toBe(
+      dedent`
+        • Steps (1/4)
+            ● done step
+            ◐ active step
+            ○ waiting step
+            ◉ broken step
+      `,
+    );
+  });
+
+  test("sorts items by order regardless of input order", () => {
+    expect(
+      renderChecklist([
+        {
+          groupId: "g1",
+          groupTitle: "Steps",
+          items: [
+            { id: "s3", label: "third", status: "pending", order: 2 },
+            { id: "s1", label: "first", status: "done", order: 0 },
+            { id: "s2", label: "second", status: "in_progress", order: 1 },
+          ],
+        },
+      ]),
+    ).toBe(
+      dedent`
+        • Steps (1/3)
+            ● first
+            ◐ second
+            ○ third
+      `,
+    );
+  });
+
+  test("renders nothing when rows are empty", () => {
+    expect(renderPlain(<ChatChecklist rows={[]} />, 96)).toBe("");
+  });
+
+  test("renders multiple checklists", () => {
+    expect(
+      renderChecklist([
+        {
+          groupId: "g1",
+          groupTitle: "Phase A",
+          items: [{ id: "a1", label: "step A", status: "done", order: 0 }],
+        },
+        {
+          groupId: "g2",
+          groupTitle: "Phase B",
+          items: [{ id: "b1", label: "step B", status: "pending", order: 0 }],
+        },
+      ]),
+    ).toBe(
+      dedent`
+        • Phase A (1/1)
+            ● step A
+
+        • Phase B (0/1)
+            ○ step B
+      `,
+    );
+  });
+
+  test("all done shows full progress", () => {
+    expect(
+      renderChecklist([
+        {
+          groupId: "g1",
+          groupTitle: "Done",
+          items: [
+            { id: "s1", label: "a", status: "done", order: 0 },
+            { id: "s2", label: "b", status: "done", order: 1 },
+          ],
+        },
+      ]),
+    ).toBe(
+      dedent`
+        • Done (2/2)
+            ● a
+            ● b
+      `,
+    );
+  });
+});

--- a/src/cli-prompt.test.ts
+++ b/src/cli-prompt.test.ts
@@ -55,6 +55,42 @@ describe("cli-prompt", () => {
     expect(session.messages[session.messages.length - 1]?.kind).toBe("tool_payload");
   });
 
+  test("checklist events print header and items", async () => {
+    const printed: string[] = [];
+    const originalWrite = process.stdout.write;
+    process.stdout.write = ((chunk: string) => {
+      printed.push(chunk);
+      return true;
+    }) as typeof process.stdout.write;
+
+    try {
+      const events: StreamEvent[] = [
+        {
+          type: "checklist",
+          groupId: "grp_1",
+          groupTitle: "Build pipeline",
+          items: [
+            { id: "s1", label: "lint", status: "done", order: 0 },
+            { id: "s2", label: "test", status: "in_progress", order: 1 },
+            { id: "s3", label: "deploy", status: "pending", order: 2 },
+          ],
+        },
+      ];
+
+      const session = createTestSession();
+      const client = createStreamingClient(events);
+      await handlePrompt("run pipeline", session, client);
+
+      const output = printed.join("");
+      expect(output).toContain("Build pipeline (1/3)");
+      expect(output).toContain("● lint");
+      expect(output).toContain("◐ test");
+      expect(output).toContain("○ deploy");
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+  });
+
   test("tool-output events with growing numWidth do not reprint earlier diffs", async () => {
     const printed: string[] = [];
     const originalWrite = process.stdout.write;

--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -1,7 +1,7 @@
 import { stdout as output } from "node:process";
 import { createWorkspaceSpecifier, type VerifyScope } from "./api";
 import { createMessage } from "./chat-session";
-import { formatChecklist } from "./checklist-contract";
+import { formatChecklist } from "./checklist-format";
 import { formatAssistantReplyOutput, printIndentedDim } from "./cli-format";
 import type { Client } from "./client-contract";
 import { nowIso } from "./datetime";

--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -1,6 +1,7 @@
 import { stdout as output } from "node:process";
 import { createWorkspaceSpecifier, type VerifyScope } from "./api";
 import { createMessage } from "./chat-session";
+import { checklistMarker, checklistProgress } from "./checklist-contract";
 import { formatAssistantReplyOutput, printIndentedDim } from "./cli-format";
 import type { Client } from "./client-contract";
 import { nowIso } from "./datetime";
@@ -149,6 +150,16 @@ export async function handlePrompt(
               }
               printDim(`• ${rendered.split("\n")[0] ?? ""}`);
               if (rendered.includes("\n")) printIndentedDim(rendered.slice(rendered.indexOf("\n") + 1));
+              hasPrintedToolProgress = true;
+              break;
+            }
+            case "checklist": {
+              const sorted = [...event.items].sort((a, b) => a.order - b.order);
+              const { done, total } = checklistProgress(sorted);
+              printDim(`• ${event.groupTitle} (${done}/${total})`);
+              for (const item of sorted) {
+                printIndentedDim(`${checklistMarker(item.status)} ${item.label}`);
+              }
               hasPrintedToolProgress = true;
               break;
             }

--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -1,7 +1,7 @@
 import { stdout as output } from "node:process";
 import { createWorkspaceSpecifier, type VerifyScope } from "./api";
 import { createMessage } from "./chat-session";
-import { checklistMarker, checklistProgress } from "./checklist-contract";
+import { formatChecklist } from "./checklist-contract";
 import { formatAssistantReplyOutput, printIndentedDim } from "./cli-format";
 import type { Client } from "./client-contract";
 import { nowIso } from "./datetime";
@@ -154,12 +154,9 @@ export async function handlePrompt(
               break;
             }
             case "checklist": {
-              const sorted = [...event.items].sort((a, b) => a.order - b.order);
-              const { done, total } = checklistProgress(sorted);
-              printDim(`• ${event.groupTitle} (${done}/${total})`);
-              for (const item of sorted) {
-                printIndentedDim(`${checklistMarker(item.status)} ${item.label}`);
-              }
+              const { header, lines } = formatChecklist(event);
+              printDim(`• ${header}`);
+              for (const line of lines) printIndentedDim(line);
               hasPrintedToolProgress = true;
               break;
             }

--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -156,7 +156,7 @@ export async function handlePrompt(
             case "checklist": {
               const { header, items } = formatChecklist(event);
               printDim(`• ${header}`);
-              for (const item of items) printIndentedDim(item.text);
+              for (const item of items) printIndentedDim(`${item.marker} ${item.label}`);
               hasPrintedToolProgress = true;
               break;
             }

--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -154,9 +154,9 @@ export async function handlePrompt(
               break;
             }
             case "checklist": {
-              const { header, lines } = formatChecklist(event);
+              const { header, items } = formatChecklist(event);
               printDim(`• ${header}`);
-              for (const line of lines) printIndentedDim(line);
+              for (const item of items) printIndentedDim(item.text);
               hasPrintedToolProgress = true;
               break;
             }

--- a/src/client-contract.ts
+++ b/src/client-contract.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { agentModeSchema } from "./agent-contract";
 import { type ChatRequest, type ChatResponse, chatResponseStateSchema } from "./api";
 import { invariant } from "./assert";
+import { checklistItemSchema } from "./checklist-contract";
 import { rpcServerMessageSchema } from "./rpc-protocol";
 import type { StatusFields } from "./status-contract";
 import { streamErrorSchema } from "./stream-error";
@@ -89,6 +90,12 @@ export const streamEventSchema = z.discriminatedUnion("type", [
   streamUsageEventSchema,
   z.object({ type: z.literal("status"), state: pendingStateSchema }),
   z.object({
+    type: z.literal("checklist"),
+    groupId: z.string().min(1),
+    groupTitle: z.string().min(1),
+    items: z.array(checklistItemSchema),
+  }),
+  z.object({
     type: z.literal("error"),
     errorMessage: z.string(),
     errorId: z.string().optional(),
@@ -116,6 +123,12 @@ type ToolResultEvent = {
 };
 type UsageEvent = { type: "usage"; inputTokens: number; outputTokens: number };
 type StatusEvent = { type: "status"; state: PendingState };
+type ChecklistEvent = {
+  type: "checklist";
+  groupId: string;
+  groupTitle: string;
+  items: z.infer<typeof checklistItemSchema>[];
+};
 type ErrorEvent = {
   type: "error";
   errorMessage: string;
@@ -132,6 +145,7 @@ export type StreamEvent =
   | ToolResultEvent
   | UsageEvent
   | StatusEvent
+  | ChecklistEvent
   | ErrorEvent;
 
 export interface Client {

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -226,8 +226,6 @@ export const EN_MESSAGES = {
   "tool.label.scan": "Scan",
   "tool.label.run": "Run",
   "tool.label.search": "Search",
-  "tool.label.set_checklist": "Checklist",
-  "tool.label.update_checklist": "Checklist",
   "tool.label.web_fetch": "Web Fetch",
   "tool.label.web_search": "Web Search",
   "unit.call": "{count} calls",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -226,6 +226,7 @@ export const EN_MESSAGES = {
   "tool.label.scan": "Scan",
   "tool.label.run": "Run",
   "tool.label.search": "Search",
+  "tool.label.update_checklist": "Checklist",
   "tool.label.web_fetch": "Web Fetch",
   "tool.label.web_search": "Web Search",
   "unit.call": "{count} calls",

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -226,6 +226,7 @@ export const EN_MESSAGES = {
   "tool.label.scan": "Scan",
   "tool.label.run": "Run",
   "tool.label.search": "Search",
+  "tool.label.set_checklist": "Checklist",
   "tool.label.update_checklist": "Checklist",
   "tool.label.web_fetch": "Web Fetch",
   "tool.label.web_search": "Web Search",

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -5,6 +5,7 @@ import type { ErrorCode } from "./error-contract";
 import type { ErrorCategory, ErrorSource } from "./error-handling";
 import type { LifecyclePolicy } from "./lifecycle-policy";
 import type { PromptBreakdownTotals } from "./lifecycle-usage";
+import type { ChecklistListener } from "./tool-contract";
 import type { SessionContext } from "./tool-guards";
 import type { ToolOutputPart } from "./tool-output-content";
 import type { ToolRecovery } from "./tool-recovery";
@@ -101,6 +102,7 @@ export type PhasePrepareInput = {
   policy: LifecyclePolicy;
   debug: RunContext["debug"];
   onOutput: (event: ToolOutputEvent) => void;
+  onChecklist: ChecklistListener;
 };
 export type PhasePrepareResult = {
   session: SessionContext;

--- a/src/lifecycle-prepare.test.ts
+++ b/src/lifecycle-prepare.test.ts
@@ -19,6 +19,7 @@ describe("phasePrepare", () => {
       policy,
       debug: () => {},
       onOutput: () => {},
+      onChecklist: () => {},
     });
     expect(prepared.session.toolTimeoutMs).toBe(1_234);
     expect(prepared.session.flags.consecutiveGuardBlockLimit).toBe(7);

--- a/src/lifecycle-prepare.ts
+++ b/src/lifecycle-prepare.ts
@@ -20,6 +20,7 @@ export function phasePrepare(input: PhasePrepareInput): PhasePrepareResult {
   const { tools, session } = toolsForAgent({
     workspace: input.workspace,
     onOutput: input.onOutput,
+    onChecklist: input.onChecklist,
     taskId: input.taskId,
     sessionId: input.request.sessionId,
   });

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -218,6 +218,9 @@ export async function runLifecycle(input: LifecycleInput, deps: LifecycleDeps = 
     onOutput: (event: ToolOutputEvent) => {
       ctxRef?.toolOutputHandler?.(event);
     },
+    onChecklist: (event) => {
+      emit({ type: "checklist", groupId: event.groupId, groupTitle: event.groupTitle, items: event.items });
+    },
   });
 
   const ctx = createRunContext(input, {

--- a/src/tool-contract.ts
+++ b/src/tool-contract.ts
@@ -1,4 +1,5 @@
 import type { z } from "zod";
+import type { ChecklistItem } from "./checklist-contract";
 import type { SessionContext } from "./tool-guards";
 import type { ToolOutputListener } from "./tool-output-format";
 
@@ -38,11 +39,7 @@ export type ToolkitDeps = {
   outputBudget: ToolOutputBudget;
 };
 
-export type ChecklistListener = (event: {
-  groupId: string;
-  groupTitle: string;
-  items: { id: string; label: string; status: "pending" | "in_progress" | "done" | "failed"; order: number }[];
-}) => void;
+export type ChecklistListener = (event: { groupId: string; groupTitle: string; items: ChecklistItem[] }) => void;
 
 export type ToolkitInput = {
   workspace: string;

--- a/src/tool-contract.ts
+++ b/src/tool-contract.ts
@@ -4,11 +4,10 @@ import type { SessionContext } from "./tool-guards";
 import type { ToolOutputListener } from "./tool-output-format";
 
 export type ToolPermission = "read" | "write" | "execute" | "network";
-export type ToolCategory = "read" | "search" | "write" | "execute" | "network";
+export type ToolCategory = "read" | "search" | "write" | "execute" | "network" | "meta";
 
 export type ToolDefinition<TInput = unknown, TOutput = unknown> = {
   readonly id: string;
-  readonly labelKey: string;
   readonly category: ToolCategory;
   readonly permissions: readonly ToolPermission[];
   readonly description: string;
@@ -16,6 +15,7 @@ export type ToolDefinition<TInput = unknown, TOutput = unknown> = {
   readonly inputSchema: z.ZodType<TInput>;
   readonly outputSchema: z.ZodType<TOutput>;
   readonly execute: (input: TInput, toolCallId: string) => Promise<TOutput>;
+  readonly labelKey?: string;
 };
 
 export type ToolOutputBudgetEntry = { maxChars: number; maxLines: number };

--- a/src/tool-contract.ts
+++ b/src/tool-contract.ts
@@ -38,10 +38,17 @@ export type ToolkitDeps = {
   outputBudget: ToolOutputBudget;
 };
 
+export type ChecklistListener = (event: {
+  groupId: string;
+  groupTitle: string;
+  items: { id: string; label: string; status: "pending" | "in_progress" | "done" | "failed"; order: number }[];
+}) => void;
+
 export type ToolkitInput = {
   workspace: string;
   session: SessionContext;
   onOutput: ToolOutputListener;
+  onChecklist: ChecklistListener;
 };
 
 export type ToolCacheEntry = {

--- a/src/tool-output.tui.test.tsx
+++ b/src/tool-output.tui.test.tsx
@@ -1,28 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import type { ChatRow } from "./chat-contract";
 import { ChatTranscript } from "./chat-transcript";
+import { dedent } from "./test-utils";
 import { formatToolOutput, type ToolOutputPart } from "./tool-output-content";
 import { renderPlain } from "./tui-test-utils";
-
-function dedent(value: string): string {
-  const lines = value.split("\n");
-  let start = 0;
-  while (start < lines.length && lines[start]?.trim().length === 0) start += 1;
-  let end = lines.length - 1;
-  while (end >= start && lines[end]?.trim().length === 0) end -= 1;
-  if (start > end) return "";
-  let prefix: string | null = null;
-  for (const line of lines.slice(start, end + 1)) {
-    if (line.trim().length === 0) continue;
-    const current = line.match(/^[ \t]*/)?.[0] ?? "";
-    if (prefix === null || current.length < prefix.length) prefix = current;
-  }
-  const p = prefix ?? "";
-  return lines
-    .slice(start, end + 1)
-    .map((line) => (line.startsWith(p) ? line.slice(p.length) : line))
-    .join("\n");
-}
 
 function renderChat(toolOutput: ToolOutputPart[]): string {
   const row: ChatRow = { id: "r1", kind: "tool", content: { parts: toolOutput } };

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -88,7 +88,7 @@ describe("toolIdsByCategory", () => {
     expect(ids).toContain("delete-file");
     expect(ids).toContain("git-add");
     expect(ids).toContain("git-commit");
-    expect(ids).toContain("update-checklist");
+    expect(ids).not.toContain("update-checklist");
     expect(ids).not.toContain("read-file");
     expect(ids).not.toContain("run-command");
     expect(ids).not.toContain("web-search");

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -12,6 +12,7 @@ describe("toolsets", () => {
   test("returns all tools", () => {
     const { tools, session } = toolsForAgent();
     expect(Object.keys(tools).sort()).toEqual([
+      "createChecklist",
       "createFile",
       "deleteFile",
       "editCode",
@@ -27,7 +28,6 @@ describe("toolsets", () => {
       "runCommand",
       "scanCode",
       "searchFiles",
-      "setChecklist",
       "updateChecklist",
       "webFetch",
       "webSearch",

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -27,6 +27,7 @@ describe("toolsets", () => {
       "runCommand",
       "scanCode",
       "searchFiles",
+      "updateChecklist",
       "webFetch",
       "webSearch",
     ]);
@@ -87,6 +88,7 @@ describe("toolIdsByCategory", () => {
     expect(ids).toContain("delete-file");
     expect(ids).toContain("git-add");
     expect(ids).toContain("git-commit");
+    expect(ids).toContain("update-checklist");
     expect(ids).not.toContain("read-file");
     expect(ids).not.toContain("run-command");
     expect(ids).not.toContain("web-search");

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -27,6 +27,7 @@ describe("toolsets", () => {
       "runCommand",
       "scanCode",
       "searchFiles",
+      "setChecklist",
       "updateChecklist",
       "webFetch",
       "webSearch",

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -78,8 +78,8 @@ function collectTools(
   workspace: string,
   session: SessionContext,
   onOutput: ToolOutputListener = noopOutput,
-  deps: ToolkitDeps = defaultToolkitDeps(),
   onChecklist: ChecklistListener = noopChecklist,
+  deps: ToolkitDeps = defaultToolkitDeps(),
 ): ToolMap {
   const combined: ToolMap = {};
   for (const toolkit of TOOLKIT_REGISTRY) {
@@ -149,7 +149,7 @@ export function toolsForAgent(options?: {
   const session = createSessionContext(options?.taskId, WRITE_TOOL_SET);
   session.cache = createToolCache(DISCOVERY_TOOL_SET, undefined, getDefaultToolCacheStore(options?.sessionId));
   return {
-    tools: collectTools(workspace, session, options?.onOutput, undefined, options?.onChecklist) as unknown as Toolset,
+    tools: collectTools(workspace, session, options?.onOutput, options?.onChecklist) as unknown as Toolset,
     session,
   };
 }

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -1,6 +1,7 @@
 import { resolve } from "node:path";
 import { appConfig } from "./app-config";
 import { invariant } from "./assert";
+import { createChecklistToolkit } from "./checklist-toolkit";
 import { createCodeToolkit } from "./code-toolkit";
 import { createFileToolkit } from "./file-toolkit";
 import { createGitToolkit } from "./git-toolkit";
@@ -8,7 +9,14 @@ import { EN_MESSAGES } from "./i18n/en";
 import { createShellToolkit } from "./shell-toolkit";
 import { createToolCache } from "./tool-cache";
 import { getDefaultToolCacheStore } from "./tool-cache-store";
-import type { ToolCategory, ToolDefinition, ToolkitDeps, ToolkitInput, ToolPermission } from "./tool-contract";
+import type {
+  ChecklistListener,
+  ToolCategory,
+  ToolDefinition,
+  ToolkitDeps,
+  ToolkitInput,
+  ToolPermission,
+} from "./tool-contract";
 import { createSessionContext, type SessionContext } from "./tool-guards";
 import type { ToolOutputListener } from "./tool-output-format";
 import { createWebToolkit } from "./web-toolkit";
@@ -20,7 +28,8 @@ type RegisteredToolkit = ReturnType<typeof createFileToolkit> &
   ReturnType<typeof createCodeToolkit> &
   ReturnType<typeof createWebToolkit> &
   ReturnType<typeof createShellToolkit> &
-  ReturnType<typeof createGitToolkit>;
+  ReturnType<typeof createGitToolkit> &
+  ReturnType<typeof createChecklistToolkit>;
 
 export type Toolset = {
   [Key in keyof RegisteredToolkit]: RegisteredToolkit[Key];
@@ -52,9 +61,14 @@ export const TOOLKIT_REGISTRY: {
     id: "git",
     createToolkit: (deps, input) => createGitToolkit(deps, input),
   },
+  {
+    id: "checklist",
+    createToolkit: (deps, input) => createChecklistToolkit(deps, input),
+  },
 ];
 
 const noopOutput: ToolOutputListener = () => {};
+const noopChecklist: ChecklistListener = () => {};
 
 const defaultToolkitDeps = (): ToolkitDeps => ({
   outputBudget: appConfig.agent.toolOutputBudget,
@@ -65,10 +79,11 @@ function collectTools(
   session: SessionContext,
   onOutput: ToolOutputListener = noopOutput,
   deps: ToolkitDeps = defaultToolkitDeps(),
+  onChecklist: ChecklistListener = noopChecklist,
 ): ToolMap {
   const combined: ToolMap = {};
   for (const toolkit of TOOLKIT_REGISTRY) {
-    Object.assign(combined, toolkit.createToolkit(deps, { workspace, session, onOutput }));
+    Object.assign(combined, toolkit.createToolkit(deps, { workspace, session, onOutput, onChecklist }));
   }
   return combined;
 }
@@ -123,6 +138,7 @@ export const DISCOVERY_TOOL_SET = new Set<string>(DISCOVERY_TOOLS);
 export function toolsForAgent(options?: {
   workspace?: string;
   onOutput?: ToolOutputListener;
+  onChecklist?: ChecklistListener;
   taskId?: string;
   sessionId?: string;
 }): {
@@ -133,7 +149,7 @@ export function toolsForAgent(options?: {
   const session = createSessionContext(options?.taskId, WRITE_TOOL_SET);
   session.cache = createToolCache(DISCOVERY_TOOL_SET, undefined, getDefaultToolCacheStore(options?.sessionId));
   return {
-    tools: collectTools(workspace, session, options?.onOutput) as unknown as Toolset,
+    tools: collectTools(workspace, session, options?.onOutput, undefined, options?.onChecklist) as unknown as Toolset,
     session,
   };
 }

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -92,14 +92,15 @@ function asToolDefinitionsById(entries: ToolMap): Record<string, AnyToolDefiniti
   const byId: Record<string, AnyToolDefinition> = {};
   for (const tool of Object.values(entries)) {
     invariant(typeof tool.id === "string" && tool.id.trim().length > 0, "tool id is required");
-    invariant(typeof tool.labelKey === "string" && tool.labelKey.trim().length > 0, `tool ${tool.id} missing labelKey`);
-    invariant(tool.labelKey in EN_MESSAGES, `tool ${tool.id} has unknown labelKey "${tool.labelKey}"`);
+    if (tool.labelKey) {
+      invariant(tool.labelKey in EN_MESSAGES, `tool ${tool.id} has unknown labelKey "${tool.labelKey}"`);
+    }
     invariant(typeof tool.category === "string" && tool.category.trim().length > 0, `tool ${tool.id} missing category`);
     invariant(
       typeof tool.instruction === "string" && tool.instruction.trim().length > 0,
       `tool ${tool.id} missing instruction`,
     );
-    invariant(Array.isArray(tool.permissions) && tool.permissions.length > 0, `tool ${tool.id} missing permissions`);
+    invariant(Array.isArray(tool.permissions), `tool ${tool.id} missing permissions`);
     byId[tool.id] = tool as AnyToolDefinition;
   }
   return byId;


### PR DESCRIPTION
## Summary

- add `create-checklist` and `update-checklist` tools for real-time progress display
- new `meta` tool category with empty permissions — available in all modes, no filesystem access
- `labelKey` optional on `ToolDefinition` for tools that don't render output rows
- checklist pinned between transcript and input, ephemeral per turn
- 7 integration tests, 6 TUI rendering tests

Fixes #49