### PR TITLE
refactor(lifecycle): replace shouldYield with run control

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -30,6 +30,14 @@ One generation pass runs, effects apply inline during tool execution, and the li
 - when the budget is exhausted, the tool call is blocked with a `budgetExhausted` error code
 - this is the only pre-tool policy check; there is no guard abstraction
 
+## Run control
+
+- `RunControl` is a first-class abstraction that owns yield and cancellation behavior for a lifecycle run
+- created at the transport layer (e.g. RPC) where queue and abort state are known, and threaded into the lifecycle as a single object
+- `shouldYield()` is checked after generation completes and before accepting the result; yielding skips result acceptance and memory commit
+- `isCancelled()` is checked at event emission boundaries and in error handlers
+- both methods are polled (not event-driven) — the answer can change over time as external state evolves
+
 ## Memory integration point
 
 - memory injection happens during request setup before generation
@@ -43,7 +51,7 @@ One generation pass runs, effects apply inline during tool execution, and the li
 - `src/lifecycle-contract.ts` — type definitions for lifecycle events, inputs, and runtime contexts
 - `src/lifecycle-effects.ts` — lifecycle-owned effects (format, lint) applied per-tool-result via callback
 - `src/lifecycle-finalize.ts` — finalization phase including token accounting and tool statistics
-- `src/lifecycle-generate.ts` — generation phase with agent creation and yield detection
+- `src/lifecycle-generate.ts` — generation phase with agent creation and tool-call loop
 - `src/lifecycle-policy.ts` — lifecycle policy configuration and constraints
 - `src/lifecycle-prepare.ts` — preparation phase including input validation and token estimation
 - `src/lifecycle-resolve.ts` — initial model resolution for the request

--- a/src/lifecycle-contract.test.ts
+++ b/src/lifecycle-contract.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { createRunControl } from "./lifecycle-contract";
+
+describe("createRunControl", () => {
+  test("defaults to no-op callbacks", () => {
+    const rc = createRunControl();
+    expect(rc.shouldYield()).toBe(false);
+    expect(rc.isCancelled()).toBe(false);
+  });
+
+  test("accepts partial overrides", () => {
+    const rc = createRunControl({ shouldYield: () => true });
+    expect(rc.shouldYield()).toBe(true);
+    expect(rc.isCancelled()).toBe(false);
+  });
+
+  test("accepts full overrides", () => {
+    const rc = createRunControl({ shouldYield: () => true, isCancelled: () => true });
+    expect(rc.shouldYield()).toBe(true);
+    expect(rc.isCancelled()).toBe(true);
+  });
+});

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -116,16 +116,28 @@ export type Effect = {
   run: (ctx: RunContext, paths?: string[]) => EffectResult;
 };
 
