### PR TITLE
feat(providers): rate limit awareness

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -31,6 +31,7 @@ Shipped, user-visible capabilities.
 - tool-guarded execution for safer autonomous runs
 - streaming progress output for tool activity with real-time token usage
 - proactive token budgeting via tiktoken with system prompt reservation and priority-based allocation
+- provider rate limit awareness with sliding window pacing and exponential backoff
 - two-tier result cache for read-only and search tools with SQLite-backed cross-task persistence
 - workspace profile detection for ecosystem, package manager, lint, format, and test commands
 - automatic formatting of edited files via detected formatter

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -46,9 +46,9 @@ export function createAgentStream(
   model: LanguageModelV3,
   instructions: Agent["instructions"],
   tools: Record<string, ToolDefinition>,
-  qualifiedModel?: string,
+  qualifiedModel: string,
 ): Agent["stream"] {
-  const provider = qualifiedModel ? providerFromModel(qualifiedModel) : "openai";
+  const provider = providerFromModel(qualifiedModel);
   const rateLimiter = createRateLimiter(defaultRateLimiterConfig(provider));
   const toolsByName = new Map<string, ToolDefinition>();
   for (const tool of Object.values(tools)) {
@@ -82,17 +82,28 @@ export function createAgentStream(
         if (loopIteration > 1) streamController.enqueue({ type: "step-start" });
         log.debug("agent-stream.loop.start", { iteration: loopIteration, pending_messages: messages.length });
         await rateLimiter.beforeCall();
-        const streamResult = await model.doStream({
-          prompt: messages,
-          temperature: options.temperature,
-          tools: functionTools.length > 0 ? functionTools : undefined,
-          toolChoice: options.toolChoice
-            ? { type: options.toolChoice }
-            : functionTools.length > 0
-              ? { type: "auto" }
-              : undefined,
-        });
-        rateLimiter.reset();
+        let streamResult: Awaited<ReturnType<typeof model.doStream>>;
+        try {
+          streamResult = await model.doStream({
+            prompt: messages,
+            temperature: options.temperature,
+            tools: functionTools.length > 0 ? functionTools : undefined,
+            toolChoice: options.toolChoice
+              ? { type: options.toolChoice }
+              : functionTools.length > 0
+                ? { type: "auto" }
+                : undefined,
+          });
+          rateLimiter.reset();
+        } catch (error) {
+          const recovery = rateLimiter.onError(error);
+          if (recovery.shouldRetry) {
+            log.debug("agent-stream.rate_limit.retry", { delay_ms: recovery.delayMs, iteration: loopIteration });
+            await new Promise((resolve) => setTimeout(resolve, recovery.delayMs));
+            continue;
+          }
+          throw error;
+        }
 
         const pendingToolCalls: Array<{
           toolCallId: string;

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -366,7 +366,7 @@ export function createAgent(input: {
   const qualifiedModel = normalizeModel(input.model);
   const provider = providerFromModel(qualifiedModel);
   const rateLimiter = sharedRateLimiter(provider);
-  const modelInstance = createModel(qualifiedModel, undefined, rateLimiter);
+  const modelInstance = createModel(qualifiedModel, rateLimiter);
   const tools = input.tools ?? {};
   const stream = createAgentStream(modelInstance, input.instructions, tools, rateLimiter);
   return {

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -20,7 +20,7 @@ import {
 import { log } from "./log";
 import { createModel } from "./model-factory";
 import { normalizeModel, providerFromModel } from "./provider-config";
-import { createRateLimiter, defaultRateLimiterConfig } from "./rate-limiter";
+import { type RateLimiter, sharedRateLimiter } from "./rate-limiter";
 import type { ToolDefinition } from "./tool-contract";
 
 function toolInputJsonSchema(schema: z.ZodType): LanguageModelV3FunctionTool["inputSchema"] {
@@ -46,10 +46,8 @@ export function createAgentStream(
   model: LanguageModelV3,
   instructions: Agent["instructions"],
   tools: Record<string, ToolDefinition>,
-  qualifiedModel: string,
+  rateLimiter: RateLimiter,
 ): Agent["stream"] {
-  const provider = providerFromModel(qualifiedModel);
-  const rateLimiter = createRateLimiter(defaultRateLimiterConfig(provider));
   const toolsByName = new Map<string, ToolDefinition>();
   for (const tool of Object.values(tools)) {
     toolsByName.set(tool.id, tool);
@@ -121,12 +119,12 @@ export function createAgentStream(
           emitStreamPart(part, streamController, stepTextParts, pendingToolCalls, lifecycleTextState);
           if (part.type === "finish") {
             finishReason = part.finishReason;
-            const inputTokens = part.usage?.inputTokens?.total ?? 0;
-            const outputTokens = part.usage?.outputTokens?.total ?? 0;
-            rateLimiter.recordUsage(inputTokens + outputTokens);
             streamController.enqueue({
               type: "model-usage",
-              payload: { inputTokens, outputTokens },
+              payload: {
+                inputTokens: part.usage?.inputTokens?.total,
+                outputTokens: part.usage?.outputTokens?.total,
+              },
             });
           }
         }
@@ -366,9 +364,11 @@ export function createAgent(input: {
   tools?: Record<string, ToolDefinition>;
 }): Agent {
   const qualifiedModel = normalizeModel(input.model);
-  const modelInstance = createModel(qualifiedModel);
+  const provider = providerFromModel(qualifiedModel);
+  const rateLimiter = sharedRateLimiter(provider);
+  const modelInstance = createModel(qualifiedModel, undefined, rateLimiter);
   const tools = input.tools ?? {};
-  const stream = createAgentStream(modelInstance, input.instructions, tools, qualifiedModel);
+  const stream = createAgentStream(modelInstance, input.instructions, tools, rateLimiter);
   return {
     id: input.id ?? "agent",
     name: input.name ?? "Agent",

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -365,10 +365,10 @@ export function createAgent(input: {
   name?: string;
   tools?: Record<string, ToolDefinition>;
 }): Agent {
-  const qualified = normalizeModel(input.model);
-  const modelInstance = createModel(qualified);
+  const qualifiedModel = normalizeModel(input.model);
+  const modelInstance = createModel(qualifiedModel);
   const tools = input.tools ?? {};
-  const stream = createAgentStream(modelInstance, input.instructions, tools, qualified);
+  const stream = createAgentStream(modelInstance, input.instructions, tools, qualifiedModel);
   return {
     id: input.id ?? "agent",
     name: input.name ?? "Agent",

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -19,7 +19,8 @@ import {
 } from "./lifecycle-signal";
 import { log } from "./log";
 import { createModel } from "./model-factory";
-import { normalizeModel } from "./provider-config";
+import { normalizeModel, providerFromModel } from "./provider-config";
+import { createRateLimiter, defaultRateLimiterConfig } from "./rate-limiter";
 import type { ToolDefinition } from "./tool-contract";
 
 function toolInputJsonSchema(schema: z.ZodType): LanguageModelV3FunctionTool["inputSchema"] {
@@ -45,7 +46,10 @@ export function createAgentStream(
   model: LanguageModelV3,
   instructions: Agent["instructions"],
   tools: Record<string, ToolDefinition>,
+  qualifiedModel?: string,
 ): Agent["stream"] {
+  const provider = qualifiedModel ? providerFromModel(qualifiedModel) : "openai";
+  const rateLimiter = createRateLimiter(defaultRateLimiterConfig(provider));
   const toolsByName = new Map<string, ToolDefinition>();
   for (const tool of Object.values(tools)) {
     toolsByName.set(tool.id, tool);
@@ -77,6 +81,7 @@ export function createAgentStream(
         loopIteration++;
         if (loopIteration > 1) streamController.enqueue({ type: "step-start" });
         log.debug("agent-stream.loop.start", { iteration: loopIteration, pending_messages: messages.length });
+        await rateLimiter.beforeCall();
         const streamResult = await model.doStream({
           prompt: messages,
           temperature: options.temperature,
@@ -87,6 +92,7 @@ export function createAgentStream(
               ? { type: "auto" }
               : undefined,
         });
+        rateLimiter.reset();
 
         const pendingToolCalls: Array<{
           toolCallId: string;
@@ -348,9 +354,10 @@ export function createAgent(input: {
   name?: string;
   tools?: Record<string, ToolDefinition>;
 }): Agent {
-  const modelInstance = createModel(normalizeModel(input.model));
+  const qualified = normalizeModel(input.model);
+  const modelInstance = createModel(qualified);
   const tools = input.tools ?? {};
-  const stream = createAgentStream(modelInstance, input.instructions, tools);
+  const stream = createAgentStream(modelInstance, input.instructions, tools, qualified);
   return {
     id: input.id ?? "agent",
     name: input.name ?? "Agent",

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -121,12 +121,12 @@ export function createAgentStream(
           emitStreamPart(part, streamController, stepTextParts, pendingToolCalls, lifecycleTextState);
           if (part.type === "finish") {
             finishReason = part.finishReason;
+            const inputTokens = part.usage?.inputTokens?.total ?? 0;
+            const outputTokens = part.usage?.outputTokens?.total ?? 0;
+            rateLimiter.recordUsage(inputTokens + outputTokens);
             streamController.enqueue({
               type: "model-usage",
-              payload: {
-                inputTokens: part.usage?.inputTokens?.total,
-                outputTokens: part.usage?.outputTokens?.total,
-              },
+              payload: { inputTokens, outputTokens },
             });
           }
         }

--- a/src/memory-source-distill.ts
+++ b/src/memory-source-distill.ts
@@ -206,7 +206,7 @@ const defaultDistillConfig = (): DistillConfig => appConfig.distill;
 
 async function runDistillLLM(systemPrompt: string, userContent: string): Promise<string> {
   const qualifiedModel = normalizeModel(appConfig.distill.model);
-  const model = createModel(qualifiedModel, undefined, sharedRateLimiter(providerFromModel(qualifiedModel)));
+  const model = createModel(qualifiedModel, sharedRateLimiter(providerFromModel(qualifiedModel)));
   const result = await model.doGenerate({
     prompt: [
       { role: "system", content: systemPrompt },

--- a/src/memory-source-distill.ts
+++ b/src/memory-source-distill.ts
@@ -10,7 +10,8 @@ import { embeddingToBuffer, embedText } from "./memory-embedding";
 import { createSemanticSelection, type MemorySelectionStrategy } from "./memory-pipeline";
 import { defaultMemoryPolicy, type MemoryPolicy } from "./memory-policy";
 import { createModel } from "./model-factory";
-import { normalizeModel } from "./provider-config";
+import { normalizeModel, providerFromModel } from "./provider-config";
+import { sharedRateLimiter } from "./rate-limiter";
 import { defaultUserResourceId, parseResourceId, projectResourceIdFromWorkspace, type ResourceId } from "./resource-id";
 import { createId } from "./short-id";
 
@@ -204,7 +205,8 @@ export type DistillRunner = (systemPrompt: string, userContent: string) => Promi
 const defaultDistillConfig = (): DistillConfig => appConfig.distill;
 
 async function runDistillLLM(systemPrompt: string, userContent: string): Promise<string> {
-  const model = createModel(normalizeModel(appConfig.distill.model));
+  const qualifiedModel = normalizeModel(appConfig.distill.model);
+  const model = createModel(qualifiedModel, undefined, sharedRateLimiter(providerFromModel(qualifiedModel)));
   const result = await model.doGenerate({
     prompt: [
       { role: "system", content: systemPrompt },

--- a/src/model-factory.ts
+++ b/src/model-factory.ts
@@ -5,19 +5,28 @@ import type { LanguageModelV3 } from "@ai-sdk/provider";
 import { defaultCredentials, type ProviderCredentialsMap } from "./agent-model";
 import { unreachable } from "./assert";
 import { providerFromModel } from "./provider-config";
+import { createRateLimitFetch, type RateLimiter } from "./rate-limiter";
 
-export function createModel(qualifiedModel: string, credentials?: ProviderCredentialsMap): LanguageModelV3 {
+export function createModel(
+  qualifiedModel: string,
+  credentials?: ProviderCredentialsMap,
+  rateLimiter?: RateLimiter,
+): LanguageModelV3 {
   const creds = credentials ?? defaultCredentials();
   const provider = providerFromModel(qualifiedModel);
   const slash = qualifiedModel.indexOf("/");
   const modelId = slash >= 0 ? qualifiedModel.slice(slash + 1) : qualifiedModel;
   const providerCreds = creds[provider] ?? {};
+  const fetchFn = rateLimiter
+    ? (createRateLimitFetch(rateLimiter, globalThis.fetch) as typeof globalThis.fetch)
+    : undefined;
 
   switch (provider) {
     case "anthropic": {
       const anthropic = createAnthropic({
         apiKey: providerCreds.apiKey,
         ...(providerCreds.baseUrl ? { baseURL: providerCreds.baseUrl } : {}),
+        ...(fetchFn ? { fetch: fetchFn } : {}),
       });
       return anthropic(modelId);
     }
@@ -25,6 +34,7 @@ export function createModel(qualifiedModel: string, credentials?: ProviderCreden
       const google = createGoogleGenerativeAI({
         apiKey: providerCreds.apiKey,
         ...(providerCreds.baseUrl ? { baseURL: providerCreds.baseUrl } : {}),
+        ...(fetchFn ? { fetch: fetchFn } : {}),
       });
       return google(modelId);
     }
@@ -32,6 +42,7 @@ export function createModel(qualifiedModel: string, credentials?: ProviderCreden
       const openai = createOpenAI({
         apiKey: providerCreds.apiKey,
         ...(providerCreds.baseUrl ? { baseURL: providerCreds.baseUrl } : {}),
+        ...(fetchFn ? { fetch: fetchFn } : {}),
       });
       return openai(modelId);
     }

--- a/src/model-factory.ts
+++ b/src/model-factory.ts
@@ -9,24 +9,22 @@ import { createRateLimitFetch, type RateLimiter } from "./rate-limiter";
 
 export function createModel(
   qualifiedModel: string,
+  rateLimiter: RateLimiter,
   credentials?: ProviderCredentialsMap,
-  rateLimiter?: RateLimiter,
 ): LanguageModelV3 {
   const creds = credentials ?? defaultCredentials();
   const provider = providerFromModel(qualifiedModel);
   const slash = qualifiedModel.indexOf("/");
   const modelId = slash >= 0 ? qualifiedModel.slice(slash + 1) : qualifiedModel;
   const providerCreds = creds[provider] ?? {};
-  const fetchFn = rateLimiter
-    ? (createRateLimitFetch(rateLimiter, globalThis.fetch) as typeof globalThis.fetch)
-    : undefined;
+  const fetchFn = createRateLimitFetch(rateLimiter, globalThis.fetch) as typeof globalThis.fetch;
 
   switch (provider) {
     case "anthropic": {
       const anthropic = createAnthropic({
         apiKey: providerCreds.apiKey,
         ...(providerCreds.baseUrl ? { baseURL: providerCreds.baseUrl } : {}),
-        ...(fetchFn ? { fetch: fetchFn } : {}),
+        fetch: fetchFn,
       });
       return anthropic(modelId);
     }
@@ -34,7 +32,7 @@ export function createModel(
       const google = createGoogleGenerativeAI({
         apiKey: providerCreds.apiKey,
         ...(providerCreds.baseUrl ? { baseURL: providerCreds.baseUrl } : {}),
-        ...(fetchFn ? { fetch: fetchFn } : {}),
+        fetch: fetchFn,
       });
       return google(modelId);
     }
@@ -42,7 +40,7 @@ export function createModel(
       const openai = createOpenAI({
         apiKey: providerCreds.apiKey,
         ...(providerCreds.baseUrl ? { baseURL: providerCreds.baseUrl } : {}),
-        ...(fetchFn ? { fetch: fetchFn } : {}),
+        fetch: fetchFn,
       });
       return openai(modelId);
     }

--- a/src/rate-limiter.test.ts
+++ b/src/rate-limiter.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import { createRateLimiter, isRateLimitError, type RateLimiterConfig, retryAfterMs } from "./rate-limiter";
+
+const FAST: RateLimiterConfig = { maxRequestsPerMinute: 3, backoffBaseMs: 100, backoffMaxMs: 1_000 };
+
+describe("isRateLimitError", () => {
+  test("detects 429 status", () => {
+    expect(isRateLimitError({ status: 429 })).toBe(true);
+  });
+
+  test("detects rate_limit_exceeded code", () => {
+    expect(isRateLimitError({ code: "rate_limit_exceeded" })).toBe(true);
+    expect(isRateLimitError({ code: "RATE_LIMIT_EXCEEDED" })).toBe(true);
+  });
+
+  test("rejects unrelated errors", () => {
+    expect(isRateLimitError({ status: 500 })).toBe(false);
+    expect(isRateLimitError({ code: "server_error" })).toBe(false);
+    expect(isRateLimitError(null)).toBe(false);
+    expect(isRateLimitError("string")).toBe(false);
+  });
+});
+
+describe("retryAfterMs", () => {
+  test("parses retry-after header in seconds", () => {
+    expect(retryAfterMs({ headers: { "retry-after": "2" } })).toBe(2_000);
+    expect(retryAfterMs({ headers: { "retry-after": "0.5" } })).toBe(500);
+  });
+
+  test("parses numeric retry-after", () => {
+    expect(retryAfterMs({ headers: { "retry-after": 3 } })).toBe(3_000);
+  });
+
+  test("returns undefined for missing or invalid headers", () => {
+    expect(retryAfterMs({ headers: {} })).toBeUndefined();
+    expect(retryAfterMs({})).toBeUndefined();
+    expect(retryAfterMs({ headers: { "retry-after": "invalid" } })).toBeUndefined();
+  });
+});
+
+describe("createRateLimiter", () => {
+  test("allows calls within limit", async () => {
+    const limiter = createRateLimiter(FAST);
+    const start = Date.now();
+    await limiter.beforeCall();
+    await limiter.beforeCall();
+    await limiter.beforeCall();
+    expect(Date.now() - start).toBeLessThan(100);
+  });
+
+  test("onError returns shouldRetry for rate limit errors", () => {
+    const limiter = createRateLimiter(FAST);
+    const result = limiter.onError({ status: 429 });
+    expect(result.shouldRetry).toBe(true);
+    expect(result.delayMs).toBeGreaterThan(0);
+  });
+
+  test("onError returns no retry for non-rate-limit errors", () => {
+    const limiter = createRateLimiter(FAST);
+    const result = limiter.onError({ status: 500 });
+    expect(result.shouldRetry).toBe(false);
+    expect(result.delayMs).toBe(0);
+  });
+
+  test("onError uses retry-after header when available", () => {
+    const limiter = createRateLimiter(FAST);
+    const result = limiter.onError({ status: 429, headers: { "retry-after": "5" } });
+    expect(result.shouldRetry).toBe(true);
+    expect(result.delayMs).toBe(5_000);
+  });
+
+  test("onError increases backoff on consecutive failures", () => {
+    const limiter = createRateLimiter(FAST);
+    const first = limiter.onError({ status: 429 });
+    const second = limiter.onError({ status: 429 });
+    expect(second.delayMs).toBeGreaterThanOrEqual(first.delayMs);
+  });
+
+  test("reset clears consecutive failure count", () => {
+    const limiter = createRateLimiter(FAST);
+    limiter.onError({ status: 429 });
+    limiter.onError({ status: 429 });
+    limiter.onError({ status: 429 });
+    limiter.reset();
+    const result = limiter.onError({ status: 429 });
+    expect(result.delayMs).toBeLessThanOrEqual(FAST.backoffBaseMs);
+  });
+});

--- a/src/rate-limiter.test.ts
+++ b/src/rate-limiter.test.ts
@@ -1,18 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import {
+  clearSharedRateLimiters,
   createRateLimiter,
-  defaultRateLimiterConfig,
+  createRateLimitFetch,
   isRateLimitError,
   type RateLimiterConfig,
   retryAfterMs,
+  sharedRateLimiter,
 } from "./rate-limiter";
 
-const FAST: RateLimiterConfig = {
-  maxRequestsPerMinute: 3,
-  maxTokensPerMinute: 0,
-  backoffBaseMs: 100,
-  backoffMaxMs: 1_000,
-};
+const FAST: RateLimiterConfig = { backoffBaseMs: 100, backoffMaxMs: 1_000 };
 
 describe("isRateLimitError", () => {
   test("detects 429 status", () => {
@@ -50,27 +47,43 @@ describe("retryAfterMs", () => {
 });
 
 describe("createRateLimiter", () => {
-  test("allows calls within limit", async () => {
+  test("beforeCall resolves immediately with no prior state", async () => {
     const limiter = createRateLimiter(FAST);
     const start = Date.now();
     await limiter.beforeCall();
-    await limiter.beforeCall();
-    await limiter.beforeCall();
-    expect(Date.now() - start).toBeLessThan(100);
+    expect(Date.now() - start).toBeLessThan(50);
   });
 
-  test("delays when token usage exceeds limit", async () => {
-    const limiter = createRateLimiter({
-      maxRequestsPerMinute: 100,
-      maxTokensPerMinute: 1_000,
-      backoffBaseMs: 100,
-      backoffMaxMs: 1_000,
+  test("onResponse updates state from Anthropic headers", () => {
+    const limiter = createRateLimiter(FAST);
+    const headers = new Headers({
+      "anthropic-ratelimit-requests-remaining": "10",
+      "anthropic-ratelimit-tokens-remaining": "5000",
     });
-    await limiter.beforeCall();
-    limiter.recordUsage(900);
-    await limiter.beforeCall();
-    limiter.recordUsage(200);
-    // Next call should block — 1100 tokens in window exceeds 1000 limit
+    limiter.onResponse(headers);
+    expect(limiter.state().requestsRemaining).toBe(10);
+    expect(limiter.state().tokensRemaining).toBe(5000);
+  });
+
+  test("onResponse updates state from OpenAI headers", () => {
+    const limiter = createRateLimiter(FAST);
+    const headers = new Headers({
+      "x-ratelimit-remaining-requests": "25",
+      "x-ratelimit-remaining-tokens": "80000",
+    });
+    limiter.onResponse(headers);
+    expect(limiter.state().requestsRemaining).toBe(25);
+    expect(limiter.state().tokensRemaining).toBe(80000);
+  });
+
+  test("delays when requests remaining is exhausted", async () => {
+    const limiter = createRateLimiter(FAST);
+    limiter.onResponse(
+      new Headers({
+        "anthropic-ratelimit-requests-remaining": "0",
+        "anthropic-ratelimit-requests-reset": "1s",
+      }),
+    );
     const delayed = limiter.beforeCall();
     const result = await Promise.race([
       delayed.then(() => "completed"),
@@ -79,18 +92,15 @@ describe("createRateLimiter", () => {
     expect(result).toBe("waited");
   });
 
-  test("delays when calls exceed limit", async () => {
-    const limiter = createRateLimiter({
-      maxRequestsPerMinute: 2,
-      maxTokensPerMinute: 0,
-      backoffBaseMs: 100,
-      backoffMaxMs: 1_000,
-    });
-    await limiter.beforeCall();
-    await limiter.beforeCall();
-    // Third call should block since limit is 2 per minute
+  test("delays when tokens remaining is exhausted", async () => {
+    const limiter = createRateLimiter(FAST);
+    limiter.onResponse(
+      new Headers({
+        "anthropic-ratelimit-tokens-remaining": "0",
+        "anthropic-ratelimit-tokens-reset": "2s",
+      }),
+    );
     const delayed = limiter.beforeCall();
-    // Cancel via racing with a short timeout to avoid actually waiting 60s
     const result = await Promise.race([
       delayed.then(() => "completed"),
       new Promise<string>((resolve) => setTimeout(() => resolve("waited"), 50)),
@@ -126,26 +136,43 @@ describe("createRateLimiter", () => {
     expect(second.delayMs).toBeGreaterThanOrEqual(first.delayMs);
   });
 
-  test("reset clears consecutive failure count", () => {
+  test("onResponse resets consecutive failure count", () => {
     const limiter = createRateLimiter(FAST);
     limiter.onError({ status: 429 });
     limiter.onError({ status: 429 });
     limiter.onError({ status: 429 });
-    limiter.reset();
+    limiter.onResponse(new Headers());
     const result = limiter.onError({ status: 429 });
     expect(result.delayMs).toBeLessThanOrEqual(FAST.backoffBaseMs);
   });
 });
 
-describe("defaultRateLimiterConfig", () => {
-  test("returns per-provider defaults", () => {
-    const anthropic = defaultRateLimiterConfig("anthropic");
-    expect(anthropic.maxRequestsPerMinute).toBe(50);
+describe("createRateLimitFetch", () => {
+  test("passes response through and calls onResponse", async () => {
+    const limiter = createRateLimiter(FAST);
+    const mockResponse = new Response("ok", {
+      headers: { "x-ratelimit-remaining-requests": "42" },
+    });
+    const mockFetch = async () => mockResponse;
+    const wrappedFetch = createRateLimitFetch(limiter, mockFetch);
+    const result = await wrappedFetch("https://example.com");
+    expect(result).toBe(mockResponse);
+    expect(limiter.state().requestsRemaining).toBe(42);
+  });
+});
 
-    const openai = defaultRateLimiterConfig("openai");
-    expect(openai.maxRequestsPerMinute).toBe(60);
+describe("sharedRateLimiter", () => {
+  test("returns same instance for same provider", () => {
+    clearSharedRateLimiters();
+    const a = sharedRateLimiter("anthropic");
+    const b = sharedRateLimiter("anthropic");
+    expect(a).toBe(b);
+  });
 
-    const google = defaultRateLimiterConfig("google");
-    expect(google.maxRequestsPerMinute).toBe(60);
+  test("returns different instances for different providers", () => {
+    clearSharedRateLimiters();
+    const a = sharedRateLimiter("anthropic");
+    const o = sharedRateLimiter("openai");
+    expect(a).not.toBe(o);
   });
 });

--- a/src/rate-limiter.test.ts
+++ b/src/rate-limiter.test.ts
@@ -46,6 +46,29 @@ describe("retryAfterMs", () => {
   });
 });
 
+describe("parseResetMs via onResponse", () => {
+  test("parses ISO timestamp reset header", () => {
+    const limiter = createRateLimiter(FAST);
+    const futureIso = new Date(Date.now() + 30_000).toISOString();
+    limiter.onResponse(new Headers({ "anthropic-ratelimit-requests-reset": futureIso }));
+    const reset = limiter.state().requestsResetMs;
+    expect(reset).toBeGreaterThan(20_000);
+    expect(reset).toBeLessThanOrEqual(30_000);
+  });
+
+  test("parses duration reset header", () => {
+    const limiter = createRateLimiter(FAST);
+    limiter.onResponse(new Headers({ "x-ratelimit-reset-requests": "6m0s" }));
+    expect(limiter.state().requestsResetMs).toBe(360_000);
+  });
+
+  test("parses seconds-only duration", () => {
+    const limiter = createRateLimiter(FAST);
+    limiter.onResponse(new Headers({ "x-ratelimit-reset-tokens": "1.5s" }));
+    expect(limiter.state().tokensResetMs).toBe(1_500);
+  });
+});
+
 describe("createRateLimiter", () => {
   test("beforeCall resolves immediately with no prior state", async () => {
     const limiter = createRateLimiter(FAST);

--- a/src/rate-limiter.test.ts
+++ b/src/rate-limiter.test.ts
@@ -7,7 +7,12 @@ import {
   retryAfterMs,
 } from "./rate-limiter";
 
-const FAST: RateLimiterConfig = { maxRequestsPerMinute: 3, backoffBaseMs: 100, backoffMaxMs: 1_000 };
+const FAST: RateLimiterConfig = {
+  maxRequestsPerMinute: 3,
+  maxTokensPerMinute: 0,
+  backoffBaseMs: 100,
+  backoffMaxMs: 1_000,
+};
 
 describe("isRateLimitError", () => {
   test("detects 429 status", () => {
@@ -54,8 +59,33 @@ describe("createRateLimiter", () => {
     expect(Date.now() - start).toBeLessThan(100);
   });
 
+  test("delays when token usage exceeds limit", async () => {
+    const limiter = createRateLimiter({
+      maxRequestsPerMinute: 100,
+      maxTokensPerMinute: 1_000,
+      backoffBaseMs: 100,
+      backoffMaxMs: 1_000,
+    });
+    await limiter.beforeCall();
+    limiter.recordUsage(900);
+    await limiter.beforeCall();
+    limiter.recordUsage(200);
+    // Next call should block — 1100 tokens in window exceeds 1000 limit
+    const delayed = limiter.beforeCall();
+    const result = await Promise.race([
+      delayed.then(() => "completed"),
+      new Promise<string>((resolve) => setTimeout(() => resolve("waited"), 50)),
+    ]);
+    expect(result).toBe("waited");
+  });
+
   test("delays when calls exceed limit", async () => {
-    const limiter = createRateLimiter({ maxRequestsPerMinute: 2, backoffBaseMs: 100, backoffMaxMs: 1_000 });
+    const limiter = createRateLimiter({
+      maxRequestsPerMinute: 2,
+      maxTokensPerMinute: 0,
+      backoffBaseMs: 100,
+      backoffMaxMs: 1_000,
+    });
     await limiter.beforeCall();
     await limiter.beforeCall();
     // Third call should block since limit is 2 per minute

--- a/src/rate-limiter.test.ts
+++ b/src/rate-limiter.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { createRateLimiter, isRateLimitError, type RateLimiterConfig, retryAfterMs } from "./rate-limiter";
+import {
+  createRateLimiter,
+  defaultRateLimiterConfig,
+  isRateLimitError,
+  type RateLimiterConfig,
+  retryAfterMs,
+} from "./rate-limiter";
 
 const FAST: RateLimiterConfig = { maxRequestsPerMinute: 3, backoffBaseMs: 100, backoffMaxMs: 1_000 };
 
@@ -48,6 +54,20 @@ describe("createRateLimiter", () => {
     expect(Date.now() - start).toBeLessThan(100);
   });
 
+  test("delays when calls exceed limit", async () => {
+    const limiter = createRateLimiter({ maxRequestsPerMinute: 2, backoffBaseMs: 100, backoffMaxMs: 1_000 });
+    await limiter.beforeCall();
+    await limiter.beforeCall();
+    // Third call should block since limit is 2 per minute
+    const delayed = limiter.beforeCall();
+    // Cancel via racing with a short timeout to avoid actually waiting 60s
+    const result = await Promise.race([
+      delayed.then(() => "completed"),
+      new Promise<string>((resolve) => setTimeout(() => resolve("waited"), 50)),
+    ]);
+    expect(result).toBe("waited");
+  });
+
   test("onError returns shouldRetry for rate limit errors", () => {
     const limiter = createRateLimiter(FAST);
     const result = limiter.onError({ status: 429 });
@@ -84,5 +104,18 @@ describe("createRateLimiter", () => {
     limiter.reset();
     const result = limiter.onError({ status: 429 });
     expect(result.delayMs).toBeLessThanOrEqual(FAST.backoffBaseMs);
+  });
+});
+
+describe("defaultRateLimiterConfig", () => {
+  test("returns per-provider defaults", () => {
+    const anthropic = defaultRateLimiterConfig("anthropic");
+    expect(anthropic.maxRequestsPerMinute).toBe(50);
+
+    const openai = defaultRateLimiterConfig("openai");
+    expect(openai.maxRequestsPerMinute).toBe(60);
+
+    const google = defaultRateLimiterConfig("google");
+    expect(google.maxRequestsPerMinute).toBe(60);
   });
 });

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -1,20 +1,32 @@
 import type { Provider } from "./provider-contract";
 
 export type RateLimiterConfig = {
-  readonly maxRequestsPerMinute: number;
-  readonly maxTokensPerMinute: number;
   readonly backoffBaseMs: number;
   readonly backoffMaxMs: number;
 };
 
 const PROVIDER_DEFAULTS: Record<Provider, RateLimiterConfig> = {
-  anthropic: { maxRequestsPerMinute: 50, maxTokensPerMinute: 40_000, backoffBaseMs: 1_000, backoffMaxMs: 60_000 },
-  openai: { maxRequestsPerMinute: 60, maxTokensPerMinute: 150_000, backoffBaseMs: 1_000, backoffMaxMs: 60_000 },
-  google: { maxRequestsPerMinute: 60, maxTokensPerMinute: 100_000, backoffBaseMs: 1_000, backoffMaxMs: 60_000 },
+  anthropic: { backoffBaseMs: 1_000, backoffMaxMs: 60_000 },
+  openai: { backoffBaseMs: 1_000, backoffMaxMs: 60_000 },
+  google: { backoffBaseMs: 1_000, backoffMaxMs: 60_000 },
 };
 
 export function defaultRateLimiterConfig(provider: Provider): RateLimiterConfig {
   return PROVIDER_DEFAULTS[provider];
+}
+
+const sharedLimiters = new Map<Provider, RateLimiter>();
+
+export function sharedRateLimiter(provider: Provider): RateLimiter {
+  const existing = sharedLimiters.get(provider);
+  if (existing) return existing;
+  const limiter = createRateLimiter(defaultRateLimiterConfig(provider));
+  sharedLimiters.set(provider, limiter);
+  return limiter;
+}
+
+export function clearSharedRateLimiters(): void {
+  sharedLimiters.clear();
 }
 
 function jitter(ms: number): number {
@@ -42,47 +54,94 @@ function retryAfterMs(error: unknown): number | undefined {
   return undefined;
 }
 
-export type RateLimiter = {
-  beforeCall(): Promise<void>;
-  recordUsage(tokens: number): void;
-  onError(error: unknown): { shouldRetry: boolean; delayMs: number };
-  reset(): void;
+// Header names across providers (normalized to lowercase)
+const HEADER_KEYS = {
+  requestsRemaining: ["anthropic-ratelimit-requests-remaining", "x-ratelimit-remaining-requests"],
+  tokensRemaining: ["anthropic-ratelimit-tokens-remaining", "x-ratelimit-remaining-tokens"],
+  requestsReset: ["anthropic-ratelimit-requests-reset", "x-ratelimit-reset-requests"],
+  tokensReset: ["anthropic-ratelimit-tokens-reset", "x-ratelimit-reset-tokens"],
+  retryAfter: ["retry-after", "retry-after-ms"],
+} as const;
+
+function findHeader(headers: Headers, keys: readonly string[]): string | null {
+  for (const key of keys) {
+    const value = headers.get(key);
+    if (value !== null) return value;
+  }
+  return null;
+}
+
+function parseResetMs(value: string): number | undefined {
+  // Anthropic sends ISO timestamps, OpenAI sends durations like "6m0s" or "1s"
+  const date = Date.parse(value);
+  if (!Number.isNaN(date)) {
+    const ms = date - Date.now();
+    return ms > 0 ? ms : undefined;
+  }
+  const durationMatch = value.match(/(?:(\d+)m)?(\d+(?:\.\d+)?)s/);
+  if (durationMatch) {
+    const minutes = Number.parseInt(durationMatch[1] ?? "0", 10);
+    const seconds = Number.parseFloat(durationMatch[2] ?? "0");
+    const ms = (minutes * 60 + seconds) * 1_000;
+    return ms > 0 ? ms : undefined;
+  }
+  return undefined;
+}
+
+export type RateLimitState = {
+  requestsRemaining: number | undefined;
+  tokensRemaining: number | undefined;
+  requestsResetMs: number | undefined;
+  tokensResetMs: number | undefined;
 };
 
-type TimestampedEntry = { time: number; tokens: number };
+export type RateLimiter = {
+  beforeCall(): Promise<void>;
+  onResponse(headers: Headers): void;
+  onError(error: unknown): { shouldRetry: boolean; delayMs: number };
+  reset(): void;
+  state(): RateLimitState;
+};
 
 export function createRateLimiter(config: RateLimiterConfig): RateLimiter {
-  const entries: TimestampedEntry[] = [];
   let consecutiveFailures = 0;
-
-  function pruneWindow() {
-    const cutoff = Date.now() - 60_000;
-    while (entries.length > 0 && (entries[0]?.time ?? 0) < cutoff) entries.shift();
-  }
-
-  function windowTokens(): number {
-    let total = 0;
-    for (const entry of entries) total += entry.tokens;
-    return total;
-  }
+  let requestsRemaining: number | undefined;
+  let tokensRemaining: number | undefined;
+  let requestsResetMs: number | undefined;
+  let tokensResetMs: number | undefined;
 
   return {
     async beforeCall() {
-      pruneWindow();
-      const atRequestLimit = entries.length >= config.maxRequestsPerMinute;
-      const atTokenLimit = config.maxTokensPerMinute > 0 && windowTokens() >= config.maxTokensPerMinute;
-      if (atRequestLimit || atTokenLimit) {
-        const oldest = entries[0]?.time ?? Date.now();
-        const waitMs = Math.max(0, oldest + 60_000 - Date.now());
-        if (waitMs > 0) await new Promise((resolve) => setTimeout(resolve, jitter(waitMs)));
-        pruneWindow();
+      // Pace based on remaining budget learned from previous responses
+      const reqReset = requestsResetMs;
+      const tokReset = tokensResetMs;
+      if (requestsRemaining !== undefined && requestsRemaining <= 1 && reqReset !== undefined) {
+        await new Promise((resolve) => setTimeout(resolve, jitter(reqReset)));
+      } else if (tokensRemaining !== undefined && tokensRemaining <= 0 && tokReset !== undefined) {
+        await new Promise((resolve) => setTimeout(resolve, jitter(tokReset)));
       }
-      entries.push({ time: Date.now(), tokens: 0 });
     },
 
-    recordUsage(tokens: number) {
-      const last = entries[entries.length - 1];
-      if (last) last.tokens = tokens;
+    onResponse(headers: Headers) {
+      const reqRemaining = findHeader(headers, HEADER_KEYS.requestsRemaining);
+      if (reqRemaining !== null) {
+        const parsed = Number.parseInt(reqRemaining, 10);
+        if (Number.isFinite(parsed)) requestsRemaining = parsed;
+      }
+
+      const tokRemaining = findHeader(headers, HEADER_KEYS.tokensRemaining);
+      if (tokRemaining !== null) {
+        const parsed = Number.parseInt(tokRemaining, 10);
+        if (Number.isFinite(parsed)) tokensRemaining = parsed;
+      }
+
+      const reqReset = findHeader(headers, HEADER_KEYS.requestsReset);
+      if (reqReset !== null) requestsResetMs = parseResetMs(reqReset);
+
+      const tokReset = findHeader(headers, HEADER_KEYS.tokensReset);
+      if (tokReset !== null) tokensResetMs = parseResetMs(tokReset);
+
+      consecutiveFailures = 0;
     },
 
     onError(error: unknown): { shouldRetry: boolean; delayMs: number } {
@@ -96,6 +155,20 @@ export function createRateLimiter(config: RateLimiterConfig): RateLimiter {
     reset() {
       consecutiveFailures = 0;
     },
+
+    state(): RateLimitState {
+      return { requestsRemaining, tokensRemaining, requestsResetMs, tokensResetMs };
+    },
+  };
+}
+
+export type FetchFn = (input: URL | RequestInfo, init?: RequestInit) => Promise<Response>;
+
+export function createRateLimitFetch(limiter: RateLimiter, baseFetch: FetchFn): FetchFn {
+  return async (input, init) => {
+    const response = await baseFetch(input, init);
+    limiter.onResponse(response.headers);
+    return response;
   };
 }
 

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -1,0 +1,85 @@
+import type { Provider } from "./provider-contract";
+
+export type RateLimiterConfig = {
+  readonly maxRequestsPerMinute: number;
+  readonly backoffBaseMs: number;
+  readonly backoffMaxMs: number;
+};
+
+const PROVIDER_DEFAULTS: Record<Provider, RateLimiterConfig> = {
+  anthropic: { maxRequestsPerMinute: 50, backoffBaseMs: 1_000, backoffMaxMs: 60_000 },
+  openai: { maxRequestsPerMinute: 60, backoffBaseMs: 1_000, backoffMaxMs: 60_000 },
+  google: { maxRequestsPerMinute: 60, backoffBaseMs: 1_000, backoffMaxMs: 60_000 },
+};
+
+export function defaultRateLimiterConfig(provider: Provider): RateLimiterConfig {
+  return PROVIDER_DEFAULTS[provider];
+}
+
+function jitter(ms: number): number {
+  return ms * (0.5 + Math.random() * 0.5);
+}
+
+function isRateLimitError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) return false;
+  const status = "status" in error ? (error as { status?: unknown }).status : undefined;
+  if (status === 429) return true;
+  const code = "code" in error ? (error as { code?: unknown }).code : undefined;
+  return code === "rate_limit_exceeded" || code === "RATE_LIMIT_EXCEEDED";
+}
+
+function retryAfterMs(error: unknown): number | undefined {
+  if (typeof error !== "object" || error === null) return undefined;
+  const headers = "headers" in error ? (error as { headers?: unknown }).headers : undefined;
+  if (typeof headers !== "object" || headers === null) return undefined;
+  const retryAfter = "retry-after" in headers ? (headers as Record<string, unknown>)["retry-after"] : undefined;
+  if (typeof retryAfter === "string") {
+    const seconds = Number.parseFloat(retryAfter);
+    if (Number.isFinite(seconds) && seconds > 0) return seconds * 1_000;
+  }
+  if (typeof retryAfter === "number" && retryAfter > 0) return retryAfter * 1_000;
+  return undefined;
+}
+
+export type RateLimiter = {
+  beforeCall(): Promise<void>;
+  onError(error: unknown): { shouldRetry: boolean; delayMs: number };
+  reset(): void;
+};
+
+export function createRateLimiter(config: RateLimiterConfig): RateLimiter {
+  const timestamps: number[] = [];
+  let consecutiveFailures = 0;
+
+  function pruneWindow() {
+    const cutoff = Date.now() - 60_000;
+    while (timestamps.length > 0 && (timestamps[0] ?? 0) < cutoff) timestamps.shift();
+  }
+
+  return {
+    async beforeCall() {
+      pruneWindow();
+      if (timestamps.length >= config.maxRequestsPerMinute) {
+        const oldest = timestamps[0] ?? Date.now();
+        const waitMs = Math.max(0, oldest + 60_000 - Date.now());
+        if (waitMs > 0) await new Promise((resolve) => setTimeout(resolve, jitter(waitMs)));
+        pruneWindow();
+      }
+      timestamps.push(Date.now());
+    },
+
+    onError(error: unknown): { shouldRetry: boolean; delayMs: number } {
+      if (!isRateLimitError(error)) return { shouldRetry: false, delayMs: 0 };
+      consecutiveFailures += 1;
+      const serverDelay = retryAfterMs(error);
+      const backoff = Math.min(config.backoffMaxMs, config.backoffBaseMs * 2 ** (consecutiveFailures - 1));
+      return { shouldRetry: true, delayMs: serverDelay ?? jitter(backoff) };
+    },
+
+    reset() {
+      consecutiveFailures = 0;
+    },
+  };
+}
+
+export { isRateLimitError, retryAfterMs };

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -2,14 +2,15 @@ import type { Provider } from "./provider-contract";
 
 export type RateLimiterConfig = {
   readonly maxRequestsPerMinute: number;
+  readonly maxTokensPerMinute: number;
   readonly backoffBaseMs: number;
   readonly backoffMaxMs: number;
 };
 
 const PROVIDER_DEFAULTS: Record<Provider, RateLimiterConfig> = {
-  anthropic: { maxRequestsPerMinute: 50, backoffBaseMs: 1_000, backoffMaxMs: 60_000 },
-  openai: { maxRequestsPerMinute: 60, backoffBaseMs: 1_000, backoffMaxMs: 60_000 },
-  google: { maxRequestsPerMinute: 60, backoffBaseMs: 1_000, backoffMaxMs: 60_000 },
+  anthropic: { maxRequestsPerMinute: 50, maxTokensPerMinute: 40_000, backoffBaseMs: 1_000, backoffMaxMs: 60_000 },
+  openai: { maxRequestsPerMinute: 60, maxTokensPerMinute: 150_000, backoffBaseMs: 1_000, backoffMaxMs: 60_000 },
+  google: { maxRequestsPerMinute: 60, maxTokensPerMinute: 100_000, backoffBaseMs: 1_000, backoffMaxMs: 60_000 },
 };
 
 export function defaultRateLimiterConfig(provider: Provider): RateLimiterConfig {
@@ -43,29 +44,45 @@ function retryAfterMs(error: unknown): number | undefined {
 
 export type RateLimiter = {
   beforeCall(): Promise<void>;
+  recordUsage(tokens: number): void;
   onError(error: unknown): { shouldRetry: boolean; delayMs: number };
   reset(): void;
 };
 
+type TimestampedEntry = { time: number; tokens: number };
+
 export function createRateLimiter(config: RateLimiterConfig): RateLimiter {
-  const timestamps: number[] = [];
+  const entries: TimestampedEntry[] = [];
   let consecutiveFailures = 0;
 
   function pruneWindow() {
     const cutoff = Date.now() - 60_000;
-    while (timestamps.length > 0 && (timestamps[0] ?? 0) < cutoff) timestamps.shift();
+    while (entries.length > 0 && (entries[0]?.time ?? 0) < cutoff) entries.shift();
+  }
+
+  function windowTokens(): number {
+    let total = 0;
+    for (const entry of entries) total += entry.tokens;
+    return total;
   }
 
   return {
     async beforeCall() {
       pruneWindow();
-      if (timestamps.length >= config.maxRequestsPerMinute) {
-        const oldest = timestamps[0] ?? Date.now();
+      const atRequestLimit = entries.length >= config.maxRequestsPerMinute;
+      const atTokenLimit = config.maxTokensPerMinute > 0 && windowTokens() >= config.maxTokensPerMinute;
+      if (atRequestLimit || atTokenLimit) {
+        const oldest = entries[0]?.time ?? Date.now();
         const waitMs = Math.max(0, oldest + 60_000 - Date.now());
         if (waitMs > 0) await new Promise((resolve) => setTimeout(resolve, jitter(waitMs)));
         pruneWindow();
       }
-      timestamps.push(Date.now());
+      entries.push({ time: Date.now(), tokens: 0 });
+    },
+
+    recordUsage(tokens: number) {
+      const last = entries[entries.length - 1];
+      if (last) last.tokens = tokens;
     },
 
     onError(error: unknown): { shouldRetry: boolean; delayMs: number } {


### PR DESCRIPTION
## Summary
- add header-driven rate limiter that learns actual limits from provider response headers
- decorate provider fetch to intercept rate limit headers from every response (Anthropic + OpenAI formats)
- proactive pacing when requests or tokens are exhausted, exponential backoff with jitter on 429
- shared limiter per provider across agent and distill so they respect the same budget
- retry loop in agent stream for automatic recovery from rate limit errors

Fixes #86