### PR TITLE
feat(trace): compact default output

### DIFF
--- a/src/cli-command-registry.ts
+++ b/src/cli-command-registry.ts
@@ -323,9 +323,9 @@ const COMMAND_REGISTRY: Record<string, CliCommand> = {
   trace: {
     help: {
       command: "trace",
-      usage: "acolyte trace [list|task <id>] [--lines <n>] [--json]",
+      usage: "acolyte trace [list|task <id>] [--lines <n>] [--verbose] [--json]",
       description: t("cli.help.desc.trace"),
-      examples: ["acolyte trace", "acolyte trace task task_abc123", "acolyte trace --json"],
+      examples: ["acolyte trace", "acolyte trace task task_abc123", "acolyte trace task --verbose"],
     },
     handler: (args) =>
       traceMode(args, {

--- a/src/cli-output.test.ts
+++ b/src/cli-output.test.ts
@@ -61,6 +61,14 @@ describe("createTextOutput", () => {
     const out = createTextOutput();
     expect(out.render()).toBe("");
   });
+
+  test("verbose defaults to false", () => {
+    expect(createTextOutput().verbose).toBe(false);
+  });
+
+  test("verbose can be set via options", () => {
+    expect(createTextOutput({ verbose: true }).verbose).toBe(true);
+  });
 });
 
 describe("createJsonOutput", () => {

--- a/src/cli-output.ts
+++ b/src/cli-output.ts
@@ -1,6 +1,11 @@
 import { alignCols } from "./chat-format";
 
+export type CliOutputOptions = {
+  verbose?: boolean;
+};
+
 export type CliOutput = {
+  readonly verbose: boolean;
   addRow: (data: Record<string, string | undefined>) => void;
   addTable: (rows: Record<string, string | undefined>[], labels?: Record<string, string>) => void;
   addHeader: (text: string) => void;
@@ -15,10 +20,11 @@ function renderKvPairs(data: Record<string, string | undefined>): string {
     .join(" ");
 }
 
-export function createTextOutput(): CliOutput {
+export function createTextOutput(options?: CliOutputOptions): CliOutput {
   const sections: string[] = [];
 
   return {
+    verbose: options?.verbose ?? false,
     addRow: (data) => sections.push(renderKvPairs(data)),
     addTable: (rows, labels) => {
       if (rows.length === 0) return;
@@ -41,10 +47,11 @@ function stripUndefined(data: Record<string, string | undefined>): Record<string
   return out;
 }
 
-export function createJsonOutput(): CliOutput {
+export function createJsonOutput(options?: CliOutputOptions): CliOutput {
   const lines: string[] = [];
 
   return {
+    verbose: options?.verbose ?? false,
     addRow: (data) => lines.push(JSON.stringify(stripUndefined(data))),
     addTable: (rows) => {
       for (const row of rows) lines.push(JSON.stringify(stripUndefined(row)));

--- a/src/cli-trace.test.ts
+++ b/src/cli-trace.test.ts
@@ -87,8 +87,8 @@ describe("traceMode", () => {
     });
     const { deps, output } = createDeps({ traceStore: store });
     await traceMode(["task", "task_1"], deps);
-    expect(output()).toContain("task_id=task_1");
-    expect(output()).not.toContain("task_id=task_12");
+    expect(output()).toContain("task_1");
+    expect(output()).not.toContain("task_12");
   });
 
   test("default lists recent tasks", async () => {
@@ -179,41 +179,41 @@ describe("traceMode", () => {
     expect(output()).toContain("No trace data available");
   });
 
-  test("task subcommand hides tool.output and tool.cache events by default", async () => {
+  test("default compact output shows tool name and duration, not raw events", async () => {
     const store = createTestStore();
     store.write({
       timestamp: "2026-01-01T00:00:00.000Z",
       taskId: "task_1",
-      event: "lifecycle.tool.call",
-      fields: { tool: "edit-code", path: "." },
+      event: "lifecycle.start",
+      fields: { mode: "work", model: "m" },
     });
-    for (let i = 0; i < 5; i++) {
-      store.write({
-        timestamp: `2026-01-01T00:00:00.${String(i).padStart(3, "0")}Z`,
-        taskId: "task_1",
-        event: "lifecycle.tool.output",
-        fields: { tool: "edit-code" },
-      });
-    }
     store.write({
       timestamp: "2026-01-01T00:00:00.100Z",
       taskId: "task_1",
-      event: "lifecycle.tool.cache",
-      fields: { tool: "edit-code", hit: "false" },
+      event: "lifecycle.tool.call",
+      fields: { tool: "edit-code", path: "src/foo.ts" },
     });
     store.write({
-      timestamp: "2026-01-01T00:00:01.000Z",
+      timestamp: "2026-01-01T00:00:00.545Z",
       taskId: "task_1",
       event: "lifecycle.tool.result",
       fields: { tool: "edit-code", duration_ms: "445", is_error: "false" },
     });
+    store.write({
+      timestamp: "2026-01-01T00:00:01.000Z",
+      taskId: "task_1",
+      event: "lifecycle.summary",
+      fields: { model_calls: "1", tool_calls: "1", write_calls: "1", has_error: "false" },
+    });
     const { deps, output } = createDeps({ traceStore: store });
     await traceMode(["task", "task_1"], deps);
     const text = output();
-    expect(text).toContain("lifecycle.tool.call");
-    expect(text).toContain("lifecycle.tool.result");
-    expect(text).not.toContain("lifecycle.tool.output");
-    expect(text).not.toContain("lifecycle.tool.cache");
+    expect(text).toContain("edit-code");
+    expect(text).toContain("src/foo.ts");
+    expect(text).toContain("445ms");
+    expect(text).toContain("status=ok");
+    expect(text).not.toContain("lifecycle.tool.call");
+    expect(text).not.toContain("lifecycle.tool.result");
   });
 
   test("task list shows blocked status for blocked tasks", async () => {
@@ -235,6 +235,213 @@ describe("traceMode", () => {
     const text = output();
     expect(text).toContain("blocked");
     expect(text).not.toContain("ok");
+  });
+
+  test("compact output shows BLOCKED with guard id", async () => {
+    const store = createTestStore();
+    store.write({
+      timestamp: "2026-01-01T00:00:00.000Z",
+      taskId: "task_1",
+      event: "lifecycle.start",
+      fields: { mode: "work", model: "m" },
+    });
+    store.write({
+      timestamp: "2026-01-01T00:00:00.100Z",
+      taskId: "task_1",
+      event: "lifecycle.tool.call",
+      fields: { tool: "edit-file", path: "src/foo.ts" },
+    });
+    store.write({
+      timestamp: "2026-01-01T00:00:00.200Z",
+      taskId: "task_1",
+      event: "lifecycle.guard",
+      fields: { guard: "post-edit-redundancy", tool: "edit-file", action: "blocked", detail: "src/foo.ts" },
+    });
+    store.write({
+      timestamp: "2026-01-01T00:00:00.200Z",
+      taskId: "task_1",
+      event: "lifecycle.tool.result",
+      fields: { tool: "edit-file", duration_ms: "100", is_error: "false" },
+    });
+    const { deps, output } = createDeps({ traceStore: store });
+    await traceMode(["task", "task_1"], deps);
+    const text = output();
+    expect(text).toContain("BLOCKED");
+    expect(text).toContain("post-edit-redundancy");
+  });
+
+  test("compact output shows regeneration separators and hides eval done", async () => {
+    const store = createTestStore();
+    store.write({
+      timestamp: "2026-01-01T00:00:00.000Z",
+      taskId: "task_1",
+      event: "lifecycle.start",
+      fields: { mode: "work", model: "m" },
+    });
+    store.write({
+      timestamp: "2026-01-01T00:00:00.100Z",
+      taskId: "task_1",
+      event: "lifecycle.tool.call",
+      fields: { tool: "read-file", path: "src/a.ts" },
+    });
+    store.write({
+      timestamp: "2026-01-01T00:00:00.200Z",
+      taskId: "task_1",
+      event: "lifecycle.tool.result",
+      fields: { tool: "read-file", duration_ms: "100", is_error: "false" },
+    });
+    store.write({
+      timestamp: "2026-01-01T00:00:01.000Z",
+      taskId: "task_1",
+      event: "lifecycle.eval.decision",
+      fields: { evaluator: "guard-recovery", action: "done" },
+    });
+    store.write({
+      timestamp: "2026-01-01T00:00:01.001Z",
+      taskId: "task_1",
+      event: "lifecycle.eval.decision",
+      fields: { evaluator: "verify-cycle", action: "regenerate", regeneration_count: "1" },
+    });
+    store.write({
+      timestamp: "2026-01-01T00:00:02.000Z",
+      taskId: "task_1",
+      event: "lifecycle.summary",
+      fields: {
+        model_calls: "2",
+        tool_calls: "1",
+        read_calls: "1",
+        regeneration_count: "1",
+        has_error: "false",
+      },
+    });
+    const { deps, output } = createDeps({ traceStore: store });
+    await traceMode(["task", "task_1"], deps);
+    const text = output();
+    expect(text).toContain("regenerate (verify-cycle)");
+    expect(text).not.toContain("action=done");
+    expect(text).toContain("regenerations=1");
+  });
+
+  test("compact output renders summary footer", async () => {
+    const store = createTestStore();
+    store.write({
+      timestamp: "2026-01-01T00:00:00.000Z",
+      taskId: "task_1",
+      event: "lifecycle.start",
+      fields: { mode: "work", model: "m" },
+    });
+    store.write({
+      timestamp: "2026-01-01T00:00:05.000Z",
+      taskId: "task_1",
+      event: "lifecycle.summary",
+      fields: {
+        model_calls: "3",
+        tool_calls: "5",
+        read_calls: "2",
+        search_calls: "1",
+        write_calls: "2",
+        regeneration_count: "0",
+        guard_blocked_count: "1",
+        has_error: "true",
+      },
+    });
+    const { deps, output } = createDeps({ traceStore: store });
+    await traceMode(["task", "task_1"], deps);
+    const text = output();
+    expect(text).toContain("model_calls=3");
+    expect(text).toContain("tools=5");
+    expect(text).toContain("read=2");
+    expect(text).toContain("write=2");
+    expect(text).toContain("guard_blocked=1");
+    expect(text).toContain("status=error");
+  });
+
+  test("compact output hides setup events", async () => {
+    const store = createTestStore();
+    store.write({
+      timestamp: "2026-01-01T00:00:00.000Z",
+      taskId: "task_1",
+      event: "lifecycle.workspace.profile",
+      fields: { ecosystem: "typescript", package_manager: "bun" },
+    });
+    store.write({
+      timestamp: "2026-01-01T00:00:00.001Z",
+      taskId: "task_1",
+      event: "lifecycle.classify",
+      fields: { mode: "work", model: "m", provider: "openai" },
+    });
+    store.write({
+      timestamp: "2026-01-01T00:00:00.002Z",
+      taskId: "task_1",
+      event: "lifecycle.prepare",
+      fields: { mode: "work", model: "m", history_messages: "2" },
+    });
+    store.write({
+      timestamp: "2026-01-01T00:00:00.003Z",
+      taskId: "task_1",
+      event: "lifecycle.start",
+      fields: { mode: "work", model: "m" },
+    });
+    store.write({
+      timestamp: "2026-01-01T00:00:00.004Z",
+      taskId: "task_1",
+      event: "lifecycle.generate.start",
+      fields: { model: "m", mode: "work" },
+    });
+    store.write({
+      timestamp: "2026-01-01T00:00:01.000Z",
+      taskId: "task_1",
+      event: "lifecycle.generate.done",
+      fields: { model: "m", tool_calls: "0", text_chars: "5" },
+    });
+    store.write({
+      timestamp: "2026-01-01T00:00:01.001Z",
+      taskId: "task_1",
+      event: "lifecycle.summary",
+      fields: { model_calls: "1", tool_calls: "0", has_error: "false" },
+    });
+    const { deps, output } = createDeps({ traceStore: store });
+    await traceMode(["task", "task_1"], deps);
+    const text = output();
+    expect(text).not.toContain("workspace.profile");
+    expect(text).not.toContain("classify");
+    expect(text).not.toContain("prepare");
+    expect(text).not.toContain("generate.start");
+    expect(text).not.toContain("generate.done");
+    expect(text).toContain("task_1");
+    expect(text).toContain("status=ok");
+  });
+
+  test("--json outputs raw events not compact format", async () => {
+    const store = createTestStore();
+    store.write({
+      timestamp: "2026-01-01T00:00:00.000Z",
+      taskId: "task_1",
+      event: "lifecycle.start",
+      fields: { mode: "work", model: "m" },
+    });
+    store.write({
+      timestamp: "2026-01-01T00:00:00.100Z",
+      taskId: "task_1",
+      event: "lifecycle.tool.call",
+      fields: { tool: "read-file", path: "src/a.ts" },
+    });
+    store.write({
+      timestamp: "2026-01-01T00:00:01.000Z",
+      taskId: "task_1",
+      event: "lifecycle.summary",
+      fields: { model_calls: "1", tool_calls: "1", has_error: "false" },
+    });
+    const { deps, output } = createDeps({ traceStore: store });
+    await traceMode(["task", "task_1", "--json"], deps);
+    const text = output();
+    const lines = text.split("\n");
+    for (const l of lines) {
+      expect(() => JSON.parse(l)).not.toThrow();
+    }
+    expect(text).toContain("lifecycle.start");
+    expect(text).toContain("lifecycle.tool.call");
+    expect(text).not.toContain("──");
   });
 
   test("task subcommand --verbose shows tool.output and tool.cache events", async () => {

--- a/src/cli-trace.ts
+++ b/src/cli-trace.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { hasBoolFlag, parseFlag, parsePositional, parseTailCount } from "./cli-args";
 import { createJsonOutput, createTextOutput } from "./cli-output";
-import { formatDuration, formatRelativeTime } from "./datetime";
+import { elapsedMs, formatDuration, formatRelativeTime } from "./datetime";
 import { t } from "./i18n";
 import type { LogLine } from "./log-parser";
 import type { TraceStore } from "./trace-store";
@@ -185,10 +185,6 @@ function extractToolArg(fields: Record<string, string>): string {
   if (fields.pattern) return `"${fields.pattern}"`;
   if (fields.paths) return parsePaths(fields.paths).join(", ");
   return "";
-}
-
-function elapsedMs(startTs: string, endTs: string): number {
-  return new Date(endTs).getTime() - new Date(startTs).getTime();
 }
 
 type CompactRow = { kind: "tool"; line: CompactToolLine } | { kind: "separator"; text: string };

--- a/src/cli-trace.ts
+++ b/src/cli-trace.ts
@@ -197,14 +197,18 @@ function formatDuration(startTs: string, endTs: string): string {
   return `${minutes}m ${seconds}s`;
 }
 
-function formatToolTable(toolLines: CompactToolLine[]): string[] {
-  if (toolLines.length === 0) return [];
-  const maxTool = Math.max(...toolLines.map((l) => l.tool.length));
-  const maxArg = Math.max(...toolLines.map((l) => l.arg.length));
-  return toolLines.map((l) => {
-    const tool = l.tool.padEnd(maxTool);
-    const arg = l.arg.padEnd(maxArg);
-    const suffix = l.status ? `  ${l.status}` : "";
+type CompactRow = { kind: "tool"; line: CompactToolLine } | { kind: "separator"; text: string };
+
+function renderCompactRows(rows: CompactRow[]): string[] {
+  const tools = rows.filter((r): r is { kind: "tool"; line: CompactToolLine } => r.kind === "tool");
+  if (tools.length === 0) return rows.filter((r) => r.kind === "separator").map((r) => r.text);
+  const maxTool = Math.max(...tools.map((r) => r.line.tool.length));
+  const maxArg = Math.max(...tools.map((r) => r.line.arg.length));
+  return rows.map((r) => {
+    if (r.kind === "separator") return r.text;
+    const tool = r.line.tool.padEnd(maxTool);
+    const arg = r.line.arg.padEnd(maxArg);
+    const suffix = r.line.status ? `  ${r.line.status}` : "";
     return `  ${tool}  ${arg}${suffix}`.trimEnd();
   });
 }
@@ -238,20 +242,13 @@ function renderCompactLines(lines: LogLine[]): string[] {
   output.push(`${taskId}  ${model}  ${mode}  ${duration}`);
   output.push("");
 
-  const toolLines: CompactToolLine[] = [];
+  const rows: CompactRow[] = [];
   let pending: CompactToolLine | null = null;
 
   const flushPending = () => {
     if (!pending) return;
-    toolLines.push(pending);
+    rows.push({ kind: "tool", line: pending });
     pending = null;
-  };
-
-  const flushSection = (separator: string) => {
-    flushPending();
-    output.push(...formatToolTable(toolLines));
-    toolLines.length = 0;
-    output.push(separator);
   };
 
   for (const line of lines) {
@@ -279,23 +276,28 @@ function renderCompactLines(lines: LogLine[]): string[] {
 
     if (event === "lifecycle.eval.decision") {
       if (line.fields.action === "regenerate") {
-        flushSection(`  ── regenerate (${line.fields.evaluator ?? ""}) ──`);
+        flushPending();
+        rows.push({ kind: "separator", text: `  ── regenerate (${line.fields.evaluator ?? ""}) ──` });
       }
       continue;
     }
 
     if (event === "lifecycle.eval.skipped") {
-      flushSection(`  ── skipped ${line.fields.evaluator ?? ""} (${line.fields.reason ?? ""}) ──`);
+      flushPending();
+      rows.push({
+        kind: "separator",
+        text: `  ── skipped ${line.fields.evaluator ?? ""} (${line.fields.reason ?? ""}) ──`,
+      });
       continue;
     }
 
     if (event === "lifecycle.signal.accepted" && line.fields.signal !== "done") {
-      output.push(`  @signal ${line.fields.signal ?? "?"}`);
+      rows.push({ kind: "separator", text: `  @signal ${line.fields.signal ?? "?"}` });
     }
   }
 
   flushPending();
-  output.push(...formatToolTable(toolLines));
+  output.push(...renderCompactRows(rows));
 
   if (summaryLine) {
     output.push("  ──");

--- a/src/cli-trace.ts
+++ b/src/cli-trace.ts
@@ -351,7 +351,7 @@ export async function traceMode(args: string[], deps: TraceModeDeps): Promise<vo
   const tailCount = parseTailCount(parseFlag(args, ["--lines", "-n"]));
   const verbose = hasBoolFlag(args, "--verbose");
   const isJson = hasBoolFlag(args, "--json");
-  const out = isJson ? createJsonOutput() : createTextOutput();
+  const out = isJson ? createJsonOutput({ verbose }) : createTextOutput({ verbose });
 
   const positional = parsePositional(args, ["--lines", "-n"]);
   const subcommand = positional[0];
@@ -376,9 +376,9 @@ export async function traceMode(args: string[], deps: TraceModeDeps): Promise<vo
         continue;
       }
       if (i > 0) out.addSeparator();
-      if (verbose || isJson) {
+      if (out.verbose || isJson) {
         for (const line of lines) {
-          if (!verbose && line.fields.event && VERBOSE_ONLY_EVENTS.has(line.fields.event)) continue;
+          if (!out.verbose && line.fields.event && VERBOSE_ONLY_EVENTS.has(line.fields.event)) continue;
           out.addRow(traceRowData(line));
         }
       } else {

--- a/src/cli-trace.ts
+++ b/src/cli-trace.ts
@@ -127,8 +127,41 @@ const EVENT_FIELDS: Record<TraceEvent, FieldSpec[]> = {
 
 const KNOWN_EVENTS = new Set<string>(traceEventSchema.options);
 
-/** Events hidden from `acolyte trace task` unless --verbose is passed. */
 const VERBOSE_ONLY_EVENTS = new Set<string>(["lifecycle.tool.output", "lifecycle.tool.cache"]);
+
+function verboseRowData(line: LogLine): Record<string, string | undefined> {
+  const event = line.fields.event;
+  const data: Record<string, string | undefined> = {
+    timestamp: line.timestamp,
+    task_id: line.taskId,
+  };
+
+  if (!event) {
+    data.msg = line.fields.msg ?? "log";
+    return data;
+  }
+
+  data.event = event;
+
+  if (KNOWN_EVENTS.has(event)) {
+    const specs = EVENT_FIELDS[event as TraceEvent];
+    for (const spec of specs) {
+      const key = typeof spec === "string" ? spec : spec.key;
+      const label = typeof spec === "string" ? spec : spec.label;
+      data[label] = line.fields[key];
+    }
+  } else if (event.startsWith("lifecycle.memory.")) {
+    data.reason = line.fields.reason;
+  }
+
+  return data;
+}
+
+type CompactToolLine = {
+  tool: string;
+  arg: string;
+  status: string;
+};
 
 function extractToolArg(fields: Record<string, string>): string {
   if (fields.path) return fields.path;
@@ -164,125 +197,6 @@ function formatDuration(startTs: string, endTs: string): string {
   return `${minutes}m ${seconds}s`;
 }
 
-type CompactToolLine = {
-  tool: string;
-  arg: string;
-  status: string;
-};
-
-function renderCompactLines(lines: LogLine[]): string[] {
-  const output: string[] = [];
-
-  // Header: task_id, model, mode, duration
-  const firstTs = lines[0]?.timestamp;
-  const lastTs = lines[lines.length - 1]?.timestamp;
-  const startLine = lines.find((l) => l.fields.event === "lifecycle.start");
-  const summaryLine = lines.find((l) => l.fields.event === "lifecycle.summary");
-  const taskId = lines[0]?.taskId ?? "unknown";
-  const model = startLine?.fields.model ?? "unknown";
-  const mode = startLine?.fields.mode ?? "unknown";
-  const duration = firstTs && lastTs ? formatDuration(firstTs, lastTs) : "?";
-  output.push(`${taskId}  ${model}  ${mode}  ${duration}`);
-  output.push("");
-
-  // Build a map of tool call index → guard/result info
-  const toolLines: CompactToolLine[] = [];
-  let pendingToolCall: { tool: string; arg: string } | null = null;
-
-  for (const line of lines) {
-    const event = line.fields.event;
-    if (!event) continue;
-
-    if (event === "lifecycle.tool.call") {
-      if (pendingToolCall) {
-        toolLines.push({ tool: pendingToolCall.tool, arg: pendingToolCall.arg, status: "" });
-      }
-      pendingToolCall = {
-        tool: line.fields.tool ?? "?",
-        arg: extractToolArg(line.fields),
-      };
-      continue;
-    }
-
-    if (event === "lifecycle.guard" && pendingToolCall) {
-      const guard = line.fields.guard ?? "";
-      toolLines.push({ tool: pendingToolCall.tool, arg: pendingToolCall.arg, status: `BLOCKED  ${guard}` });
-      pendingToolCall = null;
-      continue;
-    }
-
-    if (event === "lifecycle.tool.result" && pendingToolCall) {
-      const durationMs = line.fields.duration_ms;
-      const isTimeout = durationMs && Number(durationMs) >= 120_000;
-      const status = isTimeout
-        ? `TIMEOUT ${Math.round(Number(durationMs) / 1000)}s`
-        : durationMs
-          ? `${durationMs}ms`
-          : "";
-      toolLines.push({ tool: pendingToolCall.tool, arg: pendingToolCall.arg, status });
-      pendingToolCall = null;
-      continue;
-    }
-
-    if (event === "lifecycle.eval.decision") {
-      if (pendingToolCall) {
-        toolLines.push({ tool: pendingToolCall.tool, arg: pendingToolCall.arg, status: "" });
-        pendingToolCall = null;
-      }
-      if (line.fields.action === "regenerate") {
-        const evaluator = line.fields.evaluator ?? "";
-        output.push(...formatToolTable(toolLines));
-        toolLines.length = 0;
-        output.push(`  ── regenerate (${evaluator}) ──`);
-      }
-      continue;
-    }
-
-    if (event === "lifecycle.eval.skipped") {
-      if (pendingToolCall) {
-        toolLines.push({ tool: pendingToolCall.tool, arg: pendingToolCall.arg, status: "" });
-        pendingToolCall = null;
-      }
-      const evaluator = line.fields.evaluator ?? "";
-      const reason = line.fields.reason ?? "";
-      output.push(...formatToolTable(toolLines));
-      toolLines.length = 0;
-      output.push(`  ── skipped ${evaluator} (${reason}) ──`);
-      continue;
-    }
-
-    if (event === "lifecycle.signal.accepted" && line.fields.signal !== "done") {
-      output.push(`  @signal ${line.fields.signal ?? "?"}`);
-    }
-  }
-
-  if (pendingToolCall) {
-    toolLines.push({ tool: pendingToolCall.tool, arg: pendingToolCall.arg, status: "" });
-  }
-
-  output.push(...formatToolTable(toolLines));
-
-  // Summary footer
-  if (summaryLine) {
-    output.push("  ──");
-    const f = summaryLine.fields;
-    const totalTools = f.tool_calls ?? "0";
-    const parts = [`model_calls=${f.model_calls ?? "0"}`, `tools=${totalTools}`];
-    const toolBreakdown: string[] = [];
-    if (f.read_calls && f.read_calls !== "0") toolBreakdown.push(`read=${f.read_calls}`);
-    if (f.search_calls && f.search_calls !== "0") toolBreakdown.push(`search=${f.search_calls}`);
-    if (f.write_calls && f.write_calls !== "0") toolBreakdown.push(`write=${f.write_calls}`);
-    if (toolBreakdown.length > 0) parts[parts.length - 1] += ` (${toolBreakdown.join(" ")})`;
-    if (f.regeneration_count && f.regeneration_count !== "0") parts.push(`regenerations=${f.regeneration_count}`);
-    if (f.guard_blocked_count && f.guard_blocked_count !== "0") parts.push(`guard_blocked=${f.guard_blocked_count}`);
-    const hasError = f.has_error === "true";
-    parts.push(`status=${hasError ? "error" : "ok"}`);
-    output.push(`  ${parts.join("  ")}`);
-  }
-
-  return output;
-}
-
 function formatToolTable(toolLines: CompactToolLine[]): string[] {
   if (toolLines.length === 0) return [];
   const maxTool = Math.max(...toolLines.map((l) => l.tool.length));
@@ -295,32 +209,100 @@ function formatToolTable(toolLines: CompactToolLine[]): string[] {
   });
 }
 
-function traceRowData(line: LogLine): Record<string, string | undefined> {
-  const event = line.fields.event;
-  const data: Record<string, string | undefined> = {
-    timestamp: line.timestamp,
-    task_id: line.taskId,
+function compactSummary(fields: Record<string, string>): string {
+  const totalTools = fields.tool_calls ?? "0";
+  const parts = [`model_calls=${fields.model_calls ?? "0"}`, `tools=${totalTools}`];
+  const breakdown: string[] = [];
+  if (fields.read_calls && fields.read_calls !== "0") breakdown.push(`read=${fields.read_calls}`);
+  if (fields.search_calls && fields.search_calls !== "0") breakdown.push(`search=${fields.search_calls}`);
+  if (fields.write_calls && fields.write_calls !== "0") breakdown.push(`write=${fields.write_calls}`);
+  if (breakdown.length > 0) parts[parts.length - 1] += ` (${breakdown.join(" ")})`;
+  if (fields.regeneration_count && fields.regeneration_count !== "0")
+    parts.push(`regenerations=${fields.regeneration_count}`);
+  if (fields.guard_blocked_count && fields.guard_blocked_count !== "0")
+    parts.push(`guard_blocked=${fields.guard_blocked_count}`);
+  parts.push(`status=${fields.has_error === "true" ? "error" : "ok"}`);
+  return `  ${parts.join("  ")}`;
+}
+
+function renderCompactLines(lines: LogLine[]): string[] {
+  const output: string[] = [];
+  const firstTs = lines[0]?.timestamp;
+  const lastTs = lines[lines.length - 1]?.timestamp;
+  const startLine = lines.find((l) => l.fields.event === "lifecycle.start");
+  const summaryLine = lines.find((l) => l.fields.event === "lifecycle.summary");
+  const taskId = lines[0]?.taskId ?? "unknown";
+  const model = startLine?.fields.model ?? "unknown";
+  const mode = startLine?.fields.mode ?? "unknown";
+  const duration = firstTs && lastTs ? formatDuration(firstTs, lastTs) : "?";
+  output.push(`${taskId}  ${model}  ${mode}  ${duration}`);
+  output.push("");
+
+  const toolLines: CompactToolLine[] = [];
+  let pending: CompactToolLine | null = null;
+
+  const flushPending = () => {
+    if (!pending) return;
+    toolLines.push(pending);
+    pending = null;
   };
 
-  if (!event) {
-    data.msg = line.fields.msg ?? "log";
-    return data;
-  }
+  const flushSection = (separator: string) => {
+    flushPending();
+    output.push(...formatToolTable(toolLines));
+    toolLines.length = 0;
+    output.push(separator);
+  };
 
-  data.event = event;
+  for (const line of lines) {
+    const event = line.fields.event;
+    if (!event) continue;
 
-  if (KNOWN_EVENTS.has(event)) {
-    const specs = EVENT_FIELDS[event as TraceEvent];
-    for (const spec of specs) {
-      const key = typeof spec === "string" ? spec : spec.key;
-      const label = typeof spec === "string" ? spec : spec.label;
-      data[label] = line.fields[key];
+    if (event === "lifecycle.tool.call") {
+      flushPending();
+      pending = { tool: line.fields.tool ?? "?", arg: extractToolArg(line.fields), status: "" };
+      continue;
     }
-  } else if (event.startsWith("lifecycle.memory.")) {
-    data.reason = line.fields.reason;
+
+    if (event === "lifecycle.guard" && pending) {
+      pending.status = `BLOCKED  ${line.fields.guard ?? ""}`;
+      flushPending();
+      continue;
+    }
+
+    if (event === "lifecycle.tool.result" && pending) {
+      const ms = line.fields.duration_ms;
+      pending.status = ms && Number(ms) >= 120_000 ? `TIMEOUT ${Math.round(Number(ms) / 1000)}s` : ms ? `${ms}ms` : "";
+      flushPending();
+      continue;
+    }
+
+    if (event === "lifecycle.eval.decision") {
+      if (line.fields.action === "regenerate") {
+        flushSection(`  ── regenerate (${line.fields.evaluator ?? ""}) ──`);
+      }
+      continue;
+    }
+
+    if (event === "lifecycle.eval.skipped") {
+      flushSection(`  ── skipped ${line.fields.evaluator ?? ""} (${line.fields.reason ?? ""}) ──`);
+      continue;
+    }
+
+    if (event === "lifecycle.signal.accepted" && line.fields.signal !== "done") {
+      output.push(`  @signal ${line.fields.signal ?? "?"}`);
+    }
   }
 
-  return data;
+  flushPending();
+  output.push(...formatToolTable(toolLines));
+
+  if (summaryLine) {
+    output.push("  ──");
+    output.push(compactSummary(summaryLine.fields));
+  }
+
+  return output;
 }
 
 function parseTaskIdsArg(value: string | undefined): string[] {
@@ -379,7 +361,7 @@ export async function traceMode(args: string[], deps: TraceModeDeps): Promise<vo
       if (out.verbose || isJson) {
         for (const line of lines) {
           if (!out.verbose && line.fields.event && VERBOSE_ONLY_EVENTS.has(line.fields.event)) continue;
-          out.addRow(traceRowData(line));
+          out.addRow(verboseRowData(line));
         }
       } else {
         for (const rendered of renderCompactLines(lines)) out.addHeader(rendered);

--- a/src/cli-trace.ts
+++ b/src/cli-trace.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { hasBoolFlag, parseFlag, parsePositional, parseTailCount } from "./cli-args";
 import { createJsonOutput, createTextOutput } from "./cli-output";
-import { formatRelativeTime } from "./datetime";
+import { formatDuration, formatRelativeTime } from "./datetime";
 import { t } from "./i18n";
 import type { LogLine } from "./log-parser";
 import type { TraceStore } from "./trace-store";
@@ -163,38 +163,32 @@ type CompactToolLine = {
   status: string;
 };
 
+function parsePaths(raw: string): string[] {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((entry) => (typeof entry === "string" ? entry : entry?.path))
+      .filter((v): v is string => typeof v === "string" && v.length > 0);
+  } catch {
+    return [];
+  }
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
 function extractToolArg(fields: Record<string, string>): string {
   if (fields.path) return fields.path;
-  if (fields.command) {
-    const cmd = fields.command;
-    return cmd.length > 40 ? `${cmd.slice(0, 39)}…` : cmd;
-  }
+  if (fields.command) return truncate(fields.command, 40);
   if (fields.pattern) return `"${fields.pattern}"`;
-  if (fields.paths) {
-    try {
-      const parsed = JSON.parse(fields.paths) as unknown;
-      if (Array.isArray(parsed)) {
-        const names = parsed
-          .map((entry) => {
-            if (typeof entry === "string") return entry;
-            if (entry && typeof entry === "object" && "path" in entry) return String((entry as { path: string }).path);
-            return "";
-          })
-          .filter(Boolean);
-        return names.join(", ");
-      }
-    } catch {}
-  }
+  if (fields.paths) return parsePaths(fields.paths).join(", ");
   return "";
 }
 
-function formatDuration(startTs: string, endTs: string): string {
-  const ms = new Date(endTs).getTime() - new Date(startTs).getTime();
-  if (ms < 1000) return `${ms}ms`;
-  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
-  const minutes = Math.floor(ms / 60_000);
-  const seconds = Math.round((ms % 60_000) / 1000);
-  return `${minutes}m ${seconds}s`;
+function elapsedMs(startTs: string, endTs: string): number {
+  return new Date(endTs).getTime() - new Date(startTs).getTime();
 }
 
 type CompactRow = { kind: "tool"; line: CompactToolLine } | { kind: "separator"; text: string };
@@ -238,7 +232,7 @@ function renderCompactLines(lines: LogLine[]): string[] {
   const taskId = lines[0]?.taskId ?? "unknown";
   const model = startLine?.fields.model ?? "unknown";
   const mode = startLine?.fields.mode ?? "unknown";
-  const duration = firstTs && lastTs ? formatDuration(firstTs, lastTs) : "?";
+  const duration = firstTs && lastTs ? formatDuration(elapsedMs(firstTs, lastTs)) : "?";
   output.push(`${taskId}  ${model}  ${mode}  ${duration}`);
   output.push("");
 

--- a/src/cli-trace.ts
+++ b/src/cli-trace.ts
@@ -113,7 +113,7 @@ const EVENT_FIELDS: Record<TraceEvent, FieldSpec[]> = {
   "lifecycle.eval.tool_recovery": ["recovery_tool", "recovery_kind"],
   "lifecycle.summary": [
     "model_calls",
-    "total_tool_calls",
+    { key: "tool_calls", label: "total_tool_calls" },
     { key: "read_calls", label: "read" },
     { key: "search_calls", label: "search" },
     { key: "write_calls", label: "write" },
@@ -129,6 +129,171 @@ const KNOWN_EVENTS = new Set<string>(traceEventSchema.options);
 
 /** Events hidden from `acolyte trace task` unless --verbose is passed. */
 const VERBOSE_ONLY_EVENTS = new Set<string>(["lifecycle.tool.output", "lifecycle.tool.cache"]);
+
+function extractToolArg(fields: Record<string, string>): string {
+  if (fields.path) return fields.path;
+  if (fields.command) {
+    const cmd = fields.command;
+    return cmd.length > 40 ? `${cmd.slice(0, 39)}…` : cmd;
+  }
+  if (fields.pattern) return `"${fields.pattern}"`;
+  if (fields.paths) {
+    try {
+      const parsed = JSON.parse(fields.paths) as unknown;
+      if (Array.isArray(parsed)) {
+        const names = parsed
+          .map((entry) => {
+            if (typeof entry === "string") return entry;
+            if (entry && typeof entry === "object" && "path" in entry) return String((entry as { path: string }).path);
+            return "";
+          })
+          .filter(Boolean);
+        return names.join(", ");
+      }
+    } catch {}
+  }
+  return "";
+}
+
+function formatDuration(startTs: string, endTs: string): string {
+  const ms = new Date(endTs).getTime() - new Date(startTs).getTime();
+  if (ms < 1000) return `${ms}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const minutes = Math.floor(ms / 60_000);
+  const seconds = Math.round((ms % 60_000) / 1000);
+  return `${minutes}m ${seconds}s`;
+}
+
+type CompactToolLine = {
+  tool: string;
+  arg: string;
+  status: string;
+};
+
+function renderCompactLines(lines: LogLine[]): string[] {
+  const output: string[] = [];
+
+  // Header: task_id, model, mode, duration
+  const firstTs = lines[0]?.timestamp;
+  const lastTs = lines[lines.length - 1]?.timestamp;
+  const startLine = lines.find((l) => l.fields.event === "lifecycle.start");
+  const summaryLine = lines.find((l) => l.fields.event === "lifecycle.summary");
+  const taskId = lines[0]?.taskId ?? "unknown";
+  const model = startLine?.fields.model ?? "unknown";
+  const mode = startLine?.fields.mode ?? "unknown";
+  const duration = firstTs && lastTs ? formatDuration(firstTs, lastTs) : "?";
+  output.push(`${taskId}  ${model}  ${mode}  ${duration}`);
+  output.push("");
+
+  // Build a map of tool call index → guard/result info
+  const toolLines: CompactToolLine[] = [];
+  let pendingToolCall: { tool: string; arg: string } | null = null;
+
+  for (const line of lines) {
+    const event = line.fields.event;
+    if (!event) continue;
+
+    if (event === "lifecycle.tool.call") {
+      if (pendingToolCall) {
+        toolLines.push({ tool: pendingToolCall.tool, arg: pendingToolCall.arg, status: "" });
+      }
+      pendingToolCall = {
+        tool: line.fields.tool ?? "?",
+        arg: extractToolArg(line.fields),
+      };
+      continue;
+    }
+
+    if (event === "lifecycle.guard" && pendingToolCall) {
+      const guard = line.fields.guard ?? "";
+      toolLines.push({ tool: pendingToolCall.tool, arg: pendingToolCall.arg, status: `BLOCKED  ${guard}` });
+      pendingToolCall = null;
+      continue;
+    }
+
+    if (event === "lifecycle.tool.result" && pendingToolCall) {
+      const durationMs = line.fields.duration_ms;
+      const isTimeout = durationMs && Number(durationMs) >= 120_000;
+      const status = isTimeout
+        ? `TIMEOUT ${Math.round(Number(durationMs) / 1000)}s`
+        : durationMs
+          ? `${durationMs}ms`
+          : "";
+      toolLines.push({ tool: pendingToolCall.tool, arg: pendingToolCall.arg, status });
+      pendingToolCall = null;
+      continue;
+    }
+
+    if (event === "lifecycle.eval.decision") {
+      if (pendingToolCall) {
+        toolLines.push({ tool: pendingToolCall.tool, arg: pendingToolCall.arg, status: "" });
+        pendingToolCall = null;
+      }
+      if (line.fields.action === "regenerate") {
+        const evaluator = line.fields.evaluator ?? "";
+        output.push(...formatToolTable(toolLines));
+        toolLines.length = 0;
+        output.push(`  ── regenerate (${evaluator}) ──`);
+      }
+      continue;
+    }
+
+    if (event === "lifecycle.eval.skipped") {
+      if (pendingToolCall) {
+        toolLines.push({ tool: pendingToolCall.tool, arg: pendingToolCall.arg, status: "" });
+        pendingToolCall = null;
+      }
+      const evaluator = line.fields.evaluator ?? "";
+      const reason = line.fields.reason ?? "";
+      output.push(...formatToolTable(toolLines));
+      toolLines.length = 0;
+      output.push(`  ── skipped ${evaluator} (${reason}) ──`);
+      continue;
+    }
+
+    if (event === "lifecycle.signal.accepted" && line.fields.signal !== "done") {
+      output.push(`  @signal ${line.fields.signal ?? "?"}`);
+    }
+  }
+
+  if (pendingToolCall) {
+    toolLines.push({ tool: pendingToolCall.tool, arg: pendingToolCall.arg, status: "" });
+  }
+
+  output.push(...formatToolTable(toolLines));
+
+  // Summary footer
+  if (summaryLine) {
+    output.push("  ──");
+    const f = summaryLine.fields;
+    const totalTools = f.tool_calls ?? "0";
+    const parts = [`model_calls=${f.model_calls ?? "0"}`, `tools=${totalTools}`];
+    const toolBreakdown: string[] = [];
+    if (f.read_calls && f.read_calls !== "0") toolBreakdown.push(`read=${f.read_calls}`);
+    if (f.search_calls && f.search_calls !== "0") toolBreakdown.push(`search=${f.search_calls}`);
+    if (f.write_calls && f.write_calls !== "0") toolBreakdown.push(`write=${f.write_calls}`);
+    if (toolBreakdown.length > 0) parts[parts.length - 1] += ` (${toolBreakdown.join(" ")})`;
+    if (f.regeneration_count && f.regeneration_count !== "0") parts.push(`regenerations=${f.regeneration_count}`);
+    if (f.guard_blocked_count && f.guard_blocked_count !== "0") parts.push(`guard_blocked=${f.guard_blocked_count}`);
+    const hasError = f.has_error === "true";
+    parts.push(`status=${hasError ? "error" : "ok"}`);
+    output.push(`  ${parts.join("  ")}`);
+  }
+
+  return output;
+}
+
+function formatToolTable(toolLines: CompactToolLine[]): string[] {
+  if (toolLines.length === 0) return [];
+  const maxTool = Math.max(...toolLines.map((l) => l.tool.length));
+  const maxArg = Math.max(...toolLines.map((l) => l.arg.length));
+  return toolLines.map((l) => {
+    const tool = l.tool.padEnd(maxTool);
+    const arg = l.arg.padEnd(maxArg);
+    const suffix = l.status ? `  ${l.status}` : "";
+    return `  ${tool}  ${arg}${suffix}`.trimEnd();
+  });
+}
 
 function traceRowData(line: LogLine): Record<string, string | undefined> {
   const event = line.fields.event;
@@ -185,7 +350,8 @@ export async function traceMode(args: string[], deps: TraceModeDeps): Promise<vo
 
   const tailCount = parseTailCount(parseFlag(args, ["--lines", "-n"]));
   const verbose = hasBoolFlag(args, "--verbose");
-  const out = hasBoolFlag(args, "--json") ? createJsonOutput() : createTextOutput();
+  const isJson = hasBoolFlag(args, "--json");
+  const out = isJson ? createJsonOutput() : createTextOutput();
 
   const positional = parsePositional(args, ["--lines", "-n"]);
   const subcommand = positional[0];
@@ -210,9 +376,13 @@ export async function traceMode(args: string[], deps: TraceModeDeps): Promise<vo
         continue;
       }
       if (i > 0) out.addSeparator();
-      for (const line of lines) {
-        if (!verbose && line.fields.event && VERBOSE_ONLY_EVENTS.has(line.fields.event)) continue;
-        out.addRow(traceRowData(line));
+      if (verbose || isJson) {
+        for (const line of lines) {
+          if (!verbose && line.fields.event && VERBOSE_ONLY_EVENTS.has(line.fields.event)) continue;
+          out.addRow(traceRowData(line));
+        }
+      } else {
+        for (const rendered of renderCompactLines(lines)) out.addHeader(rendered);
       }
     }
   } else if (!subcommand || subcommand === "list") {

--- a/src/cli-visual.int.test.ts
+++ b/src/cli-visual.int.test.ts
@@ -471,14 +471,14 @@ describe("cli visual regression", () => {
     {
       args: ["trace", "help"],
       output: dedent(`
-        Usage: acolyte trace [list|task <id>] [--lines <n>] [--json]
+        Usage: acolyte trace [list|task <id>] [--lines <n>] [--verbose] [--json]
 
         Description: inspect server lifecycle traces
 
         Examples:
           acolyte trace
           acolyte trace task task_abc123
-          acolyte trace --json
+          acolyte trace task --verbose
       `),
     },
   ])("renders subcommand help output %#", async ({ args, output }) => {
@@ -513,7 +513,7 @@ describe("cli visual regression", () => {
         event: "lifecycle.summary",
         fields: {
           model_calls: "1",
-          total_tool_calls: "1",
+          tool_calls: "1",
           read_calls: "1",
           search_calls: "0",
           write_calls: "0",
@@ -528,9 +528,11 @@ describe("cli visual regression", () => {
       const out = await run(["trace", "task", "task_abc"]);
       expect(out).toBe(
         dedent(`
-          timestamp=2026-03-19T10:00:00Z task_id=task_abc event=lifecycle.start mode=work model=gpt-5-mini
-          timestamp=2026-03-19T10:00:01Z task_id=task_abc event=lifecycle.tool.call tool=read-file path=src/cli.ts
-          timestamp=2026-03-19T10:00:03Z task_id=task_abc event=lifecycle.summary model_calls=1 total_tool_calls=1 read=1 search=0 write=0 pre_write_discovery=0 regenerations=0 guard_blocked=0 guard_flag_set=0 has_error=false
+          task_abc  gpt-5-mini  work  3.0s
+
+            read-file  src/cli.ts
+            ──
+            model_calls=1  tools=1 (read=1)  status=ok
         `),
       );
     });

--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -22,6 +22,10 @@ export function formatDuration(ms: number): string {
   return `${minutes}m ${seconds}s`;
 }
 
+export function elapsedMs(startIso: string, endIso: string): number {
+  return new Date(endIso).getTime() - new Date(startIso).getTime();
+}
+
 export function parseSince(value: string, now?: number): Date | undefined {
   const match = value.match(/^(\d+)([mhd])$/);
   if (!match) return undefined;


### PR DESCRIPTION
## Summary

- show compact summary by default in `acolyte trace task`
- tool calls as one line each with name, arg, and duration or BLOCKED
- hide setup events and evaluator done decisions
- `--verbose` restores full row-by-row output
- add `verbose` option to `CliOutput` for reuse across commands
- fix `tool_calls` field key in `EVENT_FIELDS` summary mapping