### PR TITLE
feat(cli): add --update and --no-update

### DIFF
--- a/.agents/skills/issue/SKILL.md
+++ b/.agents/skills/issue/SKILL.md
@@ -14,6 +14,7 @@ Create a GitHub issue from a short description.
 - Body sections (in order): **What would you like?**, **Motivation**, **Proposed approach**, **Scope**
 - Each section is a `##` heading followed by 1–3 short paragraphs
 - Write plainly — no bullet-heavy lists, no implementation detail
+- Use normal sentence capitalization in prose sections (especially **Motivation**)
 - Inline code only when the identifier is essential to understanding the issue
 - Focus on *what* and *why*, not *how* — leave implementation to the branch
 - Scope section uses a flat bullet list of affected areas

--- a/docs/updates.md
+++ b/docs/updates.md
@@ -6,7 +6,7 @@ How Acolyte handles versioning, updates, and breaking changes.
 
 The CLI checks for updates on startup (at most once per 24 hours). When a newer version exists, it downloads the binary, verifies the checksum, replaces itself, stops the running server, and re-execs. The user sees a progress bar and then the new version starts normally.
 
-Skip the check with `--skip-update` or `ACOLYTE_SKIP_UPDATE=1`. Force a check with `acolyte update`.
+Skip the check with `--no-update` or `ACOLYTE_SKIP_UPDATE=1`. Force a check with `acolyte update`.
 
 ## Version compatibility
 

--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -3,11 +3,11 @@ import {
   hasBoolFlag,
   hasHelpFlag,
   parseFlag,
+  parseGlobalArgsAndCommand,
   parsePositional,
   parseRepeatableFlag,
   parseRequiredFlag,
   parseTailCount,
-  parseTopLevelArgs,
   stripFlag,
 } from "./cli-args";
 
@@ -95,17 +95,17 @@ describe("parsePositional", () => {
   });
 });
 
