### PR TITLE
feat(tui): add line navigation in multi-line input

### DIFF
--- a/src/chat-app.tsx
+++ b/src/chat-app.tsx
@@ -76,6 +76,7 @@ function ChatApp(props: ChatAppProps) {
         slashSuggestionIndex={state.slashSuggestionIndex}
         showHelp={state.showHelp}
         ctrlCPending={state.ctrlCPending}
+        onCursorLine={state.onCursorLine}
       />
     </Box>
   );

--- a/src/chat-app.tsx
+++ b/src/chat-app.tsx
@@ -8,7 +8,7 @@ import { type ChatAppProps, useChatState } from "./chat-state";
 import { ChatTranscript, ChatTranscriptRow } from "./chat-transcript";
 import { palette } from "./palette";
 import { Box, render, Static, Text, useApp } from "./tui";
-import { DEFAULT_COLUMNS } from "./tui/styles";
+import { DEFAULT_COLUMNS } from "./tui/constants";
 
 function ChatApp(props: ChatAppProps) {
   const { exit } = useApp();

--- a/src/chat-checklist.tsx
+++ b/src/chat-checklist.tsx
@@ -4,7 +4,7 @@ import { isChecklistOutput } from "./chat-contract";
 import type { ChecklistOutput } from "./checklist-contract";
 import { formatChecklist } from "./checklist-format";
 import { Box, Text } from "./tui";
-import { DEFAULT_COLUMNS } from "./tui/styles";
+import { DEFAULT_COLUMNS } from "./tui/constants";
 
 function renderChecklist(output: ChecklistOutput): React.ReactNode {
   const { header, items } = formatChecklist(output);

--- a/src/chat-commands.tui.test.tsx
+++ b/src/chat-commands.tui.test.tsx
@@ -1,9 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import { ChatTranscript } from "./chat-transcript";
 import { createClient, createMessageHandlerHarness, createSession, createStore, dedent } from "./test-utils";
+import { DEFAULT_TERMINAL_WIDTH } from "./tui/styles";
 import { renderPlain } from "./tui-test-utils";
 
-function renderTranscript(rows: Parameters<typeof ChatTranscript>[0]["rows"], columns = 96): string {
+function renderTranscript(
+  rows: Parameters<typeof ChatTranscript>[0]["rows"],
+  columns = DEFAULT_TERMINAL_WIDTH,
+): string {
   return dedent(renderPlain(<ChatTranscript rows={rows} pendingFrame={0} />, columns));
 }
 

--- a/src/chat-commands.tui.test.tsx
+++ b/src/chat-commands.tui.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { ChatTranscript } from "./chat-transcript";
 import { createClient, createMessageHandlerHarness, createSession, createStore, dedent } from "./test-utils";
-import { DEFAULT_TERMINAL_WIDTH } from "./tui/styles";
+import { DEFAULT_TERMINAL_WIDTH } from "./tui/constants";
 import { renderPlain } from "./tui-test-utils";
 
 function renderTranscript(

--- a/src/chat-content.test.ts
+++ b/src/chat-content.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { sanitizeAssistantContent, tokenizeForHighlighting, wrapAssistantContent } from "./chat-content";
+import { sanitizeAssistantContent, tokenizeForHighlighting, wrapAssistantContent, wrapText } from "./chat-content";
 
 describe("chat-content helpers", () => {
   test("sanitizeAssistantContent removes tools/evidence footer lines", () => {
@@ -23,6 +23,25 @@ describe("chat-content helpers", () => {
     expect(kinds).toContain("code");
     expect(kinds).toContain("path");
     expect(kinds).not.toContain("command");
+  });
+
+  test("wrapText wraps long lines at word boundaries", () => {
+    const text = "one two three four five six seven eight nine ten";
+    const wrapped = wrapText(text, 30);
+    const lines = wrapped.split("\n");
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines) {
+      expect(line.length).toBeLessThanOrEqual(30);
+    }
+  });
+
+  test("wrapText preserves explicit newlines", () => {
+    const wrapped = wrapText("first line\nsecond line", 80);
+    expect(wrapped).toBe("first line\nsecond line");
+  });
+
+  test("wrapText leaves short lines unchanged", () => {
+    expect(wrapText("hello", 80)).toBe("hello");
   });
 
   test("wrapAssistantContent uses hanging indent for numbered items", () => {

--- a/src/chat-content.ts
+++ b/src/chat-content.ts
@@ -54,6 +54,17 @@ function wrapSingleLine(line: string, width: number): string[] {
   return wrapWithIndent(baseIndent, baseIndent, body, width);
 }
 
+export function wrapText(content: string, width: number): string {
+  const normalizedWidth = Math.max(24, width);
+  return content
+    .split("\n")
+    .flatMap((line) => {
+      if (line.length <= normalizedWidth) return [line];
+      return wrapWithIndent("", "", line, normalizedWidth);
+    })
+    .join("\n");
+}
+
 export function wrapAssistantContent(content: string, width: number): string {
   const normalizedWidth = Math.max(24, width);
   return content

--- a/src/chat-input-panel.tsx
+++ b/src/chat-input-panel.tsx
@@ -25,6 +25,7 @@ type ChatInputPanelProps = {
   slashSuggestionIndex?: number;
   showHelp?: boolean;
   ctrlCPending?: boolean;
+  onCursorLine?: (line: number, lineCount: number) => void;
 };
 
 const noop = (): void => {};
@@ -134,6 +135,7 @@ export function ChatInputPanel(props: ChatInputPanelProps): React.ReactNode {
     slashSuggestionIndex = 0,
     showHelp = false,
     ctrlCPending = false,
+    onCursorLine,
   } = props;
   const caretVisible = true;
   const hasSuggestions = atQuery !== null || slashSuggestions.length > 0;
@@ -180,6 +182,7 @@ export function ChatInputPanel(props: ChatInputPanelProps): React.ReactNode {
         linePrefixRest="  "
         onChange={onChange}
         onSubmit={onSubmit}
+        onCursorLine={onCursorLine}
         key={`chat-input-${inputRevision}`}
       />
       <Text color={brandColor} dimColor>

--- a/src/chat-input-panel.tsx
+++ b/src/chat-input-panel.tsx
@@ -6,6 +6,7 @@ import { slashCommandHelp } from "./chat-slash";
 import { t } from "./i18n";
 import { PromptInput } from "./prompt-input";
 import { Box, Text } from "./tui";
+import { DEFAULT_TERMINAL_WIDTH } from "./tui/styles";
 
 type ChatInputPanelProps = {
   picker?: PickerState | null;
@@ -31,8 +32,6 @@ type ChatInputPanelProps = {
 const noop = (): void => {};
 
 const SLASH_COMMAND_COLUMN_WIDTH = 16;
-
-const DEFAULT_TERMINAL_WIDTH = 96;
 
 function resolveFooterVisible(input: { hasSuggestions: boolean; hasPicker: boolean }): boolean {
   if (input.hasSuggestions) return false;

--- a/src/chat-input-panel.tsx
+++ b/src/chat-input-panel.tsx
@@ -6,7 +6,7 @@ import { slashCommandHelp } from "./chat-slash";
 import { t } from "./i18n";
 import { PromptInput } from "./prompt-input";
 import { Box, Text } from "./tui";
-import { DEFAULT_TERMINAL_WIDTH } from "./tui/styles";
+import { DEFAULT_TERMINAL_WIDTH } from "./tui/constants";
 
 type ChatInputPanelProps = {
   picker?: PickerState | null;

--- a/src/chat-input-panel.tsx
+++ b/src/chat-input-panel.tsx
@@ -25,7 +25,7 @@ type ChatInputPanelProps = {
   slashSuggestionIndex?: number;
   showHelp?: boolean;
   ctrlCPending?: boolean;
-  onCursorLine: (line: number, lineCount: number) => void;
+  onCursorLine: (line: number) => void;
 };
 
 const noop = (): void => {};

--- a/src/chat-input-panel.tsx
+++ b/src/chat-input-panel.tsx
@@ -180,6 +180,7 @@ export function ChatInputPanel(props: ChatInputPanelProps): React.ReactNode {
         caretVisible={caretVisible}
         linePrefixFirst="❯ "
         linePrefixRest="  "
+        wrapWidth={termWidth - 2}
         onChange={onChange}
         onSubmit={onSubmit}
         onCursorLine={onCursorLine}

--- a/src/chat-input-panel.tsx
+++ b/src/chat-input-panel.tsx
@@ -25,7 +25,7 @@ type ChatInputPanelProps = {
   slashSuggestionIndex?: number;
   showHelp?: boolean;
   ctrlCPending?: boolean;
-  onCursorLine?: (line: number, lineCount: number) => void;
+  onCursorLine: (line: number, lineCount: number) => void;
 };
 
 const noop = (): void => {};
@@ -154,6 +154,7 @@ export function ChatInputPanel(props: ChatInputPanelProps): React.ReactNode {
             linePrefixFirst={pickerLabel(picker)}
             onChange={onPickerQueryChange}
             onSubmit={onPickerSubmit}
+            onCursorLine={noop}
           />
         ) : (
           <Text>{pickerLabel(picker)}</Text>

--- a/src/chat-keybindings.ts
+++ b/src/chat-keybindings.ts
@@ -115,7 +115,6 @@ type UseChatKeybindingsInput = {
   ctrlCPending: boolean;
   setCtrlCPending: (next: boolean) => void;
   cursorLineRef: { current: number };
-  lineCountRef: { current: number };
 };
 
 export function useChatKeybindings(input: UseChatKeybindingsInput): void {
@@ -170,9 +169,8 @@ export function useChatKeybindings(input: UseChatKeybindingsInput): void {
         !browsingInputHistory &&
         (input.atQuery !== null || (input.atQuery === null && input.slashSuggestions.length > 0));
       const onFirstLine = input.cursorLineRef.current === 0;
-      const onLastLine = input.cursorLineRef.current >= input.lineCountRef.current - 1;
       const historyTriggerUp = (key.upArrow && onFirstLine) || (key.ctrl && keyInput === "p");
-      const historyTriggerDown = (key.downArrow && onLastLine) || (key.ctrl && keyInput === "n");
+      const historyTriggerDown = key.downArrow || (key.ctrl && keyInput === "n");
       if (!suggestionNavActive && historyTriggerUp) {
         if (!shouldCycleInputHistory(input.inputHistoryIndex)) return;
         const transition = resolveHistoryUp(input.inputHistory, input.inputHistoryIndex, input.value);

--- a/src/chat-keybindings.ts
+++ b/src/chat-keybindings.ts
@@ -114,6 +114,8 @@ type UseChatKeybindingsInput = {
   interruptCurrentTurn: () => void;
   ctrlCPending: boolean;
   setCtrlCPending: (next: boolean) => void;
+  cursorLineRef: { current: number };
+  lineCountRef: { current: number };
 };
 
 export function useChatKeybindings(input: UseChatKeybindingsInput): void {
@@ -167,8 +169,10 @@ export function useChatKeybindings(input: UseChatKeybindingsInput): void {
       const suggestionNavActive =
         !browsingInputHistory &&
         (input.atQuery !== null || (input.atQuery === null && input.slashSuggestions.length > 0));
-      const historyTriggerUp = key.upArrow || (key.ctrl && keyInput === "p");
-      const historyTriggerDown = key.downArrow || (key.ctrl && keyInput === "n");
+      const onFirstLine = input.cursorLineRef.current === 0;
+      const onLastLine = input.cursorLineRef.current >= input.lineCountRef.current - 1;
+      const historyTriggerUp = (key.upArrow && onFirstLine) || (key.ctrl && keyInput === "p");
+      const historyTriggerDown = (key.downArrow && onLastLine) || (key.ctrl && keyInput === "n");
       if (!suggestionNavActive && historyTriggerUp) {
         if (!shouldCycleInputHistory(input.inputHistoryIndex)) return;
         const transition = resolveHistoryUp(input.inputHistory, input.inputHistoryIndex, input.value);

--- a/src/chat-keybindings.ts
+++ b/src/chat-keybindings.ts
@@ -169,8 +169,8 @@ export function useChatKeybindings(input: UseChatKeybindingsInput): void {
         !browsingInputHistory &&
         (input.atQuery !== null || (input.atQuery === null && input.slashSuggestions.length > 0));
       const onFirstLine = input.cursorLineRef.current === 0;
-      const historyTriggerUp = (key.upArrow && onFirstLine) || (key.ctrl && keyInput === "p");
-      const historyTriggerDown = key.downArrow || (key.ctrl && keyInput === "n");
+      const historyTriggerUp = key.upArrow && onFirstLine;
+      const historyTriggerDown = key.downArrow;
       if (!suggestionNavActive && historyTriggerUp) {
         if (!shouldCycleInputHistory(input.inputHistoryIndex)) return;
         const transition = resolveHistoryUp(input.inputHistory, input.inputHistoryIndex, input.value);

--- a/src/chat-layout.tsx
+++ b/src/chat-layout.tsx
@@ -1,8 +1,7 @@
 import { homedir } from "node:os";
 import { slashCommandHelp } from "./chat-slash";
 import { t } from "./i18n";
-
-const DEFAULT_TERMINAL_WIDTH = 96;
+import { DEFAULT_TERMINAL_WIDTH } from "./tui/styles";
 
 /** Terminal width at which help pane switches from 1 to 2 columns. */
 export const BREAKPOINT_TWO_COLUMN = 92;

--- a/src/chat-layout.tsx
+++ b/src/chat-layout.tsx
@@ -1,7 +1,7 @@
 import { homedir } from "node:os";
 import { slashCommandHelp } from "./chat-slash";
 import { t } from "./i18n";
-import { DEFAULT_TERMINAL_WIDTH } from "./tui/styles";
+import { DEFAULT_TERMINAL_WIDTH } from "./tui/constants";
 
 /** Terminal width at which help pane switches from 1 to 2 columns. */
 export const BREAKPOINT_TWO_COLUMN = 92;

--- a/src/chat-message-handler-stream.test.ts
+++ b/src/chat-message-handler-stream.test.ts
@@ -175,6 +175,20 @@ describe("chat-message-handler-stream", () => {
     state.dispose();
   });
 
+  test("leading newlines are stripped when creating new assistant row", async () => {
+    const { rows, setRows } = createRowsHarness();
+    const state = createMessageStreamState({ setRows });
+
+    // step-start emits "\n", then real text follows
+    state.onDelta("\n");
+    state.onDelta("Hello world");
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.kind).toBe("assistant");
+    expect(rows[0]?.content).toBe("Hello world");
+    state.dispose();
+  });
+
   test("whitespace-only pending content does not create empty assistant row", () => {
     const { rows, setRows } = createRowsHarness();
     const state = createMessageStreamState({ setRows });

--- a/src/chat-message-handler-stream.ts
+++ b/src/chat-message-handler-stream.ts
@@ -55,6 +55,9 @@ export function createMessageStreamState(input: {
     if (agentContent.trim().length === 0) return;
     input.setRows((current) => {
       if (!activeRowId) {
+        const trimmed = agentContent.trim();
+        if (trimmed.length === 0) return current;
+        agentContent = trimmed;
         activeRowId = `row_${createId()}`;
         agentRowIds.push(activeRowId);
         return [...current, { id: activeRowId, kind: "assistant", content: agentContent }];

--- a/src/chat-picker.tui.test.tsx
+++ b/src/chat-picker.tui.test.tsx
@@ -3,7 +3,7 @@ import { ChatInputPanel } from "./chat-input-panel";
 import type { PickerState } from "./chat-picker";
 import { palette } from "./palette";
 import { createSession, dedent } from "./test-utils";
-import { DEFAULT_TERMINAL_WIDTH } from "./tui/styles";
+import { DEFAULT_TERMINAL_WIDTH } from "./tui/constants";
 import { renderPlain } from "./tui-test-utils";
 
 function renderInputPanelWithPicker(picker: PickerState, columns = DEFAULT_TERMINAL_WIDTH): string {

--- a/src/chat-picker.tui.test.tsx
+++ b/src/chat-picker.tui.test.tsx
@@ -12,6 +12,7 @@ function renderInputPanelWithPicker(picker: PickerState, columns = 96): string {
       activeSessionId="sess_active"
       brandColor={palette.brand}
       footerContext="~/code/acolyte · main · gpt-5-mini"
+      onCursorLine={() => {}}
     />,
     columns,
   );

--- a/src/chat-picker.tui.test.tsx
+++ b/src/chat-picker.tui.test.tsx
@@ -3,9 +3,10 @@ import { ChatInputPanel } from "./chat-input-panel";
 import type { PickerState } from "./chat-picker";
 import { palette } from "./palette";
 import { createSession, dedent } from "./test-utils";
+import { DEFAULT_TERMINAL_WIDTH } from "./tui/styles";
 import { renderPlain } from "./tui-test-utils";
 
-function renderInputPanelWithPicker(picker: PickerState, columns = 96): string {
+function renderInputPanelWithPicker(picker: PickerState, columns = DEFAULT_TERMINAL_WIDTH): string {
   return renderPlain(
     <ChatInputPanel
       picker={picker}

--- a/src/chat-state.ts
+++ b/src/chat-state.ts
@@ -58,6 +58,7 @@ export interface ChatStateResult {
   handleInputSubmit: (next: string) => void;
   handlePickerQueryChange: (query: string) => void;
   handlePickerSubmit: () => void;
+  onCursorLine: (line: number, lineCount: number) => void;
 }
 
 export function useChatState(props: ChatAppProps, exit: () => void): ChatStateResult {
@@ -111,6 +112,8 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
   } = useSuggestions(value);
 
   const [showHelp, setShowHelp] = useState(false);
+  const cursorLineRef = useRef(0);
+  const lineCountRef = useRef(1);
   const [picker, setPicker] = useState<PickerState | null>(null);
   const [branch, setBranch] = useState<string | null>(null);
 
@@ -246,6 +249,8 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
     },
     ctrlCPending,
     setCtrlCPending,
+    cursorLineRef,
+    lineCountRef,
   });
 
   const handlePickerQueryChange = useCallback((query: string) => {
@@ -342,5 +347,9 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
     handleInputSubmit,
     handlePickerQueryChange,
     handlePickerSubmit,
+    onCursorLine: (line: number, lineCount: number) => {
+      cursorLineRef.current = line;
+      lineCountRef.current = lineCount;
+    },
   };
 }

--- a/src/chat-state.ts
+++ b/src/chat-state.ts
@@ -58,7 +58,7 @@ export interface ChatStateResult {
   handleInputSubmit: (next: string) => void;
   handlePickerQueryChange: (query: string) => void;
   handlePickerSubmit: () => void;
-  onCursorLine: (line: number, lineCount: number) => void;
+  onCursorLine: (line: number) => void;
 }
 
 export function useChatState(props: ChatAppProps, exit: () => void): ChatStateResult {
@@ -113,7 +113,6 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
 
   const [showHelp, setShowHelp] = useState(false);
   const cursorLineRef = useRef(0);
-  const lineCountRef = useRef(1);
   const [picker, setPicker] = useState<PickerState | null>(null);
   const [branch, setBranch] = useState<string | null>(null);
 
@@ -250,7 +249,6 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
     ctrlCPending,
     setCtrlCPending,
     cursorLineRef,
-    lineCountRef,
   });
 
   const handlePickerQueryChange = useCallback((query: string) => {
@@ -347,9 +345,8 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
     handleInputSubmit,
     handlePickerQueryChange,
     handlePickerSubmit,
-    onCursorLine: (line: number, lineCount: number) => {
+    onCursorLine: (line: number) => {
       cursorLineRef.current = line;
-      lineCountRef.current = lineCount;
     },
   };
 }

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { wrapText } from "./chat-content";
 import { renderAssistantContent } from "./chat-content-render";
 import type { ChatRow, CommandOutput } from "./chat-contract";
 import { isCommandOutput, isToolOutput } from "./chat-contract";
@@ -219,7 +220,7 @@ export function ChatTranscriptRow({ row, contentWidth, toolContentWidth }: ChatT
           </Text>
         ) : typeof row.content === "string" ? (
           <Text dimColor={dim} color={textColor}>
-            {row.content}
+            {wrapText(row.content, contentWidth)}
           </Text>
         ) : null}
       </Box>

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -9,7 +9,7 @@ import { t, tDynamic } from "./i18n";
 import { palette } from "./palette";
 import { renderToolOutputPart as renderToolOutputText, type ToolOutputPart } from "./tool-output-content";
 import { Box, Text } from "./tui";
-import { DEFAULT_COLUMNS } from "./tui/styles";
+import { DEFAULT_COLUMNS } from "./tui/constants";
 
 const MARKERS: Record<ChatRow["kind"], string> = {
   user: "❯ ",

--- a/src/chat.tui.test.tsx
+++ b/src/chat.tui.test.tsx
@@ -4,13 +4,17 @@ import { ChatHeader } from "./chat-header";
 import { ChatInputPanel } from "./chat-input-panel";
 import { palette } from "./palette";
 import { dedent } from "./test-utils";
+import { DEFAULT_TERMINAL_WIDTH } from "./tui/styles";
 import { renderPlain } from "./tui-test-utils";
 
 const DEFAULT_FOOTER_CONTEXT = "~/code/acolyte · main";
 
 const noopCursorLine = () => {};
 
-function renderInputPanel(overrides: Partial<ComponentProps<typeof ChatInputPanel>> = {}, columns = 96): string {
+function renderInputPanel(
+  overrides: Partial<ComponentProps<typeof ChatInputPanel>> = {},
+  columns = DEFAULT_TERMINAL_WIDTH,
+): string {
   return renderPlain(
     <ChatInputPanel
       brandColor={palette.brand}

--- a/src/chat.tui.test.tsx
+++ b/src/chat.tui.test.tsx
@@ -8,9 +8,16 @@ import { renderPlain } from "./tui-test-utils";
 
 const DEFAULT_FOOTER_CONTEXT = "~/code/acolyte · main";
 
-function renderInputPanel(overrides: ComponentProps<typeof ChatInputPanel> = {}, columns = 96): string {
+const noopCursorLine = () => {};
+
+function renderInputPanel(overrides: Partial<ComponentProps<typeof ChatInputPanel>> = {}, columns = 96): string {
   return renderPlain(
-    <ChatInputPanel brandColor={palette.brand} footerContext={DEFAULT_FOOTER_CONTEXT} {...overrides} />,
+    <ChatInputPanel
+      brandColor={palette.brand}
+      footerContext={DEFAULT_FOOTER_CONTEXT}
+      onCursorLine={noopCursorLine}
+      {...overrides}
+    />,
     columns,
   );
 }

--- a/src/chat.tui.test.tsx
+++ b/src/chat.tui.test.tsx
@@ -4,7 +4,7 @@ import { ChatHeader } from "./chat-header";
 import { ChatInputPanel } from "./chat-input-panel";
 import { palette } from "./palette";
 import { dedent } from "./test-utils";
-import { DEFAULT_TERMINAL_WIDTH } from "./tui/styles";
+import { DEFAULT_TERMINAL_WIDTH } from "./tui/constants";
 import { renderPlain } from "./tui-test-utils";
 
 const DEFAULT_FOOTER_CONTEXT = "~/code/acolyte · main";

--- a/src/prompt-input.test.ts
+++ b/src/prompt-input.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { buildPromptDisplayLines, moveWordLeft, moveWordRight } from "./prompt-input";
+import {
+  buildPromptDisplayLines,
+  cursorLineIndex,
+  moveLineDown,
+  moveLineUp,
+  moveWordLeft,
+  moveWordRight,
+} from "./prompt-input";
 
 describe("prompt input word navigation", () => {
   test("moveWordLeft jumps to previous word start", () => {
@@ -29,5 +36,45 @@ describe("prompt input word navigation", () => {
     const lines = buildPromptDisplayLines(value, value.length);
     expect(lines).toHaveLength(3);
     expect(lines[2]).toEqual({ before: "", cursor: " ", after: "" });
+  });
+});
+
+describe("cursorLineIndex", () => {
+  test("returns 0 for single-line input", () => {
+    expect(cursorLineIndex("hello", 3)).toBe(0);
+  });
+
+  test("returns correct line for multi-line input", () => {
+    expect(cursorLineIndex("ab\ncd\nef", 0)).toBe(0);
+    expect(cursorLineIndex("ab\ncd\nef", 3)).toBe(1);
+    expect(cursorLineIndex("ab\ncd\nef", 6)).toBe(2);
+  });
+});
+
+describe("moveLineUp", () => {
+  test("stays on first line", () => {
+    expect(moveLineUp("hello", 3)).toBe(3);
+  });
+
+  test("moves to previous line preserving column", () => {
+    expect(moveLineUp("abc\ndef", 5)).toBe(1); // col 1 on line 1 → col 1 on line 0
+  });
+
+  test("clamps column to shorter line", () => {
+    expect(moveLineUp("ab\ndefgh", 8)).toBe(2); // col 4 on line 1 → col 2 (end of line 0)
+  });
+});
+
+describe("moveLineDown", () => {
+  test("stays on last line", () => {
+    expect(moveLineDown("hello", 3)).toBe(3);
+  });
+
+  test("moves to next line preserving column", () => {
+    expect(moveLineDown("abc\ndef", 1)).toBe(5); // col 1 on line 0 → col 1 on line 1
+  });
+
+  test("clamps column to shorter line", () => {
+    expect(moveLineDown("abcde\nfg", 4)).toBe(8); // col 4 on line 0 → col 2 (end of line 1)
   });
 });

--- a/src/prompt-input.test.ts
+++ b/src/prompt-input.test.ts
@@ -78,3 +78,38 @@ describe("moveLineDown", () => {
     expect(moveLineDown("abcde\nfg", 4)).toBe(8); // col 4 on line 0 → col 2 (end of line 1)
   });
 });
+
+describe("buildPromptDisplayLines with wrapWidth", () => {
+  test("wraps long line into multiple display lines", () => {
+    const lines = buildPromptDisplayLines("aaa bbb ccc ddd", 0, 8);
+    expect(lines.length).toBeGreaterThan(1);
+    expect(lines[0]?.cursor).not.toBeNull(); // cursor on first display line
+  });
+
+  test("cursor on second wrapped segment", () => {
+    // "aaa bbb ccc" with wrap at 8 → ["aaa bbb", "ccc"]
+    // cursor at offset 8 (start of "ccc") should be on second display line
+    const lines = buildPromptDisplayLines("aaa bbb ccc", 8, 8);
+    expect(lines.length).toBe(2);
+    expect(lines[1]?.cursor).not.toBeNull();
+  });
+});
+
+describe("moveLineUp/Down with wrapWidth", () => {
+  test("moves up across wrapped segments", () => {
+    // "aaa bbb ccc ddd" wraps at 8 → ["aaa bbb", "ccc ddd"]
+    // cursor at offset 10 (col 2 of "ccc ddd") → should move to offset 2 (col 2 of "aaa bbb")
+    const result = moveLineUp("aaa bbb ccc ddd", 10, 8);
+    expect(result).toBe(2);
+  });
+
+  test("stays on first visual line when wrapping", () => {
+    const result = moveLineUp("aaa bbb ccc ddd", 2, 8);
+    expect(result).toBe(2);
+  });
+
+  test("moves down across wrapped segments", () => {
+    const result = moveLineDown("aaa bbb ccc ddd", 2, 8);
+    expect(result).toBe(10);
+  });
+});

--- a/src/prompt-input.tsx
+++ b/src/prompt-input.tsx
@@ -16,6 +16,7 @@ interface PromptInputProps {
   linePrefixRest?: string;
   onChange: (next: string) => void;
   onSubmit: (value: string) => void;
+  onCursorLine?: (line: number, lineCount: number) => void;
 }
 
 type PromptDisplayLine = {
@@ -44,6 +45,36 @@ export function moveWordRight(value: string, cursor: number): number {
     index += 1;
   }
   return index;
+}
+
+export function cursorLineIndex(value: string, cursorOffset: number): number {
+  const clamped = Math.max(0, Math.min(cursorOffset, value.length));
+  return value.slice(0, clamped).split("\n").length - 1;
+}
+
+export function moveLineUp(value: string, cursor: number): number {
+  const clamped = Math.max(0, Math.min(cursor, value.length));
+  const before = value.slice(0, clamped);
+  const currentLineStart = before.lastIndexOf("\n") + 1;
+  if (currentLineStart === 0) return cursor; // already on first line
+  const column = clamped - currentLineStart;
+  const prevLineEnd = currentLineStart - 1;
+  const prevLineStart = before.lastIndexOf("\n", prevLineEnd - 1) + 1;
+  const prevLineLength = prevLineEnd - prevLineStart;
+  return prevLineStart + Math.min(column, prevLineLength);
+}
+
+export function moveLineDown(value: string, cursor: number): number {
+  const clamped = Math.max(0, Math.min(cursor, value.length));
+  const before = value.slice(0, clamped);
+  const currentLineStart = before.lastIndexOf("\n") + 1;
+  const column = clamped - currentLineStart;
+  const nextNewline = value.indexOf("\n", clamped);
+  if (nextNewline === -1) return cursor; // already on last line
+  const nextLineStart = nextNewline + 1;
+  const nextNextNewline = value.indexOf("\n", nextLineStart);
+  const nextLineLength = (nextNextNewline === -1 ? value.length : nextNextNewline) - nextLineStart;
+  return nextLineStart + Math.min(column, nextLineLength);
 }
 
 export function buildPromptDisplayLines(value: string, cursorOffset: number): PromptDisplayLine[] {
@@ -75,6 +106,7 @@ export function PromptInput({
   linePrefixRest = "",
   onChange,
   onSubmit,
+  onCursorLine,
 }: PromptInputProps): React.JSX.Element {
   const [cursorOffset, setCursorOffset] = useState(value.length);
   const metaPrefixAt = useRef<number | null>(null);
@@ -86,6 +118,8 @@ export function PromptInput({
   const cursorRef = useRef(cursorOffset);
   const onChangeRef = useRef(onChange);
   const onSubmitRef = useRef(onSubmit);
+  const onCursorLineRef = useRef(onCursorLine);
+  onCursorLineRef.current = onCursorLine;
   if (valueRef.current !== value) {
     const clamped = Math.max(0, Math.min(cursorRef.current, value.length));
     cursorRef.current = clamped;
@@ -103,6 +137,9 @@ export function PromptInput({
     const moveCursor = (next: number) => {
       cursorRef.current = next;
       setCursorOffset(next);
+      const v = valueRef.current;
+      const lineCount = v.split("\n").length;
+      onCursorLineRef.current?.(cursorLineIndex(v, next), lineCount);
     };
 
     const v = valueRef.current;
@@ -153,6 +190,12 @@ export function PromptInput({
         return;
       case "move_right":
         moveCursor(Math.min(v.length, c + 1));
+        return;
+      case "move_up":
+        moveCursor(moveLineUp(v, c));
+        return;
+      case "move_down":
+        moveCursor(moveLineDown(v, c));
         return;
       case "delete_back":
         metaPrefixAt.current = null;

--- a/src/prompt-input.tsx
+++ b/src/prompt-input.tsx
@@ -16,7 +16,7 @@ interface PromptInputProps {
   linePrefixRest?: string;
   onChange: (next: string) => void;
   onSubmit: (value: string) => void;
-  onCursorLine: (line: number, lineCount: number) => void;
+  onCursorLine: (line: number) => void;
 }
 
 type PromptDisplayLine = {
@@ -137,9 +137,7 @@ export function PromptInput({
     const moveCursor = (next: number) => {
       cursorRef.current = next;
       setCursorOffset(next);
-      const v = valueRef.current;
-      const lineCount = v.split("\n").length;
-      onCursorLineRef.current(cursorLineIndex(v, next), lineCount);
+      onCursorLineRef.current(cursorLineIndex(valueRef.current, next));
     };
 
     const v = valueRef.current;

--- a/src/prompt-input.tsx
+++ b/src/prompt-input.tsx
@@ -17,13 +17,8 @@ interface PromptInputProps {
   onChange: (next: string) => void;
   onSubmit: (value: string) => void;
   onCursorLine: (line: number) => void;
+  wrapWidth?: number;
 }
-
-type PromptDisplayLine = {
-  before: string;
-  cursor: string | null;
-  after: string;
-};
 
 export function moveWordLeft(value: string, cursor: number): number {
   let index = Math.max(0, Math.min(cursor, value.length));
@@ -47,16 +42,22 @@ export function moveWordRight(value: string, cursor: number): number {
   return index;
 }
 
-export function cursorLineIndex(value: string, cursorOffset: number): number {
+export function cursorLineIndex(value: string, cursorOffset: number, wrapWidth?: number): number {
   const clamped = Math.max(0, Math.min(cursorOffset, value.length));
-  return value.slice(0, clamped).split("\n").length - 1;
+  if (!wrapWidth) return value.slice(0, clamped).split("\n").length - 1;
+  const lines = buildPromptDisplayLines(value, clamped, wrapWidth);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (lines[i]?.cursor !== null) return i;
+  }
+  return 0;
 }
 
-export function moveLineUp(value: string, cursor: number): number {
+export function moveLineUp(value: string, cursor: number, wrapWidth?: number): number {
+  if (wrapWidth) return moveVisualLine(value, cursor, wrapWidth, -1);
   const clamped = Math.max(0, Math.min(cursor, value.length));
   const before = value.slice(0, clamped);
   const currentLineStart = before.lastIndexOf("\n") + 1;
-  if (currentLineStart === 0) return cursor; // already on first line
+  if (currentLineStart === 0) return cursor;
   const column = clamped - currentLineStart;
   const prevLineEnd = currentLineStart - 1;
   const prevLineStart = before.lastIndexOf("\n", prevLineEnd - 1) + 1;
@@ -64,36 +65,127 @@ export function moveLineUp(value: string, cursor: number): number {
   return prevLineStart + Math.min(column, prevLineLength);
 }
 
-export function moveLineDown(value: string, cursor: number): number {
+export function moveLineDown(value: string, cursor: number, wrapWidth?: number): number {
+  if (wrapWidth) return moveVisualLine(value, cursor, wrapWidth, 1);
   const clamped = Math.max(0, Math.min(cursor, value.length));
   const before = value.slice(0, clamped);
   const currentLineStart = before.lastIndexOf("\n") + 1;
   const column = clamped - currentLineStart;
   const nextNewline = value.indexOf("\n", clamped);
-  if (nextNewline === -1) return cursor; // already on last line
+  if (nextNewline === -1) return cursor;
   const nextLineStart = nextNewline + 1;
   const nextNextNewline = value.indexOf("\n", nextLineStart);
   const nextLineLength = (nextNextNewline === -1 ? value.length : nextNextNewline) - nextLineStart;
   return nextLineStart + Math.min(column, nextLineLength);
 }
 
-export function buildPromptDisplayLines(value: string, cursorOffset: number): PromptDisplayLine[] {
+function moveVisualLine(value: string, cursor: number, wrapWidth: number, direction: -1 | 1): number {
+  const clamped = Math.max(0, Math.min(cursor, value.length));
+  const displayLines = buildPromptDisplayLines(value, clamped, wrapWidth);
+  let currentIdx = 0;
+  for (let i = displayLines.length - 1; i >= 0; i--) {
+    if (displayLines[i]?.cursor !== null) {
+      currentIdx = i;
+      break;
+    }
+  }
+  const targetIdx = currentIdx + direction;
+  if (targetIdx < 0 || targetIdx >= displayLines.length) return cursor;
+  let currentStartOffset = 0;
+  const logicalLines = value.split("\n");
+  let offset = 0;
+  outer: for (const line of logicalLines) {
+    const wrapped = softWrapLine(line, wrapWidth);
+    let lineOffset = offset;
+    for (const segment of wrapped) {
+      if (lineOffset <= clamped && clamped <= lineOffset + segment.length) {
+        currentStartOffset = lineOffset;
+        break outer;
+      }
+      lineOffset += segment.length;
+    }
+    offset += line.length + 1;
+  }
+  const column = clamped - currentStartOffset;
+
+  // Find target display line's start offset
+  let targetStartOffset = 0;
+  let displayIdx = 0;
+  offset = 0;
+  for (const line of logicalLines) {
+    const wrapped = softWrapLine(line, wrapWidth);
+    let lineOffset = offset;
+    for (const segment of wrapped) {
+      if (displayIdx === targetIdx) {
+        targetStartOffset = lineOffset;
+        const targetLength = segment.length;
+        return targetStartOffset + Math.min(column, targetLength);
+      }
+      lineOffset += segment.length;
+      displayIdx++;
+    }
+    offset += line.length + 1;
+  }
+  return cursor;
+}
+
+function softWrapLine(line: string, width: number): string[] {
+  if (width <= 0 || line.length <= width) return [line];
+  const words = line.split(/( +)/);
+  const result: string[] = [];
+  let current = "";
+  for (const word of words) {
+    if (current.length + word.length <= width || current.length === 0) {
+      current += word;
+    } else {
+      result.push(current);
+      current = word.trimStart();
+    }
+  }
+  if (current.length > 0) result.push(current);
+  return result.length > 0 ? result : [""];
+}
+
+export type PromptDisplayLine = {
+  before: string;
+  cursor: string | null;
+  after: string;
+};
+
+export function buildPromptDisplayLines(value: string, cursorOffset: number, wrapWidth?: number): PromptDisplayLine[] {
   const clamped = Math.max(0, Math.min(cursorOffset, value.length));
-  const beforeCursor = value.slice(0, clamped);
-  const cursorLine = beforeCursor.split("\n").length - 1;
-  const lineStart = beforeCursor.lastIndexOf("\n") + 1;
-  const cursorColumn = clamped - lineStart;
-  const lines = value.split("\n");
-  return lines.map((line, index) => {
-    if (index !== cursorLine) return { before: line, cursor: null, after: "" };
-    if (cursorColumn < line.length) {
+  const logicalLines = value.split("\n");
+  const displayLines: { text: string; startOffset: number }[] = [];
+  let offset = 0;
+  for (let i = 0; i < logicalLines.length; i++) {
+    const line = logicalLines[i] ?? "";
+    const wrapped = wrapWidth ? softWrapLine(line, wrapWidth) : [line];
+    let lineOffset = offset;
+    for (const segment of wrapped) {
+      displayLines.push({ text: segment, startOffset: lineOffset });
+      lineOffset += segment.length;
+    }
+    offset += line.length + 1; // +1 for \n
+  }
+  let cursorDisplayLine = 0;
+  for (let i = displayLines.length - 1; i >= 0; i--) {
+    const dl = displayLines[i];
+    if (dl && clamped >= dl.startOffset) {
+      cursorDisplayLine = i;
+      break;
+    }
+  }
+  return displayLines.map((dl, index) => {
+    if (index !== cursorDisplayLine) return { before: dl.text, cursor: null, after: "" };
+    const col = clamped - dl.startOffset;
+    if (col < dl.text.length) {
       return {
-        before: line.slice(0, cursorColumn),
-        cursor: line[cursorColumn] ?? " ",
-        after: line.slice(cursorColumn + 1),
+        before: dl.text.slice(0, col),
+        cursor: dl.text[col] ?? " ",
+        after: dl.text.slice(col + 1),
       };
     }
-    return { before: line, cursor: " ", after: "" };
+    return { before: dl.text, cursor: " ", after: "" };
   });
 }
 
@@ -107,6 +199,7 @@ export function PromptInput({
   onChange,
   onSubmit,
   onCursorLine,
+  wrapWidth,
 }: PromptInputProps): React.JSX.Element {
   const [cursorOffset, setCursorOffset] = useState(value.length);
   const metaPrefixAt = useRef<number | null>(null);
@@ -120,6 +213,8 @@ export function PromptInput({
   const onSubmitRef = useRef(onSubmit);
   const onCursorLineRef = useRef(onCursorLine);
   onCursorLineRef.current = onCursorLine;
+  const wrapWidthRef = useRef(wrapWidth);
+  wrapWidthRef.current = wrapWidth;
   if (valueRef.current !== value) {
     const clamped = Math.max(0, Math.min(cursorRef.current, value.length));
     cursorRef.current = clamped;
@@ -137,7 +232,7 @@ export function PromptInput({
     const moveCursor = (next: number) => {
       cursorRef.current = next;
       setCursorOffset(next);
-      onCursorLineRef.current(cursorLineIndex(valueRef.current, next));
+      onCursorLineRef.current(cursorLineIndex(valueRef.current, next, wrapWidthRef.current));
     };
 
     const v = valueRef.current;
@@ -190,10 +285,10 @@ export function PromptInput({
         moveCursor(Math.min(v.length, c + 1));
         return;
       case "move_up":
-        moveCursor(moveLineUp(v, c));
+        moveCursor(moveLineUp(v, c, wrapWidthRef.current));
         return;
       case "move_down":
-        moveCursor(moveLineDown(v, c));
+        moveCursor(moveLineDown(v, c, wrapWidthRef.current));
         return;
       case "delete_back":
         metaPrefixAt.current = null;
@@ -237,9 +332,14 @@ export function PromptInput({
   }
 
   if (!focus) {
-    const lines = value.split("\n");
+    const logicalLines = value.split("\n");
+    const allSegments: string[] = [];
+    for (const line of logicalLines) {
+      const wrapped = wrapWidth ? softWrapLine(line, wrapWidth) : [line];
+      allSegments.push(...wrapped);
+    }
     let lineOffset = 0;
-    const readonlyLines = lines.map((line) => {
+    const readonlyLines = allSegments.map((line) => {
       const key = `prompt-readonly-line-${lineOffset}-${line}`;
       lineOffset += line.length + 1;
       return { key, line };
@@ -255,7 +355,7 @@ export function PromptInput({
       </Box>
     );
   }
-  const lines = buildPromptDisplayLines(value, cursorOffset);
+  const lines = buildPromptDisplayLines(value, cursorOffset, wrapWidth);
   let lineOffset = 0;
   const focusLines = lines.map((line) => {
     const content = `${line.before}${line.cursor ?? ""}${line.after}`;

--- a/src/prompt-input.tsx
+++ b/src/prompt-input.tsx
@@ -16,7 +16,7 @@ interface PromptInputProps {
   linePrefixRest?: string;
   onChange: (next: string) => void;
   onSubmit: (value: string) => void;
-  onCursorLine?: (line: number, lineCount: number) => void;
+  onCursorLine: (line: number, lineCount: number) => void;
 }
 
 type PromptDisplayLine = {
@@ -139,7 +139,7 @@ export function PromptInput({
       setCursorOffset(next);
       const v = valueRef.current;
       const lineCount = v.split("\n").length;
-      onCursorLineRef.current?.(cursorLineIndex(v, next), lineCount);
+      onCursorLineRef.current(cursorLineIndex(v, next), lineCount);
     };
 
     const v = valueRef.current;

--- a/src/prompt-keymap.test.ts
+++ b/src/prompt-keymap.test.ts
@@ -25,11 +25,14 @@ describe("prompt keymap", () => {
     });
   });
 
-  test("noop for arrows, tab, ctrl+c", () => {
-    expect(resolvePromptAction("", key({ upArrow: true }), noMeta)).toEqual({ type: "noop" });
-    expect(resolvePromptAction("", key({ downArrow: true }), noMeta)).toEqual({ type: "noop" });
+  test("noop for tab, ctrl+c", () => {
     expect(resolvePromptAction("", key({ tab: true }), noMeta)).toEqual({ type: "noop" });
     expect(resolvePromptAction("c", key({ ctrl: true }), noMeta)).toEqual({ type: "noop" });
+  });
+
+  test("up/down arrows produce move_up/move_down", () => {
+    expect(resolvePromptAction("", key({ upArrow: true }), noMeta)).toEqual({ type: "move_up" });
+    expect(resolvePromptAction("", key({ downArrow: true }), noMeta)).toEqual({ type: "move_down" });
   });
 
   describe("home/end", () => {

--- a/src/prompt-keymap.ts
+++ b/src/prompt-keymap.ts
@@ -13,12 +13,17 @@ export type PromptAction =
   | { type: "delete_forward" }
   | { type: "delete_word_back" }
   | { type: "clear_line" }
+  | { type: "move_up" }
+  | { type: "move_down" }
   | { type: "insert"; text: string };
 
 export function resolvePromptAction(input: string, key: KeyEvent, options: { hasMetaPrefix: boolean }): PromptAction {
-  // Noop: arrows, tab, ctrl+c
-  if (key.upArrow || key.downArrow || key.tab || (key.shift && key.tab) || (key.ctrl && input === "c"))
-    return { type: "noop" };
+  // Noop: tab, ctrl+c
+  if (key.tab || (key.shift && key.tab) || (key.ctrl && input === "c")) return { type: "noop" };
+
+  // Vertical line navigation
+  if (key.upArrow) return { type: "move_up" };
+  if (key.downArrow) return { type: "move_down" };
 
   // Submit / newline
   if (key.return && key.shift) return { type: "insert", text: "\n" };

--- a/src/tui-test-utils.ts
+++ b/src/tui-test-utils.ts
@@ -4,6 +4,7 @@ import { createElement } from "./tui/dom";
 import { setOnCommit } from "./tui/host-config";
 import { reconciler } from "./tui/reconciler";
 import { stripAnsi } from "./tui/serialize";
+import { DEFAULT_TERMINAL_WIDTH } from "./tui/styles";
 
 export const trimRightLines = (value: string): string =>
   value
@@ -21,7 +22,7 @@ export function withTerminalWidth(width: number, run: () => string): string {
   }
 }
 
-export function renderPlain(node: ReactNode, columns = 96): string {
+export function renderPlain(node: ReactNode, columns = DEFAULT_TERMINAL_WIDTH): string {
   const rendered = withTerminalWidth(columns, () => renderToString(node));
   return trimRightLines(stripAnsi(rendered)).replace(/^\n+/, "").replace(/\n+$/, "");
 }

--- a/src/tui-test-utils.ts
+++ b/src/tui-test-utils.ts
@@ -1,10 +1,10 @@
 import { createElement as h, type ReactNode } from "react";
 import { renderToString } from "./tui";
+import { DEFAULT_TERMINAL_WIDTH } from "./tui/constants";
 import { createElement } from "./tui/dom";
 import { setOnCommit } from "./tui/host-config";
 import { reconciler } from "./tui/reconciler";
 import { stripAnsi } from "./tui/serialize";
-import { DEFAULT_TERMINAL_WIDTH } from "./tui/styles";
 
 export const trimRightLines = (value: string): string =>
   value

--- a/src/tui/constants.ts
+++ b/src/tui/constants.ts
@@ -1,0 +1,5 @@
+/** Default column count when stdout has no TTY dimensions. */
+export const DEFAULT_COLUMNS = 120;
+
+/** Fallback terminal width for layout calculations. */
+export const DEFAULT_TERMINAL_WIDTH = 96;

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -4,13 +4,14 @@ import { join } from "node:path";
 import type { ReactNode } from "react";
 import { createElement as reactCreateElement, StrictMode } from "react";
 import { setLogSink } from "../log";
+import { DEFAULT_COLUMNS } from "./constants";
 import { AppContext, InputContext, type InputContextValue, type InputRegistration } from "./context";
 import { createElement } from "./dom";
 import { setOnCommit } from "./host-config";
 import { createInputDispatcher } from "./input";
 import { reconciler } from "./reconciler";
 import { serializeSplit, stripAnsiLength } from "./serialize";
-import { ansi, DEFAULT_COLUMNS, kitty } from "./styles";
+import { ansi, kitty } from "./styles";
 
 function clientLogPath(): string {
   return join(homedir(), ".acolyte", "client.log");

--- a/src/tui/styles.ts
+++ b/src/tui/styles.ts
@@ -1,6 +1,9 @@
 /** Default column count when stdout has no TTY dimensions. */
 export const DEFAULT_COLUMNS = 120;
 
+/** Fallback terminal width for layout calculations. */
+export const DEFAULT_TERMINAL_WIDTH = 96;
+
 const ESC = "\x1b[";
 
 export const ansi = {

--- a/src/tui/styles.ts
+++ b/src/tui/styles.ts
@@ -1,9 +1,3 @@
-/** Default column count when stdout has no TTY dimensions. */
-export const DEFAULT_COLUMNS = 120;
-
-/** Fallback terminal width for layout calculations. */
-export const DEFAULT_TERMINAL_WIDTH = 96;
-
 const ESC = "\x1b[";
 
 export const ansi = {


### PR DESCRIPTION
## Motivation

Multi-line input had several usability issues: up/down arrows always scrolled history instead of navigating lines, long pasted text wasn't wrapped or indented, and user messages in the transcript rendered without word-wrapping.

## Summary

- add `move_up`/`move_down` actions to prompt keymap for vertical cursor navigation
- implement `moveLineUp`, `moveLineDown`, `cursorLineIndex` helpers with visual line wrapping support
- gate history navigation on cursor position: up-arrow only triggers history on first visual line
- remove unused ctrl+p/n history shortcuts
- soft-wrap long input lines at terminal width with `  ` continuation indent
- word-wrap user messages in the transcript at content width
- trim leading/trailing whitespace when creating new assistant rows to prevent empty bullets
- expose `onCursorLine` callback from PromptInput (required prop)
- consolidate `DEFAULT_TERMINAL_WIDTH` constant, move layout constants to `tui/constants.ts`