### PR TITLE
docs(benchmarks): update project list and metrics

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -29,51 +29,42 @@ Claude Code, Cursor, and Copilot are included for context but excluded from code
 
 | Project | Language | Description | Source lines | Files | Dependencies |
 |---|---|---|---|---|---|
-| **Acolyte** | TypeScript | CLI-first AI coding agent with lifecycle, post-write effects, and AST code tools | 25,284 | 193 | 12 + 6 |
-| **Codex** | Rust | Terminal AI coding agent from OpenAI with multi-platform support | 535,898 | 1,175 | 233 + 58 |
+| **Acolyte** | TypeScript | Terminal coding agent with lifecycle, effects, and AST code tools | 23,747 | 194 | 12 + 6 |
+| **OpenCode** | TypeScript | Open-source AI coding agent (TUI/web/desktop) | 233,164 | 1,122 | 180 + 82 |
+| **Codex** | Rust | Terminal AI coding agent from OpenAI | 442,773 | 1,087 | 238 + 54 |
+| **Crush** | Go | Terminal AI coding agent from Charm with Bubble Tea TUI | 47,615 | 224 | 68 + 0 |
 | **Aider** | Python | AI pair programming in your terminal | 25,943 | 105 | 35 + 17 |
+| **Goose** | Rust | Extensible AI agent from Block with MCP integration | 131,908 | 336 | 149 + 19 |
+| **Cline** | TypeScript | Autonomous AI coding agent for VS Code | 204,605 | 1,239 | 155 + 70 |
+| **Qwen Code** | TypeScript | Terminal AI coding agent from Alibaba | 228,822 | 1,058 | 91 + 86 |
+| **OpenHands** | Python | AI-driven software development platform | 125,987 | 717 | 83 + 7 |
+| **Continue** | TypeScript | AI code assistant for VS Code and JetBrains | 233,849 | 1,469 | 186 + 164 |
 | **Plandex** | Go | AI coding agent for large multi-file tasks in the terminal | 74,573 | 333 | 54 + 0 |
-| **OpenCode** | TypeScript | Open-source AI coding agent (TUI/web/desktop) | 220,421 | 1,072 | 177 + 80 |
-| **Pi** | TypeScript | Terminal coding agent harness with extensions | 103,306 | 406 | 50 + 19 |
-| **Continue** | TypeScript | AI code assistant for VS Code and JetBrains | 231,575 | 1,462 | 186 + 164 |
-| **Cline** | TypeScript | Autonomous AI coding agent for VS Code | 203,792 | 1,234 | 155 + 70 |
-| **OpenHands** | Python | AI-driven software development platform | 125,103 | 714 | 83 + 7 |
-| **Goose** | Rust | Extensible AI agent from Block with MCP integration | 128,126 | 336 | 142 + 17 |
-| **OpenClaw** | TypeScript | Personal AI assistant with coding agent skill | 803,573 | 4,749 | 115 + 49 |
-
-Each runtime dependency has a specific job — the AI SDK for model calls, Zod for validation, a custom React reconciler for the TUI, and tiktoken for token counting.
+| **Mistral Vibe** | Python | Terminal AI coding agent from Mistral | 31,072 | 223 | 34 + 13 |
 
 ## Dependency surface area
 
 Measures how much of a codebase depends on external packages.
 
-External imports include package imports that resolve **outside the repository**.
-
-| Metric | Acolyte | OpenCode | Pi | Cline | Continue | OpenClaw |
-|---|---|---|---|---|---|---|
-| External imports / 1k LOC | 6.4 | 16.5 | 9.0 | 22.2 | 10.0 | 6.4 |
-| Runtime dependencies | 12 | 177 | 50 | 155 | 186 | 115 |
+| Metric | Acolyte | OpenCode | Cline | Qwen Code | Continue |
+|---|---|---|---|---|---|
+| External imports / 1k LOC | 6.8 | 16.6 | 22.2 | 8.0 | 10.0 |
+| Runtime dependencies | 12 | 180 | 155 | 91 | 186 |
 
 _TypeScript projects only._
 
-Lower values indicate a more self-contained codebase with fewer external dependencies.
-
-Acolyte ties for the lowest external import density among TypeScript projects and has the fewest runtime dependencies by a wide margin.
+Acolyte has the lowest external import density and fewest runtime dependencies among TypeScript projects.
 
 ## Input validation coverage
 
 Measures how frequently data entering the system is validated.
 
-Includes schema validation calls such as `safeParse`, `parse`, and `validate`.
-
-| Metric | Acolyte | OpenCode | Pi | Cline | Continue | OpenClaw |
-|---|---|---|---|---|---|---|
-| Schema validations / 1k LOC | 2.2 | 0.7 | 0.7 | 1.2 | 0.9 | 0.5 |
-| `.safeParse()` calls | 1.0 | 0.1 | 0.0 | 0.0 | 0.1 | 0.0 |
+| Metric | Acolyte | OpenCode | Cline | Qwen Code | Continue |
+|---|---|---|---|---|---|
+| Schema validations / 1k LOC | 2.1 | 0.8 | 1.2 | 0.6 | 0.9 |
+| `.safeParse()` calls / 1k | 0.8 | 0.1 | 0.0 | 0.0 | 0.1 |
 
 _TypeScript projects only._
-
-Higher values indicate stronger runtime validation of model outputs, RPC payloads, and configuration data.
 
 Acolyte validates at a higher rate than every other project in the benchmark.
 
@@ -81,44 +72,41 @@ Acolyte validates at a higher rate than every other project in the benchmark.
 
 Per 1k source lines.
 
-| Metric | Acolyte | OpenCode | Pi | Cline | Continue | OpenClaw |
-|---|---|---|---|---|---|---|
-| `as any` | 0.1 | 1.8 | 1.4 | 0.8 | 2.3 | 0.1 |
-| `: any` annotations | 0.0 | 1.0 | 1.3 | 2.3 | 4.4 | 0.2 |
-| `@ts-ignore` / `@ts-expect-error` | 0.0 | 0.2 | 0.0 | 0.1 | 0.4 | 0.0 |
-| Lint ignores | 0.1 | 0.0 | 0.0 | 0.1 | 0.2 | 0.1 |
-| `: unknown` usage | 4.7 | 1.4 | 1.1 | 0.4 | 0.3 | 5.8 |
+| Metric | Acolyte | OpenCode | Cline | Qwen Code | Continue |
+|---|---|---|---|---|---|
+| `as any` | 0.1 | 1.7 | 0.8 | 0.1 | 2.4 |
+| `: any` annotations | 0.0 | 1.0 | 2.3 | 0.3 | 4.4 |
+| `@ts-ignore` / `@ts-expect-error` | 0.0 | 0.2 | 0.1 | 0.0 | 0.3 |
+| Lint ignores | 0.2 | 0.0 | 0.1 | 0.3 | 0.2 |
+| `: unknown` usage | 4.8 | 1.8 | 0.4 | 2.3 | 0.3 |
 
-Acolyte has near-zero `any` usage. It uses `unknown` with explicit narrowing — every tool output, model response, and RPC payload is validated through Zod schemas before entering the type system.
+Acolyte and Qwen Code have near-zero `any` usage. Acolyte uses `unknown` with explicit narrowing — every tool output, model response, and RPC payload is validated through Zod schemas before entering the type system.
 
 ## Cross-language type safety
 
 Per 1k source lines.
 
