### PR TITLE
feat: add database migration framework

### DIFF
--- a/docs/updates.md
+++ b/docs/updates.md
@@ -11,7 +11,7 @@ Skip the check with `--skip-update` or `ACOLYTE_SKIP_UPDATE=1`. Force a check wi
 ## Version compatibility
 
 - **Protocol** — the client-server protocol is versioned. Server and client validate the protocol version on connection and reject mismatches cleanly.
-- **Database schemas** — SQLite stores (memory, trace, cache) will use forward migrations when schemas change. No migration framework exists yet — it will be added when the first schema change requires one.
+- **Database schemas** — SQLite stores (memory, trace, cache) use versioned forward migrations (`db-migrate.ts`). Each store defines a migrations array; pending migrations run automatically on startup within transactions. Migrations are cumulative — if a user skips several versions, all intermediate migrations run in sequence.
 - **Configuration** — same approach. Config migrations will be added when a release changes the config format.
 
 ## Versioning

--- a/src/db-migrate.test.ts
+++ b/src/db-migrate.test.ts
@@ -1,0 +1,52 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { type Migration, migrateUp } from "./db-migrate";
+
+function createTestDb(): Database {
+  return new Database(":memory:");
+}
+
+const migrations: Migration[] = [
+  {
+    version: 1,
+    up: "CREATE TABLE items (id TEXT PRIMARY KEY, name TEXT NOT NULL)",
+  },
+  {
+    version: 2,
+    up: "ALTER TABLE items ADD COLUMN status TEXT NOT NULL DEFAULT 'active'",
+  },
+];
+
+describe("migrateUp", () => {
+  test("runs all migrations on empty database", () => {
+    const db = createTestDb();
+    const count = migrateUp(db, migrations);
+    expect(count).toBe(2);
+    const row = db.prepare<{ version: number }, []>("SELECT version FROM schema_version").get();
+    expect(row?.version).toBe(2);
+  });
+
+  test("skips already-applied migrations", () => {
+    const db = createTestDb();
+    migrateUp(db, migrations);
+    const count = migrateUp(db, migrations);
+    expect(count).toBe(0);
+  });
+
+  test("runs only pending migrations", () => {
+    const db = createTestDb();
+    migrateUp(db, [migrations[0]]);
+    const count = migrateUp(db, migrations);
+    expect(count).toBe(1);
+    const row = db.prepare<{ version: number }, []>("SELECT version FROM schema_version").get();
+    expect(row?.version).toBe(2);
+  });
+
+  test("creates usable tables", () => {
+    const db = createTestDb();
+    migrateUp(db, migrations);
+    db.run("INSERT INTO items (id, name) VALUES ('a', 'test')");
+    const row = db.prepare<{ id: string; name: string; status: string }, []>("SELECT * FROM items").get();
+    expect(row).toEqual({ id: "a", name: "test", status: "active" });
+  });
+});

--- a/src/db-migrate.ts
+++ b/src/db-migrate.ts
@@ -1,0 +1,31 @@
+import type { Database } from "bun:sqlite";
+
+export type Migration = {
+  version: number;
+  up: string;
+};
+
+function ensureVersionTable(db: Database): void {
+  db.run("CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)");
+  const row = db.prepare<{ version: number }, []>("SELECT version FROM schema_version LIMIT 1").get();
+  if (!row) db.run("INSERT INTO schema_version (version) VALUES (0)");
+}
+
+export function migrateUp(db: Database, migrations: Migration[]): number {
+  ensureVersionTable(db);
+  const row = db.prepare<{ version: number }, []>("SELECT version FROM schema_version LIMIT 1").get();
+  const current = row?.version ?? 0;
+  const pending = migrations.filter((m) => m.version > current).sort((a, b) => a.version - b.version);
+  for (const m of pending) {
+    db.run("BEGIN");
+    try {
+      db.run(m.up);
+      db.run("UPDATE schema_version SET version = ?", [m.version]);
+      db.run("COMMIT");
+    } catch (error) {
+      db.run("ROLLBACK");
+      throw error;
+    }
+  }
+  return pending.length;
+}

