### PR TITLE
refactor(tools): move output budgets to tool definitions

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,7 +100,7 @@ Memory Engine
 ## Dependency injection
 
 - **No container, no decorators** — dependencies are passed as typed parameters with defaults from `appConfig`.
-- **Deps vs input** — factory functions that need both configuration and runtime data take two arguments: a `*Deps` object for config that is fixed for the process lifetime, and an `*Input` object for per-request runtime data (e.g. `createFileToolkit(deps: ToolkitDeps, input: ToolkitInput)`).
+- **Toolkit input** — toolkit factory functions take a single `ToolkitInput` object containing per-request runtime data (e.g. `createFileToolkit(input: ToolkitInput)`). Output budgets are defined locally in each tool.
 - **Defaults at the edge** — library modules accept injected params; composition roots (`cli-command-registry`, `server-chat-runtime`, `cli-chat`) read `appConfig` and pass values down.
 - **Tests inject directly** — tests pass config through the new params instead of mutating `appConfig`.
 

--- a/src/checklist-toolkit.ts
+++ b/src/checklist-toolkit.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { type ChecklistItem, checklistItemStatusSchema } from "./checklist-contract";
-import type { ToolkitDeps, ToolkitInput } from "./tool-contract";
+import type { ToolkitInput } from "./tool-contract";
 import { createTool } from "./tool-contract";
 import { runTool } from "./tool-execution";
 
@@ -37,11 +37,7 @@ const updateChecklistOutputSchema = z.object({
   status: checklistItemStatusSchema,
 });
 
-function createCreateChecklistTool(
-  _deps: ToolkitDeps,
-  input: ToolkitInput,
-  state: Map<string, { title: string; items: ChecklistItem[] }>,
-) {
+function createCreateChecklistTool(input: ToolkitInput, state: Map<string, { title: string; items: ChecklistItem[] }>) {
   return createTool({
     id: "checklist-create",
     toolkit: "checklist",
@@ -67,11 +63,7 @@ function createCreateChecklistTool(
   });
 }
 
-function createUpdateChecklistTool(
-  _deps: ToolkitDeps,
-  input: ToolkitInput,
-  state: Map<string, { title: string; items: ChecklistItem[] }>,
-) {
+function createUpdateChecklistTool(input: ToolkitInput, state: Map<string, { title: string; items: ChecklistItem[] }>) {
   return createTool({
     id: "checklist-update",
     toolkit: "checklist",
@@ -102,10 +94,10 @@ function createUpdateChecklistTool(
   });
 }
 
-export function createChecklistToolkit(deps: ToolkitDeps, input: ToolkitInput) {
+export function createChecklistToolkit(input: ToolkitInput) {
   const state = new Map<string, { title: string; items: ChecklistItem[] }>();
   return {
-    createChecklist: createCreateChecklistTool(deps, input, state),
-    updateChecklist: createUpdateChecklistTool(deps, input, state),
+    createChecklist: createCreateChecklistTool(input, state),
+    updateChecklist: createUpdateChecklistTool(input, state),
   };
 }

--- a/src/code-toolkit.ts
+++ b/src/code-toolkit.ts
@@ -2,9 +2,8 @@ import { isAbsolute, relative } from "node:path";
 import { z } from "zod";
 import { editCodeEditSchema } from "./code-contract";
 import { editCode, type ScanCodeResult, scanCode } from "./code-ops";
-import { createTool, type ToolkitDeps, type ToolkitInput } from "./tool-contract";
+import { createTool, type ToolkitInput } from "./tool-contract";
 import { runTool } from "./tool-execution";
-import { compactToolOutput } from "./tool-output";
 import { diffSummaryParts, emitParts } from "./tool-output-format";
 import { numberedUnifiedDiffLines, summarizeUnifiedDiff } from "./tool-output-parse";
 
@@ -46,7 +45,7 @@ function formatScanCodeResult(result: ScanCodeResult): string {
   return lines.join("\n");
 }
 
-function createScanCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
+function createScanCodeTool(input: ToolkitInput) {
   return createTool({
     id: "code-scan",
     toolkit: "code",
@@ -72,6 +71,7 @@ function createScanCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
       patterns: z.array(z.string().min(1)),
       output: z.string(),
     }),
+    outputBudget: { maxChars: 2_400, maxLines: 80 },
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "code-scan", toolCallId, toolInput, async (callId) => {
         const paths = normalizeUniquePaths(toolInput.paths);
@@ -91,12 +91,6 @@ function createScanCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
             toolCallId: callId,
           });
         }
-        const baseBudget = deps.outputBudget.codeScan;
-        const count = paths.length * toolInput.patterns.length;
-        const budget = {
-          maxChars: Math.max(400, Math.floor(baseBudget.maxChars / count) * count),
-          maxLines: Math.max(20, Math.floor(baseBudget.maxLines / count) * count),
-        };
         const rawScan = await scanCode({
           workspace: input.workspace,
           paths,
@@ -104,14 +98,13 @@ function createScanCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
           language: toolInput.language,
           maxResults: toolInput.maxResults ?? 50,
         });
-        const result = compactToolOutput(formatScanCodeResult(rawScan), budget);
-        return { kind: "code-scan", paths, patterns: toolInput.patterns, output: result };
+        return { kind: "code-scan", paths, patterns: toolInput.patterns, output: formatScanCodeResult(rawScan) };
       });
     },
   });
 }
 
