### PR TITLE
feat(memory): track last recall time

### DIFF
--- a/src/chat-commands.test.ts
+++ b/src/chat-commands.test.ts
@@ -25,6 +25,7 @@ function createMemoryApi(overrides?: {
         scope: "user" as const,
         content: "unused",
         createdAt: "2026-02-21T00:00:00.000Z",
+        lastRecalledAt: null,
       })),
     removeMemory: overrides?.removeMemory ?? (async () => ({ kind: "not_found" as const, id: "" })),
   };
@@ -245,12 +246,14 @@ describe("chat-commands", () => {
           scope: "user" as const,
           content: "prefer concise output",
           createdAt: "2026-02-21T00:00:00.000Z",
+          lastRecalledAt: null,
         },
         {
           id: "mem_2",
           scope: "project" as const,
           content: "use bun scripts",
           createdAt: "2026-02-21T00:00:01.000Z",
+          lastRecalledAt: null,
         },
       ],
     });
@@ -270,12 +273,14 @@ describe("chat-commands", () => {
           scope: "user" as const,
           content: "prefer concise output",
           createdAt: "2026-02-21T00:00:00.000Z",
+          lastRecalledAt: null,
         },
         {
           id: "mem_2",
           scope: "project" as const,
           content: "use bun scripts",
           createdAt: "2026-02-21T00:00:01.000Z",
+          lastRecalledAt: null,
         },
       ],
     });
@@ -296,6 +301,7 @@ describe("chat-commands", () => {
           scope: "project" as const,
           content: "x",
           createdAt: "2026-02-21T00:00:00.000Z",
+          lastRecalledAt: null,
         },
       }),
     });
@@ -325,6 +331,7 @@ describe("chat-commands", () => {
           scope: "user" as const,
           content: "prefer concise output",
           createdAt: "2026-02-21T00:00:00.000Z",
+          lastRecalledAt: null,
         },
       ],
     });
@@ -341,6 +348,7 @@ describe("chat-commands", () => {
           scope: "project" as const,
           content: "use bun scripts",
           createdAt: "2026-02-21T00:00:00.000Z",
+          lastRecalledAt: null,
         },
       ],
     });
@@ -374,6 +382,7 @@ describe("chat-commands", () => {
           scope,
           content,
           createdAt: "2026-02-21T00:00:02.000Z",
+          lastRecalledAt: null,
         };
       },
     });

--- a/src/cli-memory.test.ts
+++ b/src/cli-memory.test.ts
@@ -15,6 +15,7 @@ function createOps(overrides?: Partial<MemoryOps>): MemoryOps {
         content: "remember this",
         scope: "user" as const,
         createdAt: "9999-01-01T00:00:00.000Z",
+        lastRecalledAt: null,
       },
     ],
     add: async (content, scope) => ({
@@ -22,6 +23,7 @@ function createOps(overrides?: Partial<MemoryOps>): MemoryOps {
       content,
       scope: scope ?? "user",
       createdAt: "9999-01-01T00:00:00.000Z",
+      lastRecalledAt: null,
     }),
     ...overrides,
   };
@@ -107,6 +109,7 @@ describe("cli-memory", () => {
             content,
             scope: scope ?? "user",
             createdAt: "9999-01-01T00:00:00.000Z",
+            lastRecalledAt: null,
           };
         },
       }),

--- a/src/cli-memory.ts
+++ b/src/cli-memory.ts
@@ -50,7 +50,8 @@ export async function memoryMode(args: string[], deps: MemoryModeDeps): Promise<
       rows.slice(0, 50).map((row) => ({
         id: row.id,
         content: truncateText(row.content, 80),
-        time: formatRelativeTime(row.createdAt),
+        created: formatRelativeTime(row.createdAt),
+        recalled: row.lastRecalledAt ? formatRelativeTime(row.lastRecalledAt) : "never",
       })),
     );
     const rendered = out.render();

