### PR TITLE
feat(tui): rework text formatting and tokenizer

### DIFF
--- a/src/agent-instructions.ts
+++ b/src/agent-instructions.ts
@@ -11,7 +11,7 @@ const CORE_INSTRUCTIONS = [
   "Skip unrelated or speculative detours.",
   "Avoid repeating tool calls without new information.",
   "After changing behavior, run related validation first. If validation is blocked or unavailable, say what was skipped and why.",
-  "Keep responses concise and outcome-first.",
+  "Keep responses concise and outcome-first. Format as plain text. Use `backticks` for code identifiers and **bold** for emphasis. No headings, links, or code blocks. Only use lists when absolutely necessary.",
   "Make reasonable assumptions to keep momentum; ask only when ambiguity or risk truly blocks progress.",
   "End every final response with exactly one signal line: `@signal done`, `@signal no_op`, or `@signal blocked`. If blocked, add one concise next line with what is missing and what you will do once it is provided.",
 ];

--- a/src/chat-content-render.tsx
+++ b/src/chat-content-render.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { unreachable } from "./assert";
 import { sanitizeAssistantContent, tokenizeForHighlighting, wrapAssistantContent } from "./chat-content";
 import { Text } from "./tui";
 
@@ -17,28 +18,30 @@ export function renderAssistantContent(content: string, wrapWidth: number): Reac
         const renderedTokens = tokens.map((token) => {
           const tokenKey = `${lineKey}-token-${tokenOffset}-${token.kind}-${token.text}`;
           tokenOffset += token.text.length;
-          if (token.kind === "code") {
-            return (
-              <Text key={tokenKey} dimColor>
-                {token.text.slice(1, -1)}
-              </Text>
-            );
+          switch (token.kind) {
+            case "code":
+              return (
+                <Text key={tokenKey} dimColor>
+                  {token.text.slice(1, -1)}
+                </Text>
+              );
+            case "bold":
+              return (
+                <Text key={tokenKey} bold>
+                  {token.text.slice(2, -2)}
+                </Text>
+              );
+            case "path":
+              return (
+                <Text key={tokenKey} dimColor>
+                  {token.text}
+                </Text>
+              );
+            case "plain":
+              return <Text key={tokenKey}>{token.text}</Text>;
+            default:
+              return unreachable(token.kind);
           }
-          if (token.kind === "bold") {
-            return (
-              <Text key={tokenKey} bold>
-                {token.text.slice(2, -2)}
-              </Text>
-            );
-          }
-          if (token.kind === "path") {
-            return (
-              <Text key={tokenKey} dimColor>
-                {token.text}
-              </Text>
-            );
-          }
-          return <Text key={tokenKey}>{token.text}</Text>;
         });
         lineOffset += line.length + 1;
         return (

--- a/src/chat-content-render.tsx
+++ b/src/chat-content-render.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { sanitizeAssistantContent, tokenizeForHighlighting, wrapAssistantContent } from "./chat-content";
-import { palette } from "./palette";
 import { Text } from "./tui";
 
 export function renderAssistantContent(content: string, wrapWidth: number): React.ReactNode {
@@ -20,14 +19,21 @@ export function renderAssistantContent(content: string, wrapWidth: number): Reac
           tokenOffset += token.text.length;
           if (token.kind === "code") {
             return (
-              <Text key={tokenKey} color={palette.textCode}>
+              <Text key={tokenKey} dimColor>
                 {token.text.slice(1, -1)}
+              </Text>
+            );
+          }
+          if (token.kind === "bold") {
+            return (
+              <Text key={tokenKey} bold>
+                {token.text.slice(2, -2)}
               </Text>
             );
           }
           if (token.kind === "path") {
             return (
-              <Text key={tokenKey} color={palette.textCode}>
+              <Text key={tokenKey} dimColor>
                 {token.text}
               </Text>
             );

--- a/src/chat-content-render.tsx
+++ b/src/chat-content-render.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { unreachable } from "./assert";
-import { sanitizeAssistantContent, tokenizeForHighlighting, wrapAssistantContent } from "./chat-content";
+import { sanitizeAssistantContent, tokenize, wrapAssistantContent } from "./chat-content";
 import { Text } from "./tui";
 
 export function renderAssistantContent(content: string, wrapWidth: number): React.ReactNode {
@@ -13,7 +13,7 @@ export function renderAssistantContent(content: string, wrapWidth: number): Reac
       {lines.map((line) => {
         const lineKey = `assistant-line-${lineOffset}-${line}`;
         const showBreak = lineOffset > 0;
-        const tokens = tokenizeForHighlighting(line);
+        const tokens = tokenize(line);
         let tokenOffset = 0;
         const renderedTokens = tokens.map((token) => {
           const tokenKey = `${lineKey}-token-${tokenOffset}-${token.kind}-${token.text}`;

--- a/src/chat-content.test.ts
+++ b/src/chat-content.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { sanitizeAssistantContent, tokenizeForHighlighting, wrapAssistantContent, wrapText } from "./chat-content";
+import { sanitizeAssistantContent, wrapAssistantContent, wrapText } from "./chat-content";
 
 describe("chat-content helpers", () => {
   test("sanitizeAssistantContent removes tools/evidence footer lines", () => {
@@ -15,14 +15,6 @@ describe("chat-content helpers", () => {
   test("sanitizeAssistantContent returns empty when everything is stripped", () => {
     const raw = ["Tools used: file-search", "Evidence: src/cli.ts:1"].join("\n");
     expect(sanitizeAssistantContent(raw)).toBe("");
-  });
-
-  test("tokenizeForHighlighting tags code and paths", () => {
-    const tokens = tokenizeForHighlighting("bun run verify in `src/chat-ui.tsx:42` and src/chat-ui.tsx:42");
-    const kinds = tokens.map((token) => token.kind);
-    expect(kinds).toContain("code");
-    expect(kinds).toContain("path");
-    expect(kinds).not.toContain("command");
   });
 
   test("wrapText wraps long lines at word boundaries", () => {

--- a/src/chat-content.ts
+++ b/src/chat-content.ts
@@ -1,9 +1,4 @@
-type HighlightKind = "plain" | "code" | "path";
-
-export type HighlightToken = {
-  text: string;
-  kind: HighlightKind;
-};
+export { type HighlightToken, tokenizeForHighlighting } from "./chat-tokenizer";
 
 export function sanitizeAssistantContent(content: string): string {
   const cleaned = content
@@ -71,39 +66,4 @@ export function wrapAssistantContent(content: string, width: number): string {
     .split("\n")
     .flatMap((line) => (line.length === 0 ? [""] : wrapSingleLine(line, normalizedWidth)))
     .join("\n");
-}
-
-function looksLikePathRef(token: string): boolean {
-  if (token.length === 0) return false;
-  if (token.startsWith("@")) return false;
-  const fileWithExt = /^(?:\.{1,2}\/)?[\w.-]+\.[\w-]+(?::\d+(?::\d+)?)?$/.test(token);
-  const slashPath = /^(?:\.{1,2}\/|~\/)?[\w.-]+(?:\/[\w.-]+)+(?:\.[\w-]+)?(?::\d+(?::\d+)?)?$/.test(token);
-  return fileWithExt || slashPath;
-}
-
-export function tokenizeForHighlighting(line: string): HighlightToken[] {
-  const tokens: HighlightToken[] = [];
-  const parts = line.split(/(`[^`]+`)/g).filter((part) => part.length > 0);
-  for (const part of parts) {
-    if (part.startsWith("`") && part.endsWith("`") && part.length >= 2) {
-      tokens.push({ text: part, kind: "code" });
-      continue;
-    }
-
-    const chunks = part.split(/(\s+)/).filter((chunk) => chunk.length > 0);
-    for (const chunk of chunks) {
-      if (/^\s+$/.test(chunk)) {
-        tokens.push({ text: chunk, kind: "plain" });
-        continue;
-      }
-
-      const core = chunk.replace(/^[("'`]+|[)",.;!?]+$/g, "");
-      if (looksLikePathRef(core)) {
-        tokens.push({ text: chunk, kind: "path" });
-        continue;
-      }
-      tokens.push({ text: chunk, kind: "plain" });
-    }
-  }
-  return tokens;
 }

--- a/src/chat-content.ts
+++ b/src/chat-content.ts
@@ -1,4 +1,4 @@
-export { type HighlightToken, tokenizeForHighlighting } from "./chat-tokenizer";
+export { type MarkupToken, tokenize } from "./chat-tokenizer";
 
 export function sanitizeAssistantContent(content: string): string {
   const cleaned = content

--- a/src/chat-tokenizer.test.ts
+++ b/src/chat-tokenizer.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import { tokenizeForHighlighting } from "./chat-tokenizer";
+
+function kinds(line: string): string[] {
+  return tokenizeForHighlighting(line).map((t) => t.kind);
+}
+
+function texts(line: string): string[] {
+  return tokenizeForHighlighting(line).map((t) => t.text);
+}
+
+describe("tokenizeForHighlighting", () => {
+  describe("plain text", () => {
+    test("plain text returns single token", () => {
+      expect(tokenizeForHighlighting("hello world")).toEqual([
+        { text: "hello", kind: "plain" },
+        { text: " ", kind: "plain" },
+        { text: "world", kind: "plain" },
+      ]);
+    });
+
+    test("empty string returns empty array", () => {
+      expect(tokenizeForHighlighting("")).toEqual([]);
+    });
+
+    test("preserves multiple spaces", () => {
+      expect(texts("a  b")).toEqual(["a", "  ", "b"]);
+    });
+  });
+
+  describe("code tokens", () => {
+    test("backtick-delimited code", () => {
+      const tokens = tokenizeForHighlighting("run `bun test` now");
+      expect(tokens).toEqual([
+        { text: "run", kind: "plain" },
+        { text: " ", kind: "plain" },
+        { text: "`bun test`", kind: "code" },
+        { text: " ", kind: "plain" },
+        { text: "now", kind: "plain" },
+      ]);
+    });
+
+    test("code at start of line", () => {
+      expect(kinds("`foo` is good")).toEqual(["code", "plain", "plain", "plain", "plain"]);
+    });
+
+    test("code at end of line", () => {
+      expect(kinds("use `bar`")).toEqual(["plain", "plain", "code"]);
+    });
+
+    test("multiple code spans", () => {
+      const tokens = tokenizeForHighlighting("`a` and `b`");
+      expect(tokens.filter((t) => t.kind === "code").map((t) => t.text)).toEqual(["`a`", "`b`"]);
+    });
+
+    test("unmatched backtick is plain text", () => {
+      expect(kinds("it`s fine")).not.toContain("code");
+    });
+  });
+
+  describe("bold tokens", () => {
+    test("double-star bold", () => {
+      const tokens = tokenizeForHighlighting("this is **important** stuff");
+      expect(tokens).toEqual([
+        { text: "this", kind: "plain" },
+        { text: " ", kind: "plain" },
+        { text: "is", kind: "plain" },
+        { text: " ", kind: "plain" },
+        { text: "**important**", kind: "bold" },
+        { text: " ", kind: "plain" },
+        { text: "stuff", kind: "plain" },
+      ]);
+    });
+
+    test("bold at start of line", () => {
+      expect(kinds("**Note:** read this")).toContain("bold");
+    });
+
+    test("bold and code in same line", () => {
+      const tokens = tokenizeForHighlighting("use **bold** and `code`");
+      const tagged = tokens.filter((t) => t.kind !== "plain");
+      expect(tagged).toEqual([
+        { text: "**bold**", kind: "bold" },
+        { text: "`code`", kind: "code" },
+      ]);
+    });
+  });
+
+  describe("path tokens", () => {
+    test("file with extension", () => {
+      expect(kinds("see chat-content.ts for details")).toContain("path");
+    });
+
+    test("relative path", () => {
+      expect(kinds("edit src/chat-content.ts")).toContain("path");
+    });
+
+    test("path with line number", () => {
+      const tokens = tokenizeForHighlighting("at src/foo.ts:42");
+      expect(tokens.find((t) => t.kind === "path")?.text).toBe("src/foo.ts:42");
+    });
+
+    test("@ prefix is not a path", () => {
+      expect(kinds("use @src/file.ts")).not.toContain("path");
+    });
+
+    test("path inside parentheses", () => {
+      const tokens = tokenizeForHighlighting("(src/foo.ts)");
+      expect(tokens.find((t) => t.kind === "path")?.text).toBe("(src/foo.ts)");
+    });
+  });
+
+  describe("mixed content", () => {
+    test("code, bold, path, and plain in one line", () => {
+      const tokens = tokenizeForHighlighting("**Fix** `runLifecycle` in src/lifecycle.ts now");
+      const tagged = tokens.filter((t) => t.kind !== "plain");
+      expect(tagged.map((t) => t.kind)).toEqual(["bold", "code", "path"]);
+    });
+
+    test("preserves original text order", () => {
+      const joined = texts("a `b` **c** d").join("");
+      expect(joined).toBe("a `b` **c** d");
+    });
+  });
+});

--- a/src/chat-tokenizer.test.ts
+++ b/src/chat-tokenizer.test.ts
@@ -108,6 +108,20 @@ describe("tokenizeForHighlighting", () => {
       const tokens = tokenizeForHighlighting("(src/foo.ts)");
       expect(tokens.find((t) => t.kind === "path")?.text).toBe("(src/foo.ts)");
     });
+
+    test("version numbers are not paths", () => {
+      expect(kinds("version v0.12.0 released")).not.toContain("path");
+      expect(kinds("use 1.5 here")).not.toContain("path");
+    });
+
+    test("abbreviations are not paths", () => {
+      expect(kinds("i.e. this works")).not.toContain("path");
+      expect(kinds("e.g. like this")).not.toContain("path");
+    });
+
+    test("proper nouns with dots are not paths", () => {
+      expect(kinds("use Node.js for this")).not.toContain("path");
+    });
   });
 
   describe("mixed content", () => {

--- a/src/chat-tokenizer.test.ts
+++ b/src/chat-tokenizer.test.ts
@@ -1,18 +1,18 @@
 import { describe, expect, test } from "bun:test";
-import { tokenizeForHighlighting } from "./chat-tokenizer";
+import { tokenize } from "./chat-tokenizer";
 
 function kinds(line: string): string[] {
-  return tokenizeForHighlighting(line).map((t) => t.kind);
+  return tokenize(line).map((t) => t.kind);
 }
 
 function texts(line: string): string[] {
-  return tokenizeForHighlighting(line).map((t) => t.text);
+  return tokenize(line).map((t) => t.text);
 }
 
-describe("tokenizeForHighlighting", () => {
+describe("tokenize", () => {
   describe("plain text", () => {
     test("plain text returns single token", () => {
-      expect(tokenizeForHighlighting("hello world")).toEqual([
+      expect(tokenize("hello world")).toEqual([
         { text: "hello", kind: "plain" },
         { text: " ", kind: "plain" },
         { text: "world", kind: "plain" },
@@ -20,7 +20,7 @@ describe("tokenizeForHighlighting", () => {
     });
 
     test("empty string returns empty array", () => {
-      expect(tokenizeForHighlighting("")).toEqual([]);
+      expect(tokenize("")).toEqual([]);
     });
 
     test("preserves multiple spaces", () => {
@@ -30,7 +30,7 @@ describe("tokenizeForHighlighting", () => {
 
   describe("code tokens", () => {
     test("backtick-delimited code", () => {
-      const tokens = tokenizeForHighlighting("run `bun test` now");
+      const tokens = tokenize("run `bun test` now");
       expect(tokens).toEqual([
         { text: "run", kind: "plain" },
         { text: " ", kind: "plain" },
@@ -49,7 +49,7 @@ describe("tokenizeForHighlighting", () => {
     });
 
     test("multiple code spans", () => {
-      const tokens = tokenizeForHighlighting("`a` and `b`");
+      const tokens = tokenize("`a` and `b`");
       expect(tokens.filter((t) => t.kind === "code").map((t) => t.text)).toEqual(["`a`", "`b`"]);
     });
 
@@ -60,7 +60,7 @@ describe("tokenizeForHighlighting", () => {
 
   describe("bold tokens", () => {
     test("double-star bold", () => {
-      const tokens = tokenizeForHighlighting("this is **important** stuff");
+      const tokens = tokenize("this is **important** stuff");
       expect(tokens).toEqual([
         { text: "this", kind: "plain" },
         { text: " ", kind: "plain" },
@@ -77,7 +77,7 @@ describe("tokenizeForHighlighting", () => {
     });
 
     test("bold and code in same line", () => {
-      const tokens = tokenizeForHighlighting("use **bold** and `code`");
+      const tokens = tokenize("use **bold** and `code`");
       const tagged = tokens.filter((t) => t.kind !== "plain");
       expect(tagged).toEqual([
         { text: "**bold**", kind: "bold" },
@@ -96,7 +96,7 @@ describe("tokenizeForHighlighting", () => {
     });
 
     test("path with line number", () => {
-      const tokens = tokenizeForHighlighting("at src/foo.ts:42");
+      const tokens = tokenize("at src/foo.ts:42");
       expect(tokens.find((t) => t.kind === "path")?.text).toBe("src/foo.ts:42");
     });
 
@@ -105,7 +105,7 @@ describe("tokenizeForHighlighting", () => {
     });
 
     test("path inside parentheses", () => {
-      const tokens = tokenizeForHighlighting("(src/foo.ts)");
+      const tokens = tokenize("(src/foo.ts)");
       expect(tokens.find((t) => t.kind === "path")?.text).toBe("(src/foo.ts)");
     });
 
@@ -126,7 +126,7 @@ describe("tokenizeForHighlighting", () => {
 
   describe("mixed content", () => {
     test("code, bold, path, and plain in one line", () => {
-      const tokens = tokenizeForHighlighting("**Fix** `runLifecycle` in src/lifecycle.ts now");
+      const tokens = tokenize("**Fix** `runLifecycle` in src/lifecycle.ts now");
       const tagged = tokens.filter((t) => t.kind !== "plain");
       expect(tagged.map((t) => t.kind)).toEqual(["bold", "code", "path"]);
     });

--- a/src/chat-tokenizer.ts
+++ b/src/chat-tokenizer.ts
@@ -1,12 +1,12 @@
-type HighlightKind = "plain" | "code" | "bold" | "path";
+type MarkupTokenKind = "plain" | "code" | "bold" | "path";
 
-export type HighlightToken = {
+export type MarkupToken = {
   text: string;
-  kind: HighlightKind;
+  kind: MarkupTokenKind;
 };
 
 type TokenRule = {
-  kind: Exclude<HighlightKind, "plain" | "path">;
+  kind: Exclude<MarkupTokenKind, "plain" | "path">;
   pattern: RegExp;
 };
 
@@ -74,15 +74,15 @@ function looksLikePathRef(token: string): boolean {
   return CODE_EXTENSIONS.has(fileMatch[2]?.toLowerCase() ?? "");
 }
 
-function classifyMatch(text: string): HighlightKind {
+function classifyMatch(text: string): MarkupTokenKind {
   for (const rule of TOKEN_RULES) {
     if (rule.pattern.test(text)) return rule.kind;
   }
   return "plain";
 }
 
-function tokenizePlainSegment(text: string): HighlightToken[] {
-  const tokens: HighlightToken[] = [];
+function tokenizePlainSegment(text: string): MarkupToken[] {
+  const tokens: MarkupToken[] = [];
   const chunks = text.split(/(\s+)/).filter((c) => c.length > 0);
   for (const chunk of chunks) {
     if (/^\s+$/.test(chunk)) {
@@ -95,8 +95,8 @@ function tokenizePlainSegment(text: string): HighlightToken[] {
   return tokens;
 }
 
-export function tokenizeForHighlighting(line: string): HighlightToken[] {
-  const tokens: HighlightToken[] = [];
+export function tokenize(line: string): MarkupToken[] {
+  const tokens: MarkupToken[] = [];
   let lastIndex = 0;
   for (const match of line.matchAll(COMBINED_TOKEN_PATTERN)) {
     const start = match.index;

--- a/src/chat-tokenizer.ts
+++ b/src/chat-tokenizer.ts
@@ -17,12 +17,61 @@ const TOKEN_RULES: TokenRule[] = [
 
 const COMBINED_TOKEN_PATTERN = new RegExp(`(${TOKEN_RULES.map((r) => r.pattern.source).join("|")})`, "g");
 
+const CODE_EXTENSIONS = new Set([
+  "ts",
+  "tsx",
+  "js",
+  "jsx",
+  "mjs",
+  "cjs",
+  "json",
+  "jsonl",
+  "py",
+  "rs",
+  "go",
+  "rb",
+  "java",
+  "kt",
+  "swift",
+  "c",
+  "cpp",
+  "h",
+  "hpp",
+  "css",
+  "scss",
+  "html",
+  "vue",
+  "svelte",
+  "md",
+  "mdx",
+  "yaml",
+  "yml",
+  "toml",
+  "xml",
+  "sql",
+  "sh",
+  "bash",
+  "zsh",
+  "fish",
+  "test",
+  "spec",
+  "config",
+  "lock",
+  "env",
+  "gitignore",
+  "dockerignore",
+]);
+
 function looksLikePathRef(token: string): boolean {
   if (token.length === 0) return false;
   if (token.startsWith("@")) return false;
-  const fileWithExt = /^(?:\.{1,2}\/)?[\w.-]+\.[\w-]+(?::\d+(?::\d+)?)?$/.test(token);
   const slashPath = /^(?:\.{1,2}\/|~\/)?[\w.-]+(?:\/[\w.-]+)+(?:\.[\w-]+)?(?::\d+(?::\d+)?)?$/.test(token);
-  return fileWithExt || slashPath;
+  if (slashPath) return true;
+  const fileMatch = token.match(/^(?:\.{1,2}\/)?([\w.-]+)\.([\w-]+)(?::\d+(?::\d+)?)?$/);
+  if (!fileMatch) return false;
+  const name = fileMatch[1] ?? "";
+  if (/^[A-Z]/.test(name) && !name.includes("/") && !name.includes("-")) return false;
+  return CODE_EXTENSIONS.has(fileMatch[2]?.toLowerCase() ?? "");
 }
 
 function classifyMatch(text: string): HighlightKind {

--- a/src/chat-tokenizer.ts
+++ b/src/chat-tokenizer.ts
@@ -1,0 +1,60 @@
+type HighlightKind = "plain" | "code" | "bold" | "path";
+
+export type HighlightToken = {
+  text: string;
+  kind: HighlightKind;
+};
+
+type TokenRule = {
+  kind: Exclude<HighlightKind, "plain" | "path">;
+  pattern: RegExp;
+};
+
+const TOKEN_RULES: TokenRule[] = [
+  { kind: "code", pattern: /`[^`]+`/ },
+  { kind: "bold", pattern: /\*\*[^*]+\*\*/ },
+];
+
+const COMBINED_TOKEN_PATTERN = new RegExp(`(${TOKEN_RULES.map((r) => r.pattern.source).join("|")})`, "g");
+
+function looksLikePathRef(token: string): boolean {
+  if (token.length === 0) return false;
+  if (token.startsWith("@")) return false;
+  const fileWithExt = /^(?:\.{1,2}\/)?[\w.-]+\.[\w-]+(?::\d+(?::\d+)?)?$/.test(token);
+  const slashPath = /^(?:\.{1,2}\/|~\/)?[\w.-]+(?:\/[\w.-]+)+(?:\.[\w-]+)?(?::\d+(?::\d+)?)?$/.test(token);
+  return fileWithExt || slashPath;
+}
+
+function classifyMatch(text: string): HighlightKind {
+  for (const rule of TOKEN_RULES) {
+    if (rule.pattern.test(text)) return rule.kind;
+  }
+  return "plain";
+}
+
+function tokenizePlainSegment(text: string): HighlightToken[] {
+  const tokens: HighlightToken[] = [];
+  const chunks = text.split(/(\s+)/).filter((c) => c.length > 0);
+  for (const chunk of chunks) {
+    if (/^\s+$/.test(chunk)) {
+      tokens.push({ text: chunk, kind: "plain" });
+      continue;
+    }
+    const core = chunk.replace(/^[("'`]+|[)",.;!?]+$/g, "");
+    tokens.push({ text: chunk, kind: looksLikePathRef(core) ? "path" : "plain" });
+  }
+  return tokens;
+}
+
+export function tokenizeForHighlighting(line: string): HighlightToken[] {
+  const tokens: HighlightToken[] = [];
+  let lastIndex = 0;
+  for (const match of line.matchAll(COMBINED_TOKEN_PATTERN)) {
+    const start = match.index;
+    if (start > lastIndex) tokens.push(...tokenizePlainSegment(line.slice(lastIndex, start)));
+    tokens.push({ text: match[0], kind: classifyMatch(match[0]) });
+    lastIndex = start + match[0].length;
+  }
+  if (lastIndex < line.length) tokens.push(...tokenizePlainSegment(line.slice(lastIndex)));
+  return tokens;
+}

--- a/src/palette.ts
+++ b/src/palette.ts
@@ -6,7 +6,6 @@ export const palette = {
 
   // Text
   text: "white",
-  textCode: "#D4B3FF",
   textMuted: "#6B7280",
 
   // Diff


### PR DESCRIPTION
## Motivation

The inline code highlight color (#D4B3FF purple) was too colorful for a terminal tool, the tokenizer didn't support bold markdown, and path detection had false positives on version numbers and proper nouns like Node.js.

## Summary

- extract tokenizer to `chat-tokenizer.ts` with declarative rule-based pattern matching
- add `**bold**` token support alongside backtick code and path detection
- render code/paths as dim white, bold as bold white, plain as regular white
- reduce path detection false positives: require known code extension for bare filenames, reject capitalized words
- use exhaustive switch with `unreachable` for token rendering
- remove `textCode` color from palette
- add formatting instruction to core agent instructions: plain text, backticks for code, bold for emphasis, no headings/links/code blocks, lists only when necessary
- rename `HighlightToken` → `MarkupToken`, `HighlightKind` → `MarkupTokenKind`, `tokenizeForHighlighting` → `tokenize`