-function createEditCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
+function createEditCodeTool(input: ToolkitInput) {
   const outputSchema = z.object({
     kind: z.literal("code-edit"),
     path: z.string().min(1),
@@ -143,6 +136,7 @@ function createEditCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
       edits: z.array(editCodeEditSchema).min(1),
     }),
     outputSchema,
+    outputBudget: { maxChars: 1_400, maxLines: 60 },
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "code-edit", toolCallId, toolInput, async (callId) => {
         const editResult = await editCode({
@@ -155,7 +149,6 @@ function createEditCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
         emitParts(summaryParts, "code-edit", input.onOutput, callId);
         emitParts(diffParts, "code-edit", input.onOutput, callId);
         const totals = summarizeUnifiedDiff(editResult.output);
-        const result = compactToolOutput(editResult.output, deps.outputBudget.codeEdit);
         return {
           kind: "code-edit",
           path: toolInput.path,
@@ -165,16 +158,16 @@ function createEditCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
           matches: editResult.matches,
           edits: editResult.edits,
           affectedSymbols: editResult.affectedSymbols,
-          output: result,
+          output: editResult.output,
         };
       });
     },
   });
 }
 
-export function createCodeToolkit(deps: ToolkitDeps, input: ToolkitInput) {
+export function createCodeToolkit(input: ToolkitInput) {
   return {
-    scanCode: createScanCodeTool(deps, input),
-    editCode: createEditCodeTool(deps, input),
+    scanCode: createScanCodeTool(input),
+    editCode: createEditCodeTool(input),
   };
 }

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -1,9 +1,8 @@
 import { isAbsolute, relative } from "node:path";
 import { z } from "zod";
 import { deleteTextFile, editFile, findFiles, readFileContents, searchFiles, writeTextFile } from "./file-ops";
-import { createTool, type ToolkitDeps, type ToolkitInput } from "./tool-contract";
+import { createTool, type ToolkitInput } from "./tool-contract";
 import { runTool } from "./tool-execution";
-import { compactToolOutput } from "./tool-output";
 import { diffSummaryParts, emitParts, findSummaryParts, searchSummaryParts } from "./tool-output-format";
 import {
   findResultPaths,
@@ -47,7 +46,7 @@ function deduplicatePaths(paths: Array<{ path: string }>): string[] {
   return result;
 }
 
-function createFindFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
+function createFindFilesTool(input: ToolkitInput) {
   return createTool({
     id: "file-find",
     toolkit: "file",
@@ -68,17 +67,12 @@ function createFindFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
       paths: z.array(z.string().min(1)),
       output: z.string(),
     }),
+    outputBudget: { maxChars: 2_500, maxLines: 100 },
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "file-find", toolCallId, toolInput, async (callId) => {
         const maxResults = toolInput.maxResults ?? 40;
-        const count = toolInput.patterns.length;
-        const baseBudget = deps.outputBudget.fileFind;
-        const budget = {
-          maxChars: Math.max(400, Math.floor(baseBudget.maxChars / count) * count),
-          maxLines: Math.max(20, Math.floor(baseBudget.maxLines / count) * count),
-        };
-        const result = compactToolOutput(await findFiles(input.workspace, toolInput.patterns, maxResults), budget);
-        const paths = findResultPaths(result);
+        const raw = await findFiles(input.workspace, toolInput.patterns, maxResults);
+        const paths = findResultPaths(raw);
         emitParts(
           findSummaryParts(paths, toolInput.patterns, "tool.label.file_find"),
           "file-find",
@@ -91,14 +85,14 @@ function createFindFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
           patterns: toolInput.patterns,
           matches: paths.length,
           paths,
-          output: result,
+          output: raw,
         };
       });
     },
   });
 }
 
-function createSearchFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
+function createSearchFilesTool(input: ToolkitInput) {
   return createTool({
     id: "file-search",
     toolkit: "file",
@@ -130,6 +124,7 @@ function createSearchFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
       entries: z.array(z.object({ path: z.string().min(1), hits: z.array(z.string().min(1)) })),
       output: z.string(),
     }),
+    outputBudget: { maxChars: 2_200, maxLines: 80 },
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "file-search", toolCallId, toolInput, async (callId) => {
         const maxResults = toolInput.maxResults ?? 20;
@@ -139,10 +134,7 @@ function createSearchFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
             : toolInput.pattern
               ? [toolInput.pattern]
               : [];
-        const result = compactToolOutput(
-          await searchFiles(input.workspace, patterns, maxResults, toolInput.paths),
-          deps.outputBudget.fileSearch,
-        );
+        const result = await searchFiles(input.workspace, patterns, maxResults, toolInput.paths);
         const summaryStats = searchResultSummaryStats(result, patterns);
         const summaryParts = searchSummaryParts(
           summaryStats,
@@ -165,7 +157,9 @@ function createSearchFilesTool(deps: ToolkitDeps, input: ToolkitInput) {
   });
 }
 
-function createReadFileTool(deps: ToolkitDeps, input: ToolkitInput) {
+const FILE_READ_MAX_LINES = 2_000;
+
+function createReadFileTool(input: ToolkitInput) {
   return createTool({
     id: "file-read",
     toolkit: "file",
@@ -182,6 +176,7 @@ function createReadFileTool(deps: ToolkitDeps, input: ToolkitInput) {
       paths: z.array(z.string().min(1)),
       output: z.string(),
     }),
+    outputBudget: { maxChars: 80_000, maxLines: FILE_READ_MAX_LINES },
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "file-read", toolCallId, toolInput, async (callId) => {
         const paths = deduplicatePaths(toolInput.paths);
@@ -200,15 +195,14 @@ function createReadFileTool(deps: ToolkitDeps, input: ToolkitInput) {
           },
           toolCallId: callId,
         });
-        const raw = await readFileContents(input.workspace, paths, deps.outputBudget.fileRead.maxLines);
-        const output = compactToolOutput(raw, deps.outputBudget.fileRead);
+        const output = await readFileContents(input.workspace, paths, FILE_READ_MAX_LINES);
         return { kind: "file-read", paths, output };
       });
     },
   });
 }
 