-describe("parseTopLevelArgs", () => {
+describe("parseGlobalArgsAndCommand", () => {
   test("parses --update with no command", () => {
-    expect(parseTopLevelArgs(["--update"])).toEqual({ command: undefined, args: [], update: "force" });
+    expect(parseGlobalArgsAndCommand(["--update"])).toEqual({ command: undefined, args: [], update: "force" });
   });
 
   test("parses --no-update with no command", () => {
-    expect(parseTopLevelArgs(["--no-update"])).toEqual({ command: undefined, args: [], update: "skip" });
+    expect(parseGlobalArgsAndCommand(["--no-update"])).toEqual({ command: undefined, args: [], update: "skip" });
   });
 
   test("strips global flags and preserves command and args", () => {
-    expect(parseTopLevelArgs(["--update", "run", "--model", "gpt-5-mini", "hi"])).toEqual({
+    expect(parseGlobalArgsAndCommand(["--update", "run", "--model", "gpt-5-mini", "hi"])).toEqual({
       command: "run",
       args: ["--model", "gpt-5-mini", "hi"],
       update: "force",
@@ -113,6 +113,10 @@ describe("parseTopLevelArgs", () => {
   });
 
   test("skip overrides force when both are present", () => {
-    expect(parseTopLevelArgs(["--update", "--no-update"])).toEqual({ command: undefined, args: [], update: "skip" });
+    expect(parseGlobalArgsAndCommand(["--update", "--no-update"])).toEqual({
+      command: undefined,
+      args: [],
+      update: "skip",
+    });
   });
 });

--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -7,6 +7,7 @@ import {
   parseRepeatableFlag,
   parseRequiredFlag,
   parseTailCount,
+  parseTopLevelArgs,
   stripFlag,
 } from "./cli-args";
 
@@ -91,5 +92,27 @@ describe("parsePositional", () => {
 
   test("skips boolean flags", () => {
     expect(parsePositional(["--json", "task"], [])).toEqual(["task"]);
+  });
+});
+
+describe("parseTopLevelArgs", () => {
+  test("parses --update with no command", () => {
+    expect(parseTopLevelArgs(["--update"])).toEqual({ command: undefined, args: [], update: "force" });
+  });
+
+  test("parses --no-update with no command", () => {
+    expect(parseTopLevelArgs(["--no-update"])).toEqual({ command: undefined, args: [], update: "skip" });
+  });
+
+  test("strips global flags and preserves command and args", () => {
+    expect(parseTopLevelArgs(["--update", "run", "--model", "gpt-5-mini", "hi"])).toEqual({
+      command: "run",
+      args: ["--model", "gpt-5-mini", "hi"],
+      update: "force",
+    });
+  });
+
+  test("skip overrides force when both are present", () => {
+    expect(parseTopLevelArgs(["--update", "--no-update"])).toEqual({ command: undefined, args: [], update: "skip" });
   });
 });

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -59,3 +59,31 @@ export function parsePositional(args: string[], flagsWithValues: string[]): stri
   }
   return positional;
 }
+
+export type UpdateBehavior = "auto" | "force" | "skip";
+
+export type TopLevelArgs = {
+  command: string | undefined;
+  args: string[];
+  update: UpdateBehavior;
+};
+
+export function parseTopLevelArgs(argv: string[]): TopLevelArgs {
+  let update: UpdateBehavior = "auto";
+  const filtered: string[] = [];
+
+  for (const arg of argv) {
+    if (arg === "--update") {
+      if (update !== "skip") update = "force";
+      continue;
+    }
+    if (arg === "--no-update" || arg === "--skip-update") {
+      update = "skip";
+      continue;
+    }
+    filtered.push(arg);
+  }
+
+  const [command, ...args] = filtered;
+  return { command, args, update };
+}

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -77,7 +77,7 @@ export function parseGlobalArgsAndCommand(argv: string[]): TopLevelArgs {
       if (update !== "skip") update = "force";
       continue;
     }
-    if (arg === "--no-update" || arg === "--skip-update") {
+    if (arg === "--no-update") {
       update = "skip";
       continue;
     }

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -68,7 +68,7 @@ export type TopLevelArgs = {
   update: UpdateBehavior;
 };
 
-export function parseTopLevelArgs(argv: string[]): TopLevelArgs {
+export function parseGlobalArgsAndCommand(argv: string[]): TopLevelArgs {
   let update: UpdateBehavior = "auto";
   const filtered: string[] = [];
 

--- a/src/cli-help.test.ts
+++ b/src/cli-help.test.ts
@@ -37,6 +37,8 @@ describe("cli-help", () => {
     expect(rows).toEqual([
       { option: "-h, --help", description: "print help" },
       { option: "-V, --version", description: "print version" },
+      { option: "--update", description: "check for updates before running" },
+      { option: "--no-update", description: "disable update checks" },
     ]);
   });
 

--- a/src/cli-help.ts
+++ b/src/cli-help.ts
@@ -38,6 +38,8 @@ export function createUsageOptionRows(): Array<{ option: string; description: st
   return [
     { option: "-h, --help", description: t("cli.help.option.help") },
     { option: "-V, --version", description: t("cli.help.option.version") },
+    { option: "--update", description: t("cli.help.option.update") },
+    { option: "--no-update", description: t("cli.help.option.no_update") },
   ];
 }
 

--- a/src/cli-update.ts
+++ b/src/cli-update.ts
@@ -294,9 +294,10 @@ export async function updateMode(): Promise<void> {
   await performUpdate(currentVersion, update.latest, update.downloadUrl);
 }
 
-export async function checkAndUpdateOnStartup(): Promise<boolean> {
+export async function checkAndUpdateOnStartup(options?: { skip?: boolean }): Promise<boolean> {
+  if (options?.skip) return false;
   if (process.env.ACOLYTE_SKIP_UPDATE === "1") return false;
-  if (process.argv.includes("--skip-update")) return false;
+  if (process.argv.includes("--skip-update") || process.argv.includes("--no-update")) return false;
 
   const currentVersion = resolveCliVersion();
   if (currentVersion === "dev") return false;

--- a/src/cli-update.ts
+++ b/src/cli-update.ts
@@ -297,7 +297,7 @@ export async function updateMode(): Promise<void> {
 export async function checkAndUpdateOnStartup(options?: { skip?: boolean }): Promise<boolean> {
   if (options?.skip) return false;
   if (process.env.ACOLYTE_SKIP_UPDATE === "1") return false;
-  if (process.argv.includes("--skip-update") || process.argv.includes("--no-update")) return false;
+  if (process.argv.includes("--no-update")) return false;
 
   const currentVersion = resolveCliVersion();
   if (currentVersion === "dev") return false;

--- a/src/cli-visual.int.test.ts
+++ b/src/cli-visual.int.test.ts
@@ -122,6 +122,8 @@ describe("cli visual regression", () => {
       Options
         -h, --help             print help
         -V, --version          print version
+        --update               check for updates before running
+        --no-update            disable update checks
     `),
     );
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
+import { parseTopLevelArgs } from "./cli-args";
 import { chatModeWithOptions } from "./cli-chat";
 import { commands, usage } from "./cli-command-registry";
-import { checkAndUpdateOnStartup } from "./cli-update";
+import { checkAndUpdateOnStartup, updateMode } from "./cli-update";
 import { formatVersionWithCommit, resolveCliCommitShort, resolveCliVersion } from "./cli-version";
 import { printOutput } from "./ui";
 
@@ -17,11 +18,14 @@ function isTopLevelVersionCommand(command: string | undefined): boolean {
 }
 
 async function main(): Promise<void> {
-  const [command, ...args] = process.argv.slice(2);
+  const { command, args, update } = parseTopLevelArgs(process.argv.slice(2));
 
   if (!command) {
-    const updated = await checkAndUpdateOnStartup();
-    if (updated) return;
+    if (update === "force") await updateMode();
+    else {
+      const updated = await checkAndUpdateOnStartup({ skip: update === "skip" });
+      if (updated) return;
+    }
     await chatModeWithOptions({ resumeLatest: false });
     return;
   }
@@ -33,6 +37,10 @@ async function main(): Promise<void> {
   if (isTopLevelVersionCommand(command)) {
     printOutput(CLI_VERSION_OUTPUT);
     return;
+  }
+
+  if (update === "force" && command !== "update") {
+    await updateMode();
   }
 
   const handler = commands[command];

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { parseTopLevelArgs } from "./cli-args";
+import { parseGlobalArgsAndCommand } from "./cli-args";
 import { chatModeWithOptions } from "./cli-chat";
 import { commands, usage } from "./cli-command-registry";
 import { checkAndUpdateOnStartup, updateMode } from "./cli-update";
@@ -18,7 +18,7 @@ function isTopLevelVersionCommand(command: string | undefined): boolean {
 }
 
 async function main(): Promise<void> {
-  const { command, args, update } = parseTopLevelArgs(process.argv.slice(2));
+  const { command, args, update } = parseGlobalArgsAndCommand(process.argv.slice(2));
 
   if (!command) {
     if (update === "force") await updateMode();

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -138,6 +138,8 @@ export const EN_MESSAGES = {
   "cli.help.label.description": "Description: {description}",
   "cli.help.label.usage": "Usage: {usage}",
   "cli.help.option.help": "print help",
+  "cli.help.option.no_update": "disable update checks",
+  "cli.help.option.update": "check for updates before running",
   "cli.help.option.version": "print version",
   "cli.help.section.commands": "Commands",
   "cli.help.section.options": "Options",


### PR DESCRIPTION
## Motivation

Let users explicitly force an update check (or disable it) without changing the default startup update cadence.

## Summary
- add global --update and --no-update flags to the top-level cli
- run the existing update flow before executing the requested command
- centralize global argv parsing and cover it with tests
