### PR TITLE
chore(release): drop linux-arm64 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,6 @@ jobs:
         include:
           - target: linux-x64
             runner: ubuntu-latest
-          - target: linux-arm64
-            runner: ubuntu-24.04-arm
           - target: darwin-arm64
             runner: macos-latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,6 @@ jobs:
             runner: macos-latest
           - target: linux-x64
             runner: ubuntu-latest
-          - target: linux-arm64
-            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Motivation

We only want to ship and validate release binaries for the most common developer platforms for now.

## Summary
- remove linux-arm64 from the release build matrix