+export type RunControl = {
+  shouldYield: () => boolean;
+  isCancelled: () => boolean;
+};
+
+export function createRunControl(overrides?: Partial<RunControl>): RunControl {
+  return {
+    shouldYield: overrides?.shouldYield ?? (() => false),
+    isCancelled: overrides?.isCancelled ?? (() => false),
+  };
+}
+
 export type LifecycleInput = {
   request: ChatRequest;
   soulPrompt: string;
   workspace?: string;
   taskId?: string;
   lifecyclePolicy?: Partial<LifecyclePolicy>;
+  runControl?: RunControl;
   onEvent?: (event: StreamEvent) => void;
   onDebug?: (event: LifecycleDebugEvent) => void;
   onMemoryCommit?: (metrics: MemoryCommitMetrics) => void;
-  shouldYield?: () => boolean;
 };
 
 export type RunContext = {

--- a/src/lifecycle.int.test.ts
+++ b/src/lifecycle.int.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../scripts/fake-provider-server";
 import { appConfig } from "./app-config";
 import { runLifecycle } from "./lifecycle";
+import { createRunControl } from "./lifecycle-contract";
 
 let fake: FakeProviderServer;
 let workspace: string;
@@ -203,5 +204,38 @@ exit 1
 
     expect(turnCount).toBe(2);
     expect(reply.output).toContain("Updated x to 7.");
+  });
+
+  test("runControl yield skips result acceptance", async () => {
+    setupFakeProvider((ctx) => {
+      return createMessagePayload(ctx.model, ctx.responseCounter, "Hello there.");
+    });
+
+    const debugEvents: string[] = [];
+    const reply = await runLifecycle({
+      request: { model: "gpt-5-mini", message: "hi", history: [], useMemory: false },
+      soulPrompt: "",
+      workspace,
+      runControl: createRunControl({ shouldYield: () => true }),
+      onDebug: (entry) => debugEvents.push(entry.event),
+    });
+
+    expect(reply.output).toContain("Hello there.");
+    expect(debugEvents).toContain("lifecycle.yield");
+  });
+
+  test("runControl yield replaces empty output", async () => {
+    setupFakeProvider((ctx) => {
+      return createMessagePayload(ctx.model, ctx.responseCounter, "  ");
+    });
+
+    const reply = await runLifecycle({
+      request: { model: "gpt-5-mini", message: "hi", history: [], useMemory: false },
+      soulPrompt: "",
+      workspace,
+      runControl: createRunControl({ shouldYield: () => true }),
+    });
+
+    expect(reply.output).toBe("Yielding to a newer pending message.");
   });
 });

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, mock, test } from "bun:test";
 import type { ChatResponse } from "./api";
 import type { LifecycleDeps } from "./lifecycle";
 import { runLifecycle, scheduleMemoryCommit, shouldCommitMemory } from "./lifecycle";
+import { createRunControl } from "./lifecycle-contract";
 import { defaultLifecyclePolicy } from "./lifecycle-policy";
 import type { Toolset } from "./tool-registry";
 import { createSessionContext } from "./tool-session";