--- a/src/memory-store.ts
+++ b/src/memory-store.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { type Migration, migrateUp } from "./db-migrate";
 import { log } from "./log";
 import { type MemoryRecord, type MemoryStore, scopeFromKey } from "./memory-contract";
 
@@ -9,30 +10,31 @@ export function safeScopeKey(scope: string): string | null {
   return /^(sess|user|proj)_[a-z0-9_-]+$/.test(scope) ? scope : null;
 }
 
-function initSchema(db: Database): void {
-  db.run(`
-    CREATE TABLE IF NOT EXISTS memories (
-      id TEXT PRIMARY KEY,
-      scope TEXT NOT NULL,
-      scope_key TEXT NOT NULL,
-      kind TEXT NOT NULL,
-      content TEXT NOT NULL,
-      created_at TEXT NOT NULL,
-      token_estimate INTEGER NOT NULL,
-      last_recalled_at TEXT
-    )
-  `);
-  db.run(`CREATE INDEX IF NOT EXISTS idx_memories_scope ON memories(scope)`);
-  db.run(`CREATE INDEX IF NOT EXISTS idx_memories_scope_key ON memories(scope_key)`);
-  db.run(`
-    CREATE TABLE IF NOT EXISTS memory_embeddings (
-      id TEXT PRIMARY KEY,
-      scope TEXT NOT NULL,
-      embedding BLOB NOT NULL
-    )
-  `);
-  db.run(`CREATE INDEX IF NOT EXISTS idx_embeddings_scope ON memory_embeddings(scope)`);
-}
+const MIGRATIONS: Migration[] = [
+  {
+    version: 1,
+    up: `
+      CREATE TABLE IF NOT EXISTS memories (
+        id TEXT PRIMARY KEY,
+        scope TEXT NOT NULL,
+        scope_key TEXT NOT NULL,
+        kind TEXT NOT NULL,
+        content TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        token_estimate INTEGER NOT NULL,
+        last_recalled_at TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_memories_scope ON memories(scope);
+      CREATE INDEX IF NOT EXISTS idx_memories_scope_key ON memories(scope_key);
+      CREATE TABLE IF NOT EXISTS memory_embeddings (
+        id TEXT PRIMARY KEY,
+        scope TEXT NOT NULL,
+        embedding BLOB NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_embeddings_scope ON memory_embeddings(scope);
+    `,
+  },
+];
 
 type MemoryRow = {
   id: string;
@@ -62,7 +64,7 @@ export function createSqliteMemoryStore(dbPath?: string): MemoryStore {
   mkdirSync(dirname(resolvedPath), { recursive: true });
   const db = new Database(resolvedPath, { create: true });
   db.run("PRAGMA journal_mode = WAL");
-  initSchema(db);
+  migrateUp(db, MIGRATIONS);
 
   const listByScopeStmt = db.prepare<MemoryRow, [string]>(
     "SELECT * FROM memories WHERE scope_key = ? ORDER BY created_at ASC",

--- a/src/tool-cache-store.ts
+++ b/src/tool-cache-store.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { type Migration, migrateUp } from "./db-migrate";
 import { log } from "./log";
 
 export interface ToolCacheStore {
@@ -12,30 +13,31 @@ export interface ToolCacheStore {
   close(): void;
 }
 
-function initSchema(db: Database): void {
-  db.run(`
-    CREATE TABLE IF NOT EXISTS tool_cache (
-      key TEXT PRIMARY KEY,
-      value TEXT NOT NULL,
-      created_at TEXT NOT NULL DEFAULT (datetime('now'))
-    )
-  `);
-  db.run(`
-    CREATE TABLE IF NOT EXISTS tool_cache_paths (
-      key TEXT NOT NULL,
-      path TEXT NOT NULL,
-      PRIMARY KEY (key, path)
-    )
-  `);
-  db.run(`CREATE INDEX IF NOT EXISTS idx_cache_path ON tool_cache_paths(path)`);
-}
+const MIGRATIONS: Migration[] = [
+  {
+    version: 1,
+    up: `
+      CREATE TABLE IF NOT EXISTS tool_cache (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      CREATE TABLE IF NOT EXISTS tool_cache_paths (
+        key TEXT NOT NULL,
+        path TEXT NOT NULL,
+        PRIMARY KEY (key, path)
+      );
+      CREATE INDEX IF NOT EXISTS idx_cache_path ON tool_cache_paths(path);
+    `,
+  },
+];
 
 export function createToolCacheStore(dbPath?: string): ToolCacheStore {
   const resolvedPath = dbPath ?? join(homedir(), ".acolyte", "tool.db");
   mkdirSync(dirname(resolvedPath), { recursive: true });
   const db = new Database(resolvedPath, { create: true });
   db.run("PRAGMA journal_mode = WAL");
-  initSchema(db);
+  migrateUp(db, MIGRATIONS);
   log.debug("tool.cache.store_opened", { path: resolvedPath });
 
   const getStmt = db.prepare<{ value: string }, [string]>("SELECT value FROM tool_cache WHERE key = ?");

--- a/src/trace-store.ts
+++ b/src/trace-store.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { type Migration, migrateUp } from "./db-migrate";
 import type { LogLine, TaskSummary } from "./log-parser";
 
 const PROMOTED_COLUMNS = new Set(["event", "task_id", "request_id", "session_id", "sequence"]);
@@ -23,22 +24,25 @@ export interface TraceStore {
   close(): void;
 }
 
-function initSchema(db: Database): void {
-  db.run(`
-    CREATE TABLE IF NOT EXISTS trace_events (
-      id INTEGER PRIMARY KEY AUTOINCREMENT,
-      timestamp TEXT NOT NULL,
-      task_id TEXT,
-      request_id TEXT,
-      session_id TEXT,
-      event TEXT,
-      sequence INTEGER,
-      fields_json TEXT NOT NULL DEFAULT '{}'
-    )
-  `);
-  db.run(`CREATE INDEX IF NOT EXISTS idx_trace_task ON trace_events(task_id)`);
-  db.run(`CREATE INDEX IF NOT EXISTS idx_trace_ts ON trace_events(timestamp DESC)`);
-}
+const MIGRATIONS: Migration[] = [
+  {
+    version: 1,
+    up: `
+      CREATE TABLE IF NOT EXISTS trace_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp TEXT NOT NULL,
+        task_id TEXT,
+        request_id TEXT,
+        session_id TEXT,
+        event TEXT,
+        sequence INTEGER,
+        fields_json TEXT NOT NULL DEFAULT '{}'
+      );
+      CREATE INDEX IF NOT EXISTS idx_trace_task ON trace_events(task_id);
+      CREATE INDEX IF NOT EXISTS idx_trace_ts ON trace_events(timestamp DESC);
+    `,
+  },
+];
 
 type TraceRow = {
   timestamp: string;
@@ -132,7 +136,7 @@ export function createTraceStore(dbPath?: string): TraceStore {
   mkdirSync(dirname(resolvedPath), { recursive: true });
   const db = new Database(resolvedPath, { create: true });
   db.run("PRAGMA journal_mode = WAL");
-  initSchema(db);
+  migrateUp(db, MIGRATIONS);
 
   const writeStmt = db.prepare<
     void,


### PR DESCRIPTION
## Motivation

Auto-update means users can skip versions. Without schema versioning, a database created by an older version could be incompatible with a newer one. A lightweight migration framework ensures schema changes apply safely on startup.

## Summary

- add `db-migrate.ts` with versioned up-only migrations and transaction safety
- replace `initSchema` in memory, trace, and cache stores with migration v1
- each migration runs in a transaction — partial failures roll back cleanly
- `schema_version` table tracks the current version per database
- future schema changes add a v2+ entry to the store's migrations array