### PR TITLE
feat(workspace): auto-install dependencies

### DIFF
--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -113,7 +113,7 @@ export type EffectResult = { type: "done"; lintOutput?: string };
 
 export type Effect = {
   id: string;
-  run: (ctx: RunContext, paths: string[]) => EffectResult;
+  run: (ctx: RunContext, paths?: string[]) => EffectResult;
 };
 
 export type LifecycleInput = {

--- a/src/lifecycle-effects.test.ts
+++ b/src/lifecycle-effects.test.ts
@@ -1,6 +1,8 @@
-import { describe, expect, test } from "bun:test";
-import { formatEffect, lintEffect } from "./lifecycle-effects";
-import { createRunContext } from "./test-utils";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { formatEffect, installEffect, lintEffect } from "./lifecycle-effects";
+import { createRunContext, tempDir } from "./test-utils";
 
 function ctxWith(overrides: Parameters<typeof createRunContext>[0] = {}) {
   return createRunContext({
@@ -30,6 +32,34 @@ describe("formatEffect", () => {
   test("returns done when paths are empty", () => {
     const ctx = ctxWith();
     expect(formatEffect.run(ctx, [])).toEqual({ type: "done" });
+  });
+});
+
+const { createDir, cleanupDirs } = tempDir();
+afterEach(() => cleanupDirs());
+
+describe("installEffect", () => {
+  test("returns done when workspace is undefined", () => {
+    const ctx = ctxWith({ workspace: undefined });
+    expect(installEffect.run(ctx, [])).toEqual({ type: "done" });
+  });
+
+  test("returns done when no install command is configured", () => {
+    const ctx = ctxWith({
+      policy: { ...createRunContext().policy, installCommand: undefined },
+    });
+    expect(installEffect.run(ctx, [])).toEqual({ type: "done" });
+  });
+
+  test("skips install when depsDir exists", () => {
+    const ws = createDir("acolyte-install-");
+    mkdirSync(join(ws, "node_modules"), { recursive: true });
+    const ctx = ctxWith({
+      workspace: ws,
+      policy: { ...createRunContext().policy, installCommand: { bin: "npm", args: ["install"] } },
+    });
+    ctx.session.workspaceProfile = { depsDir: "node_modules" };
+    expect(installEffect.run(ctx, [])).toEqual({ type: "done" });
   });
 });
 

--- a/src/lifecycle-effects.ts
+++ b/src/lifecycle-effects.ts
@@ -1,9 +1,11 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import type { Effect, EffectResult } from "./lifecycle-contract";
-import { renderCommandResult, runCommandWithFiles } from "./workspace-profile";
+import { formatWorkspaceCommand, renderCommandResult, runCommand, runCommandWithFiles } from "./workspace-profile";
 
 export const formatEffect: Effect = {
   id: "format",
-  run(ctx, paths): EffectResult {
+  run(ctx, paths = []): EffectResult {
     if (!ctx.workspace || !ctx.policy.formatCommand || paths.length === 0) return { type: "done" };
     runCommandWithFiles(ctx.workspace, ctx.policy.formatCommand, paths);
     ctx.debug("lifecycle.effect.format", { files: paths.length });
@@ -13,7 +15,7 @@ export const formatEffect: Effect = {
 
 export const lintEffect: Effect = {
   id: "lint",
-  run(ctx, paths): EffectResult {
+  run(ctx, paths = []): EffectResult {
     if (!ctx.workspace || !ctx.policy.lintCommand || paths.length === 0) return { type: "done" };
     const result = runCommandWithFiles(ctx.workspace, ctx.policy.lintCommand, paths);
     if (!result.hasErrors) return { type: "done" };
@@ -22,4 +24,27 @@ export const lintEffect: Effect = {
   },
 };
 
-export const EFFECTS: Effect[] = [formatEffect, lintEffect];
+const installedWorkspaces = new Set<string>();
+
+export const installEffect: Effect = {
+  id: "install",
+  run(ctx): EffectResult {
+    if (!ctx.workspace || !ctx.policy.installCommand) return { type: "done" };
+    if (installedWorkspaces.has(ctx.workspace)) return { type: "done" };
+    const profile = ctx.session.workspaceProfile;
+    if (profile?.depsDir && existsSync(join(ctx.workspace, profile.depsDir))) {
+      installedWorkspaces.add(ctx.workspace);
+      return { type: "done" };
+    }
+    const result = runCommand(ctx.workspace, ctx.policy.installCommand, 60_000);
+    ctx.debug("lifecycle.effect.install", {
+      command: formatWorkspaceCommand(ctx.policy.installCommand),
+      has_errors: result.hasErrors,
+    });
+    installedWorkspaces.add(ctx.workspace);
+    return { type: "done" };
+  },
+};
+
+export const POST_EFFECTS: Effect[] = [formatEffect, lintEffect];
+export const PRE_EFFECTS: Effect[] = [installEffect];

--- a/src/lifecycle-policy.ts
+++ b/src/lifecycle-policy.ts
@@ -15,6 +15,7 @@ export type LifecyclePolicy = {
   maxUnknownErrorsPerRequest: number;
   maxNudgesPerGeneration: number;
   toolTimeoutMs: number;
+  installCommand?: WorkspaceCommand;
   formatCommand?: WorkspaceCommand;
   lintCommand?: WorkspaceCommand;
 };

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -8,7 +8,7 @@ import type {
   RunContext,
   ToolOutputEvent,
 } from "./lifecycle-contract";
-import { EFFECTS } from "./lifecycle-effects";
+import { POST_EFFECTS, PRE_EFFECTS } from "./lifecycle-effects";
 import { phaseFinalize } from "./lifecycle-finalize";
 import { createRunAgent, phaseGenerate } from "./lifecycle-generate";
 import { resolveLifecyclePolicy } from "./lifecycle-policy";
@@ -19,7 +19,7 @@ import type { MemoryCommitContext, MemoryCommitMetrics } from "./memory-contract
 import { commitMemorySources } from "./memory-registry";
 import { createInMemoryTaskQueue } from "./task-queue";
 import { renderToolOutputPart } from "./tool-output-content";
-import { WRITE_TOOL_SET } from "./tool-registry";
+import { DISCOVERY_TOOL_SET, WRITE_TOOL_SET } from "./tool-registry";
 import { scopedCallLog } from "./tool-session";
 import { formatWorkspaceCommand, resolveWorkspaceProfile } from "./workspace-profile";
 import { resolveWorkspaceSandboxRoot } from "./workspace-sandbox";
@@ -127,12 +127,24 @@ function createRunContext(
     toolOutputHandler: null,
   };
 
-  session.onToolResult = (toolResult) => runEffects(ctx, toolResult);
+  session.onBeforeTool = (preCtx) => runPreEffects(ctx, preCtx);
+  session.onAfterTool = (toolResult) => runPostEffects(ctx, toolResult);
 
   return ctx;
 }
 
-function runEffects(
+function runPreEffects(
+  ctx: RunContext,
+  { toolId }: { toolId: string; args: Record<string, unknown> },
+): { append: string } | undefined {
+  if (DISCOVERY_TOOL_SET.has(toolId)) return undefined;
+  for (const effect of PRE_EFFECTS) {
+    effect.run(ctx);
+  }
+  return undefined;
+}
+
+function runPostEffects(
   ctx: RunContext,
   { toolId, args }: { toolId: string; args: Record<string, unknown> },
 ): { append: string } | undefined {
@@ -141,7 +153,7 @@ function runEffects(
   if (!path) return undefined;
   const paths = [path];
   let lintOutput: string | undefined;
-  for (const effect of EFFECTS) {
+  for (const effect of POST_EFFECTS) {
     const result = effect.run(ctx, paths);
     if (result.lintOutput) lintOutput = result.lintOutput;
   }
@@ -208,9 +220,10 @@ export async function runLifecycle(input: LifecycleInput, deps: LifecycleDeps = 
   let policy = deps.resolveLifecyclePolicy(input.lifecyclePolicy);
 
   const profile = resolveWorkspaceProfile(input.workspace);
-  if (profile.formatCommand || profile.lintCommand) {
+  if (profile.installCommand || profile.formatCommand || profile.lintCommand) {
     policy = {
       ...policy,
+      ...(!policy.installCommand && profile.installCommand ? { installCommand: profile.installCommand } : {}),
       ...(!policy.formatCommand && profile.formatCommand ? { formatCommand: profile.formatCommand } : {}),
       ...(!policy.lintCommand && profile.lintCommand ? { lintCommand: profile.lintCommand } : {}),
     };
@@ -232,6 +245,7 @@ export async function runLifecycle(input: LifecycleInput, deps: LifecycleDeps = 
     debug("lifecycle.workspace.profile", {
       ecosystem: profile.ecosystem,
       package_manager: profile.packageManager ?? null,
+      install_command: profile.installCommand ? formatWorkspaceCommand(profile.installCommand) : null,
       lint_command: profile.lintCommand ? formatWorkspaceCommand(profile.lintCommand) : null,
       format_command: profile.formatCommand ? formatWorkspaceCommand(profile.formatCommand) : null,
       test_command: profile.testCommand ? formatWorkspaceCommand(profile.testCommand) : null,

--- a/src/tool-execution.ts
+++ b/src/tool-execution.ts
@@ -72,6 +72,8 @@ export async function runTool(
       throw error;
     }
 
+    const preOutput = session.onBeforeTool?.({ toolId, args });
+
     const cache = session.cache;
     const timeoutMs = options?.timeoutMs ?? session.toolTimeoutMs;
     invariant(
@@ -97,9 +99,10 @@ export async function runTool(
         cache.set(toolId, args, { result: taskResult });
         cache.populateSubEntries(toolId, args, taskResult);
       }
-      const feedback = session.onToolResult?.({ toolId, args: args, result: taskResult });
-      if (feedback?.append && typeof taskResult === "object" && taskResult !== null) {
-        (taskResult as Record<string, unknown>).lifecycleFeedback = feedback.append;
+      const postOutput = session.onAfterTool?.({ toolId, args: args, result: taskResult });
+      const append = [preOutput?.append, postOutput?.append].filter(Boolean).join("\n");
+      if (append && typeof taskResult === "object" && taskResult !== null) {
+        (taskResult as Record<string, unknown>).lifecycleFeedback = append;
       }
       return taskResult;
     } catch (error) {

--- a/src/tool-session.ts
+++ b/src/tool-session.ts
@@ -18,8 +18,9 @@ export type SessionFlags = {
   totalStepLimit?: number;
 };
 
-export type ToolResultContext = { toolId: string; args: Record<string, unknown>; result: unknown };
-export type ToolResultFeedback = { append?: string };
+export type PreToolContext = { toolId: string; args: Record<string, unknown> };
+export type PostToolContext = { toolId: string; args: Record<string, unknown>; result: unknown };
+export type EffectOutput = { append?: string };
 
 export type SessionContext = {
   callLog: ToolCallRecord[];
@@ -29,7 +30,8 @@ export type SessionContext = {
   toolTimeoutMs?: number;
   cache?: ToolCache;
   onDebug?: (event: `lifecycle.${string}`, data: Record<string, unknown>) => void;
-  onToolResult?: (ctx: ToolResultContext) => ToolResultFeedback | undefined;
+  onBeforeTool?: (ctx: PreToolContext) => EffectOutput | undefined;
+  onAfterTool?: (ctx: PostToolContext) => EffectOutput | undefined;
   workspaceProfile?: WorkspaceProfile;
 };
 

--- a/src/workspace-detectors.test.ts
+++ b/src/workspace-detectors.test.ts
@@ -103,6 +103,25 @@ describe("typescript detector", () => {
     expect(profile.lintCommand?.bin).toBe("npx");
     expect(profile.formatCommand?.bin).toBe("npx");
   });
+
+  test("detects install command from package manager", () => {
+    const ws = makeWorkspace({ "package.json": '{"scripts":{}}', "bun.lock": "" });
+    const profile = resolveWorkspaceProfile(ws);
+    expect(profile.installCommand).toEqual({ bin: "bun", args: ["install"] });
+    expect(profile.depsDir).toBe("node_modules");
+  });
+
+  test("detects npm install for npm projects", () => {
+    const ws = makeWorkspace({ "package.json": '{"scripts":{}}', "package-lock.json": "" });
+    const profile = resolveWorkspaceProfile(ws);
+    expect(profile.installCommand).toEqual({ bin: "npm", args: ["install"] });
+  });
+
+  test("detects pnpm install for pnpm projects", () => {
+    const ws = makeWorkspace({ "package.json": '{"packageManager":"pnpm@9.1.0","scripts":{}}' });
+    const profile = resolveWorkspaceProfile(ws);
+    expect(profile.installCommand).toEqual({ bin: "pnpm", args: ["install"] });
+  });
 });
 
 describe("python detector", () => {
@@ -128,6 +147,25 @@ describe("python detector", () => {
     const ws = makeWorkspace({ "ruff.toml": "" });
     const profile = resolveWorkspaceProfile(ws);
     expect(profile.packageManager).toBe("pip");
+  });
+
+  test("detects uv sync as install command", () => {
+    const ws = makeWorkspace({ "pyproject.toml": "[tool.ruff]\n", "uv.lock": "" });
+    const profile = resolveWorkspaceProfile(ws);
+    expect(profile.installCommand).toEqual({ bin: "uv", args: ["sync"] });
+    expect(profile.depsDir).toBe(".venv");
+  });
+
+  test("detects poetry install for poetry projects", () => {
+    const ws = makeWorkspace({ "pyproject.toml": "", "poetry.lock": "" });
+    const profile = resolveWorkspaceProfile(ws);
+    expect(profile.installCommand).toEqual({ bin: "poetry", args: ["install"] });
+  });
+
+  test("defaults to pip install for pip projects", () => {
+    const ws = makeWorkspace({ "ruff.toml": "" });
+    const profile = resolveWorkspaceProfile(ws);
+    expect(profile.installCommand).toEqual({ bin: "pip", args: ["install", "-e", "."] });
   });
 
   test("detects ruff lint and format from ruff.toml", () => {
@@ -167,6 +205,12 @@ describe("go detector", () => {
     expect(profile.formatCommand).toEqual({ bin: "gofmt", args: ["-w", "$FILES"] });
     expect(profile.testCommand).toEqual({ bin: "go", args: ["test", "$FILES"] });
   });
+
+  test("detects go mod download as install command", () => {
+    const ws = makeWorkspace({ "go.mod": "module example.com/foo" });
+    const profile = resolveWorkspaceProfile(ws);
+    expect(profile.installCommand).toEqual({ bin: "go", args: ["mod", "download"] });
+  });
 });
 
 describe("rust detector", () => {
@@ -180,6 +224,12 @@ describe("rust detector", () => {
     });
     expect(profile.formatCommand).toEqual({ bin: "cargo", args: ["fmt", "--", "$FILES"] });
     expect(profile.testCommand).toEqual({ bin: "cargo", args: ["test", "--", "$FILES"] });
+  });
+
+  test("detects cargo fetch as install command", () => {
+    const ws = makeWorkspace({ "Cargo.toml": '[package]\nname = "foo"' });
+    const profile = resolveWorkspaceProfile(ws);
+    expect(profile.installCommand).toEqual({ bin: "cargo", args: ["fetch"] });
   });
 });
 

--- a/src/workspace-detectors.ts
+++ b/src/workspace-detectors.ts
@@ -50,23 +50,35 @@ export type EcosystemDetector = {
   id: string;
   match: (workspace: string) => boolean;
   detectPackageManager?: (workspace: string) => string | null;
+  detectInstallCommand?: (ctx: DetectContext) => WorkspaceCommand | null;
   detectLintCommand?: (ctx: DetectContext) => WorkspaceCommand | null;
   detectFormatCommand?: (ctx: DetectContext) => WorkspaceCommand | null;
   detectTestCommand?: (ctx: DetectContext) => WorkspaceCommand | null;
+  depsDir?: string;
 };
 
 function detectProfile(eco: EcosystemDetector, workspace: string): WorkspaceProfile | null {
   const packageManager = eco.detectPackageManager?.(workspace) ?? undefined;
   const ctx: DetectContext = { workspace, packageManager };
+  const installCommand = eco.detectInstallCommand?.(ctx) ?? undefined;
   const lintCommand = eco.detectLintCommand?.(ctx) ?? undefined;
   const formatCommand = eco.detectFormatCommand?.(ctx) ?? undefined;
   const testCommand = eco.detectTestCommand?.(ctx) ?? undefined;
-  return { ecosystem: eco.id, packageManager, lintCommand, formatCommand, testCommand };
+  return {
+    ecosystem: eco.id,
+    packageManager,
+    installCommand,
+    depsDir: eco.depsDir,
+    lintCommand,
+    formatCommand,
+    testCommand,
+  };
 }
 
 const typescriptDetector: EcosystemDetector = {
   id: "typescript",
   match: (workspace) => fileExists(workspace, "package.json") || fileExists(workspace, "deno.json"),
+  depsDir: "node_modules",
 
   detectPackageManager(workspace) {
     const pkg = readJson(workspace, "package.json");
@@ -78,6 +90,11 @@ const typescriptDetector: EcosystemDetector = {
     if (fileExists(workspace, "yarn.lock")) return "yarn";
     if (fileExists(workspace, "package-lock.json")) return "npm";
     return "npm";
+  },
+
+  detectInstallCommand(ctx) {
+    const pm = ctx.packageManager ?? "npm";
+    return { bin: pm, args: ["install"] };
   },
 
   detectLintCommand(ctx) {
@@ -148,12 +165,26 @@ const pythonDetector: EcosystemDetector = {
   id: "python",
   match: (workspace) =>
     fileExists(workspace, "pyproject.toml") || fileExists(workspace, "setup.py") || fileExists(workspace, "ruff.toml"),
+  depsDir: ".venv",
 
   detectPackageManager(workspace) {
     if (fileExists(workspace, "uv.lock")) return "uv";
     if (fileExists(workspace, "poetry.lock")) return "poetry";
     if (fileExists(workspace, "Pipfile.lock")) return "pipenv";
     return "pip";
+  },
+
+  detectInstallCommand(ctx) {
+    switch (ctx.packageManager) {
+      case "uv":
+        return { bin: "uv", args: ["sync"] };
+      case "poetry":
+        return { bin: "poetry", args: ["install"] };
+      case "pipenv":
+        return { bin: "pipenv", args: ["install"] };
+      default:
+        return { bin: "pip", args: ["install", "-e", "."] };
+    }
   },
 
   detectLintCommand(ctx) {
@@ -196,6 +227,7 @@ const pythonDetector: EcosystemDetector = {
 const goDetector: EcosystemDetector = {
   id: "go",
   match: (workspace) => fileExists(workspace, "go.mod"),
+  detectInstallCommand: () => ({ bin: "go", args: ["mod", "download"] }),
   detectLintCommand(ctx) {
     if (fileExists(ctx.workspace, ".golangci.yml") || fileExists(ctx.workspace, ".golangci.yaml"))
       return { bin: "golangci-lint", args: ["run", "$FILES"] };
@@ -208,6 +240,7 @@ const goDetector: EcosystemDetector = {
 const rustDetector: EcosystemDetector = {
   id: "rust",
   match: (workspace) => fileExists(workspace, "Cargo.toml"),
+  detectInstallCommand: () => ({ bin: "cargo", args: ["fetch"] }),
   detectLintCommand: () => ({ bin: "cargo", args: ["clippy", "--all-targets", "--", "-D", "warnings", "$FILES"] }),
   detectFormatCommand: () => ({ bin: "cargo", args: ["fmt", "--", "$FILES"] }),
   detectTestCommand: () => ({ bin: "cargo", args: ["test", "--", "$FILES"] }),

--- a/src/workspace-profile.ts
+++ b/src/workspace-profile.ts
@@ -48,6 +48,8 @@ export function runCommandWithFiles(workspace: string, command: WorkspaceCommand
 export type WorkspaceProfile = {
   ecosystem?: string;
   packageManager?: string;
+  installCommand?: WorkspaceCommand;
+  depsDir?: string;
   lintCommand?: WorkspaceCommand;
   formatCommand?: WorkspaceCommand;
   testCommand?: WorkspaceCommand;


### PR DESCRIPTION
## Summary

- add pre-tool-call effect pipeline symmetric with existing post-tool-call effects (format, lint)
- rename `EFFECTS` to `POST_EFFECTS`, add `PRE_EFFECTS` array, rename `onToolResult` to `onAfterTool`
- add `installEffect` that runs the detected install command before non-discovery tools
- add `detectInstallCommand` and `depsDir` to all four ecosystem detectors (TS, Python, Go, Rust)
- add `installCommand` to `WorkspaceProfile` and `LifecyclePolicy`
- module-level `installedWorkspaces` Set ensures install runs at most once per workspace per server process
- add unit tests for install detection across all ecosystems and install effect short-circuit behavior

Fixes #88