-| Metric | Aider | OpenHands | Goose | Codex | Plandex |
-|---|---|---|---|---|---|
-| `type: ignore` (Python) | 0.0 | 1.6 | — | — | — |
-| `Any` usage (Python) | 0.1 | 3.4 | — | — | — |
-| `cast()` calls (Python) | 0.0 | 0.4 | — | — | — |
-| `unsafe` (Rust) | — | — | 0.0 | 0.9 | — |
-| `.unwrap()` (Rust) | — | — | 11.7 | 2.7 | — |
-| `.expect()` (Rust) | — | — | 1.4 | 8.6 | — |
-| `any` / `interface{}` (Go) | — | — | — | — | 4.4 |
-| `panic()` (Go) | — | — | — | — | 0.3 |
-| `nolint` (Go) | — | — | — | — | 0.0 |
+| Metric | Aider | Mistral Vibe | OpenHands | Goose | Codex | Crush | Plandex |
+|---|---|---|---|---|---|---|---|
+| `type: ignore` (Python) | 0.0 | 0.1 | 1.6 | — | — | — | — |
+| `Any` usage (Python) | 0.1 | 7.1 | 3.4 | — | — | — | — |
+| `cast()` calls (Python) | 0.0 | 0.8 | 0.4 | — | — | — | — |
+| `unsafe` (Rust) | — | — | — | 0.0 | 1.1 | — | — |
+| `.unwrap()` (Rust) | — | — | — | 12.1 | 3.2 | — | — |
+| `.expect()` (Rust) | — | — | — | 1.3 | 10.8 | — | — |
+| `any` / `interface{}` (Go) | — | — | — | — | — | 3.7 | 4.4 |
+| `panic()` (Go) | — | — | — | — | — | 0.2 | 0.3 |
+| `nolint` (Go) | — | — | — | — | — | 0.2 | 0.0 |
 
-Aider shows minimal type escape hatches. Codex has much lower `.unwrap()` density than Goose but high `.expect()` density — errors are surfaced but rely on panicking assertions.
-
+Aider shows minimal type escape hatches. Mistral Vibe has high `Any` density. Codex has lower `.unwrap()` than Goose but high `.expect()` — errors are surfaced but rely on panicking assertions.
 
 ## Test quality
 
-Measures test lines relative to source lines across all projects.
-
-| Metric | Acolyte | Codex | Aider | Plandex | OpenCode | Pi | Continue | Cline | OpenHands | Goose | OpenClaw |
-|---|---|---|---|---|---|---|---|---|---|---|---|
-| Test files | 155 | 260 | 42 | 6 | 222 | 136 | 331 | 198 | 364 | 20 | 2,997 |
-| Test lines | 21,516 | 108,359 | 12,427 | 2,517 | 45,822 | 39,923 | 82,509 | 49,490 | 147,973 | 7,504 | 658,266 |
-| Test / source ratio | **0.85** | 0.20 | 0.48 | 0.03 | 0.21 | 0.39 | 0.36 | 0.24 | **1.18** | 0.06 | 0.82 |
+| Metric | Acolyte | OpenCode | Codex | Crush | Aider | Goose | Cline | Qwen Code | OpenHands | Continue | Plandex | Mistral Vibe |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Test files | 151 | 254 | 264 | 63 | 42 | 21 | 208 | 520 | 368 | 335 | 6 | 193 |
+| Test lines | 20,328 | 57,911 | 124,863 | 12,713 | 12,427 | 7,631 | 50,977 | 225,661 | 150,494 | 83,887 | 2,517 | 40,073 |
+| Ratio | 0.86 | 0.25 | 0.28 | 0.27 | 0.48 | 0.06 | 0.25 | 0.99 | 1.19 | 0.36 | 0.03 | 1.29 |
 
 Acolyte maintains a high test ratio because lifecycle phases and tools are independent modules with clean interfaces.
 
@@ -131,34 +119,28 @@ Test types include:
 
 ## Module cohesion
 
-Measures average file size, size distribution, and barrel file density.
-
-| Metric | Acolyte | Codex | Aider | Plandex | OpenCode | Pi | Continue | Cline | OpenHands | Goose | OpenClaw |
-|---|---|---|---|---|---|---|---|---|---|---|---|
-| Avg lines / file | 131 | 456 | 247 | 224 | 206 | 254 | 158 | 165 | 175 | 381 | 169 |
-| Files > 500 lines | 3 (2%) | 273 (23%) | 14 (13%) | 36 (11%) | 106 (10%) | 51 (13%) | 87 (6%) | 69 (6%) | 56 (8%) | 84 (25%) | 362 (8%) |
-| Largest file | 762 | 9,962 | 2,486 | 2,455 | 5,036 | 4,648 | 3,229 | 4,809 | 2,055 | 2,559 | 4,222 |
-| Barrel / index files | 1 | 61 | 5 | 0 | 51 | 26 | 73 | 47 | 86 | 45 | 108 |
+| Metric | Acolyte | OpenCode | Codex | Crush | Aider | Goose | Cline | Qwen Code | OpenHands | Continue | Plandex | Mistral Vibe |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Avg lines / file | 122 | 208 | 407 | 213 | 247 | 393 | 165 | 216 | 176 | 159 | 224 | 139 |
+| Files > 500 lines | 2 (1%) | 114 (10%) | 229 (21%) | 18 (8%) | 14 (13%) | 88 (26%) | 69 (6%) | 112 (11%) | 57 (8%) | 92 (6%) | 36 (11%) | 7 (3%) |
+| Largest file | 762 | 5,166 | 9,394 | 3,620 | 2,486 | 2,898 | 4,833 | 2,369 | 2,063 | 3,274 | 2,455 | 2,268 |
+| Barrel / index files | 1 | 53 | 50 | 2 | 5 | 45 | 47 | 52 | 86 | 73 | 0 | 39 |
 
 Acolyte maintains the smallest average module size and fewest large files.
-
-The `src/` layout keeps modules shallow with no re-exports and no circular dependencies.
 
 ## Error handling
 
 Per 1k source lines.
 
-| Metric | Acolyte | OpenCode | Pi | Cline | Continue | OpenClaw |
-|---|---|---|---|---|---|---|
-| `.safeParse()` calls | 1.0 | 0.1 | 0.0 | 0.0 | 0.1 | 0.0 |
-| `try { ... }` blocks | 5.1 | 1.3 | 4.2 | 6.1 | 3.8 | 4.6 |
-| `.catch()` calls | 0.5 | 2.3 | 0.4 | 1.1 | 0.3 | 1.0 |
+| Metric | Acolyte | OpenCode | Cline | Qwen Code | Continue |
+|---|---|---|---|---|---|
+| `.safeParse()` calls | 0.8 | 0.1 | 0.0 | 0.0 | 0.1 |
+| `try { ... }` blocks | 5.5 | 1.3 | 6.1 | 5.0 | 3.8 |
+| `.catch()` calls | 0.5 | 2.2 | 1.1 | 0.3 | 0.3 |
 
 _TypeScript projects only._
 
-Acolyte validates boundaries with Zod `.safeParse()` at over **10× the rate** of most other projects.
-
-RPC payloads, model responses, and configuration files are validated before entering the system.
+Acolyte validates boundaries with Zod `.safeParse()` at a higher rate than other projects. RPC payloads, model responses, and configuration files are validated before entering the system.
 
 ## Key takeaways
 
@@ -174,16 +156,14 @@ These characteristics reflect a deliberately small, strongly typed architecture 
 
 ## Summary
 
