### PR TITLE
refactor: drop legacy migrations, reset protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ An open-source, terminal-first AI coding agent with a single-pass lifecycle, on-
 curl -fsSL https://acolyte.sh/install | sh
 ```
 
+[What does this do?](scripts/install.sh)
+
 Then initialize your provider:
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,4 +35,5 @@ Developer documentation for Acolyte, a terminal-first AI coding agent. Reliable 
 - [Configuration](./configuration.md) — settings for models, providers, memory, permissions, and runtime behavior
 - [Protocol](./protocol.md) — transport-facing contract between client and server
 - [Localization](./localization.md) — translatable copy separated from protocol contracts
+- [Updates](./updates.md) — versioning, auto-update, and breaking change policy
 - [Glossary](./glossary.md) — core terminology for sessions, tasks, phases, and effects

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -20,4 +20,4 @@ Releases follow [semver](https://semver.org). Patch and minor releases are alway
 
 ## Release process
 
-The `scripts/release.sh` script bumps the version, generates a changelog entry, commits, and tags. CI builds platform binaries and publishes a GitHub release. The install script and auto-updater pull from GitHub releases.
+The [`scripts/release.sh`](../scripts/release.sh) script bumps the version, generates a changelog entry, commits, and tags. CI builds platform binaries and publishes a GitHub release. The install script and auto-updater pull from GitHub releases.

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -10,14 +10,14 @@ Skip the check with `--skip-update` or `ACOLYTE_SKIP_UPDATE=1`. Force a check wi
 
 ## Version compatibility
 
-Auto-update keeps version drift unlikely — most users are on the latest release within 24 hours. Despite this, Acolyte treats compatibility as a first-class concern:
-
 - **Protocol** — the client-server protocol is versioned. Server and client validate the protocol version on connection and reject mismatches cleanly.
-- **Database schemas** — SQLite stores (memory, trace, cache) use forward migrations when schemas change. Migrations run automatically on startup.
-- **Configuration** — config changes include migrations that preserve user settings across versions.
+- **Database schemas** — SQLite stores (memory, trace, cache) will use forward migrations when schemas change. No migration framework exists yet — it will be added when the first schema change requires one.
+- **Configuration** — same approach. Config migrations will be added when a release changes the config format.
 
-The narrow version window means we only need to support N-1 → N migrations, not arbitrary version jumps. But the migrations are always there — even when the probability of hitting them is low.
+## Versioning
+
+Releases follow [semver](https://semver.org). Patch and minor releases are always safe to apply. Major releases may include breaking changes to the protocol, configuration, or database schemas.
 
 ## Release process
 
-Releases follow semver. The `scripts/release.sh` script bumps the version, generates a changelog entry, commits, and tags. CI builds platform binaries and publishes a GitHub release. The install script and auto-updater pull from GitHub releases.
+The `scripts/release.sh` script bumps the version, generates a changelog entry, commits, and tags. CI builds platform binaries and publishes a GitHub release. The install script and auto-updater pull from GitHub releases.

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -1,0 +1,23 @@
+# Updates
+
+How Acolyte handles versioning, updates, and breaking changes.
+
+## Auto-update
+
+The CLI checks for updates on startup (at most once per 24 hours). When a newer version exists, it downloads the binary, verifies the checksum, replaces itself, stops the running server, and re-execs. The user sees a progress bar and then the new version starts normally.
+
+Skip the check with `--skip-update` or `ACOLYTE_SKIP_UPDATE=1`. Force a check with `acolyte update`.
+
+## Version compatibility
+
+Auto-update keeps version drift unlikely — most users are on the latest release within 24 hours. Despite this, Acolyte treats compatibility as a first-class concern:
+
+- **Protocol** — the client-server protocol is versioned. Server and client validate the protocol version on connection and reject mismatches cleanly.
+- **Database schemas** — SQLite stores (memory, trace, cache) use forward migrations when schemas change. Migrations run automatically on startup.
+- **Configuration** — config changes include migrations that preserve user settings across versions.
+
+The narrow version window means we only need to support N-1 → N migrations, not arbitrary version jumps. But the migrations are always there — even when the probability of hitting them is low.
+
+## Release process
+
+Releases follow semver. The `scripts/release.sh` script bumps the version, generates a changelog entry, commits, and tags. CI builds platform binaries and publishes a GitHub release. The install script and auto-updater pull from GitHub releases.

--- a/src/client-contract.ts
+++ b/src/client-contract.ts
@@ -23,12 +23,8 @@ type UsageLikePayload = {
   inputTokens?: unknown;
   outputTokens?: unknown;
   totalTokens?: unknown;
-  promptTokens?: unknown;
-  completionTokens?: unknown;
   inputBudgetTokens?: unknown;
   inputTruncated?: unknown;
-  promptBudgetTokens?: unknown;
-  promptTruncated?: unknown;
 };
 
 type ParsedUsagePayload = {
@@ -186,42 +182,23 @@ export function parseStreamEvent(raw: unknown): StreamEvent | null {
   return event;
 }
 
+function parseUsageNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
 function parseUsagePayload(raw: unknown): ParsedUsagePayload | undefined {
   if (!raw || typeof raw !== "object") return undefined;
   const usage = raw as UsageLikePayload;
-  const inputTokens = parseUsageNumber(usage.inputTokens) ?? parseUsageNumber(usage.promptTokens);
-  const outputTokens = parseUsageNumber(usage.outputTokens) ?? parseUsageNumber(usage.completionTokens);
-  const inputBudgetTokens = parseUsageOptionalNumber(usage, "inputBudgetTokens", "promptBudgetTokens");
-  const inputTruncated = parseUsageOptionalBoolean(usage, "inputTruncated", "promptTruncated");
+  const inputTokens = parseUsageNumber(usage.inputTokens);
+  const outputTokens = parseUsageNumber(usage.outputTokens);
   if (typeof inputTokens !== "number" || typeof outputTokens !== "number") return undefined;
   return {
     inputTokens,
     outputTokens,
     totalTokens: parseUsageNumber(usage.totalTokens) ?? inputTokens + outputTokens,
-    ...(typeof inputBudgetTokens === "number" ? { inputBudgetTokens } : {}),
-    ...(typeof inputTruncated === "boolean" ? { inputTruncated } : {}),
+    ...(typeof usage.inputBudgetTokens === "number" ? { inputBudgetTokens: usage.inputBudgetTokens } : {}),
+    ...(typeof usage.inputTruncated === "boolean" ? { inputTruncated: usage.inputTruncated } : {}),
   };
-}
-
-function parseUsageNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
-
-function parseUsageOptionalNumber(
-  usage: UsageLikePayload,
-  primary: keyof UsageLikePayload,
-  fallback: keyof UsageLikePayload,
-): number | undefined {
-  return parseUsageNumber(usage[primary]) ?? parseUsageNumber(usage[fallback]);
-}
-
-function parseUsageOptionalBoolean(
-  usage: UsageLikePayload,
-  primary: keyof UsageLikePayload,
-  fallback: keyof UsageLikePayload,
-): boolean | undefined {
-  const value = usage[primary];
-  return typeof value === "boolean" ? value : typeof usage[fallback] === "boolean" ? usage[fallback] : undefined;
 }
 
 export function parseChatResponse(payload: unknown): ChatResponse | null {
@@ -230,7 +207,6 @@ export function parseChatResponse(payload: unknown): ChatResponse | null {
   if (typeof json.output !== "string") return null;
   if (typeof json.model !== "string" || json.model.trim().length === 0) return null;
   const parsedUsage = json.usage ? parseUsagePayload(json.usage) : undefined;
-  // TODO(cniska): Drop legacy prompt/completion parsing at v1.0.0.
   return {
     output: json.output,
     model: json.model,

--- a/src/lifecycle-finalize.test.ts
+++ b/src/lifecycle-finalize.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseChatResponse, parseStreamEvent } from "./client-contract";
+import { parseChatResponse } from "./client-contract";
 import { phaseFinalize } from "./lifecycle-finalize";
 import { createRunContext } from "./test-utils";
 
@@ -31,34 +31,6 @@ describe("ChatResponse error field", () => {
     });
     expect(response).not.toBeNull();
     expect(response?.error).toBeUndefined();
-  });
-
-  test("parseChatResponse accepts legacy prompt/completion usage fields", () => {
-    const response = parseChatResponse({
-      output: "Hello",
-      model: "gpt-5-mini",
-      usage: {
-        promptTokens: 12,
-        completionTokens: 8,
-        totalTokens: 20,
-        promptBudgetTokens: 100,
-        promptTruncated: true,
-      },
-    });
-    expect(response?.usage?.inputTokens).toBe(12);
-    expect(response?.usage?.outputTokens).toBe(8);
-    expect(response?.usage?.totalTokens).toBe(20);
-    expect(response?.usage?.inputBudgetTokens).toBe(100);
-    expect(response?.usage?.inputTruncated).toBe(true);
-  });
-
-  test("parseStreamEvent accepts legacy usage event fields", () => {
-    const event = parseStreamEvent({
-      type: "usage",
-      promptTokens: 9,
-      completionTokens: 4,
-    });
-    expect(event).toEqual({ type: "usage", inputTokens: 9, outputTokens: 4 });
   });
 });
 

--- a/src/memory-store.int.test.ts
+++ b/src/memory-store.int.test.ts
@@ -1,16 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
 import type { MemoryRecord } from "./memory-contract";
-import { createSqliteMemoryStore, migrateFromFilesystem, migrateFromMarkdown } from "./memory-store";
-import { tempDb, tempDir } from "./test-utils";
+import { createSqliteMemoryStore } from "./memory-store";
+import { tempDb } from "./test-utils";
 
 const { create: createStore, cleanup: cleanupStores } = tempDb("acolyte-memory-", createSqliteMemoryStore);
-const { createDir, cleanupDirs } = tempDir();
-afterEach(() => {
-  cleanupStores();
-  cleanupDirs();
-});
+afterEach(cleanupStores);
 
 describe("createSqliteMemoryStore", () => {
   test("list returns empty for nonexistent session", async () => {
@@ -314,123 +308,5 @@ describe("embedding storage", () => {
     expect(store.getEmbedding(record.id)).not.toBeNull();
     await store.remove(record.id);
     expect(store.getEmbedding(record.id)).toBeNull();
-  });
-});
-
-describe("migrateFromFilesystem", () => {
-  test("migrates JSON files into SQLite store", async () => {
-    const home = createDir("acolyte-migrate-");
-    const scopeDir = join(home, ".acolyte", "distill", "sess_abc123");
-    mkdirSync(scopeDir, { recursive: true });
-
-    // Legacy format uses "tier" not "kind"
-    const legacyRecord = {
-      id: "mem_migr001",
-      scopeKey: "sess_abc123",
-      tier: "observation",
-      content: "migrated fact",
-      createdAt: "2026-03-04T12:00:00.000Z",
-      tokenEstimate: 3,
-    };
-    writeFileSync(join(scopeDir, `${legacyRecord.id}.json`), JSON.stringify(legacyRecord), "utf8");
-
-    const store = createSqliteMemoryStore(join(home, "test.db"));
-    const count = await migrateFromFilesystem(home, store);
-    expect(count).toBe(1);
-
-    const records = await store.list({ scopeKey: "sess_abc123" });
-    expect(records).toHaveLength(1);
-    expect(records[0]?.content).toBe("migrated fact");
-
-    // Old directory should be renamed to distill.bak
-    const { existsSync } = await import("node:fs");
-    expect(existsSync(join(home, ".acolyte", "distill"))).toBe(false);
-    expect(existsSync(join(home, ".acolyte", "distill.bak"))).toBe(true);
-  });
-
-  test("returns 0 when no distill directory exists", async () => {
-    const home = createDir("acolyte-migrate-");
-    const store = createSqliteMemoryStore(join(home, "test.db"));
-    const count = await migrateFromFilesystem(home, store);
-    expect(count).toBe(0);
-  });
-
-  test("skips invalid JSON files during migration", async () => {
-    const home = createDir("acolyte-migrate-");
-    const scopeDir = join(home, ".acolyte", "distill", "sess_abc123");
-    mkdirSync(scopeDir, { recursive: true });
-
-    writeFileSync(join(scopeDir, "mem_broken.json"), "not valid json", "utf8");
-
-    // Legacy format uses "tier" not "kind"
-    const validRecord = {
-      id: "mem_valid001",
-      scopeKey: "sess_abc123",
-      tier: "observation",
-      content: "valid record",
-      createdAt: "2026-03-04T12:00:00.000Z",
-      tokenEstimate: 3,
-    };
-    writeFileSync(join(scopeDir, `${validRecord.id}.json`), JSON.stringify(validRecord), "utf8");
-
-    const store = createSqliteMemoryStore(join(home, "test.db"));
-    const count = await migrateFromFilesystem(home, store);
-    expect(count).toBe(1);
-
-    const records = await store.list({ scopeKey: "sess_abc123" });
-    expect(records).toHaveLength(1);
-    expect(records[0]?.content).toBe("valid record");
-  });
-
-  test("renames distill dir even when all files are invalid", async () => {
-    const home = createDir("acolyte-migrate-");
-    const scopeDir = join(home, ".acolyte", "distill", "sess_abc123");
-    mkdirSync(scopeDir, { recursive: true });
-    writeFileSync(join(scopeDir, "mem_broken.json"), "not valid json", "utf8");
-
-    const store = createSqliteMemoryStore(join(home, "test.db"));
-    const count = await migrateFromFilesystem(home, store);
-    expect(count).toBe(0);
-
-    const { existsSync } = await import("node:fs");
-    expect(existsSync(join(home, ".acolyte", "distill"))).toBe(false);
-    expect(existsSync(join(home, ".acolyte", "distill.bak"))).toBe(true);
-  });
-});
-
-describe("migrateFromMarkdown", () => {
-  test("migrates markdown memory files into SQLite store", async () => {
-    const home = createDir("acolyte-migrate-md-");
-    const cwd = createDir("acolyte-migrate-cwd-");
-    const userDir = join(home, ".acolyte", "memory", "user");
-    mkdirSync(userDir, { recursive: true });
-    writeFileSync(
-      join(userDir, "mem_abc123.md"),
-      "---\nid: mem_abc123\ncreatedAt: 2026-03-04T12:00:00.000Z\nscope: user\n---\nPrefer concise answers",
-      "utf8",
-    );
-
-    const store = createSqliteMemoryStore(join(home, "test.db"));
-    const count = await migrateFromMarkdown(home, cwd, store);
-    expect(count).toBe(1);
-
-    const records = await store.list({ kind: "stored" });
-    expect(records).toHaveLength(1);
-    expect(records[0]?.content).toBe("Prefer concise answers");
-    expect(records[0]?.id).toBe("mem_abc123");
-
-    const { existsSync } = await import("node:fs");
-    expect(existsSync(userDir)).toBe(false);
-    expect(existsSync(`${userDir}.bak`)).toBe(true);
-    store.close();
-  });
-
-  test("returns 0 when no markdown memory directories exist", async () => {
-    const home = createDir("acolyte-migrate-md-");
-    const cwd = createDir("acolyte-migrate-cwd-");
-    const store = createSqliteMemoryStore(join(home, "test.db"));
-    const count = await migrateFromMarkdown(home, cwd, store);
-    expect(count).toBe(0);
-    store.close();
   });
 });

--- a/src/memory-store.ts
+++ b/src/memory-store.ts
@@ -1,60 +1,15 @@
 import { Database } from "bun:sqlite";
-import { existsSync, mkdirSync } from "node:fs";
-import { readdir, readFile, rename } from "node:fs/promises";
+import { mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join } from "node:path";
 import { log } from "./log";
-import { type MemoryRecord, type MemoryStore, memoryRecordSchema, scopeFromKey } from "./memory-contract";
+import { type MemoryRecord, type MemoryStore, scopeFromKey } from "./memory-contract";
 
 export function safeScopeKey(scope: string): string | null {
   return /^(sess|user|proj)_[a-z0-9_-]+$/.test(scope) ? scope : null;
 }
 
-// TODO(cniska): Drop migrateLegacySchema at v1.0.0.
-function migrateLegacySchema(db: Database): void {
-  const hasLegacyTable = db
-    .prepare<{ name: string }, []>("SELECT name FROM sqlite_master WHERE type='table' AND name='distill_records'")
-    .get();
-  if (hasLegacyTable) {
-    db.run("ALTER TABLE distill_records RENAME TO memories");
-    db.run("ALTER TABLE memories RENAME COLUMN tier TO kind");
-    db.run("ALTER TABLE memories ADD COLUMN scope TEXT NOT NULL DEFAULT ''");
-    db.run(`
-      UPDATE memories SET scope = CASE
-        WHEN scope_key LIKE 'sess_%' THEN 'session'
-        WHEN scope_key LIKE 'proj_%' THEN 'project'
-        WHEN scope_key LIKE 'user_%' THEN 'user'
-        ELSE ''
-      END
-    `);
-  }
-  const hasLegacyEmb = db
-    .prepare<{ name: string }, []>("SELECT name FROM sqlite_master WHERE type='table' AND name='distill_embeddings'")
-    .get();
-  if (hasLegacyEmb) {
-    db.run("ALTER TABLE distill_embeddings RENAME TO memory_embeddings");
-    db.run("ALTER TABLE memory_embeddings RENAME COLUMN record_id TO id");
-    db.run("ALTER TABLE memory_embeddings RENAME COLUMN scope_key TO scope");
-  }
-  // Migrate dst_ IDs to mem_ IDs (safe on fresh DBs — WHERE clause matches nothing)
-  if (hasLegacyTable || hasLegacyEmb) {
-    db.run("UPDATE memories SET id = 'mem_' || substr(id, 5) WHERE id LIKE 'dst_%'");
-    db.run("UPDATE memory_embeddings SET id = 'mem_' || substr(id, 5) WHERE id LIKE 'dst_%'");
-    db.run("DELETE FROM memory_embeddings WHERE id IN (SELECT id FROM memories WHERE kind = 'reflection')");
-    db.run("DELETE FROM memories WHERE kind = 'reflection'");
-  }
-  // Drop continuation state columns
-  const cols = db.prepare("PRAGMA table_info(memories)").all() as { name: string }[];
-  const names = new Set(cols.map((c) => c.name));
-  if (names.has("current_task")) db.run("ALTER TABLE memories DROP COLUMN current_task");
-  if (names.has("next_step")) db.run("ALTER TABLE memories DROP COLUMN next_step");
-  if (names.size > 0 && !names.has("last_recalled_at")) {
-    db.run("ALTER TABLE memories ADD COLUMN last_recalled_at TEXT");
-  }
-}
-
 function initSchema(db: Database): void {
-  migrateLegacySchema(db);
   db.run(`
     CREATE TABLE IF NOT EXISTS memories (
       id TEXT PRIMARY KEY,
@@ -203,119 +158,7 @@ export function getDefaultMemoryStore(): MemoryStore {
   if (!defaultInstance) {
     defaultInstance = createSqliteMemoryStore();
     log.debug("memory.store.opened");
-    const home = homedir();
-    migrateFromFilesystem(home, defaultInstance).catch((error) => {
-      log.warn("memory.distill.migration_failed", { error: String(error) });
-    });
-    migrateFromMarkdown(home, process.cwd(), defaultInstance).catch((error) => {
-      log.warn("memory.markdown.migration_failed", { error: String(error) });
-    });
     process.on("exit", () => defaultInstance?.close());
   }
   return defaultInstance;
-}
-
-// TODO(cniska): Drop legacy distill filesystem migration at v1.0.0.
-export async function migrateFromFilesystem(homeDir: string, store: MemoryStore): Promise<number> {
-  const distillDir = join(homeDir, ".acolyte", "distill");
-  if (!existsSync(distillDir)) return 0;
-
-  let migrated = 0;
-  const scopeDirs = await readdir(distillDir, { withFileTypes: true });
-  const records: MemoryRecord[] = [];
-  for (const entry of scopeDirs) {
-    if (!entry.isDirectory()) continue;
-    const scope = entry.name;
-    if (!safeScopeKey(scope)) continue;
-    const scopePath = join(distillDir, scope);
-    const files = await readdir(scopePath);
-    for (const file of files) {
-      if (!file.endsWith(".json")) continue;
-      try {
-        const raw = await readFile(join(scopePath, file), "utf8");
-        const json = JSON.parse(raw);
-        if (json.tier && !json.kind) json.kind = json.tier;
-        if (json.sessionId && !json.scopeKey) json.scopeKey = json.sessionId;
-        const parsed = memoryRecordSchema.safeParse(json);
-        if (parsed.success) records.push(parsed.data);
-      } catch {
-        // Skip unreadable files.
-      }
-    }
-  }
-
-  for (const record of records) {
-    await store.write(record, scopeFromKey(record.scopeKey));
-    migrated += 1;
-  }
-
-  const backupPath = join(homeDir, ".acolyte", "distill.bak");
-  if (!existsSync(backupPath)) {
-    await rename(distillDir, backupPath);
-  }
-
-  log.info("memory.distill.migration_done", { migrated });
-  return migrated;
-}
-
-// TODO(cniska): Drop legacy markdown memory migration at v1.0.0.
-export async function migrateFromMarkdown(homeDir: string, cwd: string, store: MemoryStore): Promise<number> {
-  const dirs: { path: string; scope: "user" | "project"; scopeKey: string }[] = [
-    {
-      path: join(homeDir, ".acolyte", "memory", "user"),
-      scope: "user",
-      scopeKey: `user_${new Bun.CryptoHasher("sha1").update(resolve(homeDir)).digest("hex").slice(0, 12)}`,
-    },
-    {
-      path: join(cwd, ".acolyte", "memory", "project"),
-      scope: "project",
-      scopeKey: `proj_${new Bun.CryptoHasher("sha1").update(resolve(cwd)).digest("hex").slice(0, 12)}`,
-    },
-  ];
-
-  let migrated = 0;
-  for (const { path: dir, scope, scopeKey } of dirs) {
-    if (!existsSync(dir)) continue;
-    const files = await readdir(dir);
-    for (const file of files) {
-      if (!file.endsWith(".md")) continue;
-      try {
-        const raw = await readFile(join(dir, file), "utf8");
-        const match = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
-        if (!match) continue;
-        const meta: Record<string, string> = {};
-        for (const line of match[1].split("\n")) {
-          const idx = line.indexOf(":");
-          if (idx <= 0) continue;
-          meta[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
-        }
-        const id = meta.id?.trim();
-        const createdAt = meta.createdAt?.trim();
-        const content = match[2].trim();
-        if (!id || !createdAt || !content) continue;
-
-        await store.write(
-          {
-            id,
-            scopeKey,
-            kind: "stored",
-            content,
-            createdAt,
-            tokenEstimate: Math.ceil(content.length / 4),
-          },
-          scope,
-        );
-        migrated += 1;
-      } catch {
-        // Skip unreadable files.
-      }
-    }
-    const backupPath = `${dir}.bak`;
-    if (!existsSync(backupPath)) {
-      await rename(dir, backupPath);
-    }
-  }
-
-  if (migrated > 0) log.info("memory.markdown.migration_done", { migrated });
-  return migrated;
 }

--- a/src/protocol.test.ts
+++ b/src/protocol.test.ts
@@ -3,7 +3,7 @@ import { formatServerCapabilities, PROTOCOL_VERSION } from "./protocol";
 
 describe("protocol metadata", () => {
   test("exposes stable protocol version", () => {
-    expect(PROTOCOL_VERSION).toBe("4");
+    expect(PROTOCOL_VERSION).toBe("1");
   });
 
   test("formats server capabilities as deterministic csv", () => {

--- a/src/protocol.ts
+++ b/src/protocol.ts
@@ -1,4 +1,4 @@
-export const PROTOCOL_VERSION = "4";
+export const PROTOCOL_VERSION = "1";
 
 export const SERVER_CAPABILITIES = ["stream.sse", "error.structured", "workspace.path"] as const;
 

--- a/src/storage.test.ts
+++ b/src/storage.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { normalizeStore } from "./storage";
 
 describe("storage", () => {
-  test("normalizeStore defaults missing tokenUsage to an empty list", () => {
+  test("normalizeStore drops sessions missing tokenUsage", () => {
     const normalized = normalizeStore({
       activeSessionId: "sess_1",
       sessions: [
@@ -17,8 +17,7 @@ describe("storage", () => {
       ] as never,
     });
 
-    expect(normalized.sessions).toHaveLength(1);
-    expect(normalized.sessions[0]?.tokenUsage).toEqual([]);
+    expect(normalized.sessions).toHaveLength(0);
   });
 
   test("normalizeStore preserves existing tokenUsage entries", () => {

--- a/src/storage.test.ts
+++ b/src/storage.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { normalizeStore } from "./storage";
+import { parseSessionState } from "./storage";
 
 describe("storage", () => {
-  test("normalizeStore drops sessions missing tokenUsage", () => {
-    const normalized = normalizeStore({
+  test("parseSessionState drops sessions missing tokenUsage", () => {
+    const normalized = parseSessionState({
       activeSessionId: "sess_1",
       sessions: [
         {
@@ -20,8 +20,8 @@ describe("storage", () => {
     expect(normalized.sessions).toHaveLength(0);
   });
 
-  test("normalizeStore preserves existing tokenUsage entries", () => {
-    const normalized = normalizeStore({
+  test("parseSessionState preserves existing tokenUsage entries", () => {
+    const normalized = parseSessionState({
       activeSessionId: "sess_1",
       sessions: [
         {
@@ -52,8 +52,8 @@ describe("storage", () => {
     expect(normalized.sessions[0]?.tokenUsage[0]?.modelCalls).toBe(2);
   });
 
-  test("normalizeStore defaults missing message kind to text", () => {
-    const normalized = normalizeStore({
+  test("parseSessionState defaults missing message kind to text", () => {
+    const normalized = parseSessionState({
       activeSessionId: "sess_1",
       sessions: [
         {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -12,72 +12,8 @@ const STORE_PATH = join(DATA_DIR, "sessions.json");
 
 const EMPTY_STORE: SessionState = { sessions: [] };
 
-type LegacySessionTokenUsageEntry = {
-  id?: unknown;
-  usage?: {
-    inputTokens?: unknown;
-    outputTokens?: unknown;
-    totalTokens?: unknown;
-    inputBudgetTokens?: unknown;
-    inputTruncated?: unknown;
-    promptTokens?: unknown;
-    completionTokens?: unknown;
-    promptBudgetTokens?: unknown;
-    promptTruncated?: unknown;
-  };
-  promptBreakdown?: unknown;
-
-  modelCalls?: unknown;
-};
-
-function normalizeLegacyTokenUsageEntry(entry: unknown): unknown | null {
-  if (!entry || typeof entry !== "object") return null;
-  const record = entry as LegacySessionTokenUsageEntry;
-  if (!record.usage || typeof record.usage !== "object") return null;
-  const usage = record.usage;
-  if (
-    typeof usage.inputTokens === "number" &&
-    typeof usage.outputTokens === "number" &&
-    typeof usage.totalTokens === "number"
-  ) {
-    return record;
-  }
-  if (
-    typeof usage.promptTokens !== "number" ||
-    typeof usage.completionTokens !== "number" ||
-    typeof usage.totalTokens !== "number"
-  ) {
-    return null;
-  }
-  // TODO(cniska): Drop legacy session usage support at v1.0.0.
-  return {
-    ...record,
-    usage: {
-      inputTokens: usage.promptTokens,
-      outputTokens: usage.completionTokens,
-      totalTokens: usage.totalTokens,
-      ...(typeof usage.promptBudgetTokens === "number" ? { inputBudgetTokens: usage.promptBudgetTokens } : {}),
-      ...(typeof usage.promptTruncated === "boolean" ? { inputTruncated: usage.promptTruncated } : {}),
-    },
-  };
-}
-
 export function normalizeStore(parsed: SessionState): SessionState {
-  const normalized = {
-    sessions: Array.isArray(parsed.sessions)
-      ? parsed.sessions.map((session) => {
-          const rawTokenUsage = Array.isArray((session as Partial<Session>).tokenUsage)
-            ? ((session as Partial<Session>).tokenUsage as unknown[])
-            : [];
-          const tokenUsage = rawTokenUsage
-            .map(normalizeLegacyTokenUsageEntry)
-            .filter((entry): entry is Session["tokenUsage"][number] => entry !== null);
-          return { ...session, tokenUsage } as Session;
-        })
-      : [],
-    activeSessionId: parsed.activeSessionId,
-  };
-  const result = sessionStateSchema.safeParse(normalized);
+  const result = sessionStateSchema.safeParse(parsed);
   return result.success ? result.data : EMPTY_STORE;
 }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -12,8 +12,8 @@ const STORE_PATH = join(DATA_DIR, "sessions.json");
 
 const EMPTY_STORE: SessionState = { sessions: [] };
 
-export function normalizeStore(parsed: SessionState): SessionState {
-  const result = sessionStateSchema.safeParse(parsed);
+export function normalizeStore(input: SessionState): SessionState {
+  const result = sessionStateSchema.safeParse(input);
   return result.success ? result.data : EMPTY_STORE;
 }
 

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -10,22 +10,22 @@ import { createId } from "./short-id";
 const DATA_DIR = join(homedir(), ".acolyte");
 const STORE_PATH = join(DATA_DIR, "sessions.json");
 
-const EMPTY_STORE: SessionState = { sessions: [] };
+const DEFAULT_SESSION_STATE: SessionState = { sessions: [] };
 
-export function normalizeStore(input: SessionState): SessionState {
+export function parseSessionState(input: SessionState): SessionState {
   const result = sessionStateSchema.safeParse(input);
-  return result.success ? result.data : EMPTY_STORE;
+  return result.success ? result.data : DEFAULT_SESSION_STATE;
 }
 
 export async function readStore(): Promise<SessionState> {
-  if (!existsSync(STORE_PATH)) return EMPTY_STORE;
+  if (!existsSync(STORE_PATH)) return DEFAULT_SESSION_STATE;
 
   try {
     const raw = await readFile(STORE_PATH, "utf8");
     const parsed = JSON.parse(raw) as SessionState;
-    return normalizeStore(parsed);
+    return parseSessionState(parsed);
   } catch {
-    return EMPTY_STORE;
+    return DEFAULT_SESSION_STATE;
   }
 }
 


### PR DESCRIPTION
## Motivation

No external users have used Acolyte in production yet. All legacy data formats (distill filesystem, markdown memory, prompt/completion token naming) predate any real usage. Carrying these migrations forward is dead code.

## Summary

- drop `migrateLegacySchema`, `migrateFromFilesystem`, `migrateFromMarkdown` from memory store
- drop legacy `promptTokens`/`completionTokens` fallback parsing from client contract
- drop legacy session usage normalization from storage
- reset protocol version from "4" to "1" — clean slate for the public API
- remove migration tests, update affected test expectations
- add `docs/updates.md` documenting auto-update, version compatibility, and release process
- link install script from README for transparency