### PR TITLE
feat(memory): sync AGENTS.md via project memory

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -21,7 +21,9 @@ Create a pull request for the current branch against `main`.
    - working directory is clean (`git status`)
    - branch has commits ahead of `main` (`git log main..HEAD --oneline`)
    - `bun run verify` passes
-2. **Run the review checklist** (`docs/skills/review.md`):
+2. **Run review**:
+   - Acolyte: use the `skill-activate` tool to activate `review`
+   - Others: follow the repo review checklist at `docs/skills/review.md`
    - if there are must-fix findings, stop and report them — do not create the PR
 3. **Gather context**:
    - read `.github/pull_request_template.md`

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -21,7 +21,7 @@ Create a pull request for the current branch against `main`.
    - working directory is clean (`git status`)
    - branch has commits ahead of `main` (`git log main..HEAD --oneline`)
    - `bun run verify` passes
-2. **Run the review skill** (`.agents/skills/review/SKILL.md`):
+2. **Run the review checklist** (`docs/skills/review.md`):
    - if there are must-fix findings, stop and report them — do not create the PR
 3. **Gather context**:
    - read `.github/pull_request_template.md`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,6 +78,29 @@ acolyte config set --project model openai-compatible/<model>
 acolyte config set logFormat json
 ```
 
+## Feature flags
+
+Feature flags are opt-in toggles for experimental behavior. They are configured under `[features]` in `config.toml`.
+
+### `features.syncAgents`
+
+When enabled:
+- `AGENTS.md` is synced into a deterministic project memory record (`mem_agentsmd`)
+- `AGENTS.md` is not automatically inlined into the system prompt; the model is expected to recall it via `memory-search` when needed
+
+Enable via TOML:
+
+```toml
+[features]
+syncAgents = true
+```
+
+Enable via CLI:
+
+```bash
+acolyte config set --project features.syncAgents true
+```
+
 ## All settable keys
 
 | Key | Description |
@@ -93,3 +116,4 @@ acolyte config set logFormat json
 | `vercelBaseUrl` | Vercel AI Gateway base URL |
 | `logFormat` | log output format (`logfmt` or `json`) |
 | `embeddingModel` | embedding model for semantic recall |
+| `features.syncAgents` | opt-in: sync `AGENTS.md` to project memory and omit it from prompt |

--- a/src/agents-memory-sync.int.test.ts
+++ b/src/agents-memory-sync.int.test.ts
@@ -26,7 +26,7 @@ describe("syncAgentsMdToProjectMemory", () => {
     const records = await store.list({ scopeKey, kind: "stored" });
     expect(records.length).toBe(1);
     expect(records[0]?.id).toBe("mem_agentsmd");
-    expect(records[0]?.content).toContain("Repository Instructions (AGENTS.md):");
+    expect(records[0]?.content).toContain("Project rules (AGENTS.md):");
     expect(records[0]?.content).toContain("Rules.");
   });
 

--- a/src/agents-memory-sync.int.test.ts
+++ b/src/agents-memory-sync.int.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { syncAgentsMdToProjectMemory } from "./agents-memory-sync";
+import { createSqliteMemoryStore } from "./memory-store";
+import { projectResourceIdFromWorkspace } from "./resource-id";
+import { tempDb, tempDir } from "./test-utils";
+
+const { create: createStore, cleanup: cleanupStores } = tempDb("acolyte-agents-sync-", createSqliteMemoryStore);
+const { createDir, cleanupDirs } = tempDir();
+afterEach(() => {
+  cleanupStores();
+  cleanupDirs();
+});
+
+describe("syncAgentsMdToProjectMemory", () => {
+  test("writes deterministic project memory record when AGENTS.md exists", async () => {
+    const workspace = createDir("acolyte-agents-workspace-");
+    writeFileSync(join(workspace, "AGENTS.md"), "Rules.\n", "utf8");
+    const store = createStore();
+
+    const result = await syncAgentsMdToProjectMemory({ workspace, store });
+    expect(result.kind).toBe("synced");
+
+    const scopeKey = projectResourceIdFromWorkspace(workspace);
+    const records = await store.list({ scopeKey, kind: "stored" });
+    expect(records.length).toBe(1);
+    expect(records[0]?.id).toBe("mem_agentsmd");
+    expect(records[0]?.content).toContain("Repository Instructions (AGENTS.md):");
+    expect(records[0]?.content).toContain("Rules.");
+  });
+
+  test("removes deterministic record when AGENTS.md is missing or empty", async () => {
+    const workspace = createDir("acolyte-agents-workspace-");
+    mkdirSync(workspace, { recursive: true });
+    writeFileSync(join(workspace, "AGENTS.md"), "Rules.\n", "utf8");
+    const store = createStore();
+
+    await syncAgentsMdToProjectMemory({ workspace, store });
+    rmSync(join(workspace, "AGENTS.md"));
+
+    const removed = await syncAgentsMdToProjectMemory({ workspace, store });
+    expect(removed.kind).toBe("removed");
+
+    const scopeKey = projectResourceIdFromWorkspace(workspace);
+    const records = await store.list({ scopeKey, kind: "stored" });
+    expect(records).toEqual([]);
+  });
+});

--- a/src/agents-memory-sync.ts
+++ b/src/agents-memory-sync.ts
@@ -1,0 +1,72 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { estimateTokens } from "./agent-input";
+import { log } from "./log";
+import type { MemoryStore } from "./memory-contract";
+import { getDefaultMemoryStore } from "./memory-store";
+import { projectResourceIdFromWorkspace } from "./resource-id";
+
+export const AGENTS_MD_MEMORY_ID = "mem_agentsmd";
+
+type SyncResult = { kind: "synced" } | { kind: "removed" } | { kind: "skipped"; reason: string };
+
+const lastSyncedPromptByWorkspace = new Map<string, string>();
+
+function agentsPromptFromWorkspace(workspace: string): { kind: "present"; prompt: string } | { kind: "absent" } {
+  const agentsPath = join(workspace, "AGENTS.md");
+  if (!existsSync(agentsPath)) return { kind: "absent" };
+  try {
+    const content = readFileSync(agentsPath, "utf8").trim();
+    if (content.length === 0) return { kind: "absent" };
+    return { kind: "present", prompt: ["Repository Instructions (AGENTS.md):", content].join("\n") };
+  } catch {
+    return { kind: "absent" };
+  }
+}
+
+/**
+ * Best-effort sync between `AGENTS.md` and a deterministic project-scoped memory record.
+ *
+ * This is intentionally non-throwing: a broken/unreadable AGENTS.md should never prevent the app from starting.
+ */
+export async function syncAgentsMdToProjectMemory(options: {
+  workspace: string;
+  store?: MemoryStore;
+}): Promise<SyncResult> {
+  const { workspace, store = getDefaultMemoryStore() } = options;
+  const snapshot = agentsPromptFromWorkspace(workspace);
+  if (snapshot.kind === "absent") {
+    if (lastSyncedPromptByWorkspace.has(workspace)) lastSyncedPromptByWorkspace.delete(workspace);
+    try {
+      await store.remove(AGENTS_MD_MEMORY_ID);
+      return { kind: "removed" };
+    } catch (error) {
+      log.warn("agents.memory.sync.remove_failed", { error: String(error) });
+      return { kind: "skipped", reason: "remove_failed" };
+    }
+  }
+
+  const prev = lastSyncedPromptByWorkspace.get(workspace);
+  if (prev === snapshot.prompt) return { kind: "skipped", reason: "unchanged" };
+
+  try {
+    const scopeKey = projectResourceIdFromWorkspace(workspace);
+    await store.write(
+      {
+        id: AGENTS_MD_MEMORY_ID,
+        scopeKey,
+        kind: "stored",
+        content: snapshot.prompt,
+        createdAt: new Date().toISOString(),
+        tokenEstimate: estimateTokens(snapshot.prompt),
+        lastRecalledAt: null,
+      },
+      "project",
+    );
+    lastSyncedPromptByWorkspace.set(workspace, snapshot.prompt);
+    return { kind: "synced" };
+  } catch (error) {
+    log.warn("agents.memory.sync.write_failed", { error: String(error) });
+    return { kind: "skipped", reason: "write_failed" };
+  }
+}

--- a/src/agents-memory-sync.ts
+++ b/src/agents-memory-sync.ts
@@ -18,7 +18,7 @@ function agentsPromptFromWorkspace(workspace: string): { kind: "present"; prompt
   try {
     const content = readFileSync(agentsPath, "utf8").trim();
     if (content.length === 0) return { kind: "absent" };
-    return { kind: "present", prompt: ["Repository Instructions (AGENTS.md):", content].join("\n") };
+    return { kind: "present", prompt: ["Project rules (AGENTS.md):", content].join("\n") };
   } catch {
     return { kind: "absent" };
   }

--- a/src/config-contract.ts
+++ b/src/config-contract.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { type FeatureFlags, featureFlagsSchema } from "./feature-flags-contract";
 import { type TranslationLocale, translationLocaleSchema } from "./i18n/locales";
 
 export const logFormatSchema = z.enum(["logfmt", "json"]);
@@ -38,6 +39,7 @@ export interface Config {
   replyTimeoutMs?: number;
   reasoning?: ReasoningLevel;
   embeddingModel?: string;
+  features?: FeatureFlags;
 }
 
 export interface ResolvedConfig {
@@ -54,6 +56,7 @@ export interface ResolvedConfig {
   replyTimeoutMs: number;
   reasoning?: ReasoningLevel;
   embeddingModel: string;
+  features: Required<FeatureFlags>;
 }
 
 export const CONFIG_SET_SCHEMAS: Partial<Record<keyof Config, z.ZodTypeAny>> = {
@@ -68,6 +71,7 @@ export const CONFIG_SET_SCHEMAS: Partial<Record<keyof Config, z.ZodTypeAny>> = {
   logFormat: logFormatSchema,
   reasoning: reasoningLevelSchema,
   embeddingModel: nonEmptyStringSchema,
+  features: featureFlagsSchema,
 };
 
 export function toConfig(input: Record<string, unknown>): Config {
@@ -90,5 +94,6 @@ export function toConfig(input: Record<string, unknown>): Config {
     replyTimeoutMs: parseField(parseIntegerSchema(1_000, MAX_RUN_REPLY_TIMEOUT_MS), input.replyTimeoutMs),
     reasoning: parseField(reasoningLevelSchema, input.reasoning),
     embeddingModel: parseField(nonEmptyStringSchema, input.embeddingModel),
+    features: parseField(featureFlagsSchema, input.features),
   };
 }

--- a/src/config.int.test.ts
+++ b/src/config.int.test.ts
@@ -194,6 +194,19 @@ describe("config store", () => {
     expect(loaded.replyTimeoutMs).toBe(220000);
   });
 
+  test("reads feature flags from [features] section in config.toml", () => {
+    const home = createDir("acolyte-config-home-");
+    const dataDir = join(home, ".acolyte");
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(join(dataDir, "config.toml"), ["[features]", "syncAgents = true"].join("\n"), "utf8");
+
+    const loaded = readConfigSync({ homeDir: home, cwd: home });
+    expect(loaded.features).toEqual({ syncAgents: true });
+
+    const resolved = readResolvedConfigSync({ homeDir: home, cwd: home });
+    expect(resolved.features.syncAgents).toBe(true);
+  });
+
   test("readResolvedConfigSync applies defaults and model fallbacks", () => {
     const home = createDir("acolyte-config-home-");
     const dataDir = join(home, ".acolyte");
@@ -253,6 +266,35 @@ describe("config store", () => {
     await setConfigValue("locale", "en", { homeDir: home, cwd: home });
     const loaded = readConfigSync({ homeDir: home, cwd: home });
     expect(loaded.locale).toBe("en");
+  });
+
+  test("setConfigValue supports dotted feature flags keys", async () => {
+    const home = createDir("acolyte-config-home-");
+    const dataDir = join(home, ".acolyte");
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(join(dataDir, "config.toml"), "", "utf8");
+
+    await setConfigValue("features.syncAgents", "true", { homeDir: home, cwd: home });
+    const rawToml = readFileSync(join(dataDir, "config.toml"), "utf8");
+    expect(rawToml).toContain("[features]");
+    expect(rawToml).toContain("syncAgents = true");
+
+    const resolved = readResolvedConfigSync({ homeDir: home, cwd: home });
+    expect(resolved.features.syncAgents).toBe(true);
+  });
+
+  test("unsetConfigValue supports dotted feature flags keys", async () => {
+    const home = createDir("acolyte-config-home-");
+    const dataDir = join(home, ".acolyte");
+    mkdirSync(dataDir, { recursive: true });
+    writeFileSync(join(dataDir, "config.toml"), ["[features]", "syncAgents = true"].join("\n"), "utf8");
+
+    await unsetConfigValue("features.syncAgents", { homeDir: home, cwd: home });
+    const rawToml = readFileSync(join(dataDir, "config.toml"), "utf8");
+    expect(rawToml).not.toContain("[features]");
+
+    const resolved = readResolvedConfigSync({ homeDir: home, cwd: home });
+    expect(resolved.features.syncAgents).toBe(false);
   });
 
   test("project config overrides user config", async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ import {
   type ResolvedConfig,
   toConfig,
 } from "./config-contract";
+import { featureFlagsSchema } from "./feature-flags-contract";
 import { resolveHomeDir } from "./home-dir";
 import { t } from "./i18n";
 
@@ -24,6 +25,7 @@ function createDefaultConfig() {
     logFormat: "logfmt" as LogFormat,
     replyTimeoutMs: 180_000,
     embeddingModel: "text-embedding-3-small",
+    features: {},
   };
 }
 
@@ -118,6 +120,11 @@ function serializeToml(config: Config): string {
   if (typeof config.replyTimeoutMs === "number") lines.push(`replyTimeoutMs = ${config.replyTimeoutMs}`);
   if (config.reasoning) lines.push(`reasoning = ${JSON.stringify(config.reasoning)}`);
   if (config.embeddingModel) lines.push(`embeddingModel = ${JSON.stringify(config.embeddingModel)}`);
+  if (config.features && Object.keys(config.features).length > 0) {
+    lines.push("");
+    lines.push("[features]");
+    if (typeof config.features.syncAgents === "boolean") lines.push(`syncAgents = ${config.features.syncAgents}`);
+  }
   return `${lines.join("\n")}${lines.length > 0 ? "\n" : ""}`;
 }
 
@@ -125,6 +132,8 @@ function resolveConfig(config: Config): ResolvedConfig {
   const defaults = createDefaultConfig();
   const model = config.model ?? defaults.model;
   const port = config.port ?? defaults.port;
+  const parsedFeatures = featureFlagsSchema.safeParse(config.features ?? {});
+  const features = parsedFeatures.success ? parsedFeatures.data : {};
   return {
     port,
     locale: config.locale ?? defaults.locale,
@@ -139,6 +148,9 @@ function resolveConfig(config: Config): ResolvedConfig {
     replyTimeoutMs: config.replyTimeoutMs ?? defaults.replyTimeoutMs,
     reasoning: config.reasoning,
     embeddingModel: config.embeddingModel ?? defaults.embeddingModel,
+    features: {
+      syncAgents: features.syncAgents ?? false,
+    },
   };
 }
 
@@ -177,7 +189,7 @@ export async function writeConfig(config: Config, options?: ConfigOptions): Prom
 }
 
 const RECORD_VALID_KEYS: Partial<Record<keyof Config, Set<string>>> = {
-  // No dotted keys are currently supported.
+  features: new Set(["syncAgents"]),
 };
 
 function parseDottedKey(key: string): { section: keyof Config; subKey: string } | null {

--- a/src/feature-flags-contract.ts
+++ b/src/feature-flags-contract.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+const parseBoolSchema = z.preprocess((value) => {
+  if (typeof value !== "string") return value;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "true" || normalized === "1" || normalized === "yes" || normalized === "on") return true;
+  if (normalized === "false" || normalized === "0" || normalized === "no" || normalized === "off") return false;
+  return value;
+}, z.boolean());
+
+export const featureFlagsSchema = z.object({
+  // When enabled, keep a single deterministic project-memory record in sync with AGENTS.md.
+  syncAgents: parseBoolSchema.optional(),
+});
+
+export type FeatureFlags = z.infer<typeof featureFlagsSchema>;

--- a/src/server-chat-runtime.ts
+++ b/src/server-chat-runtime.ts
@@ -1,7 +1,9 @@
 import { existsSync, statSync } from "node:fs";
 import { resolve } from "node:path";
+import { syncAgentsMdToProjectMemory } from "./agents-memory-sync";
 import type { ChatRequest } from "./api";
 import { appConfig } from "./app-config";
+import { readResolvedConfigSync } from "./config";
 import { createDebugLogger } from "./debug-flags";
 import { createStreamError, errorIdSchema, parseError } from "./error-handling";
 import { runLifecycle } from "./lifecycle";
@@ -195,6 +197,10 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
   const runControl = handlers.runControl;
   try {
     await loadSkills(workspaceResolution.workspacePath);
+    const config = readResolvedConfigSync({ cwd: workspaceResolution.workspacePath });
+    if (config.features.syncAgents) {
+      await syncAgentsMdToProjectMemory({ workspace: workspaceResolution.workspacePath });
+    }
     const soulPrompt = await createSoulPrompt({
       cwd: workspaceResolution.workspacePath,
     });

--- a/src/server-chat-runtime.ts
+++ b/src/server-chat-runtime.ts
@@ -203,6 +203,8 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
     }
     const soulPrompt = await createSoulPrompt({
       cwd: workspaceResolution.workspacePath,
+      includeAgents: !config.features.syncAgents,
+      agentsHint: config.features.syncAgents ? "memory" : "none",
     });
     const reply = await runLifecycle({
       request: lifecycleRequest,

--- a/src/soul.int.test.ts
+++ b/src/soul.int.test.ts
@@ -27,6 +27,15 @@ describe("soul prompt loading", () => {
     expect(prompt).toContain("Rules.");
   });
 
+  test("loadSystemPrompt can omit agents prompt and include a memory hint", () => {
+    const dir = createDir("acolyte-omit-agents-");
+    writeFileSync(join(dir, "AGENTS.md"), "Rules.", "utf8");
+    const prompt = loadSystemPrompt(dir, { includeAgents: false, agentsHint: "memory" });
+    expect(prompt).toContain("Acolyte");
+    expect(prompt).not.toContain("Rules.");
+    expect(prompt).toContain("memory-search");
+  });
+
   test("createSoulPrompt returns prompt string", async () => {
     const result = await createSoulPrompt();
     expect(result).toContain("Acolyte");

--- a/src/soul.ts
+++ b/src/soul.ts
@@ -19,7 +19,7 @@ export function loadAgentsPrompt(cwd = process.cwd()): string {
   try {
     const content = readFileSync(agentsPath, "utf8").trim();
     if (content.length === 0) return "";
-    return ["Repository Instructions (AGENTS.md):", content].join("\n");
+    return ["Project rules (AGENTS.md):", content].join("\n");
   } catch {
     return "";
   }
@@ -32,7 +32,7 @@ export function loadSystemPrompt(cwd = process.cwd(), options: Omit<SoulPromptOp
   if (agents) return `${soul}\n\n${agents}`;
 
   if (options.agentsHint === "memory") {
-    return `${soul}\n\nRepository instructions are available via project memory. Use memory-search to retrieve them when needed.`;
+    return `${soul}\n\nProject rules are available via project memory. Use memory-search to retrieve them when needed.`;
   }
 
   return soul;

--- a/src/soul.ts
+++ b/src/soul.ts
@@ -2,6 +2,12 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import bundledSoul from "../docs/soul.md" with { type: "text" };
 
+export type SoulPromptOptions = {
+  cwd?: string;
+  includeAgents?: boolean;
+  agentsHint?: "none" | "memory";
+};
+
 export function loadSoulPrompt(): string {
   return (bundledSoul as string).trim();
 }
@@ -19,13 +25,20 @@ export function loadAgentsPrompt(cwd = process.cwd()): string {
   }
 }
 
-export function loadSystemPrompt(cwd = process.cwd()): string {
+export function loadSystemPrompt(cwd = process.cwd(), options: Omit<SoulPromptOptions, "cwd"> = {}): string {
   const soul = loadSoulPrompt();
-  const agents = loadAgentsPrompt(cwd);
-  return agents ? `${soul}\n\n${agents}` : soul;
+  const includeAgents = options.includeAgents ?? true;
+  const agents = includeAgents ? loadAgentsPrompt(cwd) : "";
+  if (agents) return `${soul}\n\n${agents}`;
+
+  if (options.agentsHint === "memory") {
+    return `${soul}\n\nRepository instructions are available via project memory. Use memory-search to retrieve them when needed.`;
+  }
+
+  return soul;
 }
 
-export async function createSoulPrompt(options: { cwd?: string } = {}): Promise<string> {
+export async function createSoulPrompt(options: SoulPromptOptions = {}): Promise<string> {
   const cwd = options.cwd ?? process.cwd();
-  return loadSystemPrompt(cwd);
+  return loadSystemPrompt(cwd, options);
 }


### PR DESCRIPTION
## Motivation

Opt-in support for keeping AGENTS.md available without always paying prompt tokens.

## Summary
- add feature flag support in config (features.syncAgents)
- sync AGENTS.md into a deterministic project memory record when enabled
- omit AGENTS.md from the system prompt when enabled and add a memory-search hint
- add integration tests for config flags and AGENTS.md sync

Fixes #96