-Consolidated comparison across all measured dimensions.
-
-| Dimension | Acolyte | Codex | Aider | Plandex | OpenCode | Pi | Continue | Cline | OpenHands | Goose | OpenClaw |
-|---|---|---|---|---|---|---|---|---|---|---|---|
-| Type safety | High | Medium | High | Medium | Medium | Medium | Lower | Medium | Ignore-heavy | Panic-heavy | High |
-| Test density | High (0.85) | Low (0.20) | Medium (0.48) | Low (0.03) | Low (0.21) | Medium (0.39) | Medium (0.36) | Low (0.24) | Highest (1.18) | Lowest (0.06) | High (0.82) |
-| Module size | Smallest (131) | Large (456) | Medium (247) | Medium (224) | Medium (206) | Medium (254) | Medium (158) | Medium (165) | Medium (175) | Largest (381) | Medium (169) |
-| Dependencies | Lightest (18) | Heavy (291) | Light (52) | Light (54) | Heavy (257) | Light (69) | Heavy (350) | Heavy (225) | Medium (90) | Heavy (159) | Heavy (164) |
-| Maturity | New | Shipped | Shipped | Shipped | Shipped | Shipped | Shipped | Shipped | Shipped | Shipped | Shipped |
+| Dimension | Acolyte | OpenCode | Codex | Crush | Aider | Goose | Cline | Qwen Code | OpenHands | Continue | Plandex | Mistral Vibe |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Type safety | High | Medium | Medium | Medium | High | Panic-heavy | Medium | High | Ignore-heavy | Lower | Medium | Any-heavy |
+| Test density | High (0.86) | Low (0.25) | Low (0.28) | Low (0.27) | Medium (0.48) | Lowest (0.06) | Low (0.25) | High (0.99) | Highest (1.19) | Medium (0.36) | Low (0.03) | Highest (1.29) |
+| Module size | Smallest (122) | Medium (208) | Large (407) | Medium (213) | Medium (247) | Largest (393) | Medium (165) | Medium (216) | Medium (176) | Medium (159) | Medium (224) | Small (139) |
+| Dependencies | Lightest (18) | Heavy (262) | Heavy (292) | Light (68) | Light (52) | Heavy (168) | Heavy (225) | Heavy (177) | Medium (90) | Heavy (350) | Light (54) | Light (47) |
+| First commit | Feb 2026 | Apr 2025 | Apr 2025 | May 2025 | May 2023 | Aug 2024 | Jul 2024 | Jun 2025 | Mar 2024 | May 2023 | Oct 2023 | Dec 2025 |
 
 Acolyte leads on type safety, module size, and dependency count while remaining the smallest codebase in the benchmark.
 
-Updated 24 March 2026.
+Updated 1 April 2026.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -8,7 +8,7 @@ All metrics extracted with [`scripts/benchmark.ts`](../scripts/benchmark.ts).
 
 ## Methodology
 
-- **Source lines** = non-blank, non-comment lines of source code (SLOC)
+- **Source lines** = total lines of source code (including blanks and comments)
 - Test files, generated code, and files over **10k lines** are excluded
 - Metrics normalized **per 1k source lines** where applicable
 - Dependencies shown as **runtime + development** dependencies
@@ -30,26 +30,23 @@ Claude Code, Cursor, and Copilot are included for context but excluded from code
 | Project | Language | Description | Source lines | Files | Dependencies |
 |---|---|---|---|---|---|
 | **Acolyte** | TypeScript | Terminal coding agent with lifecycle, effects, and AST code tools | 23,747 | 194 | 12 + 6 |
-| **OpenCode** | TypeScript | Open-source AI coding agent (TUI/web/desktop) | 233,164 | 1,122 | 180 + 82 |
-| **Codex** | Rust | Terminal AI coding agent from OpenAI | 442,773 | 1,087 | 238 + 54 |
-| **Crush** | Go | Terminal AI coding agent from Charm with Bubble Tea TUI | 47,615 | 224 | 68 + 0 |
-| **Aider** | Python | AI pair programming in your terminal | 25,943 | 105 | 35 + 17 |
-| **Goose** | Rust | Extensible AI agent from Block with MCP integration | 131,908 | 336 | 149 + 19 |
-| **Cline** | TypeScript | Autonomous AI coding agent for VS Code | 204,605 | 1,239 | 155 + 70 |
-| **Qwen Code** | TypeScript | Terminal AI coding agent from Alibaba | 228,822 | 1,058 | 91 + 86 |
-| **OpenHands** | Python | AI-driven software development platform | 125,987 | 717 | 83 + 7 |
-| **Continue** | TypeScript | AI code assistant for VS Code and JetBrains | 233,849 | 1,469 | 186 + 164 |
-| **Plandex** | Go | AI coding agent for large multi-file tasks in the terminal | 74,573 | 333 | 54 + 0 |
-| **Mistral Vibe** | Python | Terminal AI coding agent from Mistral | 31,072 | 223 | 34 + 13 |
+| OpenCode | TypeScript | Open-source AI coding agent (TUI/web/desktop) | 233,164 | 1,122 | 180 + 82 |
+| Codex | Rust | Terminal AI coding agent from OpenAI | 442,773 | 1,087 | 238 + 54 |
+| Crush | Go | Terminal AI coding agent from Charm with Bubble Tea TUI | 47,615 | 224 | 68 + 0 |
+| Aider | Python | AI pair programming in your terminal | 25,943 | 105 | 35 + 17 |
+| Goose | Rust | Extensible AI agent from Block with MCP integration | 131,908 | 336 | 149 + 19 |
+| Qwen Code | TypeScript | Terminal AI coding agent from Alibaba | 228,822 | 1,058 | 91 + 86 |
+| Plandex | Go | AI coding agent for large multi-file tasks in the terminal | 74,573 | 333 | 54 + 0 |
+| Mistral Vibe | Python | Terminal AI coding agent from Mistral | 31,072 | 223 | 34 + 13 |
 
 ## Dependency surface area
 
 Measures how much of a codebase depends on external packages.
 
-| Metric | Acolyte | OpenCode | Cline | Qwen Code | Continue |
-|---|---|---|---|---|---|
-| External imports / 1k LOC | 6.8 | 16.6 | 22.2 | 8.0 | 10.0 |
-| Runtime dependencies | 12 | 180 | 155 | 91 | 186 |
+| Metric | Acolyte | OpenCode | Qwen Code |
+|---|---|---|---|
+| External imports / 1k LOC | 6.8 | 16.6 | 8.0 |
+| Runtime dependencies | 12 | 180 | 91 |
 
 _TypeScript projects only._
 
@@ -59,10 +56,10 @@ Acolyte has the lowest external import density and fewest runtime dependencies a
 
 Measures how frequently data entering the system is validated.
 
-| Metric | Acolyte | OpenCode | Cline | Qwen Code | Continue |
-|---|---|---|---|---|---|
-| Schema validations / 1k LOC | 2.1 | 0.8 | 1.2 | 0.6 | 0.9 |
-| `.safeParse()` calls / 1k | 0.8 | 0.1 | 0.0 | 0.0 | 0.1 |
+| Metric | Acolyte | OpenCode | Qwen Code |
+|---|---|---|---|
+| Schema validations / 1k LOC | 2.1 | 0.8 | 0.6 |
+| `.safeParse()` calls / 1k | 0.8 | 0.1 | 0.0 |
 
 _TypeScript projects only._
 
@@ -72,13 +69,13 @@ Acolyte validates at a higher rate than every other project in the benchmark.
 
 Per 1k source lines.
 