-function createEditFileTool(deps: ToolkitDeps, input: ToolkitInput) {
+function createEditFileTool(input: ToolkitInput) {
   const outputSchema = z.object({
     kind: z.literal("file-edit"),
     path: z.string().min(1),
@@ -243,6 +237,7 @@ function createEditFileTool(deps: ToolkitDeps, input: ToolkitInput) {
         .min(1),
     }),
     outputSchema,
+    outputBudget: { maxChars: 1_400, maxLines: 60 },
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "file-edit", toolCallId, toolInput, async (callId) => {
         const rawResult = await editFile({
@@ -255,21 +250,20 @@ function createEditFileTool(deps: ToolkitDeps, input: ToolkitInput) {
         emitParts(summaryParts, "file-edit", input.onOutput, callId);
         emitParts(diffParts, "file-edit", input.onOutput, callId);
         const totals = summarizeUnifiedDiff(rawResult);
-        const result = compactToolOutput(rawResult, deps.outputBudget.fileEdit);
         return {
           kind: "file-edit",
           path: toolInput.path,
           files: totals.files > 0 ? totals.files : 1,
           added: totals.added,
           removed: totals.removed,
-          output: result,
+          output: rawResult,
         };
       });
     },
   });
 }
 
-function createCreateFileTool(deps: ToolkitDeps, input: ToolkitInput) {
+function createCreateFileTool(input: ToolkitInput) {
   return createTool({
     id: "file-create",
     toolkit: "file",
@@ -289,6 +283,7 @@ function createCreateFileTool(deps: ToolkitDeps, input: ToolkitInput) {
       removed: z.number().int().nonnegative(),
       output: z.string(),
     }),
+    outputBudget: { maxChars: 3_000, maxLines: 100 },
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "file-create", toolCallId, toolInput, async (callId) => {
         const rawResult = await writeTextFile({
@@ -302,21 +297,20 @@ function createCreateFileTool(deps: ToolkitDeps, input: ToolkitInput) {
         emitParts(summaryParts, "file-create", input.onOutput, callId);
         emitParts(diffParts, "file-create", input.onOutput, callId);
         const totals = summarizeUnifiedDiff(rawResult);
-        const result = compactToolOutput(rawResult, deps.outputBudget.fileCreate);
         return {
           kind: "file-create",
           path: toolInput.path,
           files: totals.files > 0 ? totals.files : 1,
           added: totals.added,
           removed: totals.removed,
-          output: result,
+          output: rawResult,
         };
       });
     },
   });
 }
 
-function createDeleteFileTool(deps: ToolkitDeps, input: ToolkitInput) {
+function createDeleteFileTool(input: ToolkitInput) {
   return createTool({
     id: "file-delete",
     toolkit: "file",
@@ -332,6 +326,7 @@ function createDeleteFileTool(deps: ToolkitDeps, input: ToolkitInput) {
       deleted: z.number().int().nonnegative(),
       output: z.string(),
     }),
+    outputBudget: { maxChars: 1_400, maxLines: 60 },
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "file-delete", toolCallId, toolInput, async (callId) => {
         const paths = normalizeUniquePaths(toolInput.paths);
@@ -347,20 +342,19 @@ function createDeleteFileTool(deps: ToolkitDeps, input: ToolkitInput) {
           resultParts.push(rawResult);
         }
         const rawResult = resultParts.join("\n\n");
-        const result = compactToolOutput(rawResult, deps.outputBudget.fileEdit);
-        return { kind: "file-delete", paths, deleted: paths.length, output: result };
+        return { kind: "file-delete", paths, deleted: paths.length, output: rawResult };
       });
     },
   });
 }
 