@@ -219,5 +220,131 @@ describe("scheduleMemoryCommit", () => {
     expect(done?.fields?.user_promoted_facts).toBe(1);
     expect(done?.fields?.session_scoped_facts).toBe(3);
     expect(done?.fields?.dropped_untagged_facts).toBe(4);
+  });
+});
+
+describe("createRunControl", () => {
+  test("defaults to no-op callbacks", () => {
+    const rc = createRunControl();
+    expect(rc.shouldYield()).toBe(false);
+    expect(rc.isCancelled()).toBe(false);
+  });
+
+  test("accepts partial overrides", () => {
+    const rc = createRunControl({ shouldYield: () => true });
+    expect(rc.shouldYield()).toBe(true);
+    expect(rc.isCancelled()).toBe(false);
+  });
+
+  test("accepts full overrides", () => {
+    const rc = createRunControl({ shouldYield: () => true, isCancelled: () => true });
+    expect(rc.shouldYield()).toBe(true);
+    expect(rc.isCancelled()).toBe(true);
+  });
+});
+
+describe("runLifecycle yield", () => {
+  function createDeps(overrides?: Partial<LifecycleDeps>): LifecycleDeps {
+    return {
+      resolveModel: () => ({ model: "gpt-5-mini", provider: "openai" }),
+      createLifecyclePolicy: () => ({
+        ...defaultLifecyclePolicy,
+        initialMaxSteps: 3,
+        stepTimeoutMs: 1000,
+        totalMaxSteps: 12,
+        maxNudgesPerGeneration: 1,
+      }),
+      phasePrepare: mock(() => ({
+        session: createSessionContext(),
+        tools: {} as unknown as Toolset,
+        baseAgentInput: "BASE_INPUT",
+        promptUsage: {
+          inputTokens: 0,
+          inputBudgetTokens: 8000,
+          systemPromptTokens: 0,
+          toolTokens: 0,
+          memoryTokens: 0,
+          messageTokens: 0,
+          inputTruncated: false,
+          includedHistoryMessages: 0,
+          totalHistoryMessages: 0,
+        },
+      })),
+      createRunAgent: mock(() => ({
+        id: "test-agent",
+        name: "test-agent",
+        instructions: "",
+        model: {} as never,
+        tools: {},
+        async stream() {
+          throw new Error("unused");
+        },
+      })),
+      phaseGenerate: mock(async (ctx: { result?: unknown }) => {
+        ctx.result = { text: "Generated output", toolCalls: [], signal: "done" };
+      }),
+      phaseFinalize: mock(
+        (ctx: { result?: { text: string } }): ChatResponse => ({
+          state: "done",
+          model: "gpt-5-mini",
+          output: ctx.result?.text ?? "",
+        }),
+      ),
+      ...overrides,
+    };
+  }
+
+  const baseInput = {
+    request: { model: "gpt-5-mini" as const, message: "test", history: [] as never[], useMemory: false },
+    soulPrompt: "SOUL",
+    workspace: process.cwd(),
+    taskId: "task_test",
+  };
+
+  test("skips acceptResult when runControl yields", async () => {
+    const deps = createDeps();
+    const debugEvents: string[] = [];
+    const response = await runLifecycle(
+      {
+        ...baseInput,
+        runControl: createRunControl({ shouldYield: () => true }),
+        onDebug: (entry) => debugEvents.push(entry.event),
+      },
+      deps,
+    );
+    expect(response.output).toBe("Generated output");
+    expect(debugEvents).toContain("lifecycle.yield");
+  });
+
+  test("replaces empty text when yielding", async () => {
+    const deps = createDeps({
+      phaseGenerate: mock(async (ctx: { result?: unknown }) => {
+        ctx.result = { text: "  ", toolCalls: [{ toolCallId: "tc1", toolName: "read", args: {} }] };
+      }),
+      phaseFinalize: mock(
+        (ctx: { result?: { text: string } }): ChatResponse => ({
+          state: "done",
+          model: "gpt-5-mini",
+          output: ctx.result?.text ?? "",
+        }),
+      ),
+    });
+    const response = await runLifecycle(
+      {
+        ...baseInput,
+        runControl: createRunControl({ shouldYield: () => true }),
+      },
+      deps,
+    );
+    expect(response.output).toBe("Yielding to a newer pending message.");
+  });
+
+  test("proceeds normally without runControl", async () => {
+    const deps = createDeps();
+    const debugEvents: string[] = [];
+    const onDebug = (entry: { event: string }) => debugEvents.push(entry.event);
+    const response = await runLifecycle({ ...baseInput, onDebug }, deps);
+    expect(response.output).toBe("Generated output");
+    expect(debugEvents).not.toContain("lifecycle.yield");
   });
 });

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -167,26 +167,6 @@ describe("scheduleMemoryCommit", () => {
   });
 });
 
