### PR TITLE
test(cli): add cli visual harness

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.5/schema.json",
   "files": {
     "includes": ["**", "!**/.git", "!**/node_modules", "!**/dist", "!**/build", "!**/coverage", "!talks"]
   },

--- a/src/cli-prompt.test.ts
+++ b/src/cli-prompt.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { createMessage } from "./chat-session";
 import { handlePrompt } from "./cli-prompt";
+import { captureCliOutput } from "./cli-test-harness";
 import type { Client, StreamEvent } from "./client-contract";
 import type { Session } from "./session-contract";
 import { expectIntent } from "./test-utils";
@@ -29,6 +30,18 @@ function createStreamingClient(events: StreamEvent[]): Client {
   };
 }
 
+async function runPromptAndCapture(
+  prompt: string,
+  session: Session,
+  client: Client,
+): Promise<{ ok: boolean; output: string }> {
+  let ok = false;
+  const output = await captureCliOutput(async () => {
+    ok = await handlePrompt(prompt, session, client);
+  });
+  return { ok, output };
+}
+
 describe("cli-prompt", () => {
   test("createMessage creates a timestamped chat message", () => {
     const message = createMessage("user", "hello");
@@ -51,122 +64,86 @@ describe("cli-prompt", () => {
       taskStatus: async () => null,
     };
 
-    const ok = await handlePrompt("hello", session, client);
+    const { ok } = await runPromptAndCapture("hello", session, client);
     expect(ok).toBe(true);
     expect(session.messages[session.messages.length - 1]?.kind).toBe("tool_payload");
   });
 
   test("checklist events print header and items", async () => {
-    const printed: string[] = [];
-    const originalWrite = process.stdout.write;
-    process.stdout.write = ((chunk: string) => {
-      printed.push(chunk);
-      return true;
-    }) as typeof process.stdout.write;
+    const events: StreamEvent[] = [
+      {
+        type: "checklist",
+        groupId: "grp_1",
+        groupTitle: "Build pipeline",
+        items: [
+          { id: "s1", label: "lint", status: "done", order: 0 },
+          { id: "s2", label: "test", status: "in_progress", order: 1 },
+          { id: "s3", label: "deploy", status: "pending", order: 2 },
+        ],
+      },
+    ];
 
-    try {
-      const events: StreamEvent[] = [
-        {
-          type: "checklist",
-          groupId: "grp_1",
-          groupTitle: "Build pipeline",
-          items: [
-            { id: "s1", label: "lint", status: "done", order: 0 },
-            { id: "s2", label: "test", status: "in_progress", order: 1 },
-            { id: "s3", label: "deploy", status: "pending", order: 2 },
-          ],
-        },
-      ];
+    const session = createTestSession();
+    const client = createStreamingClient(events);
+    const { output } = await runPromptAndCapture("run pipeline", session, client);
 
-      const session = createTestSession();
-      const client = createStreamingClient(events);
-      await handlePrompt("run pipeline", session, client);
-
-      const output = printed.join("");
-      expectIntent(output, [["build pipeline", "1/3"], ["lint"], ["test"], ["deploy"]]);
-    } finally {
-      process.stdout.write = originalWrite;
-    }
+    expectIntent(output, [["build pipeline", "1/3"], ["lint"], ["test"], ["deploy"]]);
   });
 
   test("text-delta renders before subsequent tool-output", async () => {
-    const printed: string[] = [];
-    const originalWrite = process.stdout.write;
-    process.stdout.write = ((chunk: string) => {
-      printed.push(chunk);
-      return true;
-    }) as typeof process.stdout.write;
+    const events: StreamEvent[] = [
+      { type: "text-delta", text: "Reading the file." },
+      {
+        type: "tool-output",
+        toolCallId: "call_1",
+        toolName: "file-read",
+        content: { kind: "tool-header" as const, labelKey: "tool.file_read.header", detail: "src/a.ts" },
+      },
+    ];
 
-    try {
-      const events: StreamEvent[] = [
-        { type: "text-delta", text: "Reading the file." },
-        {
-          type: "tool-output",
-          toolCallId: "call_1",
-          toolName: "file-read",
-          content: { kind: "tool-header" as const, labelKey: "tool.file_read.header", detail: "src/a.ts" },
-        },
-      ];
+    const session = createTestSession();
+    const client = createStreamingClient(events);
+    const { output } = await runPromptAndCapture("read a.ts", session, client);
 
-      const session = createTestSession();
-      const client = createStreamingClient(events);
-      await handlePrompt("read a.ts", session, client);
-
-      const output = printed.join("");
-      const textPos = output.indexOf("Reading the file.");
-      const toolPos = output.indexOf("src/a.ts");
-      expect(textPos).toBeGreaterThanOrEqual(0);
-      expect(toolPos).toBeGreaterThan(textPos);
-    } finally {
-      process.stdout.write = originalWrite;
-    }
+    const textPos = output.indexOf("Reading the file.");
+    const toolPos = output.indexOf("src/a.ts");
+    expect(textPos).toBeGreaterThanOrEqual(0);
+    expect(toolPos).toBeGreaterThan(textPos);
   });
 
   test("tool-output events with growing numWidth do not reprint earlier diffs", async () => {
-    const printed: string[] = [];
-    const originalWrite = process.stdout.write;
-    process.stdout.write = ((chunk: string) => {
-      printed.push(chunk);
-      return true;
-    }) as typeof process.stdout.write;
+    const callId = "call_1";
+    const toolName = "code-edit";
 
-    try {
-      const callId = "call_1";
-      const toolName = "code-edit";
+    const header: ToolOutputPart = {
+      kind: "edit-header",
+      labelKey: "tool.edit_code.header",
+      path: "src/foo.ts",
+      files: 1,
+      added: 2,
+      removed: 1,
+    };
 
-      const header: ToolOutputPart = {
-        kind: "edit-header",
-        labelKey: "tool.edit_code.header",
-        path: "src/foo.ts",
-        files: 1,
-        added: 2,
-        removed: 1,
-      };
+    // First diff: line 4, numWidth = 1
+    const diff1: ToolOutputPart = { kind: "diff", marker: "context", lineNumber: 4, text: "const a = 1;" };
+    // Second diff: line 5, numWidth still 1
+    const diff2: ToolOutputPart = { kind: "diff", marker: "add", lineNumber: 5, text: "const b = 2;" };
+    // Third diff at line 100 — numWidth jumps from 1 to 3, changing all earlier renders
+    const diff3: ToolOutputPart = { kind: "diff", marker: "add", lineNumber: 100, text: "const c = 3;" };
 
-      // First diff: line 4, numWidth = 1
-      const diff1: ToolOutputPart = { kind: "diff", marker: "context", lineNumber: 4, text: "const a = 1;" };
-      // Second diff: line 5, numWidth still 1
-      const diff2: ToolOutputPart = { kind: "diff", marker: "add", lineNumber: 5, text: "const b = 2;" };
-      // Third diff at line 100 — numWidth jumps from 1 to 3, changing all earlier renders
-      const diff3: ToolOutputPart = { kind: "diff", marker: "add", lineNumber: 100, text: "const c = 3;" };
+    const events: StreamEvent[] = [
+      { type: "tool-output", toolCallId: callId, toolName, content: header },
+      { type: "tool-output", toolCallId: callId, toolName, content: diff1 },
+      { type: "tool-output", toolCallId: callId, toolName, content: diff2 },
+      { type: "tool-output", toolCallId: callId, toolName, content: diff3 },
+    ];
 
-      const events: StreamEvent[] = [
-        { type: "tool-output", toolCallId: callId, toolName, content: header },
-        { type: "tool-output", toolCallId: callId, toolName, content: diff1 },
-        { type: "tool-output", toolCallId: callId, toolName, content: diff2 },
-        { type: "tool-output", toolCallId: callId, toolName, content: diff3 },
-      ];
+    const session = createTestSession();
+    const client = createStreamingClient(events);
+    const { output } = await runPromptAndCapture("rename foo", session, client);
 
-      const session = createTestSession();
-      const client = createStreamingClient(events);
-      await handlePrompt("rename foo", session, client);
-
-      const output = printed.join("");
-      // The edit-header text should appear only once
-      const headerMatches = output.match(/src\/foo\.ts/g) ?? [];
-      expect(headerMatches.length).toBe(1);
-    } finally {
-      process.stdout.write = originalWrite;
-    }
+    // The edit-header text should appear only once
+    const headerMatches = output.match(/src\/foo\.ts/g) ?? [];
+    expect(headerMatches.length).toBe(1);
   });
 });

--- a/src/cli-test-harness.test.ts
+++ b/src/cli-test-harness.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from "bun:test";
+import { captureCliOutput } from "./cli-test-harness";
+
+describe("cli test harness", () => {
+  test("captureCliOutput cannot be nested", async () => {
+    await expect(async () => {
+      await captureCliOutput(async () => {
+        await captureCliOutput(() => {});
+      });
+    }).toThrow("captureCliOutput cannot be nested");
+  });
+});

--- a/src/cli-test-harness.ts
+++ b/src/cli-test-harness.ts
@@ -1,0 +1,35 @@
+import { stripAnsi } from "./tui/serialize";
+import { trimRightLines } from "./tui-test-utils";
+import { setUiSink } from "./ui";
+
+export async function captureCliOutput(fn: () => Promise<void> | void): Promise<string> {
+  const chunks: string[] = [];
+  const originalStdoutWrite = process.stdout.write;
+  const originalStderrWrite = process.stderr.write;
+
+  setUiSink((chunk) => {
+    chunks.push(chunk);
+  });
+
+  process.stdout.write = ((chunk: string | Uint8Array) => {
+    chunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+    return true;
+  }) as typeof process.stdout.write;
+
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    chunks.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    await fn();
+  } finally {
+    setUiSink(null);
+    process.stdout.write = originalStdoutWrite;
+    process.stderr.write = originalStderrWrite;
+  }
+
+  return trimRightLines(stripAnsi(chunks.join("")))
+    .replace(/^\n+/, "")
+    .replace(/\n+$/, "");
+}

