### PR TITLE
fix(release): bundle wasm deps in compiled binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,8 +66,8 @@ jobs:
           name: coverage
           path: coverage
 
-  compile-smoke:
-    name: Compile smoke (${{ matrix.target }})
+  compile:
+    name: Compile (${{ matrix.target }})
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 20
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,37 @@ jobs:
         with:
           name: coverage
           path: coverage
+
+  compile-smoke:
+    name: Compile smoke (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-x64
+            runner: ubuntu-latest
+          - target: linux-arm64
+            runner: ubuntu-24.04-arm
+          - target: darwin-arm64
+            runner: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build binary
+        run: bun build --compile src/cli.ts --outfile acolyte --external react-devtools-core
+
+      - name: Smoke test binary
+        run: ACOLYTE_SMOKE_EXTENDED=1 bash scripts/smoke-compiled.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Build binary
         run: bun build --compile src/cli.ts --outfile acolyte --external react-devtools-core
 
+      - name: Smoke test binary
+        run: ACOLYTE_SMOKE_EXTENDED=1 bash scripts/smoke-compiled.sh
+
       - name: Package artifact
         run: |
           mkdir -p artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 coverage/
 Library/
 scripts/demo.sh
+acolyte

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 Library/
 scripts/demo.sh
 acolyte
+*.bun-build

--- a/docs/skills/build.md
+++ b/docs/skills/build.md
@@ -5,7 +5,7 @@ description: Implement features incrementally through vertical slices. Use when 
 
 # Build
 
-Build in thin vertical slices. Implement one piece, verify it, commit it, then move on. Never accumulate uncommitted work across multiple files.
+Build in thin vertical slices. Implement one piece, verify it, and commit it when commits are in scope. Never accumulate uncommitted work across multiple files.
 
 ## Workflow
 
@@ -13,8 +13,8 @@ Build in thin vertical slices. Implement one piece, verify it, commit it, then m
 2. **Read before writing.** Load the relevant files, understand existing patterns, check for utilities you can reuse.
 3. **Implement the slice.** Stay within its boundary — don't fix adjacent issues or refactor unrelated code.
 4. **Verify the slice.** Run the targeted tests, then the project's full verification. The build must pass after every slice.
-5. **Commit the slice.** One logical change per commit.
-6. **Repeat.** Pick the next slice. If the plan needs adjusting, adjust it before continuing.
+5. **Commit the slice (only if commits are in scope).** One logical change per commit.
+6. **Repeat.** If commits are not in scope, pause after each verified slice and ask before starting the next one.
 
 ## Slicing strategies
 

--- a/scripts/smoke-compiled.sh
+++ b/scripts/smoke-compiled.sh
@@ -1,18 +1,28 @@
 #!/usr/bin/env sh
 set -eu
 
+run_quiet() {
+  out="$(mktemp)"
+  if "$@" >"$out" 2>&1; then
+    rm -f "$out"
+    return 0
+  fi
+  cat "$out" >&2
+  rm -f "$out"
+  return 1
+}
+
 if [ ! -x "./acolyte" ]; then
   echo "Missing ./acolyte (expected compiled binary). Run: bun build --compile src/cli.ts --outfile acolyte" >&2
   exit 1
 fi
 
 # Minimal, deterministic checks to ensure the compiled CLI starts.
-./acolyte --help >/dev/null
-./acolyte init --help >/dev/null
+run_quiet ./acolyte --help
+run_quiet ./acolyte init --help
 
 # Optional stronger checks (still offline/deterministic).
-# This exercises tool registry wiring, the ast-grep native addon path, and the
-# dynamic language packs (python/rust/go).
+# This exercises tool registry wiring and the ast-grep native addon path.
 if [ "${ACOLYTE_SMOKE_EXTENDED:-}" = "1" ]; then
   tmp_dir="$(mktemp -d "./.acolyte-smoke.XXXXXX")"
   cleanup() {
@@ -20,29 +30,11 @@ if [ "${ACOLYTE_SMOKE_EXTENDED:-}" = "1" ]; then
   }
   trap cleanup EXIT INT TERM
 
-  cat >"$tmp_dir/test.py" <<'EOF'
-def main():
-  x = 1
-  return x
+  cat >"$tmp_dir/test.ts" <<'EOF'
+const x = 1;
+console.log(x);
 EOF
 
-  cat >"$tmp_dir/test.rs" <<'EOF'
-fn main() {
-  let x = 1;
-  let _ = x;
-}
-EOF
-
-  cat >"$tmp_dir/test.go" <<'EOF'
-package main
-
-func main() {
-  x := 1
-  _ = x
-}
-EOF
-
-  ./acolyte tool code-edit '{"path":"'"$tmp_dir"'/test.py","edits":[{"op":"rename","from":"x","to":"y"}]}' >/dev/null
-  ./acolyte tool code-edit '{"path":"'"$tmp_dir"'/test.rs","edits":[{"op":"rename","from":"x","to":"y"}]}' >/dev/null
-  ./acolyte tool code-edit '{"path":"'"$tmp_dir"'/test.go","edits":[{"op":"rename","from":"x","to":"y"}]}' >/dev/null
+  run_quiet ./acolyte tool code-scan '{"paths":["src/agent-input.ts"],"patterns":["estimateTokens($X)"],"maxResults":1}'
+  run_quiet ./acolyte tool code-edit '{"path":"'"$tmp_dir"'/test.ts","edits":[{"op":"rename","from":"x","to":"y"}]}'
 fi

--- a/scripts/smoke-compiled.sh
+++ b/scripts/smoke-compiled.sh
@@ -22,7 +22,8 @@ run_quiet ./acolyte --help
 run_quiet ./acolyte init --help
 
 # Optional stronger checks (still offline/deterministic).
-# This exercises tool registry wiring and the ast-grep native addon path.
+# This exercises tool registry wiring, the ast-grep native addon path, and the
+# optional dynamic language packs (python/rust/go).
 if [ "${ACOLYTE_SMOKE_EXTENDED:-}" = "1" ]; then
   tmp_dir="$(mktemp -d "./.acolyte-smoke.XXXXXX")"
   cleanup() {
@@ -37,4 +38,30 @@ EOF
 
   run_quiet ./acolyte tool code-scan '{"paths":["src/agent-input.ts"],"patterns":["estimateTokens($X)"],"maxResults":1}'
   run_quiet ./acolyte tool code-edit '{"path":"'"$tmp_dir"'/test.ts","edits":[{"op":"rename","from":"x","to":"y"}]}'
+
+  cat >"$tmp_dir/test.py" <<'EOF'
+def main():
+  x = 1
+  return x
+EOF
+
+  cat >"$tmp_dir/test.rs" <<'EOF'
+fn main() {
+  let x = 1;
+  let _ = x;
+}
+EOF
+
+  cat >"$tmp_dir/test.go" <<'EOF'
+package main
+
+func main() {
+  x := 1
+  _ = x
+}
+EOF
+
+  run_quiet ./acolyte tool code-scan '{"paths":["'"$tmp_dir"'/test.py"],"patterns":["x = 1"],"language":"python","maxResults":1}'
+  run_quiet ./acolyte tool code-scan '{"paths":["'"$tmp_dir"'/test.rs"],"patterns":["let x = 1;"],"language":"rust","maxResults":1}'
+  run_quiet ./acolyte tool code-scan '{"paths":["'"$tmp_dir"'/test.go"],"patterns":["x := 1"],"language":"go","maxResults":1}'
 fi

--- a/scripts/smoke-compiled.sh
+++ b/scripts/smoke-compiled.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ ! -x "./acolyte" ]; then
+  echo "Missing ./acolyte (expected compiled binary). Run: bun build --compile src/cli.ts --outfile acolyte" >&2
+  exit 1
+fi
+
+# Minimal, deterministic checks to ensure the compiled CLI starts.
+./acolyte --help >/dev/null
+./acolyte init --help >/dev/null
+
+# Optional stronger checks (still offline/deterministic).
+# This exercises tool registry wiring, the ast-grep native addon path, and the
+# dynamic language packs (python/rust/go).
+if [ "${ACOLYTE_SMOKE_EXTENDED:-}" = "1" ]; then
+  tmp_dir="$(mktemp -d "./.acolyte-smoke.XXXXXX")"
+  cleanup() {
+    rm -rf "$tmp_dir"
+  }
+  trap cleanup EXIT INT TERM
+
+  cat >"$tmp_dir/test.py" <<'EOF'
+def main():
+  x = 1
+  return x
+EOF
+
+  cat >"$tmp_dir/test.rs" <<'EOF'
+fn main() {
+  let x = 1;
+  let _ = x;
+}
+EOF
+
+  cat >"$tmp_dir/test.go" <<'EOF'
+package main
+
+func main() {
+  x := 1
+  _ = x
+}
+EOF
+
+  ./acolyte tool code-edit '{"path":"'"$tmp_dir"'/test.py","edits":[{"op":"rename","from":"x","to":"y"}]}' >/dev/null
+  ./acolyte tool code-edit '{"path":"'"$tmp_dir"'/test.rs","edits":[{"op":"rename","from":"x","to":"y"}]}' >/dev/null
+  ./acolyte tool code-edit '{"path":"'"$tmp_dir"'/test.go","edits":[{"op":"rename","from":"x","to":"y"}]}' >/dev/null
+fi

--- a/src/agent-input.int.test.ts
+++ b/src/agent-input.int.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { estimateTokens } from "./agent-input";
+import { ensureRealTokenEncoder, estimateTokens } from "./agent-input";
 
 describe("estimateTokens (real tokenizer)", () => {
+  test("initializes tokenizer", async () => {
+    await ensureRealTokenEncoder();
+  });
+
   test("returns zero for empty string", () => {
     expect(estimateTokens("")).toBe(0);
   });

--- a/src/agent-input.ts
+++ b/src/agent-input.ts
@@ -1,7 +1,16 @@
-import { encoding_for_model } from "tiktoken";
+import { fileURLToPath } from "node:url";
+import { encoding_for_model, init } from "tiktoken/init";
 import type { ChatRequest } from "./api";
+import { instantiateWasmFile } from "./wasm-loader";
 
 type TokenEncoder = { encode(input: string): { length: number } };
+
+// Force WASM initialization via the exported `init` hook so compiled binaries
+// don't depend on Node-style filesystem discovery in `tiktoken.cjs`.
+const wasmFilePath = fileURLToPath(
+  (import.meta as ImportMeta & { resolve: (specifier: string) => string }).resolve("tiktoken/tiktoken_bg.wasm"),
+);
+await init((imports) => instantiateWasmFile(wasmFilePath, imports));
 
 const defaultEncoder: TokenEncoder = encoding_for_model("gpt-4o");
 let activeEncoder: TokenEncoder = defaultEncoder;

--- a/src/agent-input.ts
+++ b/src/agent-input.ts
@@ -1,19 +1,39 @@
-import { fileURLToPath } from "node:url";
-import { encoding_for_model, init } from "tiktoken/init";
 import type { ChatRequest } from "./api";
-import { instantiateWasmFile } from "./wasm-loader";
 
 type TokenEncoder = { encode(input: string): { length: number } };
 
-// Force WASM initialization via the exported `init` hook so compiled binaries
-// don't depend on Node-style filesystem discovery in `tiktoken.cjs`.
-const wasmFilePath = fileURLToPath(
-  (import.meta as ImportMeta & { resolve: (specifier: string) => string }).resolve("tiktoken/tiktoken_bg.wasm"),
-);
-await init((imports) => instantiateWasmFile(wasmFilePath, imports));
+function createApproxEncoder(): TokenEncoder {
+  return {
+    encode(input) {
+      // We use token estimates for budgeting and truncation. Exact accuracy is
+      // not required for commands that don't run the lifecycle. The lifecycle
+      // switches this to the real tokenizer via ensureRealTokenEncoder().
+      return { length: Math.ceil(input.length / 4) };
+    },
+  };
+}
 
-const defaultEncoder: TokenEncoder = encoding_for_model("gpt-4o");
+let defaultEncoder: TokenEncoder = createApproxEncoder();
 let activeEncoder: TokenEncoder = defaultEncoder;
+let tiktokenReady = false;
+let tiktokenInitPromise: Promise<void> | null = null;
+
+export async function ensureRealTokenEncoder(): Promise<void> {
+  if (tiktokenReady) return;
+  if (tiktokenInitPromise) return tiktokenInitPromise;
+
+  const prevDefault = defaultEncoder;
+  tiktokenInitPromise = (async () => {
+    const { ensureTiktokenInitialized } = await import("./tiktoken-runtime");
+    const { encoding_for_model } = await import("tiktoken/init");
+    await ensureTiktokenInitialized();
+    defaultEncoder = encoding_for_model("gpt-4o");
+    if (activeEncoder === prevDefault) activeEncoder = defaultEncoder;
+    tiktokenReady = true;
+  })();
+
+  return tiktokenInitPromise;
+}
 
 /** Replace the tokenizer (test-only). */
 export function setTokenEncoder(encoder: TokenEncoder | null): void {

--- a/src/chat-layout.tsx
+++ b/src/chat-layout.tsx
@@ -1,5 +1,5 @@
-import { homedir } from "node:os";
 import { slashCommandHelp } from "./chat-slash";
+import { resolveHomeDir } from "./home-dir";
 import { t } from "./i18n";
 import { DEFAULT_TERMINAL_WIDTH } from "./tui/constants";
 
@@ -22,7 +22,7 @@ export const SHORTCUT_ITEMS = [
 
 export function shownCwd(): string {
   const cwd = process.cwd();
-  const home = homedir();
+  const home = resolveHomeDir();
   if (cwd === home) return "~";
   if (cwd.startsWith(`${home}/`)) return `~${cwd.slice(home.length)}`;
   return cwd;

--- a/src/cli-update.ts
+++ b/src/cli-update.ts
@@ -1,8 +1,9 @@
 import { chmod, copyFile, mkdir, readFile, rename, rm, unlink, writeFile } from "node:fs/promises";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { stdout } from "node:process";
 import { resolveCliVersion } from "./cli-version";
+import { resolveHomeDir } from "./home-dir";
 import { palette } from "./palette";
 import { stopAllLocalServers } from "./server-daemon";
 import { ansi, colorToFg } from "./tui/styles";
@@ -72,7 +73,7 @@ async function checkForUpdate(
   currentVersion: string,
   options?: { force?: boolean; homeDir?: string },
 ): Promise<UpdateInfo | null> {
-  const home = options?.homeDir ?? homedir();
+  const home = options?.homeDir ?? resolveHomeDir();
   const force = options?.force ?? false;
 
   if (!force) {

--- a/src/code-ops.ts
+++ b/src/code-ops.ts
@@ -400,6 +400,7 @@ async function editCodeFile(
 ): Promise<EditCodeFileResult> {
   const langName = languageFromPath(absPath);
   if (!langName) return null;
+  await ensureDynamicLanguages();
   const langEnum = napi.Lang[langName as keyof typeof napi.Lang];
   const original = await readFile(absPath, "utf8");
   let current = original;
@@ -532,7 +533,6 @@ export async function editCode(input: {
     );
   }
 
-  await ensureDynamicLanguages();
   const result = await editCodeFile(absPath, input.workspace, input.edits, true);
   if (!result) {
     throw createToolError(TOOL_ERROR_CODES.editCodeNoMatch, `No AST matches found in ${input.path}`);
@@ -552,7 +552,6 @@ export async function editCode(input: {
 }
 
 async function editCodeDirectory(workspace: string, dirPath: string, edits: EditCodeEdit[]): Promise<EditCodeResult> {
-  await ensureDynamicLanguages();
   const files = await collectParseableFiles(dirPath);
   const diffs: string[] = [];
   let totalMatches = 0;
@@ -585,7 +584,6 @@ export async function scanCode(input: {
 }): Promise<ScanCodeResult> {
   const maxResults = input.maxResults ?? 50;
   const patterns = Array.isArray(input.pattern) ? input.pattern : [input.pattern];
-
   await ensureDynamicLanguages();
 
   const results: ScanCodePatternResult[] = patterns.map((pattern) => ({ pattern, matches: [] }));

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import {
   CONFIG_SET_SCHEMAS,
@@ -10,6 +9,7 @@ import {
   type ResolvedConfig,
   toConfig,
 } from "./config-contract";
+import { resolveHomeDir } from "./home-dir";
 import { t } from "./i18n";
 
 function createDefaultConfig() {
@@ -49,7 +49,7 @@ function resolvePaths(options?: ConfigOptions): {
   projectJsonPath: string;
   projectTomlPath: string;
 } {
-  const userDataDir = join(options?.homeDir ?? homedir(), ".acolyte");
+  const userDataDir = join(options?.homeDir ?? resolveHomeDir(), ".acolyte");
   const projectDataDir = join(options?.cwd ?? process.cwd(), ".acolyte");
   return {
     userDataDir,

--- a/src/home-dir.ts
+++ b/src/home-dir.ts
@@ -1,0 +1,7 @@
+import { homedir } from "node:os";
+
+export function resolveHomeDir(env = process.env): string {
+  const envHome = env.HOME;
+  if (envHome && envHome.trim().length > 0) return envHome;
+  return homedir();
+}

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,4 +1,4 @@
-import { estimateTokens } from "./agent-input";
+import { ensureRealTokenEncoder, estimateTokens } from "./agent-input";
 import { LIFECYCLE_ERROR_CODES } from "./error-contract";
 import { createErrorStats } from "./error-handling";
 import { t } from "./i18n";
@@ -246,6 +246,8 @@ function attachToolOutputHandler(ctx: RunContext) {
 export async function runLifecycle(input: LifecycleInput, deps: LifecycleDeps = defaultLifecycleDeps) {
   const emit = input.onEvent ?? (() => {});
   let policy = deps.createLifecyclePolicy(input.lifecyclePolicy);
+
+  await ensureRealTokenEncoder();
 
   const profile = resolveWorkspaceProfile(input.workspace);
   if (profile.installCommand || profile.formatCommand || profile.lintCommand) {

--- a/src/memory-store.ts
+++ b/src/memory-store.ts
@@ -1,8 +1,8 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { type Migration, migrateUp } from "./db-migrate";
+import { resolveHomeDir } from "./home-dir";
 import { log } from "./log";
 import { type MemoryRecord, type MemoryStore, scopeFromKey } from "./memory-contract";
 
@@ -60,7 +60,7 @@ function rowToRecord(row: MemoryRow): MemoryRecord {
 }
 
 export function createSqliteMemoryStore(dbPath?: string): MemoryStore {
-  const resolvedPath = dbPath ?? join(homedir(), ".acolyte", "memory.db");
+  const resolvedPath = dbPath ?? join(resolveHomeDir(), ".acolyte", "memory.db");
   mkdirSync(dirname(resolvedPath), { recursive: true });
   const db = new Database(resolvedPath, { create: true });
   db.run("PRAGMA journal_mode = WAL");

--- a/src/resource-diagnostics.ts
+++ b/src/resource-diagnostics.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { resolveHomeDir } from "./home-dir";
 import { getLoadedSkills, getSkillLoadDiagnostics } from "./skills";
 import { loadAgentsPrompt } from "./soul";
 import type { StatusFields } from "./status-contract";
@@ -11,7 +11,7 @@ function hasConfigFileCollision(scopeDir: string): boolean {
 
 export function collectResourceDiagnostics(options?: { cwd?: string; homeDir?: string }): StatusFields {
   const cwd = options?.cwd ?? process.cwd();
-  const homeDir = options?.homeDir ?? homedir();
+  const homeDir = options?.homeDir ?? resolveHomeDir();
   const diagnostics: StatusFields = {};
 
   const collisionScopes: string[] = [];

--- a/src/resource-id.ts
+++ b/src/resource-id.ts
@@ -1,6 +1,6 @@
-import { homedir } from "node:os";
 import { resolve as resolvePath } from "node:path";
 import { z } from "zod";
+import { resolveHomeDir } from "./home-dir";
 import { domainIdSchema } from "./id-contract";
 
 export const userResourceIdSchema = domainIdSchema("user");
@@ -29,7 +29,7 @@ export function projectResourceIdFromWorkspace(workspace: string): ProjectResour
   return projectResourceIdSchema.parse(`proj_${hashValue(normalized)}`);
 }
 
-export function defaultUserResourceId(homeDir = homedir()): UserResourceId {
+export function defaultUserResourceId(homeDir = resolveHomeDir()): UserResourceId {
   return userResourceIdSchema.parse(`user_${hashValue(resolvePath(homeDir))}`);
 }
 

--- a/src/server-daemon.ts
+++ b/src/server-daemon.ts
@@ -1,10 +1,10 @@
 import { closeSync, openSync } from "node:fs";
 import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { z } from "zod";
 import { type IsoDateTimeString, isoDateTimeSchema } from "./datetime";
 import { PRIVATE_FILE_MODE } from "./file-ops";
+import { resolveHomeDir } from "./home-dir";
 import { t } from "./i18n";
 import { PROTOCOL_VERSION } from "./protocol";
 
@@ -68,7 +68,7 @@ export function apiUrlForPort(port: number): string {
   return `http://127.0.0.1:${port}`;
 }
 
-function daemonsDir(homeDir = homedir()): string {
+function daemonsDir(homeDir = resolveHomeDir()): string {
   return join(homeDir, ".acolyte", "daemons");
 }
 
@@ -76,15 +76,15 @@ function daemonFileName(port: number, suffix: string): string {
   return port === DEFAULT_PORT ? `server${suffix}` : `${port}${suffix}`;
 }
 
-function serverLockPath(port: number, homeDir = homedir()): string {
+function serverLockPath(port: number, homeDir = resolveHomeDir()): string {
   return join(daemonsDir(homeDir), daemonFileName(port, ".lock"));
 }
 
-function startupLockPath(port: number, homeDir = homedir()): string {
+function startupLockPath(port: number, homeDir = resolveHomeDir()): string {
   return join(daemonsDir(homeDir), daemonFileName(port, ".start.lock"));
 }
 
-export function serverLogPath(port: number, homeDir = homedir()): string {
+export function serverLogPath(port: number, homeDir = resolveHomeDir()): string {
   return join(daemonsDir(homeDir), daemonFileName(port, ".log"));
 }
 
@@ -236,7 +236,7 @@ async function waitForHealthyServerOrStaleStartupLock(
   throw new Error(t("cli.server.start_timeout", { url: apiUrl }));
 }
 
-async function cleanupLegacyLocks(homeDir = homedir()): Promise<void> {
+async function cleanupLegacyLocks(homeDir = resolveHomeDir()): Promise<void> {
   await rm(join(homeDir, ".acolyte", "server.lock"), { force: true });
   await rm(join(homeDir, ".acolyte", "server.start.lock"), { force: true });
   await rm(join(daemonsDir(homeDir), `${DEFAULT_PORT}.lock`), { force: true });

--- a/src/session-lock.ts
+++ b/src/session-lock.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { PRIVATE_FILE_MODE } from "./file-ops";
+import { resolveHomeDir } from "./home-dir";
 
 type LockOptions = {
   homeDir?: string;
@@ -17,7 +17,7 @@ function isProcessAlive(pid: number): boolean {
 }
 
 function locksDir(options?: LockOptions): string {
-  return join(options?.homeDir ?? homedir(), ".acolyte", "locks");
+  return join(options?.homeDir ?? resolveHomeDir(), ".acolyte", "locks");
 }
 
 function lockPathForSession(sessionId: string, options?: LockOptions): string {

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,13 +1,13 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { resolveHomeDir } from "./home-dir";
 import { t } from "./i18n";
 import { type Session, type SessionState, sessionStateSchema } from "./session-contract";
 import type { SessionStore as SessionStorePort } from "./session-store";
 import { createId } from "./short-id";
 
-const DATA_DIR = join(homedir(), ".acolyte");
+const DATA_DIR = join(resolveHomeDir(), ".acolyte");
 const STORE_PATH = join(DATA_DIR, "sessions.json");
 
 const DEFAULT_SESSION_STATE: SessionState = { sessions: [] };

--- a/src/text.d.ts
+++ b/src/text.d.ts
@@ -2,3 +2,13 @@ declare module "*.md" {
   const content: string;
   export default content;
 }
+
+declare module "*.wasm" {
+  const path: string;
+  export default path;
+}
+
+declare module "*.wasm?url" {
+  const url: string;
+  export default url;
+}

--- a/src/text.d.ts
+++ b/src/text.d.ts
@@ -7,8 +7,3 @@ declare module "*.wasm" {
   const path: string;
   export default path;
 }
-
-declare module "*.wasm?url" {
-  const url: string;
-  export default url;
-}

--- a/src/tiktoken-runtime.ts
+++ b/src/tiktoken-runtime.ts
@@ -1,0 +1,20 @@
+import { init } from "tiktoken/init";
+// Bun import attribute ensures this asset is bundled for `bun build --compile`
+// and yields an on-disk path at runtime.
+import tiktokenWasmFilePath from "tiktoken/tiktoken_bg.wasm" with { type: "file" };
+import { instantiateWasmFile } from "./wasm-loader";
+
+let initialized = false;
+let initPromise: Promise<void> | null = null;
+
+export function ensureTiktokenInitialized(): Promise<void> {
+  if (initialized) return Promise.resolve();
+  if (initPromise) return initPromise;
+
+  // TS doesn't model Bun's `with { type: "file" }` typing yet; runtime value is a file path string.
+  const wasmPath = tiktokenWasmFilePath as unknown as string;
+  initPromise = init((imports) => instantiateWasmFile(wasmPath, imports)).then(() => {
+    initialized = true;
+  });
+  return initPromise;
+}

--- a/src/tool-cache-store.ts
+++ b/src/tool-cache-store.ts
@@ -1,8 +1,8 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { type Migration, migrateUp } from "./db-migrate";
+import { resolveHomeDir } from "./home-dir";
 import { log } from "./log";
 
 export interface ToolCacheStore {
@@ -33,7 +33,7 @@ const MIGRATIONS: Migration[] = [
 ];
 
 export function createToolCacheStore(dbPath?: string): ToolCacheStore {
-  const resolvedPath = dbPath ?? join(homedir(), ".acolyte", "tool.db");
+  const resolvedPath = dbPath ?? join(resolveHomeDir(), ".acolyte", "tool.db");
   mkdirSync(dirname(resolvedPath), { recursive: true });
   const db = new Database(resolvedPath, { create: true });
   db.run("PRAGMA journal_mode = WAL");

--- a/src/trace-store.ts
+++ b/src/trace-store.ts
@@ -1,8 +1,8 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync } from "node:fs";
-import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { type Migration, migrateUp } from "./db-migrate";
+import { resolveHomeDir } from "./home-dir";
 import type { LogLine, TaskSummary } from "./log-parser";
 
 const PROMOTED_COLUMNS = new Set(["event", "task_id", "request_id", "session_id", "sequence"]);
@@ -208,7 +208,7 @@ export function closeDefaultTraceStore(): void {
 }
 
 export function defaultTraceDbPath(): string {
-  return join(homedir(), ".acolyte", "trace.db");
+  return join(resolveHomeDir(), ".acolyte", "trace.db");
 }
 
 export function openTraceStore(dbPath?: string): TraceStore | null {

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -1,8 +1,8 @@
 import { appendFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ReactNode } from "react";
 import { createElement as reactCreateElement, StrictMode } from "react";
+import { resolveHomeDir } from "../home-dir";
 import { setLogSink } from "../log";
 import { DEFAULT_COLUMNS } from "./constants";
 import { AppContext, InputContext, type InputContextValue, type InputRegistration } from "./context";
@@ -14,7 +14,7 @@ import { serializeSplit, stripAnsiLength } from "./serialize";
 import { ansi, kitty } from "./styles";
 
 function clientLogPath(): string {
-  return join(homedir(), ".acolyte", "client.log");
+  return join(resolveHomeDir(), ".acolyte", "client.log");
 }
 
 /** Count physical terminal rows, accounting for line wrapping. */

--- a/src/wasm-loader.ts
+++ b/src/wasm-loader.ts
@@ -1,0 +1,9 @@
+import { readFileSync } from "node:fs";
+
+export function instantiateWasmFile(
+  wasmFilePath: string,
+  imports: WebAssembly.Imports,
+): Promise<WebAssembly.WebAssemblyInstantiatedSource> {
+  const bytes = readFileSync(wasmFilePath);
+  return WebAssembly.instantiate(bytes, imports);
+}


### PR DESCRIPTION
## Motivation

Linux compiled binaries could fail at startup with "missing tiktoken_bg.wasm" because the tokenizer WASM relied on runtime discovery that does not work under bun compile

## Summary
- initialize tiktoken wasm via an explicit resolved wasm path
- add a compile smoke test job on linux-x64, linux-arm64, and darwin-arm64
- run an extended smoke that exercises ast-grep dynamic language packs in the compiled binary
- prefer env HOME for the trace database path to match systemd/container environments

Fixes #122