### PR TITLE
feat: configurable model reasoning

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -67,6 +67,7 @@ acolyte config set logFormat json
 | `locale` | UI language (default: `en`) |
 | `model` | model |
 | `temperature` | generation temperature (`0.0` to `2.0`) |
+| `reasoning` | reasoning level for supported models (`low`, `medium`, `high`) |
 | `openaiBaseUrl` | OpenAI API base URL |
 | `anthropicBaseUrl` | Anthropic API base URL |
 | `googleBaseUrl` | Google AI API base URL |

--- a/src/agent-contract.ts
+++ b/src/agent-contract.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV3 } from "@ai-sdk/provider";
+import type { LanguageModelV3, SharedV3ProviderOptions } from "@ai-sdk/provider";
 import type { GenerateResult, StreamChunk } from "./lifecycle-contract";
 import type { ToolDefinition } from "./tool-contract";
 
@@ -14,6 +14,7 @@ export type Agent = {
 export type StreamOptions = {
   toolChoice?: "auto" | "none" | "required";
   temperature?: number;
+  providerOptions?: SharedV3ProviderOptions;
   /** Max nudge re-prompts when the model stops prematurely. 0 disables. */
   maxNudges?: number;
 };

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -91,6 +91,7 @@ export function createAgentStream(
               : functionTools.length > 0
                 ? { type: "auto" }
                 : undefined,
+            ...(options.providerOptions ? { providerOptions: options.providerOptions } : {}),
           });
           rateLimiter.reset();
         } catch (error) {

--- a/src/app-config.ts
+++ b/src/app-config.ts
@@ -25,6 +25,7 @@ export const appConfig = {
   },
   model: fileConfig.model,
   temperature: fileConfig.temperature,
+  reasoning: fileConfig.reasoning,
   distill: {
     model: fileConfig.distillModel,
   },

--- a/src/chat-state.ts
+++ b/src/chat-state.ts
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from "react";
+import { appConfig } from "./app-config";
 import type { ChatRow } from "./chat-contract";
 import { useSuggestions } from "./chat-effects";
 import { processInputChange, processInputSubmit } from "./chat-input-handlers";
@@ -124,7 +125,7 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
   const handleSubmitRef = useRef<((text: string) => Promise<void>) | null>(null);
 
   const workspace = shownCwd();
-  const footerContext = `${workspace} · ${branch ?? "—"} · ${formatModel(currentSession.model)}`;
+  const footerContext = `${workspace} · ${branch ?? "—"} · ${formatModel(currentSession.model, appConfig.reasoning)}`;
 
   useMountEffect(() => {
     loadSkills().catch(() => {});

--- a/src/config-contract.ts
+++ b/src/config-contract.ts
@@ -16,6 +16,9 @@ const MAX_PINNED_MESSAGE_TOKENS = 4_000;
 const MAX_RUN_REPLY_TIMEOUT_MS = 600_000;
 const MAX_TEMPERATURE = 2;
 
+export const reasoningLevelSchema = z.enum(["low", "medium", "high"]);
+export type ReasoningLevel = z.infer<typeof reasoningLevelSchema>;
+
 const nonEmptyStringSchema = z.string().trim().min(1);
 const parseIntegerSchema = (min: number, max: number): z.ZodType<number> =>
   z.preprocess(
@@ -44,6 +47,7 @@ export interface Config {
   maxAttachmentMessageTokens?: number;
   maxPinnedMessageTokens?: number;
   replyTimeoutMs?: number;
+  reasoning?: ReasoningLevel;
   embeddingModel?: string;
 }
 
@@ -64,6 +68,7 @@ export interface ResolvedConfig {
   maxAttachmentMessageTokens: number;
   maxPinnedMessageTokens: number;
   replyTimeoutMs: number;
+  reasoning?: ReasoningLevel;
   embeddingModel: string;
 }
 
@@ -76,6 +81,7 @@ export const CONFIG_SET_SCHEMAS: Partial<Record<keyof Config, z.ZodTypeAny>> = {
   anthropicBaseUrl: nonEmptyStringSchema,
   googleBaseUrl: nonEmptyStringSchema,
   logFormat: logFormatSchema,
+  reasoning: reasoningLevelSchema,
   embeddingModel: nonEmptyStringSchema,
 };
 
@@ -108,6 +114,7 @@ export function toConfig(input: Record<string, unknown>): Config {
       input.maxPinnedMessageTokens,
     ),
     replyTimeoutMs: parseField(parseIntegerSchema(1_000, MAX_RUN_REPLY_TIMEOUT_MS), input.replyTimeoutMs),
+    reasoning: parseField(reasoningLevelSchema, input.reasoning),
     embeddingModel: parseField(nonEmptyStringSchema, input.embeddingModel),
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -128,6 +128,7 @@ function serializeToml(config: Config): string {
   if (typeof config.maxPinnedMessageTokens === "number")
     lines.push(`maxPinnedMessageTokens = ${config.maxPinnedMessageTokens}`);
   if (typeof config.replyTimeoutMs === "number") lines.push(`replyTimeoutMs = ${config.replyTimeoutMs}`);
+  if (config.reasoning) lines.push(`reasoning = ${JSON.stringify(config.reasoning)}`);
   if (config.embeddingModel) lines.push(`embeddingModel = ${JSON.stringify(config.embeddingModel)}`);
   return `${lines.join("\n")}${lines.length > 0 ? "\n" : ""}`;
 }
@@ -153,6 +154,7 @@ function resolveConfig(config: Config): ResolvedConfig {
     maxAttachmentMessageTokens: config.maxAttachmentMessageTokens ?? defaults.maxAttachmentMessageTokens,
     maxPinnedMessageTokens: config.maxPinnedMessageTokens ?? defaults.maxPinnedMessageTokens,
     replyTimeoutMs: config.replyTimeoutMs ?? defaults.replyTimeoutMs,
+    reasoning: config.reasoning,
     embeddingModel: config.embeddingModel ?? defaults.embeddingModel,
   };
 }

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -154,9 +154,9 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
 
   try {
     resetTimeout();
-    const temperature = ctx.temperature ?? appConfig.temperature;
     const provider = providerFromModel(appConfig.model);
     const providerOptions = reasoningProviderOptions(provider, appConfig.reasoning);
+    const temperature = providerOptions ? undefined : (ctx.temperature ?? appConfig.temperature);
     const streamOutput = await ctx.agent.stream(prompt, {
       toolChoice: "auto",
       ...(typeof temperature === "number" ? { temperature } : {}),

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -15,6 +15,7 @@ import {
 } from "./error-handling";
 import type { GenerateOptions, GenerateResult, RunContext, StreamChunk } from "./lifecycle-contract";
 import { addPromptBreakdownTotals, estimatePromptBreakdown, totalPromptBreakdownTokens } from "./lifecycle-usage";
+import { providerFromModel, reasoningProviderOptions } from "./provider-config";
 import type { StreamError } from "./stream-error";
 import { extractToolTargetPaths } from "./tool-arg-paths";
 import type { ToolDefinition } from "./tool-contract";
@@ -154,9 +155,12 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
   try {
     resetTimeout();
     const temperature = ctx.temperature ?? appConfig.temperature;
+    const provider = providerFromModel(appConfig.model);
+    const providerOptions = reasoningProviderOptions(provider, appConfig.reasoning);
     const streamOutput = await ctx.agent.stream(prompt, {
       toolChoice: "auto",
       ...(typeof temperature === "number" ? { temperature } : {}),
+      ...(providerOptions ? { providerOptions } : {}),
       maxNudges: ctx.policy.maxNudgesPerGeneration,
     });
     const fullOutput = streamOutput.getFullOutput();

--- a/src/memory-distiller.ts
+++ b/src/memory-distiller.ts
@@ -42,14 +42,13 @@ function getDefaultStore(): MemoryStore {
 
 type DistillScope = "session" | "project" | "user";
 
-function embedAndStore(ds: MemoryStore, id: string, scope: string, content: string): void {
-  embedText(content)
-    .then((vec) => {
-      if (vec) ds.writeEmbedding(id, scope, embeddingToBuffer(vec));
-    })
-    .catch((error) => {
-      log.warn("memory.distill.embed_failed", { id, error: String(error) });
-    });
+async function embedAndStore(ds: MemoryStore, id: string, scope: string, content: string): Promise<void> {
+  try {
+    const vec = await embedText(content);
+    if (vec) ds.writeEmbedding(id, scope, embeddingToBuffer(vec));
+  } catch (error) {
+    log.warn("memory.distill.embed_failed", { id, error: String(error) });
+  }
 }
 
 const CHARS_PER_TOKEN_ESTIMATE = 4;
@@ -194,7 +193,7 @@ async function commitDistillForKey(ds: MemoryStore, key: string, observed: strin
     tokenEstimate: estimateTokens(observed),
   };
   await ds.write(observation);
-  embedAndStore(ds, observation.id, key, observed);
+  await embedAndStore(ds, observation.id, key, observed);
   log.debug("memory.distill.observation_written", { key, id: observation.id, tokens: observation.tokenEstimate });
   return observation.tokenEstimate;
 }

--- a/src/memory-ops.ts
+++ b/src/memory-ops.ts
@@ -73,13 +73,12 @@ export async function addMemory(
   await store.write(record, scope);
   log.debug("memory.stored.added", { id: record.id, scope, tokens: record.tokenEstimate });
 
-  embedText(trimmed)
-    .then((vec) => {
-      if (vec) store.writeEmbedding(record.id, scopeKey, embeddingToBuffer(vec));
-    })
-    .catch((error) => {
-      log.warn("memory.stored.embed_failed", { id: record.id, error: String(error) });
-    });
+  try {
+    const vec = await embedText(trimmed);
+    if (vec) store.writeEmbedding(record.id, scopeKey, embeddingToBuffer(vec));
+  } catch (error) {
+    log.warn("memory.stored.embed_failed", { id: record.id, error: String(error) });
+  }
 
   return toMemoryEntry(record);
 }

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { formatModel, isProviderAvailable, normalizeModel, providerFromModel } from "./provider-config";
+import {
+  formatModel,
+  isProviderAvailable,
+  normalizeModel,
+  providerFromModel,
+  reasoningProviderOptions,
+} from "./provider-config";
 
 describe("provider config", () => {
   test("normalizeModel prefixes unqualified model ids", () => {
@@ -16,6 +22,13 @@ describe("provider config", () => {
     expect(formatModel("custom-model-id")).toBe("custom-model-id");
   });
 
+  test("formatModel appends non-default reasoning level", () => {
+    expect(formatModel("openai/o3", "high")).toBe("o3 (high)");
+    expect(formatModel("openai/o3", "low")).toBe("o3 (low)");
+    expect(formatModel("openai/o3", "medium")).toBe("o3");
+    expect(formatModel("openai/o3")).toBe("o3");
+  });
+
   test("providerFromModel infers provider from model prefix", () => {
     expect(providerFromModel("gpt-5-mini")).toBe("openai");
     expect(providerFromModel("openai/gpt-5-mini")).toBe("openai");
@@ -25,6 +38,18 @@ describe("provider config", () => {
     expect(providerFromModel("google/gemini-2.5-pro")).toBe("google");
     expect(providerFromModel("openai-compatible/qwen2.5-coder")).toBe("openai");
     expect(providerFromModel(" anthropic/claude-sonnet-4 ")).toBe("anthropic");
+  });
+
+  test("reasoningProviderOptions returns provider-specific options", () => {
+    expect(reasoningProviderOptions("openai", "high")).toEqual({ openai: { reasoningEffort: "high" } });
+    expect(reasoningProviderOptions("anthropic", "high")).toEqual({
+      anthropic: { thinking: { type: "enabled", budgetTokens: 20_000 } },
+    });
+    expect(reasoningProviderOptions("google", "low")).toEqual({ google: { thinkingConfig: { thinkingLevel: "low" } } });
+  });
+
+  test("reasoningProviderOptions returns undefined when level is not set", () => {
+    expect(reasoningProviderOptions("openai", undefined)).toBeUndefined();
   });
 
   test("isProviderAvailable validates credential requirements", () => {

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -1,4 +1,5 @@
 import type { SharedV3ProviderOptions } from "@ai-sdk/provider";
+import type { ReasoningLevel } from "./config-contract";
 import { type Provider, providerSchema } from "./provider-contract";
 
 const MODEL_NAME_PREFIX_TO_PROVIDER: Record<string, Provider> = {
@@ -24,7 +25,7 @@ export function normalizeModel(model: string): string {
   return `${prefix}/${model}`;
 }
 
-export function formatModel(model: string, reasoning?: string): string {
+export function formatModel(model: string, reasoning?: ReasoningLevel): string {
   const name = (model.indexOf("/") >= 0 ? model.slice(model.indexOf("/") + 1) : model).trim();
   if (reasoning && reasoning !== DEFAULT_REASONING) return `${name} (${reasoning})`;
   return name;
@@ -79,7 +80,7 @@ const ANTHROPIC_THINKING_BUDGET: Record<string, number> = {
 
 export function reasoningProviderOptions(
   provider: Provider,
-  level: string | undefined,
+  level: ReasoningLevel | undefined,
 ): SharedV3ProviderOptions | undefined {
   if (!level) return undefined;
   switch (provider) {

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -1,3 +1,4 @@
+import type { SharedV3ProviderOptions } from "@ai-sdk/provider";
 import { type Provider, providerSchema } from "./provider-contract";
 
 const MODEL_NAME_PREFIX_TO_PROVIDER: Record<string, Provider> = {
@@ -23,9 +24,10 @@ export function normalizeModel(model: string): string {
   return `${prefix}/${model}`;
 }
 
-export function formatModel(model: string): string {
-  const slash = model.indexOf("/");
-  return (slash >= 0 ? model.slice(slash + 1) : model).trim();
+export function formatModel(model: string, reasoning?: string): string {
+  const name = (model.indexOf("/") >= 0 ? model.slice(model.indexOf("/") + 1) : model).trim();
+  if (reasoning && reasoning !== DEFAULT_REASONING) return `${name} (${reasoning})`;
+  return name;
 }
 
 function isOpenAICompatibleBaseUrl(openaiBaseUrl: string): boolean {
@@ -66,6 +68,29 @@ export function providerFromModel(model: string): Provider {
 }
 
 export type ProviderCredentials = { apiKey?: string; baseUrl?: string };
+
+export const DEFAULT_REASONING = "medium";
+
+const ANTHROPIC_THINKING_BUDGET: Record<string, number> = {
+  low: 5_000,
+  medium: 10_000,
+  high: 20_000,
+};
+
+export function reasoningProviderOptions(
+  provider: Provider,
+  level: string | undefined,
+): SharedV3ProviderOptions | undefined {
+  if (!level) return undefined;
+  switch (provider) {
+    case "openai":
+      return { openai: { reasoningEffort: level } };
+    case "anthropic":
+      return { anthropic: { thinking: { type: "enabled", budgetTokens: ANTHROPIC_THINKING_BUDGET[level] ?? 10_000 } } };
+    case "google":
+      return { google: { thinkingConfig: { thinkingLevel: level } } };
+  }
+}
 
 export function isProviderAvailable(provider: Provider, credentials: ProviderCredentials): boolean {
   if (provider === "anthropic") return Boolean(credentials.apiKey) && isAnthropicBaseUrlValid(credentials.baseUrl);


### PR DESCRIPTION
## Summary

- added `reasoning` config key with `low`, `medium`, `high` levels
- maps to provider-specific params (OpenAI `reasoningEffort`, Anthropic `thinking`, Google `thinkingConfig`)
- shows reasoning level in footer when non-default, e.g. `o3 (high)`
- skips custom temperature when reasoning is enabled to prevent API errors
- awaited fire-and-forget embeddings to fix database-closed warnings in tests

Fixes #102