--- a/src/cli-test-harness.ts
+++ b/src/cli-test-harness.ts
@@ -2,7 +2,14 @@ import { stripAnsi } from "./tui/serialize";
 import { trimRightLines } from "./tui-test-utils";
 import { setUiSink } from "./ui";
 
+let isCapturingCliOutput = false;
+
 export async function captureCliOutput(fn: () => Promise<void> | void): Promise<string> {
+  if (isCapturingCliOutput) {
+    throw new Error("captureCliOutput cannot be nested");
+  }
+  isCapturingCliOutput = true;
+
   const chunks: string[] = [];
   const originalStdoutWrite = process.stdout.write;
   const originalStderrWrite = process.stderr.write;
@@ -27,6 +34,7 @@ export async function captureCliOutput(fn: () => Promise<void> | void): Promise<
     setUiSink(null);
     process.stdout.write = originalStdoutWrite;
     process.stderr.write = originalStderrWrite;
+    isCapturingCliOutput = false;
   }
 
   return trimRightLines(stripAnsi(chunks.join("")))

--- a/src/cli-visual.harness.test.ts
+++ b/src/cli-visual.harness.test.ts
@@ -47,7 +47,8 @@ describe("cli visual regression (harness)", () => {
 
   test("update command prints network error when github api is unavailable", async () => {
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = (async () => new Response("no", { status: 503 })) as typeof fetch;
+    globalThis.fetch = (async (..._args: Parameters<typeof fetch>) =>
+      new Response("no", { status: 503 })) as unknown as typeof fetch;
     try {
       const out = await captureCliOutput(async () => {
         await updateMode();

--- a/src/cli-visual.harness.test.ts
+++ b/src/cli-visual.harness.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { usage } from "./cli-command-registry";
+import { captureCliOutput } from "./cli-test-harness";
+import { updateMode } from "./cli-update";
+import { dedent } from "./test-utils";
+
+describe("cli visual regression (harness)", () => {
+  test("top-level help output stays stable", async () => {
+    const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as { version: string };
+    const out = await captureCliOutput(() => {
+      usage(packageJson.version);
+    });
+    expect(out).toBe(
+      dedent(`
+      Acolyte v${packageJson.version}
+
+      Usage
+        acolyte
+        acolyte <COMMAND> [ARGS]
+
+      Commands
+        init [provider]        initialize provider API key
+        resume [id]            resume previous session
+        run <prompt>           run a single prompt
+        history                show recent sessions
+        start                  start server
+        stop                   stop all servers
+        restart                restart server
+        ps                     list running servers
+        status                 show server status
+        memory                 manage memory
+        config                 manage config
+        skill <name> [prompt]  run a prompt with an active skill
+        logs                   view server logs
+        update                 check for and install updates
+        trace                  inspect server lifecycle traces
+
+      Options
+        -h, --help             print help
+        -V, --version          print version
+        --update               check for updates before running
+        --no-update            disable update checks
+    `),
+    );
+  });
+
+  test("update command prints network error when github api is unavailable", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response("no", { status: 503 })) as typeof fetch;
+    try {
+      const out = await captureCliOutput(async () => {
+        await updateMode();
+      });
+      expect(out).toBe("Could not check for updates. Check your network connection.");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/src/cli-visual.int.test.ts
+++ b/src/cli-visual.int.test.ts
@@ -92,49 +92,6 @@ describe("cli visual regression", () => {
     expect(out).toMatch(new RegExp(`^${packageJson.version}( \\([0-9a-f]{7}\\))?$`));
   });
 
-  test("top-level help output stays stable", async () => {
-    const out = await runCliPlain(["--help"]);
-    expect(out).toBe(
-      dedent(`
-      Acolyte v0.15.0
-
-      Usage
-        acolyte
-        acolyte <COMMAND> [ARGS]
-
-      Commands
-        init [provider]        initialize provider API key
-        resume [id]            resume previous session
-        run <prompt>           run a single prompt
-        history                show recent sessions
-        start                  start server
-        stop                   stop all servers
-        restart                restart server
-        ps                     list running servers
-        status                 show server status
-        memory                 manage memory
-        config                 manage config
-        skill <name> [prompt]  run a prompt with an active skill
-        logs                   view server logs
-        update                 check for and install updates
-        trace                  inspect server lifecycle traces
-
-      Options
-        -h, --help             print help
-        -V, --version          print version
-        --update               check for updates before running
-        --no-update            disable update checks
-    `),
-    );
-  });
-
-  test("update command prints up-to-date or network error", async () => {
-    const out = await runCliPlain(["update"]);
-    const isUpToDate = out.includes("Already up to date");
-    const isNetworkError = out.includes("Could not check for updates");
-    expect(isUpToDate || isNetworkError).toBe(true);
-  });
-
   test("history command renders aligned session rows", async () => {
     await withCliTestEnv(async ({ run, writeSessionsStore }) => {
       await writeSessionsStore({

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,6 +1,20 @@
 import { stdout } from "node:process";
 import { palette } from "./palette";
 
+let uiSink: ((chunk: string) => void) | null = null;
+
+export function setUiSink(sink: ((chunk: string) => void) | null): void {
+  uiSink = sink;
+}
+
+function write(chunk: string): void {
+  if (uiSink) {
+    uiSink(chunk);
+    return;
+  }
+  stdout.write(chunk);
+}
+
 function hexToAnsi(hex: string): string {
   const n = Number.parseInt(hex.replace("#", ""), 16);
   return `\x1b[38;2;${(n >> 16) & 255};${(n >> 8) & 255};${n & 255}m`;
@@ -26,34 +40,34 @@ export function tokenizeStreamContent(content: string): string[] {
 
 export async function streamText(content: string): Promise<void> {
   for (const token of tokenizeStreamContent(content)) {
-    stdout.write(token);
+    write(token);
     if (!/^\s+$/.test(token)) await Bun.sleep(12);
   }
-  if (!content.endsWith("\n")) stdout.write("\n");
+  if (!content.endsWith("\n")) write("\n");
 }
 
 export function printDim(content: string): void {
-  stdout.write(`${color.dim(content)}\n`);
+  write(`${color.dim(content)}\n`);
 }
 
 export function printToolHeader(title: string, detail?: string): void {
   const base = color.bold(color.white(title));
   const suffix = detail ? ` ${color.dim(detail)}` : "";
-  stdout.write(`${base}${suffix}\n`);
+  write(`${base}${suffix}\n`);
 }
 
 export function printOutput(content: string): void {
-  stdout.write(`${content}\n`);
+  write(`${content}\n`);
 }
 
 export function printWarning(content: string): void {
-  stdout.write(`${color.dim(color.yellow(content))}\n`);
+  write(`${color.dim(color.yellow(content))}\n`);
 }
 
 export function printError(content: string): void {
-  stdout.write(`${color.red(content)}\n`);
+  write(`${color.red(content)}\n`);
 }
 
 export function clearScreen(): void {
-  stdout.write("\x1b[2J\x1b[H");
+  write("\x1b[2J\x1b[H");
 }


### PR DESCRIPTION
## Motivation

CLI output regressions are currently only covered via subprocess integration tests, which are slower and more fragile than in-process harness-based snapshots.

## Summary
- add a pluggable ui sink to capture cli output in-process
- add a cli output capture harness for snapshot-style assertions
- migrate help and update snapshots from subprocess integration tests
- migrate cli-prompt tests off ad-hoc stdout monkeypatching
- guard against nested cli output capture to avoid flaky tests
- align biome schema url with the pinned biome version so verify stays green

Fixes #116
