### PR TITLE
refactor(lifecycle): separate effect output from tool result

### DIFF
--- a/.agents/skills/issue/SKILL.md
+++ b/.agents/skills/issue/SKILL.md
@@ -13,7 +13,8 @@ Create a GitHub issue from a short description.
 - Label: `enhancement` for features, `bug` for bugs
 - Body sections (in order): **What would you like?**, **Motivation**, **Proposed approach**, **Scope**
 - Each section is a `##` heading followed by 1–3 short paragraphs
-- Write plainly — no code blocks, no bullet-heavy lists, no implementation detail
+- Write plainly — no bullet-heavy lists, no implementation detail
+- Inline code only when the identifier is essential to understanding the issue
 - Focus on *what* and *why*, not *how* — leave implementation to the branch
 - Scope section uses a flat bullet list of affected areas
 

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -11,7 +11,8 @@ Create a pull request for the current branch against `main`.
 
 - Title: Conventional Commit format (`type(scope): description`), under 60 chars, no trailing period
 - Body: follow `.github/pull_request_template.md` exactly — fill in each section, do not add or remove sections
-- Bullets: plain English, describe *what* changed and *why* — no code blocks, no prose paragraphs
+- Bullets: plain English, describe *what* changed and *why* — no prose paragraphs
+- Inline code only when the identifier is essential to understanding the change
 - If an issue matches the branch work, add `Fixes #<number>` at the end of the body
 
 ## Workflow

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -22,6 +22,7 @@ import { createModel } from "./model-factory";
 import { normalizeModel, providerFromModel } from "./provider-config";
 import { type RateLimiter, sharedRateLimiter } from "./rate-limiter";
 import type { ToolDefinition } from "./tool-contract";