-export function createFileToolkit(deps: ToolkitDeps, input: ToolkitInput) {
+export function createFileToolkit(input: ToolkitInput) {
   return {
-    findFiles: createFindFilesTool(deps, input),
-    searchFiles: createSearchFilesTool(deps, input),
-    readFile: createReadFileTool(deps, input),
-    editFile: createEditFileTool(deps, input),
-    createFile: createCreateFileTool(deps, input),
-    deleteFile: createDeleteFileTool(deps, input),
+    findFiles: createFindFilesTool(input),
+    searchFiles: createSearchFilesTool(input),
+    readFile: createReadFileTool(input),
+    editFile: createEditFileTool(input),
+    createFile: createCreateFileTool(input),
+    deleteFile: createDeleteFileTool(input),
   };
 }

--- a/src/git-toolkit.ts
+++ b/src/git-toolkit.ts
@@ -1,10 +1,9 @@
 import { z } from "zod";
 import { gitAdd, gitCommit, gitDiff, gitLog, gitShow, gitStatusShort } from "./git-ops";
 import { t } from "./i18n";
-import type { ToolkitDeps, ToolkitInput } from "./tool-contract";
+import type { ToolkitInput } from "./tool-contract";
 import { createTool } from "./tool-contract";
 import { runTool } from "./tool-execution";
-import { compactToolOutput } from "./tool-output";
 import { emitParts, resultChunkParts, textHeadTailParts } from "./tool-output-format";
 import { TOOL_PROGRESS_LIMITS } from "./tool-policy";
 
@@ -88,7 +87,7 @@ function stripGitShowMetadataForPreview(rawText: string): string {
     .join("\n");
 }
 
-function createGitStatusTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
+function createGitStatusTool(git: GitOps, input: ToolkitInput) {
   return createTool({
     id: "git-status",
     toolkit: "git",
@@ -100,6 +99,7 @@ function createGitStatusTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput
       output: z.string(),
     }),
     inputSchema: z.object({}).optional(),
+    outputBudget: { maxChars: 1_800, maxLines: 80 },
     execute: async (_toolInput, toolCallId) => {
       return runTool(input.session, "git-status", toolCallId, {}, async (callId) => {
         input.onOutput({
@@ -110,14 +110,13 @@ function createGitStatusTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput
         const rawStatus = await git.statusShort();
         const previewParts = textHeadTailParts(rawStatus);
         emitParts(previewParts, "git-status", input.onOutput, callId);
-        const result = compactToolOutput(rawStatus, deps.outputBudget.gitStatus);
-        return { kind: "git-status", output: result };
+        return { kind: "git-status", output: rawStatus };
       });
     },
   });
 }
 
-function createGitDiffTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
+function createGitDiffTool(git: GitOps, input: ToolkitInput) {
   return createTool({
     id: "git-diff",
     toolkit: "git",
@@ -135,6 +134,7 @@ function createGitDiffTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) 
       path: z.string().optional(),
       contextLines: z.number().int().min(0).max(20).optional(),
     }),
+    outputBudget: { maxChars: 3_200, maxLines: 120 },
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "git-diff", toolCallId, toolInput, async (callId) => {
         input.onOutput({
@@ -145,14 +145,13 @@ function createGitDiffTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) 
         const rawDiff = await git.diff({ path: toolInput.path, contextLines: toolInput.contextLines ?? 3 });
         const previewParts = textHeadTailParts(rawDiff, { headRows: 2, tailRows: 2 });
         emitParts(previewParts, "git-diff", input.onOutput, callId);
-        const result = compactToolOutput(rawDiff, deps.outputBudget.gitDiff);
-        return { kind: "git-diff", path: toolInput.path, contextLines: toolInput.contextLines ?? 3, output: result };
+        return { kind: "git-diff", path: toolInput.path, contextLines: toolInput.contextLines ?? 3, output: rawDiff };
       });
     },
   });
 }
 
-function createGitLogTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
+function createGitLogTool(git: GitOps, input: ToolkitInput) {
   return createTool({
     id: "git-log",
     toolkit: "git",
@@ -169,6 +168,7 @@ function createGitLogTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
       path: z.string().optional(),
       limit: z.number().int().min(1).max(50).optional(),
     }),
+    outputBudget: { maxChars: 3_200, maxLines: 120 },
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "git-log", toolCallId, toolInput, async (callId) => {
         input.onOutput({
@@ -179,14 +179,13 @@ function createGitLogTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
         const rawLog = await git.log({ path: toolInput.path, limit: toolInput.limit });
         const previewParts = resultChunkParts(rawLog, 4);
         emitParts(previewParts, "git-log", input.onOutput, callId);
-        const result = compactToolOutput(rawLog, deps.outputBudget.gitDiff);
-        return { kind: "git-log", path: toolInput.path, limit: toolInput.limit, output: result };
+        return { kind: "git-log", path: toolInput.path, limit: toolInput.limit, output: rawLog };
       });
     },
   });
 }
 
-function createGitShowTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
+function createGitShowTool(git: GitOps, input: ToolkitInput) {
   return createTool({
     id: "git-show",
     toolkit: "git",
@@ -206,6 +205,7 @@ function createGitShowTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) 
       path: z.string().optional(),
       contextLines: z.number().int().min(0).max(20).optional(),
     }),
+    outputBudget: { maxChars: 3_200, maxLines: 120 },
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "git-show", toolCallId, toolInput, async (callId) => {
         input.onOutput({
@@ -221,20 +221,19 @@ function createGitShowTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) 
         const previewText = stripGitShowMetadataForPreview(rawShow);
         const previewParts = textHeadTailParts(previewText);
         emitParts(previewParts, "git-show", input.onOutput, callId);
-        const result = compactToolOutput(rawShow, deps.outputBudget.gitDiff);
         return {
           kind: "git-show",
           ref: toolInput.ref,
           path: toolInput.path,
           contextLines: toolInput.contextLines ?? 3,
-          output: result,
+          output: rawShow,
         };
       });
     },
   });
 }
 
-function createGitAddTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
+function createGitAddTool(git: GitOps, input: ToolkitInput) {
   return createTool({
     id: "git-add",
     toolkit: "git",
@@ -252,6 +251,7 @@ function createGitAddTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
       paths: z.array(z.string().min(1)).max(200).optional(),
       all: z.boolean().optional(),
     }),
+    outputBudget: { maxChars: 1_800, maxLines: 80 },
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "git-add", toolCallId, toolInput, async (callId) => {
         const paths = (toolInput.paths ?? []).filter((p) => p.trim().length > 0);
@@ -274,14 +274,13 @@ function createGitAddTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
             });
           }
         }
-        const result = compactToolOutput(rawAdd, deps.outputBudget.gitStatus);
-        return { kind: "git-add", all: toolInput.all, paths: toolInput.paths, output: result };
+        return { kind: "git-add", all: toolInput.all, paths: toolInput.paths, output: rawAdd };
       });
     },
   });
 }
 