-| Metric | Acolyte | OpenCode | Cline | Qwen Code | Continue |
-|---|---|---|---|---|---|
-| `as any` | 0.1 | 1.7 | 0.8 | 0.1 | 2.4 |
-| `: any` annotations | 0.0 | 1.0 | 2.3 | 0.3 | 4.4 |
-| `@ts-ignore` / `@ts-expect-error` | 0.0 | 0.2 | 0.1 | 0.0 | 0.3 |
-| Lint ignores | 0.2 | 0.0 | 0.1 | 0.3 | 0.2 |
-| `: unknown` usage | 4.8 | 1.8 | 0.4 | 2.3 | 0.3 |
+| Metric | Acolyte | OpenCode | Qwen Code |
+|---|---|---|---|
+| `as any` | 0.1 | 1.7 | 0.1 |
+| `: any` annotations | 0.0 | 1.0 | 0.3 |
+| `@ts-ignore` / `@ts-expect-error` | 0.0 | 0.2 | 0.0 |
+| Lint ignores | 0.2 | 0.0 | 0.3 |
+| `: unknown` usage | 4.8 | 1.8 | 2.3 |
 
 Acolyte and Qwen Code have near-zero `any` usage. Acolyte uses `unknown` with explicit narrowing — every tool output, model response, and RPC payload is validated through Zod schemas before entering the type system.
 
@@ -86,27 +83,27 @@ Acolyte and Qwen Code have near-zero `any` usage. Acolyte uses `unknown` with ex
 
 Per 1k source lines.
 
-| Metric | Aider | Mistral Vibe | OpenHands | Goose | Codex | Crush | Plandex |
-|---|---|---|---|---|---|---|---|
-| `type: ignore` (Python) | 0.0 | 0.1 | 1.6 | — | — | — | — |
-| `Any` usage (Python) | 0.1 | 7.1 | 3.4 | — | — | — | — |
-| `cast()` calls (Python) | 0.0 | 0.8 | 0.4 | — | — | — | — |
-| `unsafe` (Rust) | — | — | — | 0.0 | 1.1 | — | — |
-| `.unwrap()` (Rust) | — | — | — | 12.1 | 3.2 | — | — |
-| `.expect()` (Rust) | — | — | — | 1.3 | 10.8 | — | — |
-| `any` / `interface{}` (Go) | — | — | — | — | — | 3.7 | 4.4 |
-| `panic()` (Go) | — | — | — | — | — | 0.2 | 0.3 |
-| `nolint` (Go) | — | — | — | — | — | 0.2 | 0.0 |
+| Metric | Aider | Mistral Vibe | Goose | Codex | Crush | Plandex |
+|---|---|---|---|---|---|---|
+| `type: ignore` (Python) | 0.0 | 0.1 | — | — | — | — |
+| `Any` usage (Python) | 0.1 | 7.1 | — | — | — | — |
+| `cast()` calls (Python) | 0.0 | 0.8 | — | — | — | — |
+| `unsafe` (Rust) | — | — | 0.0 | 1.1 | — | — |
+| `.unwrap()` (Rust) | — | — | 12.1 | 3.2 | — | — |
+| `.expect()` (Rust) | — | — | 1.3 | 10.8 | — | — |
+| `any` / `interface{}` (Go) | — | — | — | — | 3.7 | 4.4 |
+| `panic()` (Go) | — | — | — | — | 0.2 | 0.3 |
+| `nolint` (Go) | — | — | — | — | 0.2 | 0.0 |
 
 Aider shows minimal type escape hatches. Mistral Vibe has high `Any` density. Codex has lower `.unwrap()` than Goose but high `.expect()` — errors are surfaced but rely on panicking assertions.
 
 ## Test quality
 
-| Metric | Acolyte | OpenCode | Codex | Crush | Aider | Goose | Cline | Qwen Code | OpenHands | Continue | Plandex | Mistral Vibe |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Test files | 151 | 254 | 264 | 63 | 42 | 21 | 208 | 520 | 368 | 335 | 6 | 193 |
-| Test lines | 20,328 | 57,911 | 124,863 | 12,713 | 12,427 | 7,631 | 50,977 | 225,661 | 150,494 | 83,887 | 2,517 | 40,073 |
-| Ratio | 0.86 | 0.25 | 0.28 | 0.27 | 0.48 | 0.06 | 0.25 | 0.99 | 1.19 | 0.36 | 0.03 | 1.29 |
+| Metric | Acolyte | OpenCode | Codex | Crush | Aider | Goose | Qwen Code | Plandex | Mistral Vibe |
+|---|---|---|---|---|---|---|---|---|---|
+| Test files | 151 | 254 | 264 | 63 | 42 | 21 | 520 | 6 | 193 |
+| Test lines | 20,328 | 57,911 | 124,863 | 12,713 | 12,427 | 7,631 | 225,661 | 2,517 | 40,073 |
+| Ratio | 0.86 | 0.25 | 0.28 | 0.27 | 0.48 | 0.06 | 0.99 | 0.03 | 1.29 |
 
 Acolyte maintains a high test ratio because lifecycle phases and tools are independent modules with clean interfaces.
 
@@ -119,12 +116,12 @@ Test types include:
 
 ## Module cohesion
 
-| Metric | Acolyte | OpenCode | Codex | Crush | Aider | Goose | Cline | Qwen Code | OpenHands | Continue | Plandex | Mistral Vibe |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Avg lines / file | 122 | 208 | 407 | 213 | 247 | 393 | 165 | 216 | 176 | 159 | 224 | 139 |
-| Files > 500 lines | 2 (1%) | 114 (10%) | 229 (21%) | 18 (8%) | 14 (13%) | 88 (26%) | 69 (6%) | 112 (11%) | 57 (8%) | 92 (6%) | 36 (11%) | 7 (3%) |
-| Largest file | 762 | 5,166 | 9,394 | 3,620 | 2,486 | 2,898 | 4,833 | 2,369 | 2,063 | 3,274 | 2,455 | 2,268 |
-| Barrel / index files | 1 | 53 | 50 | 2 | 5 | 45 | 47 | 52 | 86 | 73 | 0 | 39 |
+| Metric | Acolyte | OpenCode | Codex | Crush | Aider | Goose | Qwen Code | Plandex | Mistral Vibe |
+|---|---|---|---|---|---|---|---|---|---|
+| Avg lines / file | 122 | 208 | 407 | 213 | 247 | 393 | 216 | 224 | 139 |
+| Files > 500 lines | 2 (1%) | 114 (10%) | 229 (21%) | 18 (8%) | 14 (13%) | 88 (26%) | 112 (11%) | 36 (11%) | 7 (3%) |
+| Largest file | 762 | 5,166 | 9,394 | 3,620 | 2,486 | 2,898 | 2,369 | 2,455 | 2,268 |
+| Barrel / index files | 1 | 53 | 50 | 2 | 5 | 45 | 52 | 0 | 39 |
 
 Acolyte maintains the smallest average module size and fewest large files.
 
@@ -132,11 +129,11 @@ Acolyte maintains the smallest average module size and fewest large files.
 
 Per 1k source lines.
 
-| Metric | Acolyte | OpenCode | Cline | Qwen Code | Continue |
-|---|---|---|---|---|---|
-| `.safeParse()` calls | 0.8 | 0.1 | 0.0 | 0.0 | 0.1 |
-| `try { ... }` blocks | 5.5 | 1.3 | 6.1 | 5.0 | 3.8 |
-| `.catch()` calls | 0.5 | 2.2 | 1.1 | 0.3 | 0.3 |
+| Metric | Acolyte | OpenCode | Qwen Code |
+|---|---|---|---|
+| `.safeParse()` calls | 0.8 | 0.1 | 0.0 |
+| `try { ... }` blocks | 5.5 | 1.3 | 5.0 |
+| `.catch()` calls | 0.5 | 2.2 | 0.3 |
 
 _TypeScript projects only._
 
