### PR TITLE
feat(code): workspace scope for cross-file edits

### DIFF
--- a/src/code-contract.ts
+++ b/src/code-contract.ts
@@ -1,11 +1,9 @@
 import { z } from "zod";
 
-export const editCodeEditScopeSchema = z.enum(["file", "workspace"]);
-
 const editCodeScopeSchema = {
   within: z.string().min(1).optional(),
   withinSymbol: z.string().min(1).optional(),
-  scope: editCodeEditScopeSchema.optional(),
+  scope: z.literal("workspace").optional(),
 };
 
 export const editCodeRenameTargetSchema = z.enum(["local", "member"]);

--- a/src/code-contract.ts
+++ b/src/code-contract.ts
@@ -1,8 +1,11 @@
 import { z } from "zod";
 
+export const editCodeEditScopeSchema = z.enum(["file", "workspace"]);
+
 const editCodeScopeSchema = {
   within: z.string().min(1).optional(),
   withinSymbol: z.string().min(1).optional(),
+  scope: editCodeEditScopeSchema.optional(),
 };
 
 export const editCodeRenameTargetSchema = z.enum(["local", "member"]);

--- a/src/code-ops.test.ts
+++ b/src/code-ops.test.ts
@@ -657,6 +657,26 @@ describe("editCode", () => {
     expect(bContent).toContain("newName");
   });
 
+  test("workspace scope renames across all project files", async () => {
+    const dirPath = join(WORKSPACE, `acolyte-test-ast-ws-${testUuid()}`);
+    tempDirs.push(dirPath);
+    await mkdir(dirPath, { recursive: true });
+    await writeFile(join(dirPath, "lib.ts"), "export function oldName() { return 1; }\n", "utf8");
+    await writeFile(join(dirPath, "main.ts"), "import { oldName } from './lib';\noldName();\n", "utf8");
+    tempFiles.push(join(dirPath, "lib.ts"), join(dirPath, "main.ts"));
+    const result = await editCode({
+      workspace: dirPath,
+      path: join(dirPath, "lib.ts"),
+      edits: [{ op: "rename", from: "oldName", to: "newName", scope: "workspace" }],
+    });
+    expect(result.matches).toBeGreaterThanOrEqual(3);
+    const libContent = await readFile(join(dirPath, "lib.ts"), "utf8");
+    const mainContent = await readFile(join(dirPath, "main.ts"), "utf8");
+    expect(libContent).toContain("newName");
+    expect(mainContent).toContain("newName");
+    expect(mainContent).not.toContain("oldName");
+  });
+
   test("rejects unsupported non-code files", async () => {
     const filePath = join(WORKSPACE, `acolyte-test-ast-md-${testUuid()}.md`);
     tempFiles.push(filePath);

--- a/src/code-ops.test.ts
+++ b/src/code-ops.test.ts
@@ -677,6 +677,25 @@ describe("editCode", () => {
     expect(mainContent).not.toContain("oldName");
   });
 
+  test("workspace scope replaces across all project files", async () => {
+    const dirPath = join(WORKSPACE, `acolyte-test-ast-ws-replace-${testUuid()}`);
+    tempDirs.push(dirPath);
+    await mkdir(dirPath, { recursive: true });
+    await writeFile(join(dirPath, "a.ts"), "console.log('hello');\n", "utf8");
+    await writeFile(join(dirPath, "b.ts"), "console.log('world');\n", "utf8");
+    tempFiles.push(join(dirPath, "a.ts"), join(dirPath, "b.ts"));
+    const result = await editCode({
+      workspace: dirPath,
+      path: join(dirPath, "a.ts"),
+      edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.info($ARG)", scope: "workspace" }],
+    });
+    expect(result.matches).toBe(2);
+    const aContent = await readFile(join(dirPath, "a.ts"), "utf8");
+    const bContent = await readFile(join(dirPath, "b.ts"), "utf8");
+    expect(aContent).toContain("logger.info");
+    expect(bContent).toContain("logger.info");
+  });
+
   test("rejects unsupported non-code files", async () => {
     const filePath = join(WORKSPACE, `acolyte-test-ast-md-${testUuid()}.md`);
     tempFiles.push(filePath);

--- a/src/code-ops.ts
+++ b/src/code-ops.ts
@@ -504,11 +504,19 @@ async function editCodeFile(
   return { matches: totalMatches, affectedSymbols: Array.from(affectedSymbols), diff };
 }
 
+function hasWorkspaceScope(edits: EditCodeEdit[]): boolean {
+  return edits.some((edit) => edit.scope === "workspace");
+}
+
 export async function editCode(input: {
   workspace: string;
   path: string;
   edits: EditCodeEdit[];
 }): Promise<EditCodeResult> {
+  if (hasWorkspaceScope(input.edits)) {
+    return editCodeDirectory(input.workspace, input.workspace, input.edits);
+  }
+
   const absPath = ensurePathWithinSandbox(input.path, input.workspace);
   const pathStats = await stat(absPath);
 

--- a/src/code-toolkit.ts
+++ b/src/code-toolkit.ts
@@ -134,6 +134,7 @@ function createEditCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
       "Prefer explicit `rename` or `replace` operations.",
       "For ambiguous local/member renames, set `target` to `local` or `member`.",
       "Use `withinSymbol` to keep edits scoped.",
+      "Set `scope` to `workspace` on a rename to apply it across all project files.",
       "Read the target file directly before editing.",
       "If `code-edit` reports no matches, refine scope/rule from current file evidence instead of broadening blindly.",
       "Use the diff preview to confirm bounded changes and stop.",

--- a/src/code-toolkit.ts
+++ b/src/code-toolkit.ts
@@ -134,7 +134,7 @@ function createEditCodeTool(deps: ToolkitDeps, input: ToolkitInput) {
       "Prefer explicit `rename` or `replace` operations.",
       "For ambiguous local/member renames, set `target` to `local` or `member`.",
       "Use `withinSymbol` to keep edits scoped.",
-      "Set `scope` to `workspace` on a rename to apply it across all project files.",
+      "Set `scope` to `workspace` to apply edits across all project files.",
       "Read the target file directly before editing.",
       "If `code-edit` reports no matches, refine scope/rule from current file evidence instead of broadening blindly.",
       "Use the diff preview to confirm bounded changes and stop.",


### PR DESCRIPTION
## Summary

- added optional `scope: "workspace"` to both rename and replace edit operations
- when set, scans all parseable files in the workspace regardless of the `path` argument
- reuses existing `editCodeDirectory` for the actual file traversal

Fixes #67