--- a/src/memory-contract.ts
+++ b/src/memory-contract.ts
@@ -13,6 +13,7 @@ export interface MemoryEntry {
   readonly id: MemoryId;
   readonly content: string;
   readonly createdAt: IsoDateTimeString;
+  readonly lastRecalledAt: IsoDateTimeString | null;
   readonly scope: MemoryScope;
 }
 
@@ -67,6 +68,7 @@ export const memoryRecordSchema = z.object({
   content: z.string().min(1),
   createdAt: isoDateTimeSchema,
   tokenEstimate: z.number().int().min(0),
+  lastRecalledAt: isoDateTimeSchema.nullable().optional(),
 });
 export type MemoryRecord = z.infer<typeof memoryRecordSchema>;
 
@@ -74,6 +76,7 @@ export interface MemoryStore {
   list(options?: { scopeKey?: string; kind?: MemoryKind }): Promise<readonly MemoryRecord[]>;
   write(record: MemoryRecord, scope?: MemoryScope): Promise<void>;
   remove(id: string): Promise<void>;
+  touchRecalled(ids: string[]): void;
   writeEmbedding(id: string, scopeKey: string, embedding: Buffer): void;
   removeEmbedding(id: string): void;
   getEmbedding(id: string): Buffer | null;

--- a/src/memory-distiller.test.ts
+++ b/src/memory-distiller.test.ts
@@ -33,6 +33,7 @@ function createMockStore(records: MemoryRecord[] = []): MemoryStore & { written:
       const idx = records.findIndex((r) => r.id === id);
       if (idx >= 0) records.splice(idx, 1);
     },
+    touchRecalled() {},
     writeEmbedding() {},
     removeEmbedding() {},
     getEmbedding() {

--- a/src/memory-ops.ts
+++ b/src/memory-ops.ts
@@ -30,11 +30,18 @@ function scopeKeysForScope(scope: MemoryScope | undefined, workspace?: string): 
   return keys;
 }
 
-function toMemoryEntry(record: { id: string; scopeKey: string; content: string; createdAt: string }): MemoryEntry {
+function toMemoryEntry(record: {
+  id: string;
+  scopeKey: string;
+  content: string;
+  createdAt: string;
+  lastRecalledAt?: string | null;
+}): MemoryEntry {
   return {
     id: record.id,
     content: record.content,
     createdAt: record.createdAt,
+    lastRecalledAt: record.lastRecalledAt ?? null,
     scope: scopeFromKey(record.scopeKey),
   };
 }
@@ -87,14 +94,19 @@ export async function removeMemory(id: string, options: MemoryOptions = {}): Pro
   const trimmed = id.trim();
   if (!trimmed) throw new Error("Memory id cannot be empty");
 
-  const entries = await listMemories(options);
-  const entry = entries.find((e) => e.id === trimmed);
-  if (!entry) return { kind: "not_found", id: trimmed };
-
-  const { store = getDefaultMemoryStore() } = options;
-  await store.remove(entry.id);
-  log.debug("memory.stored.removed", { id: entry.id, scope: entry.scope });
-  return { kind: "removed", entry };
+  const { scope, workspace, store = getDefaultMemoryStore() } = options;
+  const keys = scopeKeysForScope(scope, workspace);
+  for (const key of keys) {
+    const records = await store.list({ scopeKey: key, kind: "stored" });
+    const record = records.find((r) => r.id === trimmed);
+    if (record) {
+      const entry = toMemoryEntry(record);
+      await store.remove(entry.id);
+      log.debug("memory.stored.removed", { id: entry.id, scope: entry.scope });
+      return { kind: "removed", entry };
+    }
+  }
+  return { kind: "not_found", id: trimmed };
 }
 
 export const fileMemoryStore = {

--- a/src/memory-store.test.ts
+++ b/src/memory-store.test.ts
@@ -32,7 +32,7 @@ describe("createSqliteMemoryStore", () => {
     await store.write(record);
     const records = await store.list({ scopeKey: "sess_abc123" });
     expect(records).toHaveLength(1);
-    expect(records[0]).toEqual(record);
+    expect(records[0]).toEqual({ ...record, lastRecalledAt: null });
   });
 
   test("list returns records sorted chronologically", async () => {
@@ -216,6 +216,58 @@ describe("createSqliteMemoryStore", () => {
     await store.write(projectRecord);
     expect((await store.list({ scopeKey: "user_abc123" })).map((record) => record.content)).toEqual(["user fact"]);
     expect((await store.list({ scopeKey: "proj_abc123" })).map((record) => record.content)).toEqual(["project fact"]);
+  });
+});
+
+describe("touchRecalled", () => {
+  test("sets last_recalled_at on specified records", async () => {
+    const store = createStore();
+    const record: MemoryRecord = {
+      id: "mem_touch001",
+      scopeKey: "user_abc123",
+      kind: "stored",
+      content: "recall me",
+      createdAt: "2026-03-04T12:00:00.000Z",
+      tokenEstimate: 2,
+    };
+    await store.write(record);
+    const before = await store.list({ scopeKey: "user_abc123" });
+    expect(before[0]?.lastRecalledAt).toBeNull();
+
+    store.touchRecalled(["mem_touch001"]);
+    const after = await store.list({ scopeKey: "user_abc123" });
+    expect(after[0]?.lastRecalledAt).not.toBeNull();
+  });
+
+  test("does not touch records not in the id list", async () => {
+    const store = createStore();
+    await store.write({
+      id: "mem_touched1",
+      scopeKey: "user_abc123",
+      kind: "stored",
+      content: "will be touched",
+      createdAt: "2026-03-04T12:00:00.000Z",
+      tokenEstimate: 2,
+    });
+    await store.write({
+      id: "mem_untouchd",
+      scopeKey: "user_abc123",
+      kind: "stored",
+      content: "will not be touched",
+      createdAt: "2026-03-04T12:00:01.000Z",
+      tokenEstimate: 3,
+    });
+    store.touchRecalled(["mem_touched1"]);
+    const records = await store.list({ scopeKey: "user_abc123" });
+    const touched = records.find((r) => r.id === "mem_touched1");
+    const untouched = records.find((r) => r.id === "mem_untouchd");
+    expect(touched?.lastRecalledAt).not.toBeNull();
+    expect(untouched?.lastRecalledAt).toBeNull();
+  });
+
+  test("no-ops on empty id list", () => {
+    const store = createStore();
+    expect(() => store.touchRecalled([])).not.toThrow();
   });
 });
 

--- a/src/memory-store.ts
+++ b/src/memory-store.ts
@@ -48,6 +48,9 @@ function migrateLegacySchema(db: Database): void {
   const names = new Set(cols.map((c) => c.name));
   if (names.has("current_task")) db.run("ALTER TABLE memories DROP COLUMN current_task");
   if (names.has("next_step")) db.run("ALTER TABLE memories DROP COLUMN next_step");
+  if (names.size > 0 && !names.has("last_recalled_at")) {
+    db.run("ALTER TABLE memories ADD COLUMN last_recalled_at TEXT");
+  }
 }
 
 function initSchema(db: Database): void {
@@ -60,7 +63,8 @@ function initSchema(db: Database): void {
       kind TEXT NOT NULL,
       content TEXT NOT NULL,
       created_at TEXT NOT NULL,
-      token_estimate INTEGER NOT NULL
+      token_estimate INTEGER NOT NULL,
+      last_recalled_at TEXT
     )
   `);
   db.run(`CREATE INDEX IF NOT EXISTS idx_memories_scope ON memories(scope)`);
@@ -83,6 +87,7 @@ type MemoryRow = {
   content: string;
   created_at: string;
   token_estimate: number;
+  last_recalled_at: string | null;
 };
 
 function rowToRecord(row: MemoryRow): MemoryRecord {
@@ -93,6 +98,7 @@ function rowToRecord(row: MemoryRow): MemoryRecord {
     content: row.content,
     createdAt: row.created_at,
     tokenEstimate: row.token_estimate,
+    lastRecalledAt: row.last_recalled_at ?? null,
   };
 }
 
@@ -152,6 +158,12 @@ export function createSqliteMemoryStore(dbPath?: string): MemoryStore {
         record.createdAt,
         record.tokenEstimate,
       );
+    },
+    touchRecalled(ids) {
+      if (ids.length === 0) return;
+      const now = new Date().toISOString();
+      const placeholders = ids.map(() => "?").join(",");
+      db.run(`UPDATE memories SET last_recalled_at = ? WHERE id IN (${placeholders})`, [now, ...ids]);
     },
     async remove(id) {
       removeStmt.run(id);

--- a/src/memory-toolkit.ts
+++ b/src/memory-toolkit.ts
@@ -18,7 +18,11 @@ export async function searchMemories(
   if (filtered.length === 0) return [];
 
   const queryEmbedding = await embedText(query);
-  if (!queryEmbedding) return filtered.slice(0, limit);
+  if (!queryEmbedding) {
+    const fallback = filtered.slice(0, limit);
+    store.touchRecalled(fallback.map((r) => r.id));
+    return [...fallback];
+  }
 
   const ids = filtered.map((r) => r.id);
   const embeddings = store.getEmbeddings(ids);
@@ -29,7 +33,9 @@ export async function searchMemories(
     return { record, score };
   });
   scored.sort((a, b) => b.score - a.score);
-  return scored.slice(0, limit).map((s) => s.record);
+  const results = scored.slice(0, limit).map((s) => s.record);
+  store.touchRecalled(results.map((r) => r.id));
+  return results;
 }
 
 function createMemorySearchTool(input: ToolkitInput) {
@@ -53,6 +59,7 @@ function createMemorySearchTool(input: ToolkitInput) {
           content: z.string(),
           scope: memoryScopeSchema.extract(["user", "project"]),
           createdAt: z.string(),
+          lastRecalledAt: z.string().nullable(),
         }),
       ),
     }),
@@ -76,6 +83,7 @@ function createMemorySearchTool(input: ToolkitInput) {
             content: r.content,
             scope: scopeFromKey(r.scopeKey),
             createdAt: r.createdAt,
+            lastRecalledAt: r.lastRecalledAt ?? null,
           })),
         };
       });

--- a/src/memory.int.test.ts
+++ b/src/memory.int.test.ts
@@ -1,9 +1,12 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import { setLogSink } from "./log";
 import { addMemory, listMemories, removeMemory } from "./memory-ops";
 import { createSqliteMemoryStore } from "./memory-store";
 import { tempDb } from "./test-utils";
 
 const { create: createDb, cleanup } = tempDb("acolyte-memory-", createSqliteMemoryStore);
+beforeAll(() => setLogSink(() => {}));
+afterAll(() => setLogSink(null));
 afterEach(cleanup);
 
 describe("sqlite memory store", () => {


### PR DESCRIPTION
## Motivation

Memories persist indefinitely with no signal for staleness. Tracking when a memory was last recalled gives future garbage collection a clear criterion — memories never recalled (or not recalled in a long time) are the strongest candidates for cleanup.

## Summary

- add nullable `last_recalled_at` column to the memories table with migration for existing DBs
- add `lastRecalledAt` to `MemoryRecord`, `MemoryEntry`, and `MemoryStore.touchRecalled`
- update `searchMemories` to touch recalled memories when results are returned to the agent
- decouple `removeMemory` from `listMemories` to avoid inflating recall timestamps on delete
- expose `recalled` column in CLI `memory list` output
- silence log output leaking from memory integration tests