@@ -156,13 +153,13 @@ These characteristics reflect a deliberately small, strongly typed architecture 
 
 ## Summary
 
-| Dimension | Acolyte | OpenCode | Codex | Crush | Aider | Goose | Cline | Qwen Code | OpenHands | Continue | Plandex | Mistral Vibe |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Type safety | High | Medium | Medium | Medium | High | Panic-heavy | Medium | High | Ignore-heavy | Lower | Medium | Any-heavy |
-| Test density | High (0.86) | Low (0.25) | Low (0.28) | Low (0.27) | Medium (0.48) | Lowest (0.06) | Low (0.25) | High (0.99) | Highest (1.19) | Medium (0.36) | Low (0.03) | Highest (1.29) |
-| Module size | Smallest (122) | Medium (208) | Large (407) | Medium (213) | Medium (247) | Largest (393) | Medium (165) | Medium (216) | Medium (176) | Medium (159) | Medium (224) | Small (139) |
-| Dependencies | Lightest (18) | Heavy (262) | Heavy (292) | Light (68) | Light (52) | Heavy (168) | Heavy (225) | Heavy (177) | Medium (90) | Heavy (350) | Light (54) | Light (47) |
-| First commit | Feb 2026 | Apr 2025 | Apr 2025 | May 2025 | May 2023 | Aug 2024 | Jul 2024 | Jun 2025 | Mar 2024 | May 2023 | Oct 2023 | Dec 2025 |
+| Dimension | Acolyte | OpenCode | Codex | Crush | Aider | Goose | Qwen Code | Plandex | Mistral Vibe |
+|---|---|---|---|---|---|---|---|---|---|
+| Type safety | High | Medium | Medium | Medium | High | Panic-heavy | High | Medium | Any-heavy |
+| Test density | High (0.86) | Low (0.25) | Low (0.28) | Low (0.27) | Medium (0.48) | Lowest (0.06) | High (0.99) | Low (0.03) | Highest (1.29) |
+| Module size | Smallest (122) | Medium (208) | Large (407) | Medium (213) | Medium (247) | Largest (393) | Medium (216) | Medium (224) | Small (139) |
+| Dependencies | Lightest (18) | Heavy (262) | Heavy (292) | Light (68) | Light (52) | Heavy (168) | Heavy (177) | Light (54) | Light (47) |
+| First commit | Feb 2026 | Apr 2025 | Apr 2025 | May 2025 | May 2023 | Aug 2024 | Jun 2025 | Oct 2023 | Dec 2025 |
 
 Acolyte leads on type safety, module size, and dependency count while remaining the smallest codebase in the benchmark.
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -2,38 +2,37 @@
 
 Detailed feature comparison between Acolyte and other open-source AI agents. See [Why Acolyte](./why-acolyte.md) for a summary.
 
