### PR TITLE
refactor: move tool labels to UI layer

### DIFF
--- a/src/cli-format.ts
+++ b/src/cli-format.ts
@@ -3,8 +3,8 @@ import { wrapAssistantContent } from "./chat-content";
 import { formatCompactNumber } from "./chat-format";
 import { t, tDynamic } from "./i18n";
 import { formatToolOutput, type ToolOutputPart } from "./tool-output-content";
+import { toolLabelKey } from "./tool-output-format";
 import { CLI_TOOL_OUTPUT_LIMITS } from "./tool-policy";
-import { toolDefinitionsById } from "./tool-registry";
 import { printDim, printToolHeader } from "./ui";
 
 export function displayPath(pathInput: string): string {
@@ -20,7 +20,7 @@ export function printIndentedDim(content: string): void {
 }
 
 export function printToolResult(toolId: string, raw: string, detail?: string): void {
-  const labelKey = toolDefinitionsById[toolId]?.labelKey ?? toolId;
+  const labelKey = toolLabelKey(toolId);
   const content = formatForTool(toolId, raw);
   const items: ToolOutputPart[] = [{ kind: "tool-header", labelKey, detail }];
   if (content.length === 0) {

--- a/src/code-toolkit.ts
+++ b/src/code-toolkit.ts
@@ -50,7 +50,6 @@ function createScanCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "code-scan",
     toolkit: "code",
-    labelKey: "tool.label.code_scan",
     category: "search",
     description:
       "Scan files for structural code patterns using AST matching. Pass `paths` as an array of file or directory paths and `patterns` as an array of structural queries.",
@@ -127,7 +126,6 @@ function createEditCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "code-edit",
     toolkit: "code",
-    labelKey: "tool.label.code_edit",
     category: "write",
     description:
       'Edit code structurally with AST-aware operations. Pass `edits` as operation objects like {op:"rename", from, to, withinSymbol?, target?} or {op:"replace", rule, replacement, within?, withinSymbol?}. For `replace`, `rule` may be a string/pattern object shorthand or a recursive ast-grep rule object. `path` may be a file or directory (`.` for workspace-wide). For non-code files use `file-edit`.',

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -51,7 +51,6 @@ function createFindFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "file-find",
     toolkit: "file",
-    labelKey: "tool.label.file_find",
     category: "search",
     description:
       "Find files in the repository by name or path pattern. Pass `patterns` as an array to batch multiple lookups in one call. To search file contents use `file-search` instead.",
@@ -103,7 +102,6 @@ function createSearchFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "file-search",
     toolkit: "file",
-    labelKey: "tool.label.file_search",
     category: "search",
     description:
       "Search file contents in the repository for text or regex patterns. Optionally scope with `paths` (files or directories). To locate files by name use `file-find` instead.",
@@ -171,7 +169,6 @@ function createReadFileTool(deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "file-read",
     toolkit: "file",
-    labelKey: "tool.label.file_read",
     category: "read",
     description:
       "Read one or more text files. Pass `paths` as an array of {path} objects. Never re-read a file you already have.",
@@ -223,7 +220,6 @@ function createEditFileTool(deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "file-edit",
     toolkit: "file",
-    labelKey: "tool.label.file_edit",
     category: "write",
     description:
       "Edit an existing file. Pass `edits` as an array of either {find, replace} pairs (for small surgical edits using exact text match) or {startLine, endLine, replace} objects (for larger block replacements). Line numbers MUST come from `file-read` output — do not guess. endLine must not exceed the file length. All edits are applied atomically. You MUST read the file first. For new files, use `file-create`. For code renames or structural edits use `code-edit`.",
@@ -277,7 +273,6 @@ function createCreateFileTool(deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "file-create",
     toolkit: "file",
-    labelKey: "tool.label.file_create",
     category: "write",
     description:
       "Create a new file with full content. For editing existing files, use `file-edit` or `code-edit` instead.",
@@ -325,7 +320,6 @@ function createDeleteFileTool(deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "file-delete",
     toolkit: "file",
-    labelKey: "tool.label.file_delete",
     category: "write",
     description: "Delete a file from the repository.",
     instruction: "Use `file-delete` to remove files. Pass `paths` as an array and batch related deletes.",

--- a/src/git-toolkit.ts
+++ b/src/git-toolkit.ts
@@ -92,7 +92,6 @@ function createGitStatusTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput
   return createTool({
     id: "git-status",
     toolkit: "git",
-    labelKey: "tool.label.git_status",
     category: "search",
     description: "Show working tree status (short format with branch) for the current repository.",
     instruction: "Use `git-status` when repo-wide state matters. Skip it for already-understood file-scoped edits.",
@@ -122,7 +121,6 @@ function createGitDiffTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) 
   return createTool({
     id: "git-diff",
     toolkit: "git",
-    labelKey: "tool.label.git_diff",
     category: "search",
     description: "Show unstaged changes (unified diff) for the repository or a specific file path.",
     instruction:
@@ -158,7 +156,6 @@ function createGitLogTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "git-log",
     toolkit: "git",
-    labelKey: "tool.label.git_log",
     category: "search",
     description: "Show recent commits in compact one-line form (optionally scoped to a file/path).",
     instruction: "Use `git-log` for committed history (optionally scoped by path), not for uncommitted edits.",
@@ -193,7 +190,6 @@ function createGitShowTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) 
   return createTool({
     id: "git-show",
     toolkit: "git",
-    labelKey: "tool.label.git_show",
     category: "search",
     description: "Show commit details and patch for a ref (default HEAD), optionally scoped to a path.",
     instruction:
@@ -242,7 +238,6 @@ function createGitAddTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "git-add",
     toolkit: "git",
-    labelKey: "tool.label.git_add",
     category: "write",
     description:
       "Stage tracked/untracked files. Prefer explicit `paths` scoped to files edited in the current task. Use `all=true` only when explicitly needed.",
@@ -290,7 +285,6 @@ function createGitCommitTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput
   return createTool({
     id: "git-commit",
     toolkit: "git",
-    labelKey: "tool.label.git_commit",
     category: "write",
     description: "Create a git commit with a required subject line and optional body lines.",
     instruction: "Use `git-commit` only when the user explicitly asks. Set `message` to the subject line.",

--- a/src/memory-toolkit.ts
+++ b/src/memory-toolkit.ts
@@ -36,7 +36,6 @@ function createMemorySearchTool(_deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "memory-search",
     toolkit: "memory",
-    labelKey: "tool.label.memory_search",
     category: "meta",
     description: "Search all memories by relevance. Returns entries ranked by semantic similarity to the query.",
     instruction:
@@ -88,7 +87,6 @@ function createMemoryAddTool(_deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "memory-add",
     toolkit: "memory",
-    labelKey: "tool.label.memory_add",
     category: "meta",
     description:
       "Store a new memory. Use project scope for workspace-specific facts and user scope for cross-project preferences.",
@@ -116,7 +114,6 @@ function createMemoryRemoveTool(_deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "memory-remove",
     toolkit: "memory",
-    labelKey: "tool.label.memory_remove",
     category: "meta",
     description: "Remove a memory by its ID. Use after finding stale or incorrect memories via memory-search.",
     instruction: "Use `memory-remove` to clean up outdated or incorrect memories found via `memory-search`.",

--- a/src/shell-toolkit.ts
+++ b/src/shell-toolkit.ts
@@ -10,7 +10,6 @@ function createRunCommandTool(deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "shell-run",
     toolkit: "shell",
-    labelKey: "tool.label.shell_run",
     category: "execute",
     description:
       "Run a command in the repository and capture stdout/stderr without shell evaluation. Never use shell commands as fallbacks for file discovery/reading/editing when dedicated tools are available.",

--- a/src/test-toolkit.ts
+++ b/src/test-toolkit.ts
@@ -13,7 +13,6 @@ function createRunTestsTool(deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "test-run",
     toolkit: "test",
-    labelKey: "tool.label.test_run",
     category: "execute",
     description:
       "Run the project's test runner against specific files. The test command is auto-detected from the workspace.",

--- a/src/tool-contract.ts
+++ b/src/tool-contract.ts
@@ -15,7 +15,6 @@ export type ToolDefinition<TInput = unknown, TOutput = unknown> = {
   readonly inputSchema: z.ZodType<TInput>;
   readonly outputSchema: z.ZodType<TOutput>;
   readonly execute: (input: TInput, toolCallId: string) => Promise<RunToolResult<TOutput>>;
-  readonly labelKey?: string;
 };
 
 export type ToolOutputBudgetEntry = { maxChars: number; maxLines: number };

--- a/src/tool-output-format.test.ts
+++ b/src/tool-output-format.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { resultChunkParts, textHeadTailParts } from "./tool-output-format";
+import { resultChunkParts, textHeadTailParts, toolLabelKey } from "./tool-output-format";
 import { findResultPaths, numberedUnifiedDiffLines, searchResultSummaryStats } from "./tool-output-parse";
 
 describe("textHeadTailParts", () => {
@@ -203,5 +203,16 @@ describe("numberedUnifiedDiffLines", () => {
     const textParts = items.filter((i) => i.kind === "text");
     // b.ts has no changes so its header should not appear; a.ts keeps its header.
     expect(textParts).toEqual([{ kind: "text", text: "a.ts (+1 -1)" }]);
+  });
+});
+
+describe("toolLabelKey", () => {
+  test("returns label key for known tool", () => {
+    expect(toolLabelKey("file-read")).toBe("tool.label.file_read");
+    expect(toolLabelKey("git-commit")).toBe("tool.label.git_commit");
+  });
+
+  test("falls back to tool id for unknown tool", () => {
+    expect(toolLabelKey("unknown-tool")).toBe("unknown-tool");
   });
 });

--- a/src/tool-output-format.ts
+++ b/src/tool-output-format.ts
@@ -1,4 +1,5 @@
 import { isAbsolute, relative } from "node:path";
+import type { TranslationKey } from "./i18n";
 import { t } from "./i18n";
 import type { ToolOutputPart } from "./tool-output-content";
 import { compactPatternLabels, type SearchSummaryStats, summarizeUnifiedDiff } from "./tool-output-parse";
@@ -6,7 +7,7 @@ import { TOOL_PROGRESS_LIMITS } from "./tool-policy";
 
 export type ToolOutputListener = (event: { toolName: string; content: ToolOutputPart; toolCallId?: string }) => void;
 
-const TOOL_LABEL_KEYS: Record<string, string> = {
+const TOOL_LABEL_KEYS: Record<string, TranslationKey> = {
   "file-find": "tool.label.file_find",
   "file-search": "tool.label.file_search",
   "file-read": "tool.label.file_read",

--- a/src/tool-output-format.ts
+++ b/src/tool-output-format.ts
@@ -6,6 +6,34 @@ import { TOOL_PROGRESS_LIMITS } from "./tool-policy";
 
 export type ToolOutputListener = (event: { toolName: string; content: ToolOutputPart; toolCallId?: string }) => void;
 
+const TOOL_LABEL_KEYS: Record<string, string> = {
+  "file-find": "tool.label.file_find",
+  "file-search": "tool.label.file_search",
+  "file-read": "tool.label.file_read",
+  "file-edit": "tool.label.file_edit",
+  "file-create": "tool.label.file_create",
+  "file-delete": "tool.label.file_delete",
+  "git-status": "tool.label.git_status",
+  "git-diff": "tool.label.git_diff",
+  "git-log": "tool.label.git_log",
+  "git-show": "tool.label.git_show",
+  "git-add": "tool.label.git_add",
+  "git-commit": "tool.label.git_commit",
+  "shell-run": "tool.label.shell_run",
+  "web-search": "tool.label.web_search",
+  "web-fetch": "tool.label.web_fetch",
+  "code-scan": "tool.label.code_scan",
+  "code-edit": "tool.label.code_edit",
+  "test-run": "tool.label.test_run",
+  "memory-search": "tool.label.memory_search",
+  "memory-add": "tool.label.memory_add",
+  "memory-remove": "tool.label.memory_remove",
+};
+
+export function toolLabelKey(toolId: string): string {
+  return TOOL_LABEL_KEYS[toolId] ?? toolId;
+}
+
 export function emitParts(
   parts: ToolOutputPart[],
   toolName: string,

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -5,7 +5,6 @@ import { createChecklistToolkit } from "./checklist-toolkit";
 import { createCodeToolkit } from "./code-toolkit";
 import { createFileToolkit } from "./file-toolkit";
 import { createGitToolkit } from "./git-toolkit";
-import { EN_MESSAGES } from "./i18n/en";
 import { createMemoryToolkit } from "./memory-toolkit";
 import { createShellToolkit } from "./shell-toolkit";
 import { createTestToolkit } from "./test-toolkit";
@@ -97,9 +96,6 @@ function asToolDefinitionsById(entries: ToolMap): Record<string, AnyToolDefiniti
   const byId: Record<string, AnyToolDefinition> = {};
   for (const tool of Object.values(entries)) {
     invariant(typeof tool.id === "string" && tool.id.trim().length > 0, "tool id is required");
-    if (tool.labelKey) {
-      invariant(tool.labelKey in EN_MESSAGES, `tool ${tool.id} has unknown labelKey "${tool.labelKey}"`);
-    }
     invariant(typeof tool.category === "string" && tool.category.trim().length > 0, `tool ${tool.id} missing category`);
     invariant(
       typeof tool.instruction === "string" && tool.instruction.trim().length > 0,

--- a/src/web-toolkit.ts
+++ b/src/web-toolkit.ts
@@ -60,7 +60,6 @@ function createWebSearchTool(deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "web-search",
     toolkit: "web",
-    labelKey: "tool.label.web_search",
     category: "network",
     description:
       "Search the public web for recent information and return top results. Use for questions not answerable from the repo.",
@@ -102,7 +101,6 @@ function createWebFetchTool(deps: ToolkitDeps, input: ToolkitInput) {
   return createTool({
     id: "web-fetch",
     toolkit: "web",
-    labelKey: "tool.label.web_fetch",
     category: "network",
     description:
       "Fetch a public URL and return extracted text content. Use to read docs, API references, or linked resources by URL.",


### PR DESCRIPTION
## Summary

- removed `labelKey` from `ToolDefinition` and all `createTool` call sites
- added a static tool ID to label key map in the tool output layer
- map values typed as `TranslationKey` for compile-time i18n validation
- updated CLI format to resolve labels from the map instead of tool definitions

Fixes #100