-function createGitCommitTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput) {
+function createGitCommitTool(git: GitOps, input: ToolkitInput) {
   return createTool({
     id: "git-commit",
     toolkit: "git",
@@ -298,6 +297,7 @@ function createGitCommitTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput
       message: z.string().min(1),
       body: z.array(z.string().min(1)).max(10).optional(),
     }),
+    outputBudget: { maxChars: 3_200, maxLines: 120 },
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "git-commit", toolCallId, toolInput, async (callId) => {
         const rawCommit = await git.commit({ message: toolInput.message, body: toolInput.body });
@@ -322,21 +322,20 @@ function createGitCommitTool(git: GitOps, deps: ToolkitDeps, input: ToolkitInput
             });
           }
         }
-        const result = compactToolOutput(rawCommit, deps.outputBudget.gitDiff);
-        return { kind: "git-commit", message: toolInput.message, body: toolInput.body, output: result };
+        return { kind: "git-commit", message: toolInput.message, body: toolInput.body, output: rawCommit };
       });
     },
   });
 }
 
-export function createGitToolkit(deps: ToolkitDeps, input: ToolkitInput) {
+export function createGitToolkit(input: ToolkitInput) {
   const git = createGitOps(input.workspace);
   return {
-    gitStatus: createGitStatusTool(git, deps, input),
-    gitDiff: createGitDiffTool(git, deps, input),
-    gitLog: createGitLogTool(git, deps, input),
-    gitShow: createGitShowTool(git, deps, input),
-    gitAdd: createGitAddTool(git, deps, input),
-    gitCommit: createGitCommitTool(git, deps, input),
+    gitStatus: createGitStatusTool(git, input),
+    gitDiff: createGitDiffTool(git, input),
+    gitLog: createGitLogTool(git, input),
+    gitShow: createGitShowTool(git, input),
+    gitAdd: createGitAddTool(git, input),
+    gitCommit: createGitCommitTool(git, input),
   };
 }

--- a/src/memory-toolkit.ts
+++ b/src/memory-toolkit.ts
@@ -3,7 +3,7 @@ import { type MemoryRecord, type MemoryStore, memoryScopeSchema, scopeFromKey } 
 import { bufferToEmbedding, cosineSimilarity, embedText } from "./memory-embedding";
 import { addMemory, removeMemory } from "./memory-ops";
 import { getDefaultMemoryStore } from "./memory-store";
-import type { ToolkitDeps, ToolkitInput } from "./tool-contract";
+import type { ToolkitInput } from "./tool-contract";
 import { createTool } from "./tool-contract";
 import { runTool } from "./tool-execution";
 
@@ -32,7 +32,7 @@ export async function searchMemories(
   return scored.slice(0, limit).map((s) => s.record);
 }
 
-function createMemorySearchTool(_deps: ToolkitDeps, input: ToolkitInput) {
+function createMemorySearchTool(input: ToolkitInput) {
   return createTool({
     id: "memory-search",
     toolkit: "memory",
@@ -83,7 +83,7 @@ function createMemorySearchTool(_deps: ToolkitDeps, input: ToolkitInput) {
   });
 }
 
-function createMemoryAddTool(_deps: ToolkitDeps, input: ToolkitInput) {
+function createMemoryAddTool(input: ToolkitInput) {
   return createTool({
     id: "memory-add",
     toolkit: "memory",
@@ -110,7 +110,7 @@ function createMemoryAddTool(_deps: ToolkitDeps, input: ToolkitInput) {
   });
 }
 
-function createMemoryRemoveTool(_deps: ToolkitDeps, input: ToolkitInput) {
+function createMemoryRemoveTool(input: ToolkitInput) {
   return createTool({
     id: "memory-remove",
     toolkit: "memory",
@@ -133,10 +133,10 @@ function createMemoryRemoveTool(_deps: ToolkitDeps, input: ToolkitInput) {
   });
 }
 
-export function createMemoryToolkit(deps: ToolkitDeps, input: ToolkitInput) {
+export function createMemoryToolkit(input: ToolkitInput) {
   return {
-    memorySearch: createMemorySearchTool(deps, input),
-    memoryAdd: createMemoryAddTool(deps, input),
-    memoryRemove: createMemoryRemoveTool(deps, input),
+    memorySearch: createMemorySearchTool(input),
+    memoryAdd: createMemoryAddTool(input),
+    memoryRemove: createMemoryRemoveTool(input),
   };
 }

--- a/src/shell-toolkit.ts
+++ b/src/shell-toolkit.ts
@@ -1,12 +1,11 @@
 import { z } from "zod";
 import { compactDetail } from "./compact-text";
 import { formatShellCommand, parseExitCode, runShellCommand } from "./shell-ops";
-import { createTool, type ToolkitDeps, type ToolkitInput } from "./tool-contract";
+import { createTool, type ToolkitInput } from "./tool-contract";
 import { runTool } from "./tool-execution";
-import { compactToolOutput } from "./tool-output";
 import { emitParts, shellHeadTailParts } from "./tool-output-format";
 
-function createRunCommandTool(deps: ToolkitDeps, input: ToolkitInput) {
+function createRunCommandTool(input: ToolkitInput) {
   return createTool({
     id: "shell-run",
     toolkit: "shell",
@@ -26,6 +25,7 @@ function createRunCommandTool(deps: ToolkitDeps, input: ToolkitInput) {
       exitCode: z.number().int().optional(),
       output: z.string(),
     }),
+    outputBudget: { maxChars: 2_600, maxLines: 120 },
     execute: async (toolInput, toolCallId) => {
       return runTool(
         input.session,
@@ -91,12 +91,11 @@ function createRunCommandTool(deps: ToolkitDeps, input: ToolkitInput) {
           flushRemainder("stderr");
           const previewParts = shellHeadTailParts(streamed);
           emitParts(previewParts, "shell-run", input.onOutput, callId);
-          const result = compactToolOutput(rawResult, deps.outputBudget.shellRun);
           return {
             kind: "shell-run",
             command: displayCommand,
             exitCode: parseExitCode(rawResult),
-            output: result,
+            output: rawResult,
           };
         },
         { timeoutMs: toolInput.timeoutMs },
@@ -105,8 +104,8 @@ function createRunCommandTool(deps: ToolkitDeps, input: ToolkitInput) {
   });
 }
 
-export function createShellToolkit(deps: ToolkitDeps, input: ToolkitInput) {
+export function createShellToolkit(input: ToolkitInput) {
   return {
-    runCommand: createRunCommandTool(deps, input),
+    runCommand: createRunCommandTool(input),
   };
 }

--- a/src/test-toolkit.test.ts
+++ b/src/test-toolkit.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { createTestToolkit } from "./test-toolkit";
-import { createToolkitDeps } from "./test-utils";
 import { createSessionContext } from "./tool-session";
 
 function createToolkit(testCommand?: { bin: string; args: string[] }) {
   const session = createSessionContext();
   if (testCommand) session.workspaceProfile = { testCommand };
   const output: unknown[] = [];
-  const toolkit = createTestToolkit(createToolkitDeps(), {
+  const toolkit = createTestToolkit({
     workspace: process.cwd(),
     session,
     onOutput: (e) => output.push(e),

--- a/src/test-toolkit.ts
+++ b/src/test-toolkit.ts
@@ -1,13 +1,12 @@
 import { z } from "zod";
 import { compactDetail } from "./compact-text";
 import { parseExitCode, runShellCommand } from "./shell-ops";
-import { createTool, type ToolkitDeps, type ToolkitInput } from "./tool-contract";
+import { createTool, type ToolkitInput } from "./tool-contract";
 import { runTool } from "./tool-execution";
-import { compactToolOutput } from "./tool-output";
 import { emitParts, shellHeadTailParts } from "./tool-output-format";
 import { formatWorkspaceCommand, resolveCommandFiles } from "./workspace-profile";
 
-function createRunTestsTool(deps: ToolkitDeps, input: ToolkitInput) {
+function createRunTestsTool(input: ToolkitInput) {
   const { session, onOutput } = input;
 
   return createTool({
@@ -28,6 +27,7 @@ function createRunTestsTool(deps: ToolkitDeps, input: ToolkitInput) {
       exitCode: z.number().int().optional(),
       output: z.string(),
     }),
+    outputBudget: { maxChars: 2_600, maxLines: 120 },
     execute: async (toolInput, toolCallId) => {
       return runTool(session, "test-run", toolCallId, toolInput, async (callId) => {
         const profile = session.workspaceProfile;
@@ -58,15 +58,14 @@ function createRunTestsTool(deps: ToolkitDeps, input: ToolkitInput) {
         const previewParts = shellHeadTailParts(streamed);
         emitParts(previewParts, "test-run", onOutput, callId);
 
-        const result = compactToolOutput(rawResult, deps.outputBudget.testRun);
-        return { kind: "test-run" as const, command, exitCode: parseExitCode(rawResult), output: result };
+        return { kind: "test-run" as const, command, exitCode: parseExitCode(rawResult), output: rawResult };
       });
     },
   });
 }
 
-export function createTestToolkit(deps: ToolkitDeps, input: ToolkitInput) {
+export function createTestToolkit(input: ToolkitInput) {
   return {
-    runTests: createRunTestsTool(deps, input),
+    runTests: createRunTestsTool(input),
   };
 }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -13,7 +13,6 @@ import type { RunContext } from "./lifecycle-contract";
 import { defaultLifecyclePolicy } from "./lifecycle-policy";
 import { createEmptyPromptBreakdownTotals } from "./lifecycle-usage";
 import type { Session, SessionState, SessionTokenUsageEntry } from "./session-contract";
-import type { ToolkitDeps } from "./tool-contract";
 import { createSessionContext } from "./tool-session";
 
 export function tempDir(): { createDir: (prefix: string) => string; cleanupDirs: () => void } {
@@ -508,26 +507,4 @@ export function createCommandContext(
     ...overrides,
   };
   return { ctx, spies };
-}
-
-const DEFAULT_BUDGET_ENTRY = { maxChars: 2000, maxLines: 80 };
-
-export function createToolkitDeps(): ToolkitDeps {
-  return {
-    outputBudget: {
-      fileFind: DEFAULT_BUDGET_ENTRY,
-      fileSearch: DEFAULT_BUDGET_ENTRY,
-      fileRead: DEFAULT_BUDGET_ENTRY,
-      fileEdit: DEFAULT_BUDGET_ENTRY,
-      fileCreate: DEFAULT_BUDGET_ENTRY,
-      codeEdit: DEFAULT_BUDGET_ENTRY,
-      codeScan: DEFAULT_BUDGET_ENTRY,
-      gitStatus: DEFAULT_BUDGET_ENTRY,
-      gitDiff: DEFAULT_BUDGET_ENTRY,
-      shellRun: DEFAULT_BUDGET_ENTRY,
-      testRun: DEFAULT_BUDGET_ENTRY,
-      webSearch: DEFAULT_BUDGET_ENTRY,
-      webFetch: DEFAULT_BUDGET_ENTRY,
-    },
-  };
 }

--- a/src/tool-contract.ts
+++ b/src/tool-contract.ts
@@ -1,10 +1,13 @@
 import type { z } from "zod";
 import type { ChecklistItem } from "./checklist-contract";
 import type { RunToolResult } from "./tool-execution";
+import { compactToolOutput } from "./tool-output";
 import type { ToolOutputListener } from "./tool-output-format";
 import type { SessionContext } from "./tool-session";
 
 export type ToolCategory = "read" | "search" | "write" | "execute" | "network" | "meta";
+
+export type ToolOutputBudget = { maxChars: number; maxLines: number };
 
 export type ToolDefinition<TInput = unknown, TOutput = unknown> = {
   readonly id: string;
@@ -14,29 +17,8 @@ export type ToolDefinition<TInput = unknown, TOutput = unknown> = {
   readonly instruction: string;
   readonly inputSchema: z.ZodType<TInput>;
   readonly outputSchema: z.ZodType<TOutput>;
+  readonly outputBudget?: ToolOutputBudget;
   readonly execute: (input: TInput, toolCallId: string) => Promise<RunToolResult<TOutput>>;
-};
-
-export type ToolOutputBudgetEntry = { maxChars: number; maxLines: number };
-
-export type ToolOutputBudget = {
-  fileFind: ToolOutputBudgetEntry;
-  fileSearch: ToolOutputBudgetEntry;
-  fileRead: ToolOutputBudgetEntry;
-  fileEdit: ToolOutputBudgetEntry;
-  fileCreate: ToolOutputBudgetEntry;
-  codeEdit: ToolOutputBudgetEntry;
-  codeScan: ToolOutputBudgetEntry;
-  gitStatus: ToolOutputBudgetEntry;
-  gitDiff: ToolOutputBudgetEntry;
-  shellRun: ToolOutputBudgetEntry;
-  testRun: ToolOutputBudgetEntry;
-  webSearch: ToolOutputBudgetEntry;
-  webFetch: ToolOutputBudgetEntry;
-};
-
-export type ToolkitDeps = {
-  outputBudget: ToolOutputBudget;
 };
 
 export type ChecklistListener = (event: { groupId: string; groupTitle: string; items: ChecklistItem[] }) => void;
@@ -67,7 +49,14 @@ export function createTool<TInput, TOutput>(config: ToolDefinition<TInput, TOutp
     ...config,
     execute: async (input, toolCallId) => {
       const runResult = await config.execute(input, toolCallId);
-      return { ...runResult, result: config.outputSchema.parse(runResult.result) };
+      const parsed = config.outputSchema.parse(runResult.result);
+      if (config.outputBudget && parsed && typeof parsed === "object" && "output" in parsed) {
+        const record = parsed as Record<string, unknown>;
+        if (typeof record.output === "string") {
+          record.output = compactToolOutput(record.output, config.outputBudget);
+        }
+      }
+      return { ...runResult, result: parsed };
     },
   };
 }

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -9,7 +9,7 @@ import { createShellToolkit } from "./shell-toolkit";
 import { createTestToolkit } from "./test-toolkit";
 import { createToolCache } from "./tool-cache";
 import { getDefaultToolCacheStore } from "./tool-cache-store";
-import type { ChecklistListener, ToolCategory, ToolDefinition, ToolkitDeps, ToolkitInput } from "./tool-contract";
+import type { ChecklistListener, ToolCategory, ToolDefinition, ToolkitInput } from "./tool-contract";
 import type { ToolOutputListener } from "./tool-output-format";
 import { createSessionContext, type SessionContext } from "./tool-session";
 import { createWebToolkit } from "./web-toolkit";
@@ -34,75 +34,54 @@ type AnyToolDefinition = ToolDefinition<unknown>;
 
 export const TOOLKIT_REGISTRY: {
   id: string;
-  createToolkit: (deps: ToolkitDeps, input: ToolkitInput) => ToolMap;
+  createToolkit: (input: ToolkitInput) => ToolMap;
 }[] = [
   {
     id: "file",
-    createToolkit: (deps, input) => createFileToolkit(deps, input),
+    createToolkit: (input) => createFileToolkit(input),
   },
   {
     id: "code",
-    createToolkit: (deps, input) => createCodeToolkit(deps, input),
+    createToolkit: (input) => createCodeToolkit(input),
   },
   {
     id: "web",
-    createToolkit: (deps, input) => createWebToolkit(deps, input),
+    createToolkit: (input) => createWebToolkit(input),
   },
   {
     id: "shell",
-    createToolkit: (deps, input) => createShellToolkit(deps, input),
+    createToolkit: (input) => createShellToolkit(input),
   },
   {
     id: "test",
-    createToolkit: (deps, input) => createTestToolkit(deps, input),
+    createToolkit: (input) => createTestToolkit(input),
   },
   {
     id: "git",
-    createToolkit: (deps, input) => createGitToolkit(deps, input),
+    createToolkit: (input) => createGitToolkit(input),
   },
   {
     id: "checklist",
-    createToolkit: (deps, input) => createChecklistToolkit(deps, input),
+    createToolkit: (input) => createChecklistToolkit(input),
   },
   {
     id: "memory",
-    createToolkit: (deps, input) => createMemoryToolkit(deps, input),
+    createToolkit: (input) => createMemoryToolkit(input),
   },
 ];
 
 const noopOutput: ToolOutputListener = () => {};
 const noopChecklist: ChecklistListener = () => {};
 
-const TOOL_BUDGETS = {
-  fileFind: { maxChars: 2_500, maxLines: 100 },
-  fileSearch: { maxChars: 2_200, maxLines: 80 },
-  fileRead: { maxChars: 80_000, maxLines: 2_000 },
-  fileEdit: { maxChars: 1_400, maxLines: 60 },
-  fileCreate: { maxChars: 3_000, maxLines: 100 },
-  codeEdit: { maxChars: 1_400, maxLines: 60 },
-  codeScan: { maxChars: 2_400, maxLines: 80 },
-  gitStatus: { maxChars: 1_800, maxLines: 80 },
-  gitDiff: { maxChars: 3_200, maxLines: 120 },
-  shellRun: { maxChars: 2_600, maxLines: 120 },
-  testRun: { maxChars: 2_600, maxLines: 120 },
-  webSearch: { maxChars: 2_400, maxLines: 80 },
-  webFetch: { maxChars: 2_600, maxLines: 90 },
-} as const;
-
-const defaultToolkitDeps = (): ToolkitDeps => ({
-  outputBudget: TOOL_BUDGETS,
-});
-
 function collectTools(
   workspace: string,
   session: SessionContext,
   onOutput: ToolOutputListener = noopOutput,
   onChecklist: ChecklistListener = noopChecklist,
-  deps: ToolkitDeps = defaultToolkitDeps(),
 ): ToolMap {
   const combined: ToolMap = {};
   for (const toolkit of TOOLKIT_REGISTRY) {
-    Object.assign(combined, toolkit.createToolkit(deps, { workspace, session, onOutput, onChecklist }));
+    Object.assign(combined, toolkit.createToolkit({ workspace, session, onOutput, onChecklist }));
   }
   return combined;
 }

--- a/src/web-toolkit.ts
+++ b/src/web-toolkit.ts
@@ -1,9 +1,8 @@
 import { z } from "zod";
 import { compactDetail } from "./compact-text";
 import { t } from "./i18n";
-import { createTool, type ToolkitDeps, type ToolkitInput } from "./tool-contract";
+import { createTool, type ToolkitInput } from "./tool-contract";
 import { runTool } from "./tool-execution";
-import { compactToolOutput } from "./tool-output";
 import { emitParts, resultChunkParts } from "./tool-output-format";
 import { fetchWeb, searchWeb } from "./web-ops";
 
@@ -56,7 +55,7 @@ export function webSearchStreamRows(result: string, query?: string): string {
   return out.join("\n");
 }
 
-function createWebSearchTool(deps: ToolkitDeps, input: ToolkitInput) {
+function createWebSearchTool(input: ToolkitInput) {
   return createTool({
     id: "web-search",
     toolkit: "web",
@@ -73,6 +72,7 @@ function createWebSearchTool(deps: ToolkitDeps, input: ToolkitInput) {
       query: z.string().min(1),
       output: z.string(),
     }),
+    outputBudget: { maxChars: 2_400, maxLines: 80 },
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "web-search", toolCallId, toolInput, async (callId) => {
         input.onOutput({
@@ -84,10 +84,7 @@ function createWebSearchTool(deps: ToolkitDeps, input: ToolkitInput) {
           },
           toolCallId: callId,
         });
-        const result = compactToolOutput(
-          await searchWeb(toolInput.query, toolInput.maxResults ?? WEB_SEARCH_MAX_RESULTS),
-          deps.outputBudget.webSearch,
-        );
+        const result = await searchWeb(toolInput.query, toolInput.maxResults ?? WEB_SEARCH_MAX_RESULTS);
         const previewRows = webSearchStreamRows(result, toolInput.query);
         const previewParts = resultChunkParts(previewRows, 80);
         emitParts(previewParts, "web-search", input.onOutput, callId);
@@ -97,7 +94,7 @@ function createWebSearchTool(deps: ToolkitDeps, input: ToolkitInput) {
   });
 }
 
-function createWebFetchTool(deps: ToolkitDeps, input: ToolkitInput) {
+function createWebFetchTool(input: ToolkitInput) {
   return createTool({
     id: "web-fetch",
     toolkit: "web",
@@ -114,6 +111,7 @@ function createWebFetchTool(deps: ToolkitDeps, input: ToolkitInput) {
       url: z.string().min(1),
       output: z.string(),
     }),
+    outputBudget: { maxChars: 2_600, maxLines: 90 },
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "web-fetch", toolCallId, toolInput, async (callId) => {
         input.onOutput({
@@ -121,19 +119,16 @@ function createWebFetchTool(deps: ToolkitDeps, input: ToolkitInput) {
           content: { kind: "tool-header", labelKey: "tool.label.web_fetch", detail: toolInput.url },
           toolCallId: callId,
         });
-        const result = compactToolOutput(
-          await fetchWeb(toolInput.url, toolInput.maxChars ?? 5000),
-          deps.outputBudget.webFetch,
-        );
+        const result = await fetchWeb(toolInput.url, toolInput.maxChars ?? 5000);
         return { kind: "web-fetch", url: toolInput.url, output: result };
       });
     },
   });
 }
 
-export function createWebToolkit(deps: ToolkitDeps, input: ToolkitInput) {
+export function createWebToolkit(input: ToolkitInput) {
   return {
-    webSearch: createWebSearchTool(deps, input),
-    webFetch: createWebFetchTool(deps, input),
+    webSearch: createWebSearchTool(input),
+    webFetch: createWebFetchTool(input),
   };
 }


### PR DESCRIPTION
## Motivation

Tool output budgets were defined in a central map in tool-registry.ts and threaded through every toolkit via ToolkitDeps. Each toolkit had to manually call compactToolOutput with the right budget key. This coupling meant adding a tool required updating the central map, the type, and the toolkit.

## Summary

- add optional `outputBudget` to `ToolDefinition` — each tool declares its own budget
- move output compaction into `createTool` wrapper — tools return raw output
- remove `ToolkitDeps`, `ToolOutputBudget` map type, `TOOL_BUDGETS` constant
- remove `deps` parameter from all toolkit factory functions
- remove `compactToolOutput` from toolkit execute functions (except file-find and code-scan which compute derived budgets per call)
- remove `createToolkitDeps()` test helper