-Projects compared: [Codex](https://github.com/openai/codex), [Aider](https://github.com/Aider-AI/aider), [Plandex](https://github.com/plandex-ai/plandex), [OpenCode](https://github.com/anomalyco/opencode), [Pi](https://github.com/badlogic/pi-mono), [Continue](https://github.com/continuedev/continue), [Cline](https://github.com/cline/cline), [OpenHands](https://github.com/All-Hands-AI/OpenHands), [Goose](https://github.com/block/goose), [OpenClaw](https://github.com/openclaw/openclaw).
-
-The comparison spans different categories — not all projects are pure coding agents.
+Projects compared: [OpenCode](https://github.com/anomalyco/opencode), [Codex](https://github.com/openai/codex), [Crush](https://github.com/charmbracelet/crush), [Aider](https://github.com/Aider-AI/aider), [Goose](https://github.com/block/goose), [Cline](https://github.com/cline/cline), [Qwen Code](https://github.com/QwenLM/qwen-code), [OpenHands](https://github.com/All-Hands-AI/OpenHands), [Continue](https://github.com/continuedev/continue), [Plandex](https://github.com/plandex-ai/plandex), [Mistral Vibe](https://github.com/mistralai/mistral-vibe).
 
 | Project | Category |
 |---|---|
 | Acolyte | Terminal coding agent |
+| OpenCode | Terminal coding agent |
 | Codex | Terminal coding agent |
+| Crush | Terminal coding agent |
 | Aider | Terminal coding agent |
-| Plandex | Terminal coding agent |
-| OpenCode | Coding agent (TUI/web/desktop) |
-| Pi | Agent SDK harness |
-| Continue | IDE extension |
-| Cline | IDE extension |
+| Goose | Terminal coding agent |
+| Cline | IDE extension + CLI |
+| Qwen Code | Terminal coding agent |
 | OpenHands | Agent platform |
-| Goose | Developer productivity agent |
-| OpenClaw | Personal AI assistant |
+| Continue | IDE extension |
+| Plandex | Terminal coding agent |
+| Mistral Vibe | Terminal coding agent |
 
 ## Feature overview
 
 High-level capability comparison across all projects.
 
-| Capability | Acolyte | Codex | Aider | Plandex | OpenCode | Pi | Goose | OpenHands | Continue | Cline | OpenClaw |
-|---|---|---|---|---|---|---|---|---|---|---|---|
-| Multi-provider | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Lifecycle pipeline | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | partial | partial | ✗ | ✗ | ✗ |
-| Post-write effects | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | partial | partial | ✗ | ✗ | ✗ |
-| Task state machine | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | partial | ✗ | ✗ | ✗ |
-| Workspace detection | ✓ | ✗ | partial | ✗ | ✗ | ✗ | partial | ✗ | ✗ | ✗ | ✗ |
-| Workspace sandboxing | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ |
-| Observable execution | ✓ | partial | partial | ✗ | partial | ✗ | partial | partial | ✗ | ✗ | ✗ |
-| Daemon architecture | ✓ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✓ | ✗ | ✗ | ✓ |
+| Capability | Acolyte | OpenCode | Codex | Crush | Aider | Goose | Cline | Qwen Code | OpenHands | Continue | Plandex | Mistral Vibe |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| Multi-provider | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| Lifecycle pipeline | ✓ | ✗ | ✗ | ✗ | ✗ | partial | ✗ | ✗ | partial | ✗ | ✗ | ✗ |
+| Post-write effects | ✓ | ✗ | ✗ | ✗ | ✗ | partial | ✗ | ✗ | partial | ✗ | ✗ | ✗ |
+| Task state machine | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | partial | ✗ | ✗ | ✗ |
+| Workspace detection | ✓ | ✗ | ✗ | ✗ | partial | partial | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Workspace sandboxing | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ |
+| Observable execution | ✓ | partial | partial | partial | partial | partial | ✗ | partial | partial | ✗ | ✗ | partial |
+| Daemon architecture | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ |
 
 ## Architecture
 
@@ -42,16 +41,17 @@ How each project structures its runtime and where it runs.
 | Project | Architecture | Deployment model |
 |---|---|---|
 | **Acolyte** | Headless daemon + typed RPC clients | daemon |
-| Codex | Rust CLI with optional Node.js wrapper | single-process |
-| Aider | Pure CLI process | single-process |
-| Plandex | Go CLI agent with long-running planner | single-process |
 | OpenCode | HTTP/WebSocket server + TUI/desktop clients | server |
-| Pi | SDK with RPC as one mode | embedded |
-| Continue | VS Code / JetBrains extension + CLI | extension |
-| Cline | VS Code extension + CLI | extension |
-| OpenHands | Web platform with Docker sandboxing | platform |
+| Codex | Rust CLI with optional Node.js wrapper | single-process |
+| Crush | Go CLI with Bubble Tea TUI | single-process |
+| Aider | Pure CLI process | single-process |
 | Goose | Single-process with MCP extensions | single-process |
-| OpenClaw | Node.js gateway + WebSocket control plane | server |
+| Cline | VS Code extension + CLI | extension |
+| Qwen Code | CLI (Gemini CLI fork) + IDE extensions | single-process |
+| OpenHands | Web platform with Docker sandboxing | platform |
+| Continue | VS Code / JetBrains extension + CLI | extension |
+| Plandex | Go CLI agent with long-running planner | single-process |
+| Mistral Vibe | Python CLI with Devstral models | single-process |
 
 Acolyte runs as a headless daemon. The CLI, future editor plugins, and third-party clients all connect over the same typed RPC protocol.
 
@@ -199,7 +199,7 @@ Acolyte supports the [SKILL.md standard](https://agentskills.io) for declarative
 
 Skills live in `.agents/skills/` and are invoked via slash commands.
 
-OpenCode, Pi, and Cline also implement the SKILL.md standard.
+OpenCode, Crush, Cline, Qwen Code, and Mistral Vibe also implement the SKILL.md standard.
 
 Goose instead uses MCP-based extensions.
 
@@ -225,13 +225,12 @@ How each agent retains knowledge across sessions.
 |---|---|
 | **Acolyte** | Context distillation to 3-tier persistent memory with semantic recall |
 | OpenHands | Microagent recall + condenser pipeline |
-| OpenClaw | Vector search via LanceDB |
 | Goose | Session search via MCP |
 | Continue | Codebase embeddings (deprecated) |
 | Aider | Repository map + chat restore |
 | Cline | Task history persistence |
 | Plandex | Session-based planning memory |
-| Codex, OpenCode, Pi | No cross-session memory |
+| Codex, OpenCode, Crush, Qwen Code, Mistral Vibe | No cross-session memory |
 
 Most agents manage context through **compaction** (summarization or truncation).
 
@@ -258,16 +257,17 @@ How each agent manages the token window when context grows large.
 | Project | Token budgeting |
 |---|---|
 | **Acolyte** | Proactive budgeting with token measurement |
-| OpenHands | Condenser pipeline |
-| Goose | Summarization fallback |
 | OpenCode | LLM compaction |
-| Aider | Repo map ranking |
-| OpenClaw | Token counting |
-| Cline | Window truncation |
-| Pi | Branch summarization |
-| Continue | Retrieval parameters |
 | Codex | Conversation truncation |
+| Crush | Conversation truncation |
+| Aider | Repo map ranking |
+| Goose | Summarization fallback |
+| Cline | Window truncation |
+| Qwen Code | Conversation truncation |
+| OpenHands | Condenser pipeline |
+| Continue | Retrieval parameters |
 | Plandex | Conversation summarization on token limit |
+| Mistral Vibe | Conversation truncation |
 
 Acolyte budgets context **before assembly** using [tiktoken](https://github.com/openai/tiktoken).
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,65 +1,45 @@
 # Comparison
 
-Detailed feature comparison between Acolyte and other open-source AI agents. See [Why Acolyte](./why-acolyte.md) for a summary.
+Detailed feature comparison between Acolyte and other open-source terminal coding agents.
 
-Projects compared: [OpenCode](https://github.com/anomalyco/opencode), [Codex](https://github.com/openai/codex), [Crush](https://github.com/charmbracelet/crush), [Aider](https://github.com/Aider-AI/aider), [Goose](https://github.com/block/goose), [Cline](https://github.com/cline/cline), [Qwen Code](https://github.com/QwenLM/qwen-code), [OpenHands](https://github.com/All-Hands-AI/OpenHands), [Continue](https://github.com/continuedev/continue), [Plandex](https://github.com/plandex-ai/plandex), [Mistral Vibe](https://github.com/mistralai/mistral-vibe).
+See [Why Acolyte](./why-acolyte.md) for a summary.
 
-| Project | Category |
-|---|---|
-| Acolyte | Terminal coding agent |
-| OpenCode | Terminal coding agent |
-| Codex | Terminal coding agent |
-| Crush | Terminal coding agent |
-| Aider | Terminal coding agent |
-| Goose | Terminal coding agent |
-| Cline | IDE extension + CLI |
-| Qwen Code | Terminal coding agent |
-| OpenHands | Agent platform |
-| Continue | IDE extension |
-| Plandex | Terminal coding agent |
-| Mistral Vibe | Terminal coding agent |
+Projects compared: [OpenCode](https://github.com/anomalyco/opencode), [Codex](https://github.com/openai/codex), [Crush](https://github.com/charmbracelet/crush), [Aider](https://github.com/Aider-AI/aider), [Goose](https://github.com/block/goose), [Qwen Code](https://github.com/QwenLM/qwen-code), [Plandex](https://github.com/plandex-ai/plandex), [Mistral Vibe](https://github.com/mistralai/mistral-vibe).
 
 ## Feature overview
 
-High-level capability comparison across all projects.
-
-| Capability | Acolyte | OpenCode | Codex | Crush | Aider | Goose | Cline | Qwen Code | OpenHands | Continue | Plandex | Mistral Vibe |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| Multi-provider | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
-| Lifecycle pipeline | ✓ | ✗ | ✗ | ✗ | ✗ | partial | ✗ | ✗ | partial | ✗ | ✗ | ✗ |
-| Post-write effects | ✓ | ✗ | ✗ | ✗ | ✗ | partial | ✗ | ✗ | partial | ✗ | ✗ | ✗ |
-| Task state machine | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | partial | ✗ | ✗ | ✗ |
-| Workspace detection | ✓ | ✗ | ✗ | ✗ | partial | partial | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
-| Workspace sandboxing | ✓ | ✗ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ |
-| Observable execution | ✓ | partial | partial | partial | partial | partial | ✗ | partial | partial | ✗ | ✗ | partial |
-| Daemon architecture | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✓ | ✗ | ✗ | ✗ |
+| Capability | Acolyte | OpenCode | Codex | Crush | Aider | Goose | Qwen Code | Plandex | Mistral Vibe |
+|---|---|---|---|---|---|---|---|---|---|
+| Multi-provider | ✓ | ✓ | partial | ✓ | ✓ | ✓ | ✓ | ✓ | ✗ |
+| Daemon architecture | ✓ | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Lifecycle pipeline | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Lifecycle effects | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Workspace detection | ✓ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ | ✗ |
+| Workspace sandboxing | ✓ | partial | ✓ | ✗ | ✗ | partial | ✓ | ✗ | ✗ |
+| Observable execution | ✓ | partial | partial | partial | partial | partial | partial | partial | partial |
+| SKILL.md support | ✓ | partial | ✓ | ✓ | ✗ | ✗ | ✓ | ✗ | ✓ |
 
 ## Architecture
-
-How each project structures its runtime and where it runs.
 
 | Project | Architecture | Deployment model |
 |---|---|---|
 | **Acolyte** | Headless daemon + typed RPC clients | daemon |
-| OpenCode | HTTP/WebSocket server + TUI/desktop clients | server |
+| OpenCode | HTTP/WebSocket server + TUI/desktop clients | daemon |
 | Codex | Rust CLI with optional Node.js wrapper | single-process |
 | Crush | Go CLI with Bubble Tea TUI | single-process |
 | Aider | Pure CLI process | single-process |
 | Goose | Single-process with MCP extensions | single-process |
-| Cline | VS Code extension + CLI | extension |
 | Qwen Code | CLI (Gemini CLI fork) + IDE extensions | single-process |
-| OpenHands | Web platform with Docker sandboxing | platform |
-| Continue | VS Code / JetBrains extension + CLI | extension |
 | Plandex | Go CLI agent with long-running planner | single-process |
 | Mistral Vibe | Python CLI with Devstral models | single-process |
 
 Acolyte runs as a headless daemon. The CLI, future editor plugins, and third-party clients all connect over the same typed RPC protocol.
 
-The optional TUI is a custom React terminal renderer built on `react-reconciler` and provides an interactive CLI experience.
+Every chat request becomes a task with a state machine (`accepted → queued → running → completed | failed | cancelled`). Tasks are durable entities with stable IDs and explicit state transitions. The RPC protocol exposes task transitions so clients can show real-time progress.
+
+The TUI is a custom React terminal renderer built on `react-reconciler`. Most competing CLIs use `prompt-toolkit` (Aider), Bubble Tea (Crush), or custom TUI frameworks (OpenCode).
 
 ## Lifecycle pipeline
-
-Acolyte separates the agent lifecycle into explicit phases with strict contracts between them.
 
 Every request flows through four phases, each implemented as its own module with its own tests:
 
@@ -69,34 +49,12 @@ resolve → prepare → generate → finalize
 
 - **resolve**: pick model and policy
 - **prepare**: wire tools and session context
-- **generate**: run the model with tool calls (single pass, effects apply per-tool-result)
+- **generate**: run the model with tool calls, effects apply per-tool-result
 - **finalize**: accept lifecycle signal, persist results, emit the response
 
-The lifecycle trusts the model to make good decisions within a single generation pass. Format and lint effects run automatically after writes, and lint errors surface in the tool result for the model to decide on.
+The lifecycle trusts the model to make good decisions. Format and lint effects run automatically after writes, and lint errors surface in the tool result for the model to decide on. A step budget inlined into tool execution enforces per-cycle and total tool-call limits to prevent runaway loops.
 
-Most other agents use flat tool loops or implicit state machines.
-
-Goose comes closest with `prepare → generate → categorize → execute`, but the phases are orchestrated inside a single streaming loop.
-
-## Step budget
-
-A step budget inlined into tool execution enforces per-cycle and total tool-call limits to prevent runaway loops. When the budget is exhausted, the tool call is blocked. This is a lightweight runtime safeguard rather than a pluggable guard system.
-
-## Post-write effects
-
-After generation, format and lint effects run automatically on written files:
-
-- format applies the detected workspace formatter
-- lint runs the detected workspace linter; errors surface in the tool result for the model to decide on
-- scoped test execution is available via the `test-run` tool during generation
-
-The model uses an ecosystem-aware `test-run` tool to validate changes against specific test files rather than running the full test suite.
-
-Goose has a `RetryManager` that checks shell command success.
-
-OpenHands has a **Critic** that scores outcomes but does not automatically retry.
-
-Most other agents rely on prompt instructions such as "please run the tests".
+Most other agents use flat tool loops or implicit state machines. Goose comes closest with `prepare → generate → categorize → execute`, but the phases are orchestrated inside a single streaming loop.
 
 ## Workspace detection
 
@@ -106,9 +64,6 @@ Acolyte auto-detects project tooling from workspace config files at lifecycle st
 |---|---|
 | **Acolyte** | Auto-detect from config files (biome.json, ruff.toml, Cargo.toml, go.mod, etc.) |
 | Aider | User-configured per-language lint commands (`--lint-cmd`) |
-| Cline | User-written `.clinerules` prose |
-| Continue | IDE-provided workspace context |
-| Goose | Package manager detection via Rust crate |
 | Others | No workspace detection |
 
 ## Workspace sandboxing
@@ -119,33 +74,12 @@ Acolyte enforces a workspace sandbox that prevents tool operations outside the r
 |---|---|
 | **Acolyte** | Path validation against resolved workspace root |
 | Codex | Network-disabled sandbox with writable directory restrictions |
-| OpenHands | Docker container isolation |
+| Qwen Code | Path validation for shell and skills |
 | Others | No sandboxing |
-
-## Developer experience
-
-The CLI ships a custom React terminal renderer built on `react-reconciler` with a full TUI:
-
-- Structured tool output with typed rendering
-- Colored diffs and contextual output
-- Fuzzy search and autocomplete
-- Model picker that queries provider APIs
-- Session management and history navigation
-- Daemon lifecycle commands (`start`, `stop`, `status`)
-- AST-based code editing via [ast-grep](https://ast-grep.github.io/)
-- Slash commands and skill invocation
-
-Most competing CLIs use `prompt-toolkit` (Aider) or custom TUI frameworks (OpenCode).
-
-IDE-based agents such as Cline and Continue primarily operate through extensions.
 
 ## Observability
 
-Every lifecycle event emits structured debug logs describing:
-
-- Tool calls
-- Effect decisions
-- Task state transitions
+Every lifecycle event emits structured debug logs describing tool calls, effect decisions, and task state transitions.
 
 The `acolyte trace` command converts daemon logs into timelines:
 
@@ -156,66 +90,15 @@ timestamp=... task_id=task_abc123 event=lifecycle.eval.decision effect=lint acti
 timestamp=... task_id=task_abc123 event=lifecycle.summary model_calls=1 read=3 search=1 write=1
 ```
 
-These traces allow developers to debug agent behavior step-by-step.
-
 Most other agents expose only console logs or partial traces.
-
-## Code quality
-
-Across the benchmarked projects, Acolyte leads on:
-
-- Type safety
-- Dependency footprint
-- Module size
-
-
-These characteristics reflect architectural choices:
-
-- Few dependencies because external packages are only added when strictly necessary
-- Small modules because clear boundaries and contracts keep each one focused
-- High test density because modules are independently testable
-
-See [Benchmarks](./benchmarks.md) for full measured comparisons.
-
-## Task architecture
-
-Every chat request becomes a **task** with a state machine:
-
-```
-accepted → queued → running → completed | failed | cancelled
-```
-
-Tasks are durable entities with stable IDs and explicit state transitions.
-
-Tool call logs and lifecycle events are isolated per task.
-
-The RPC protocol exposes task transitions so clients can show real-time progress.
-
-Most other agents run requests inline or use implicit controller state.
 
 ## Skills and extensibility
 
-Acolyte supports the [SKILL.md standard](https://agentskills.io) for declarative prompt extensions.
+Acolyte supports the [SKILL.md standard](https://agentskills.io) for declarative prompt extensions. Skills live in `.agents/skills/` and are invoked via slash commands.
 
-Skills live in `.agents/skills/` and are invoked via slash commands.
+OpenCode, Crush, Qwen Code, and Mistral Vibe also implement the SKILL.md standard. Goose uses MCP-based extensions instead.
 
-OpenCode, Crush, Cline, Qwen Code, and Mistral Vibe also implement the SKILL.md standard.
-
-Goose instead uses MCP-based extensions.
-
-Other agents have limited or no plugin systems.
-
-## Extension seams
-
-Core systems expose minimal, well-defined extension points:
-
-- Lifecycle policies
-- Tool registration
-- Memory strategies
-- Skill metadata
-- Configuration layers
-
-Extensions implement typed contracts. The surface is intentionally narrow — Acolyte is an opinionated product, not a general-purpose agent framework.
+Core systems expose minimal, well-defined extension points: lifecycle policies, tool registration, memory strategies, skill metadata, and configuration layers. The surface is intentionally narrow — Acolyte is an opinionated product, not a general-purpose agent framework.
 
 ## Memory
 
@@ -224,31 +107,12 @@ How each agent retains knowledge across sessions.
 | Project | Approach |
 |---|---|
 | **Acolyte** | Context distillation to 3-tier persistent memory with semantic recall |
-| OpenHands | Microagent recall + condenser pipeline |
 | Goose | Session search via MCP |
-| Continue | Codebase embeddings (deprecated) |
 | Aider | Repository map + chat restore |
-| Cline | Task history persistence |
 | Plandex | Session-based planning memory |
-| Codex, OpenCode, Crush, Qwen Code, Mistral Vibe | No cross-session memory |
+| Others | No cross-session memory |
 
-Most agents manage context through **compaction** (summarization or truncation).
-
-Acolyte instead uses **context distillation**:
-
-```
-ingest → normalize → select → inject → commit
-```
-
-Facts extracted from conversations persist across sessions.
-
-Memory tiers:
-
-- **Session**
-- **Project**
-- **User**
-
-At query time, entries are ranked by semantic similarity to the current task using provider embeddings and cosine similarity. Records without embeddings fall back to recency ordering.
+Acolyte uses **context distillation** (`ingest → normalize → select → inject → commit`) rather than compaction. Facts extracted from conversations persist across sessions in three tiers: session, project, and user. At query time, entries are ranked by semantic similarity using provider embeddings and cosine similarity.
 
 ## Context budgeting
 
@@ -258,22 +122,13 @@ How each agent manages the token window when context grows large.
 |---|---|
 | **Acolyte** | Proactive budgeting with token measurement |
 | OpenCode | LLM compaction |
-| Codex | Conversation truncation |
-| Crush | Conversation truncation |
 | Aider | Repo map ranking |
 | Goose | Summarization fallback |
-| Cline | Window truncation |
-| Qwen Code | Conversation truncation |
-| OpenHands | Condenser pipeline |
-| Continue | Retrieval parameters |
 | Plandex | Conversation summarization on token limit |
-| Mistral Vibe | Conversation truncation |
+| Others | Conversation truncation |
 
-Acolyte budgets context **before assembly** using [tiktoken](https://github.com/openai/tiktoken).
+Acolyte budgets context **before assembly** using [tiktoken](https://github.com/openai/tiktoken): system prompt reservation, priority-based context allocation, age-based tool compaction, and visible truncation notices.
 
-Key behaviors:
+## Code quality
 
-- System prompt reservation
-- Priority-based context allocation
-- Age-based tool compaction
-- Visible truncation notices
+See [Benchmarks](./benchmarks.md) for full measured comparisons. Across the benchmarked projects, Acolyte leads on type safety, dependency footprint, and module size — reflecting architectural choices around minimal dependencies, clear boundaries, and independently testable modules.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -67,15 +67,15 @@ Internal implementations may share compilers, rule objects, or AST helpers, but 
 
 ## Key files
 
-- `src/gitignore.ts` — Gitignore pattern compilation and evaluation.
-- `src/file-toolkit.ts` — File operations (read, write, find, search, edit).
-- `src/code-toolkit.ts` — Code manipulation for scanning and editing source files.
-- `src/git-toolkit.ts` — Git operations (status, diff, log, show, add, commit).
-- `src/tool-registry.ts` — Tool registration and agent-facing surface.
+- `src/gitignore.ts` — gitignore pattern compilation and evaluation
+- `src/file-toolkit.ts` — file operations (read, write, find, search, edit)
+- `src/code-toolkit.ts` — code manipulation for scanning and editing source files
+- `src/git-toolkit.ts` — git operations (status, diff, log, show, add, commit)
+- `src/tool-registry.ts` — tool registration and agent-facing surface
 - `src/tool-session.ts` — session context, call recording, and step-budget check
-- `src/tool-execution.ts` — Tool execution with budget enforcement and error shaping.
-- `src/tool-cache.ts` — Per-task result caching with stable key generation.
+- `src/tool-execution.ts` — tool execution with budget enforcement and error shaping
+- `src/tool-cache.ts` — per-task result caching with stable key generation
 
 ## Further reading
 
-[Edit the Tree](https://crisu.me/blog/edit-the-tree) — AST-based code editing and scanning.
+[Edit the Tree](https://crisu.me/blog/edit-the-tree) — AST-based code editing and scanning

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -20,10 +20,7 @@ const PROJECTS: Project[] = [
   { name: "crush", url: "https://github.com/charmbracelet/crush.git", lang: "go" },
   { name: "aider", url: "https://github.com/Aider-AI/aider.git", lang: "python" },
   { name: "goose", url: "https://github.com/block/goose.git", lang: "rust" },
-  { name: "cline", url: "https://github.com/cline/cline.git", lang: "typescript" },
   { name: "qwen-code", url: "https://github.com/QwenLM/qwen-code.git", lang: "typescript" },
-  { name: "openhands", url: "https://github.com/All-Hands-AI/OpenHands.git", lang: "python" },
-  { name: "continue", url: "https://github.com/continuedev/continue.git", lang: "typescript" },
   { name: "plandex", url: "https://github.com/plandex-ai/plandex.git", lang: "go" },
   { name: "mistral-vibe", url: "https://github.com/mistralai/mistral-vibe.git", lang: "python" },
 ];

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -16,16 +16,16 @@ interface Project {
 const PROJECTS: Project[] = [
   { name: "acolyte", url: "https://github.com/cniska/acolyte.git", lang: "typescript" },
   { name: "opencode", url: "https://github.com/anomalyco/opencode.git", lang: "typescript" },
+  { name: "codex", url: "https://github.com/openai/codex.git", lang: "rust" },
   { name: "crush", url: "https://github.com/charmbracelet/crush.git", lang: "go" },
   { name: "aider", url: "https://github.com/Aider-AI/aider.git", lang: "python" },
-  { name: "pi", url: "https://github.com/badlogic/pi-mono.git", lang: "typescript" },
   { name: "goose", url: "https://github.com/block/goose.git", lang: "rust" },
+  { name: "cline", url: "https://github.com/cline/cline.git", lang: "typescript" },
+  { name: "qwen-code", url: "https://github.com/QwenLM/qwen-code.git", lang: "typescript" },
   { name: "openhands", url: "https://github.com/All-Hands-AI/OpenHands.git", lang: "python" },
   { name: "continue", url: "https://github.com/continuedev/continue.git", lang: "typescript" },
-  { name: "cline", url: "https://github.com/cline/cline.git", lang: "typescript" },
-  { name: "openclaw", url: "https://github.com/openclaw/openclaw.git", lang: "typescript" },
   { name: "plandex", url: "https://github.com/plandex-ai/plandex.git", lang: "go" },
-  { name: "codex", url: "https://github.com/openai/codex.git", lang: "rust" },
+  { name: "mistral-vibe", url: "https://github.com/mistralai/mistral-vibe.git", lang: "python" },
 ];
 
 // --- file collection ---


### PR DESCRIPTION
## Summary

- drop Pi (SDK), OpenClaw (not a coding agent), Cline (IDE extension)
- add Qwen Code and Mistral Vibe as new terminal agent comparisons
- re-run benchmark metrics for all 9 projects
- verify feature claims from source code
- update comparison tables with verified data
- fix methodology description (total lines, not SLOC)
- fix typo in tooling docs