+import type { ToolRunResult } from "./tool-execution";
 
 function toolInputJsonSchema(schema: z.ZodType): LanguageModelV3FunctionTool["inputSchema"] {
   const { $schema: _, ...rest } = z.toJSONSchema(schema);
@@ -205,16 +206,17 @@ export function createAgentStream(
 
           try {
             const args = JSON.parse(tc.input);
-            const result = await tool.execute(args, tc.toolCallId);
+            const { result, effectOutput } = (await tool.execute(args, tc.toolCallId)) as ToolRunResult;
             streamController.enqueue({
               type: "tool-result",
               payload: { toolCallId: tc.toolCallId, toolName: tc.toolName, result },
             });
+            const outputValue = effectOutput ? `${JSON.stringify(result)}\n${effectOutput}` : JSON.stringify(result);
             toolResultParts.push({
               type: "tool-result",
               toolCallId: tc.toolCallId,
               toolName: tc.toolName,
-              output: { type: "text", value: JSON.stringify(result) },
+              output: { type: "text", value: outputValue },
             });
           } catch (error) {
             batchHadError = true;

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -22,7 +22,6 @@ import { createModel } from "./model-factory";
 import { normalizeModel, providerFromModel } from "./provider-config";
 import { type RateLimiter, sharedRateLimiter } from "./rate-limiter";
 import type { ToolDefinition } from "./tool-contract";
-import type { ToolRunResult } from "./tool-execution";
 
 function toolInputJsonSchema(schema: z.ZodType): LanguageModelV3FunctionTool["inputSchema"] {
   const { $schema: _, ...rest } = z.toJSONSchema(schema);
@@ -206,7 +205,7 @@ export function createAgentStream(
 
           try {
             const args = JSON.parse(tc.input);
-            const { result, effectOutput } = (await tool.execute(args, tc.toolCallId)) as ToolRunResult;
+            const { result, effectOutput } = await tool.execute(args, tc.toolCallId);
             streamController.enqueue({
               type: "tool-result",
               payload: { toolCallId: tc.toolCallId, toolName: tc.toolName, result },

--- a/src/soul.int.test.ts
+++ b/src/soul.int.test.ts
@@ -1,9 +1,19 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import type { MemoryRegistry } from "./memory-registry";
 import { createId } from "./short-id";
 import { createSoulPrompt, formatMemoryResumeBlock, loadAgentsPrompt, loadSoulPrompt, loadSystemPrompt } from "./soul";
 import { expectIntent, tempDir } from "./test-utils";
+
+const emptyMemoryRegistry: MemoryRegistry = {
+  async load() {
+    return { prompt: "", tokenEstimate: 0, entryCount: 0, continuationSelected: false, continuation: {} };
+  },
+  async commit() {
+    return {};
+  },
+};
 
 const { createDir, cleanupDirs } = tempDir();
 afterEach(cleanupDirs);
@@ -58,6 +68,7 @@ describe("soul prompt loading", () => {
       sessionId: `sess_${createId()}`,
       resourceId: `user_${createId()}`,
       workspace: dir,
+      memoryRegistry: emptyMemoryRegistry,
       onDebug: (event) => {
         events.push(event);
       },

--- a/src/soul.ts
+++ b/src/soul.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { estimateTokens } from "./agent-input";
 import { appConfig } from "./app-config";
-import { loadMemoryContext } from "./memory-registry";
+import { loadMemoryContext, type MemoryRegistry } from "./memory-registry";
 import type { ResourceId } from "./resource-id";
 
 export function loadSoulPrompt(cwd = process.cwd()): string {
@@ -50,6 +50,7 @@ type CreateSoulPromptOptions = {
   useMemory?: boolean;
   memoryBudgetTokens?: number;
   onDebug?: (event: string, fields?: Record<string, unknown>) => void;
+  memoryRegistry?: MemoryRegistry;
 };
 
 export function formatMemoryResumeBlock(continuation: { currentTask?: string; nextStep?: string }): string {
@@ -78,7 +79,8 @@ export async function createSoulPrompt(options: CreateSoulPromptOptions = {}): P
     options.onDebug?.("lifecycle.memory.load_skipped", { ...debugBaseFields, reason: "budget_disabled" });
     return { prompt: base, memoryTokens: 0 };
   }
-  const memoryContext = await loadMemoryContext(
+  const load = options.memoryRegistry?.load ?? loadMemoryContext;
+  const memoryContext = await load(
     {
       sessionId: options.sessionId,
       resourceId: options.resourceId,

--- a/src/test-toolkit.test.ts
+++ b/src/test-toolkit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createTestToolkit } from "./test-toolkit";
 import { createToolkitDeps } from "./test-utils";
+import type { ToolRunResult } from "./tool-execution";
 import { createSessionContext } from "./tool-session";
 
 type TestResult = { kind: string; command: string; exitCode?: number; output: string };
@@ -19,7 +20,8 @@ function createToolkit(testCommand?: { bin: string; args: string[] }) {
 }
 
 async function runTests(toolkit: ReturnType<typeof createToolkit>["toolkit"], files: string[]): Promise<TestResult> {
-  return (await toolkit.runTests.execute({ files }, "call_1")) as TestResult;
+  const runResult: ToolRunResult = await toolkit.runTests.execute({ files }, "call_1");
+  return runResult.result as TestResult;
 }
 
 describe("test-run tool", () => {

--- a/src/test-toolkit.test.ts
+++ b/src/test-toolkit.test.ts
@@ -1,10 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createTestToolkit } from "./test-toolkit";
 import { createToolkitDeps } from "./test-utils";
-import type { ToolRunResult } from "./tool-execution";
 import { createSessionContext } from "./tool-session";
-
-type TestResult = { kind: string; command: string; exitCode?: number; output: string };
 
 function createToolkit(testCommand?: { bin: string; args: string[] }) {
   const session = createSessionContext();
@@ -19,9 +16,11 @@ function createToolkit(testCommand?: { bin: string; args: string[] }) {
   return { toolkit, output };
 }
 
-async function runTests(toolkit: ReturnType<typeof createToolkit>["toolkit"], files: string[]): Promise<TestResult> {
-  const runResult: ToolRunResult = await toolkit.runTests.execute({ files }, "call_1");
-  return runResult.result as TestResult;
+type TestResult = { kind: string; command: string; exitCode?: number; output: string };
+
+async function runTests(toolkit: ReturnType<typeof createToolkit>["toolkit"], files: string[]) {
+  const { result } = await toolkit.runTests.execute({ files }, "call_1");
+  return result as TestResult;
 }
 
 describe("test-run tool", () => {

--- a/src/test-toolkit.ts
+++ b/src/test-toolkit.ts
@@ -33,7 +33,9 @@ function createRunTestsTool(deps: ToolkitDeps, input: ToolkitInput) {
       const profile = session.workspaceProfile;
       const testCommand = profile?.testCommand;
       if (!testCommand) {
-        return { kind: "test-run" as const, command: "", exitCode: 1, output: "No test command detected." };
+        return {
+          result: { kind: "test-run" as const, command: "", exitCode: 1, output: "No test command detected." },
+        };
       }
 
       const resolved = resolveCommandFiles(testCommand, toolInput.files);

--- a/src/test-toolkit.ts
+++ b/src/test-toolkit.ts
@@ -30,19 +30,16 @@ function createRunTestsTool(deps: ToolkitDeps, input: ToolkitInput) {
       output: z.string(),
     }),
     execute: async (toolInput, toolCallId) => {
-      const profile = session.workspaceProfile;
-      const testCommand = profile?.testCommand;
-      if (!testCommand) {
-        return {
-          result: { kind: "test-run" as const, command: "", exitCode: 1, output: "No test command detected." },
-        };
-      }
-
-      const resolved = resolveCommandFiles(testCommand, toolInput.files);
-      const commandSpec = { cmd: resolved.bin, args: [...resolved.args] };
-      const command = formatWorkspaceCommand(resolved);
-
       return runTool(session, "test-run", toolCallId, toolInput, async (callId) => {
+        const profile = session.workspaceProfile;
+        const testCommand = profile?.testCommand;
+        if (!testCommand) {
+          return { kind: "test-run" as const, command: "", exitCode: 1, output: "No test command detected." };
+        }
+
+        const resolved = resolveCommandFiles(testCommand, toolInput.files);
+        const commandSpec = { cmd: resolved.bin, args: [...resolved.args] };
+        const command = formatWorkspaceCommand(resolved);
         onOutput({
           toolName: "test-run",
           content: { kind: "tool-header", labelKey: "tool.label.test_run", detail: compactDetail(command) },

--- a/src/tool-contract.ts
+++ b/src/tool-contract.ts
@@ -1,6 +1,6 @@
 import type { z } from "zod";
 import type { ChecklistItem } from "./checklist-contract";
-import type { ToolRunResult } from "./tool-execution";
+import type { RunToolResult } from "./tool-execution";
 import type { ToolOutputListener } from "./tool-output-format";
 import type { SessionContext } from "./tool-session";
 
@@ -14,7 +14,7 @@ export type ToolDefinition<TInput = unknown, TOutput = unknown> = {
   readonly instruction: string;
   readonly inputSchema: z.ZodType<TInput>;
   readonly outputSchema: z.ZodType<TOutput>;
-  readonly execute: (input: TInput, toolCallId: string) => Promise<ToolRunResult<TOutput>>;
+  readonly execute: (input: TInput, toolCallId: string) => Promise<RunToolResult<TOutput>>;
   readonly labelKey?: string;
 };
 

--- a/src/tool-contract.ts
+++ b/src/tool-contract.ts
@@ -14,7 +14,7 @@ export type ToolDefinition<TInput = unknown, TOutput = unknown> = {
   readonly instruction: string;
   readonly inputSchema: z.ZodType<TInput>;
   readonly outputSchema: z.ZodType<TOutput>;
-  readonly execute: (input: TInput, toolCallId: string) => Promise<ToolRunResult>;
+  readonly execute: (input: TInput, toolCallId: string) => Promise<ToolRunResult<TOutput>>;
   readonly labelKey?: string;
 };
 
@@ -67,8 +67,7 @@ export function createTool<TInput, TOutput>(config: ToolDefinition<TInput, TOutp
     ...config,
     execute: async (input, toolCallId) => {
       const runResult = await config.execute(input, toolCallId);
-      config.outputSchema.parse(runResult.result);
-      return runResult;
+      return { ...runResult, result: config.outputSchema.parse(runResult.result) };
     },
   };
 }

--- a/src/tool-contract.ts
+++ b/src/tool-contract.ts
@@ -1,5 +1,6 @@
 import type { z } from "zod";
 import type { ChecklistItem } from "./checklist-contract";
+import type { ToolRunResult } from "./tool-execution";
 import type { ToolOutputListener } from "./tool-output-format";
 import type { SessionContext } from "./tool-session";
 
@@ -13,7 +14,7 @@ export type ToolDefinition<TInput = unknown, TOutput = unknown> = {
   readonly instruction: string;
   readonly inputSchema: z.ZodType<TInput>;
   readonly outputSchema: z.ZodType<TOutput>;
-  readonly execute: (input: TInput, toolCallId: string) => Promise<TOutput>;
+  readonly execute: (input: TInput, toolCallId: string) => Promise<ToolRunResult>;
   readonly labelKey?: string;
 };
 
@@ -64,6 +65,10 @@ export type ToolCache = {
 export function createTool<TInput, TOutput>(config: ToolDefinition<TInput, TOutput>): ToolDefinition<TInput, TOutput> {
   return {
     ...config,
-    execute: async (input, toolCallId) => config.outputSchema.parse(await config.execute(input, toolCallId)),
+    execute: async (input, toolCallId) => {
+      const runResult = await config.execute(input, toolCallId);
+      config.outputSchema.parse(runResult.result);
+      return runResult;
+    },
   };
 }

--- a/src/tool-execution.test.ts
+++ b/src/tool-execution.test.ts
@@ -47,6 +47,24 @@ describe("per-tool timeout", () => {
     expect(result).toEqual({ result: "done" });
   });
 
+  test("returns effectOutput from lifecycle hooks", async () => {
+    const session = createSessionContext();
+    session.toolTimeoutMs = 500;
+    session.onAfterTool = () => ({ append: "Lint errors:\nsrc/foo.ts:1 missing semicolon" });
+    const result = await runTool(session, "file-edit", "call_1", {}, async () => ({ ok: true }));
+    expect(result.result).toEqual({ ok: true });
+    expect(result.effectOutput).toBe("Lint errors:\nsrc/foo.ts:1 missing semicolon");
+  });
+
+  test("omits effectOutput when lifecycle hooks return no feedback", async () => {
+    const session = createSessionContext();
+    session.toolTimeoutMs = 500;
+    session.onAfterTool = () => undefined;
+    const result = await runTool(session, "file-edit", "call_1", {}, async () => ({ ok: true }));
+    expect(result.result).toEqual({ ok: true });
+    expect(result.effectOutput).toBeUndefined();
+  });
+
   test("uses explicit timeout override when provided", async () => {
     const session = createSessionContext();
     session.toolTimeoutMs = 50;

--- a/src/tool-execution.test.ts
+++ b/src/tool-execution.test.ts
@@ -44,7 +44,7 @@ describe("per-tool timeout", () => {
     const session = createSessionContext();
     session.toolTimeoutMs = 500;
     const result = await runTool(session, "fast-tool", "call_1", {}, async () => "done");
-    expect(result).toBe("done");
+    expect(result).toEqual({ result: "done" });
   });
 
   test("uses explicit timeout override when provided", async () => {
@@ -58,6 +58,6 @@ describe("per-tool timeout", () => {
       () => new Promise((resolve) => setTimeout(() => resolve("done"), 100)),
       { timeoutMs: 300 },
     );
-    expect(result).toBe("done");
+    expect(result).toEqual({ result: "done" });
   });
 });

--- a/src/tool-execution.ts
+++ b/src/tool-execution.ts
@@ -55,7 +55,7 @@ export async function withToolError<T>(toolId: string, task: () => Promise<T>): 
   }
 }
 
-export type ToolRunResult<T = unknown> = { result: T; effectOutput?: string };
+export type RunToolResult<T = unknown> = { result: T; effectOutput?: string };
 
 export async function runTool(
   session: SessionContext,
@@ -64,7 +64,7 @@ export async function runTool(
   args: Record<string, unknown>,
   execute: (toolCallId: string) => Promise<unknown>,
   options?: { timeoutMs?: number },
-): Promise<ToolRunResult> {
+): Promise<RunToolResult> {
   return withToolError(toolId, async () => {
     const budgetError = checkStepBudget(session);
     if (budgetError) {

--- a/src/tool-execution.ts
+++ b/src/tool-execution.ts
@@ -55,7 +55,7 @@ export async function withToolError<T>(toolId: string, task: () => Promise<T>): 
   }
 }
 
-export type ToolRunResult = { result: unknown; effectOutput?: string };
+export type ToolRunResult<T = unknown> = { result: T; effectOutput?: string };
 
 export async function runTool(
   session: SessionContext,

--- a/src/tool-execution.ts
+++ b/src/tool-execution.ts
@@ -55,6 +55,8 @@ export async function withToolError<T>(toolId: string, task: () => Promise<T>): 
   }
 }
 
+export type ToolRunResult = { result: unknown; effectOutput?: string };
+
 export async function runTool(
   session: SessionContext,
   toolId: string,
@@ -62,7 +64,7 @@ export async function runTool(
   args: Record<string, unknown>,
   execute: (toolCallId: string) => Promise<unknown>,
   options?: { timeoutMs?: number },
-): Promise<unknown> {
+): Promise<ToolRunResult> {
   return withToolError(toolId, async () => {
     const budgetError = checkStepBudget(session);
     if (budgetError) {
@@ -86,7 +88,7 @@ export async function runTool(
       if (cached) {
         session.onDebug?.("lifecycle.tool.cache", { tool: toolId, hit: true, ...cache.stats() });
         recordCall(session, toolId, args, hashResultValue(cached.result), "succeeded");
-        return cached.result;
+        return { result: cached.result };
       }
       session.onDebug?.("lifecycle.tool.cache", { tool: toolId, hit: false, ...cache.stats() });
     }
@@ -101,10 +103,7 @@ export async function runTool(
       }
       const postOutput = session.onAfterTool?.({ toolId, args: args, result: taskResult });
       const append = [preOutput?.append, postOutput?.append].filter(Boolean).join("\n");
-      if (append && typeof taskResult === "object" && taskResult !== null) {
-        (taskResult as Record<string, unknown>).lifecycleFeedback = append;
-      }
-      return taskResult;
+      return { result: taskResult, effectOutput: append || undefined };
     } catch (error) {
       taskFailed = true;
       throw error;

--- a/src/trace-store.ts
+++ b/src/trace-store.ts
@@ -162,6 +162,7 @@ export function createTraceStore(dbPath?: string): TraceStore {
       return queries.listByTask.all(taskId).map(rowToLogLine);
     },
     close() {
+      db.run("PRAGMA wal_checkpoint(TRUNCATE)");
       db.close();
     },
   };


### PR DESCRIPTION
## Summary

- `runTool` returns generic `RunToolResult<T>` instead of mutating results
- agent stream composes `effectOutput` into model message separately
- test-toolkit early return routed through `runTool`
- soul integration test isolated from global memory store

Fixes #90