-describe("createRunControl", () => {
-  test("defaults to no-op callbacks", () => {
-    const rc = createRunControl();
-    expect(rc.shouldYield()).toBe(false);
-    expect(rc.isCancelled()).toBe(false);
-  });
-
-  test("accepts partial overrides", () => {
-    const rc = createRunControl({ shouldYield: () => true });
-    expect(rc.shouldYield()).toBe(true);
-    expect(rc.isCancelled()).toBe(false);
-  });
-
-  test("accepts full overrides", () => {
-    const rc = createRunControl({ shouldYield: () => true, isCancelled: () => true });
-    expect(rc.shouldYield()).toBe(true);
-    expect(rc.isCancelled()).toBe(true);
-  });
-});
-
 describe("runLifecycle yield", () => {
   const baseInput = {
     request: { model: "gpt-5-mini" as const, message: "test", history: [] as never[], useMemory: false },

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -1,68 +1,12 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { ChatResponse } from "./api";
-import type { LifecycleDeps } from "./lifecycle";
 import { runLifecycle, scheduleMemoryCommit, shouldCommitMemory } from "./lifecycle";
 import { createRunControl } from "./lifecycle-contract";
-import { defaultLifecyclePolicy } from "./lifecycle-policy";
-import type { Toolset } from "./tool-registry";
-import { createSessionContext } from "./tool-session";
-
-const phasePrepare = mock(() => ({
-  session: createSessionContext(),
-  tools: {} as unknown as Toolset,
-  baseAgentInput: "BASE_INPUT",
-  promptUsage: {
-    inputTokens: 0,
-    inputBudgetTokens: 8000,
-    systemPromptTokens: 0,
-    toolTokens: 0,
-    memoryTokens: 0,
-    messageTokens: 0,
-    inputTruncated: false,
-    includedHistoryMessages: 0,
-    totalHistoryMessages: 0,
-  },
-}));
-
-const phaseGenerate = mock(async (ctx: { result?: unknown }) => {
-  ctx.result = { text: "Generated output", toolCalls: [], signal: "done" };
-});
-
-const phaseFinalize = mock(
-  (ctx: { result?: { text: string } }): ChatResponse => ({
-    state: "done",
-    model: "gpt-5-mini",
-    output: ctx.result?.text ?? "",
-  }),
-);
-
-const createRunAgent = mock(() => ({
-  id: "test-agent",
-  name: "test-agent",
-  instructions: "",
-  model: {} as never,
-  tools: {},
-  async stream() {
-    throw new Error("createRunAgent stream should not be called in runLifecycle unit test");
-  },
-}));
+import { createLifecycleDeps } from "./test-utils";
 
 describe("runLifecycle", () => {
   test("orchestrates phases", async () => {
-    const deps: LifecycleDeps = {
-      resolveModel: () => ({ model: "gpt-5-mini", provider: "openai" }),
-      createLifecyclePolicy: () => ({
-        ...defaultLifecyclePolicy,
-        initialMaxSteps: 3,
-        stepTimeoutMs: 1000,
-        totalMaxSteps: 12,
-        maxNudgesPerGeneration: 1,
-      }),
-      phasePrepare,
-      createRunAgent,
-      phaseGenerate,
-      phaseFinalize,
-    };
+    const deps = createLifecycleDeps();
 
     const response = await runLifecycle(
       {
@@ -74,10 +18,10 @@ describe("runLifecycle", () => {
       deps,
     );
 
-    expect(phasePrepare).toHaveBeenCalledTimes(1);
-    expect(createRunAgent).toHaveBeenCalledTimes(1);
-    expect(phaseGenerate).toHaveBeenCalledTimes(1);
-    expect(phaseFinalize).toHaveBeenCalledTimes(1);
+    expect(deps.phasePrepare).toHaveBeenCalledTimes(1);
+    expect(deps.createRunAgent).toHaveBeenCalledTimes(1);
+    expect(deps.phaseGenerate).toHaveBeenCalledTimes(1);
+    expect(deps.phaseFinalize).toHaveBeenCalledTimes(1);
     expect(response).toEqual({ state: "done", model: "gpt-5-mini", output: "Generated output" });
   });
 });
@@ -244,56 +188,6 @@ describe("createRunControl", () => {
 });
 
 describe("runLifecycle yield", () => {
-  function createDeps(overrides?: Partial<LifecycleDeps>): LifecycleDeps {
-    return {
-      resolveModel: () => ({ model: "gpt-5-mini", provider: "openai" }),
-      createLifecyclePolicy: () => ({
-        ...defaultLifecyclePolicy,
-        initialMaxSteps: 3,
-        stepTimeoutMs: 1000,
-        totalMaxSteps: 12,
-        maxNudgesPerGeneration: 1,
-      }),
-      phasePrepare: mock(() => ({
-        session: createSessionContext(),
-        tools: {} as unknown as Toolset,
-        baseAgentInput: "BASE_INPUT",
-        promptUsage: {
-          inputTokens: 0,
-          inputBudgetTokens: 8000,
-          systemPromptTokens: 0,
-          toolTokens: 0,
-          memoryTokens: 0,
-          messageTokens: 0,
-          inputTruncated: false,
-          includedHistoryMessages: 0,
-          totalHistoryMessages: 0,
-        },
-      })),
-      createRunAgent: mock(() => ({
-        id: "test-agent",
-        name: "test-agent",
-        instructions: "",
-        model: {} as never,
-        tools: {},
-        async stream() {
-          throw new Error("unused");
-        },
-      })),
-      phaseGenerate: mock(async (ctx: { result?: unknown }) => {
-        ctx.result = { text: "Generated output", toolCalls: [], signal: "done" };
-      }),
-      phaseFinalize: mock(
-        (ctx: { result?: { text: string } }): ChatResponse => ({
-          state: "done",
-          model: "gpt-5-mini",
-          output: ctx.result?.text ?? "",
-        }),
-      ),
-      ...overrides,
-    };
-  }
-
   const baseInput = {
     request: { model: "gpt-5-mini" as const, message: "test", history: [] as never[], useMemory: false },
     soulPrompt: "SOUL",
@@ -302,7 +196,7 @@ describe("runLifecycle yield", () => {
   };
 
   test("skips acceptResult when runControl yields", async () => {
-    const deps = createDeps();
+    const deps = createLifecycleDeps();
     const debugEvents: string[] = [];
     const response = await runLifecycle(
       {
@@ -317,7 +211,7 @@ describe("runLifecycle yield", () => {
   });
 
   test("replaces empty text when yielding", async () => {
-    const deps = createDeps({
+    const deps = createLifecycleDeps({
       phaseGenerate: mock(async (ctx: { result?: unknown }) => {
         ctx.result = { text: "  ", toolCalls: [{ toolCallId: "tc1", toolName: "read", args: {} }] };
       }),
@@ -340,7 +234,7 @@ describe("runLifecycle yield", () => {
   });
 
   test("proceeds normally without runControl", async () => {
-    const deps = createDeps();
+    const deps = createLifecycleDeps();
     const debugEvents: string[] = [];
     const onDebug = (entry: { event: string }) => debugEvents.push(entry.event);
     const response = await runLifecycle({ ...baseInput, onDebug }, deps);

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -324,7 +324,7 @@ export async function runLifecycle(input: LifecycleInput, deps: LifecycleDeps = 
   });
 
   if (!ctx.result) return deps.phaseFinalize(ctx);
-  if (input.shouldYield?.()) {
+  if (input.runControl?.shouldYield()) {
     ctx.debug("lifecycle.yield", {});
     if (!ctx.result.text.trim()) {
       ctx.result = { text: "Yielding to a newer pending message.", toolCalls: ctx.result.toolCalls };

--- a/src/server-chat-runtime.ts
+++ b/src/server-chat-runtime.ts
@@ -190,6 +190,7 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
     transport_path: handlers.path,
   });
 
+  const runControl = handlers.runControl;
   try {
     await loadSkills(workspaceResolution.workspacePath);
     const soulPrompt = await createSoulPrompt({
@@ -200,9 +201,9 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
       soulPrompt,
       workspace: workspaceResolution.workspacePath,
       taskId: handlers.taskId,
-      shouldYield: handlers.shouldYield,
+      runControl,
       onEvent: (event) => {
-        if (handlers.isCancelled?.()) return;
+        if (runControl?.isCancelled()) return;
         if ((event as { type?: string }).type === "tool-output")
           debug.log("tool-stream-forward", {
             task_id: handlers.taskId ?? null,
@@ -225,7 +226,7 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
         });
       },
     });
-    if (handlers.isCancelled?.()) {
+    if (runControl?.isCancelled()) {
       log.info("chat request cancelled", {
         request_id: requestId,
         task_id: handlers.taskId ?? null,
@@ -252,7 +253,7 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
     });
     handlers.onDone(reply);
   } catch (error) {
-    if (handlers.isCancelled?.()) return;
+    if (runControl?.isCancelled()) return;
     const payload = streamErrorPayload(error);
     log.error("chat stream failed", {
       request_id: requestId,

--- a/src/server-contract.ts
+++ b/src/server-contract.ts
@@ -1,5 +1,6 @@
 import type { ChatResponse } from "./api";
 import type { ErrorId } from "./error-handling";
+import type { RunControl } from "./lifecycle-contract";
 import type { MemoryCommitMetrics } from "./memory-contract";
 import type { StreamError } from "./stream-error";
 import type { TaskId } from "./task-contract";
@@ -17,10 +18,9 @@ export type RunChatHandlers = {
   path: string;
   method: string;
   taskId?: TaskId;
+  runControl?: RunControl;
   onEvent: (event: Record<string, unknown>) => void;
   onDone: (reply: ChatResponse) => void;
   onError: (payload: StreamErrorPayload) => void;
-  isCancelled?: () => boolean;
-  shouldYield?: () => boolean;
   onMemoryCommit?: (metrics: MemoryCommitMetrics) => void;
 };

--- a/src/server-rpc.ts
+++ b/src/server-rpc.ts
@@ -1,5 +1,6 @@
 import type { z } from "zod";
 import type { ChatRequest, ChatResponse } from "./api";
+import { createRunControl } from "./lifecycle-contract";
 import { log } from "./log";
 import { type RpcRequestId, rpcClientMessageSchema, rpcRequestIdSchema } from "./rpc-protocol";
 import { createSerialPerConnectionQueuePolicy } from "./rpc-queue";
@@ -41,7 +42,6 @@ type WorkerRunInput = {
   taskId: TaskId;
   request: ChatRequest;
   state: ActiveRpcChatState;
-  shouldYield: () => boolean;
   emitEvent: (event: Record<string, unknown>) => void;
   emitDone: (reply: ChatResponse) => void;
   emitError: (payload: StreamErrorPayload) => void;
@@ -95,7 +95,7 @@ function parseRpcMessageEnvelope(raw: string | Buffer | Uint8Array): ParsedRpcEn
   return { id: parsed.data.id, message: parsed.data };
 }
 
-function runWorkerTask(input: WorkerRunInput, deps: RpcDeps): Promise<void> {
+function runWorkerTask(input: WorkerRunInput, queue: QueuedRpcChat[], deps: RpcDeps): Promise<void> {
   deps.transitionTaskState(input.taskId, { state: "running" }, { reason: "chat_started", transport: "rpc" });
   log.info("rpc task started", {
     event: "rpc.task.started",
@@ -106,8 +106,10 @@ function runWorkerTask(input: WorkerRunInput, deps: RpcDeps): Promise<void> {
     path: "/v1/rpc",
     method: "WS",
     taskId: input.taskId,
-    isCancelled: () => input.state.aborted,
-    shouldYield: input.shouldYield,
+    runControl: createRunControl({
+      isCancelled: () => input.state.aborted,
+      shouldYield: () => rpcQueuePolicy.shouldYield(queue),
+    }),
     onEvent: input.emitEvent,
     onDone: (reply) => {
       deps.transitionTaskState(
@@ -308,11 +310,11 @@ export function createRpcWebsocketHandlers(deps: RpcDeps): Bun.WebSocketHandler<
             taskId: state.taskId,
             request,
             state,
-            shouldYield: () => rpcQueuePolicy.shouldYield(ws.data.queue),
             emitEvent: (event) => sendForId(requestId, { type: "chat.event", event }),
             emitDone: (reply) => sendForId(requestId, { type: "chat.done", reply }),
             emitError: (payload) => sendForId(requestId, { type: "chat.error", ...payload }),
           },
+          ws.data.queue,
           deps,
         ).finally(() => {
           ws.data.activeChats.delete(requestId);

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,18 +1,21 @@
-import { expect } from "bun:test";
+import { expect, mock } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { ChatResponse } from "./api";
 import type { CommandContext } from "./chat-commands";
 import type { ChatMessage, ChatRow } from "./chat-contract";
 import { createMessageHandler } from "./chat-message-handler";
 import { type CreatePickerHandlersInput, createPickerHandlers } from "./chat-picker-handlers";
 import type { Client, PendingState, StreamEvent } from "./client-contract";
 import { createErrorStats } from "./error-handling";
+import type { LifecycleDeps } from "./lifecycle";
 import type { RunContext } from "./lifecycle-contract";
 import { defaultLifecyclePolicy } from "./lifecycle-policy";
 import { createEmptyPromptBreakdownTotals } from "./lifecycle-usage";
 import type { Session, SessionState, SessionTokenUsageEntry } from "./session-contract";
+import type { Toolset } from "./tool-registry";
 import { createSessionContext } from "./tool-session";
 
 export function tempDir(): { createDir: (prefix: string) => string; cleanupDirs: () => void } {
@@ -425,6 +428,56 @@ export type CommandContextSpies = {
   currentSessionIds: string[];
   tokenUsageSets: SessionTokenUsageEntry[][];
 };
+
+export function createLifecycleDeps(overrides?: Partial<LifecycleDeps>): LifecycleDeps {
+  return {
+    resolveModel: () => ({ model: "gpt-5-mini", provider: "openai" }),
+    createLifecyclePolicy: () => ({
+      ...defaultLifecyclePolicy,
+      initialMaxSteps: 3,
+      stepTimeoutMs: 1000,
+      totalMaxSteps: 12,
+      maxNudgesPerGeneration: 1,
+    }),
+    phasePrepare: mock(() => ({
+      session: createSessionContext(),
+      tools: {} as unknown as Toolset,
+      baseAgentInput: "BASE_INPUT",
+      promptUsage: {
+        inputTokens: 0,
+        inputBudgetTokens: 8000,
+        systemPromptTokens: 0,
+        toolTokens: 0,
+        memoryTokens: 0,
+        messageTokens: 0,
+        inputTruncated: false,
+        includedHistoryMessages: 0,
+        totalHistoryMessages: 0,
+      },
+    })),
+    createRunAgent: mock(() => ({
+      id: "test-agent",
+      name: "test-agent",
+      instructions: "",
+      model: {} as never,
+      tools: {},
+      async stream() {
+        throw new Error("createRunAgent stream should not be called in unit test");
+      },
+    })),
+    phaseGenerate: mock(async (ctx: { result?: unknown }) => {
+      ctx.result = { text: "Generated output", toolCalls: [], signal: "done" };
+    }),
+    phaseFinalize: mock(
+      (ctx: { result?: { text: string } }): ChatResponse => ({
+        state: "done",
+        model: "gpt-5-mini",
+        output: ctx.result?.text ?? "",
+      }),
+    ),
+    ...overrides,
+  };
+}
 
 export function createRunContext(overrides: Partial<RunContext> = {}): RunContext {
   return {


### PR DESCRIPTION
## Motivation

The `shouldYield` and `isCancelled` callbacks leak scheduler concerns into multiple parts of the lifecycle as loose optional callbacks threaded through the call stack. A first-class control abstraction makes interruption behavior explicit and consistent.

## Summary

- add `RunControl` type and `createRunControl()` factory in `lifecycle-contract.ts`
- replace separate `shouldYield` and `isCancelled` callbacks on `LifecycleInput` and `RunChatHandlers` with a single `runControl` object
- create `RunControl` at the RPC transport layer where queue and abort state are known
- add unit tests for factory defaults, partial/full overrides, and lifecycle yield behavior
- add integration tests for yield with fake provider
- add "Run control" section to `docs/lifecycle.md`

Fixes #74