### PR TITLE
refactor(chat): table-driven slash dispatch

### DIFF
--- a/src/chat-app.test.ts
+++ b/src/chat-app.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, test } from "bun:test";
-import { formatSessionList, resolveResumeSession } from "./chat-commands";
 import {
   applyAtSuggestion,
   extractAtReferencePaths,
@@ -9,49 +8,9 @@ import {
 } from "./chat-file-ref";
 import { appendPromotedItems, applyPromotion } from "./chat-promotion";
 import { toRows } from "./chat-session";
-import { createSession, createStore } from "./test-utils";
-
-function createUiStore() {
-  return createStore({
-    activeSessionId: "sess_aaaa1111",
-    sessions: [
-      createSession({ id: "sess_aaaa1111", title: "First" }),
-      createSession({ id: "sess_bbbb2222", title: "Second" }),
-    ],
-  });
-}
+import { createSession } from "./test-utils";
 
 describe("chat-ui helpers", () => {
-  test("resolveResumeSession reports usage when no prefix is provided", () => {
-    const resolved = resolveResumeSession(createUiStore(), "/resume");
-    expect(resolved.kind).toBe("usage");
-  });
-
-  test("resolveResumeSession reports not_found for unknown prefix", () => {
-    const resolved = resolveResumeSession(createUiStore(), "/resume sess_missing");
-    expect(resolved.kind).toBe("not_found");
-    if (resolved.kind === "not_found") expect(resolved.prefix).toBe("sess_missing");
-  });
-
-  test("resolveResumeSession reports ambiguous for multi-match prefix", () => {
-    const store = createUiStore();
-    const resolved = resolveResumeSession(store, "/resume sess_");
-    expect(resolved.kind).toBe("ambiguous");
-    if (resolved.kind === "ambiguous") expect(resolved.matches).toHaveLength(2);
-  });
-
-  test("resolveResumeSession returns target session for exact-ish prefix", () => {
-    const resolved = resolveResumeSession(createUiStore(), "/resume sess_bbbb");
-    expect(resolved.kind).toBe("ok");
-    if (resolved.kind === "ok") expect(resolved.session.id).toBe("sess_bbbb2222");
-  });
-
-  test("formatSessionList marks active session", () => {
-    const lines = formatSessionList(createUiStore());
-    expect(lines[0]?.startsWith("● ")).toBe(true);
-    expect(lines[1]?.startsWith("  ")).toBe(true);
-  });
-
   test("extractAtReferenceQuery parses @prefix", () => {
     expect(extractAtReferenceQuery("@cli")).toBe("cli");
     expect(extractAtReferenceQuery(" @cli")).toBe("cli");

--- a/src/chat-commands-contract.ts
+++ b/src/chat-commands-contract.ts
@@ -1,6 +1,7 @@
 import type { ChatRow } from "./chat-contract";
 import type { Client } from "./client-contract";
 import type { ConfigScope } from "./config-contract";
+import type { addMemory, listMemories, removeMemory } from "./memory-ops";
 import type { Session, SessionState, SessionTokenUsageEntry } from "./session-contract";
 
 export type CommandResult = {
@@ -31,9 +32,9 @@ export type CommandContext = {
   clearTranscript: (sessionId?: string) => void;
   tokenUsage: SessionTokenUsageEntry[];
   memoryApi?: {
-    listMemories: typeof import("./memory-ops").listMemories;
-    addMemory: typeof import("./memory-ops").addMemory;
-    removeMemory: typeof import("./memory-ops").removeMemory;
+    listMemories: typeof listMemories;
+    addMemory: typeof addMemory;
+    removeMemory: typeof removeMemory;
   };
 };
 

--- a/src/chat-commands-contract.ts
+++ b/src/chat-commands-contract.ts
@@ -1,0 +1,44 @@
+import type { ChatRow } from "./chat-contract";
+import type { Client } from "./client-contract";
+import type { ConfigScope } from "./config-contract";
+import type { Session, SessionState, SessionTokenUsageEntry } from "./session-contract";
+
+export type CommandResult = {
+  stop: boolean;
+  userText: string;
+};
+
+export type CommandContext = {
+  text: string;
+  resolvedText: string;
+  client: Client;
+  store: SessionState;
+  currentSession: Session;
+  setCurrentSession: (next: Session) => void;
+  setTokenUsage?: (updater: (current: SessionTokenUsageEntry[]) => SessionTokenUsageEntry[]) => void;
+  toRows: (messages: Session["messages"]) => ChatRow[];
+  setRows: (updater: (current: ChatRow[]) => ChatRow[]) => void;
+  setShowHelp: (updater: (current: boolean) => boolean) => void;
+  setValue: (next: string) => void;
+  persist: () => Promise<void>;
+  exit: () => void;
+  openSkillsPanel: () => Promise<void>;
+  openResumePanel: () => void;
+  openModelPanel: () => void | Promise<void>;
+  persistModelConfig?: (key: string, value: string, scope: ConfigScope) => Promise<void>;
+  activateSkill?: (skillName: string, args: string) => Promise<boolean>;
+  startAssistantTurn?: (userText: string) => Promise<void>;
+  clearTranscript: (sessionId?: string) => void;
+  tokenUsage: SessionTokenUsageEntry[];
+  memoryApi?: {
+    listMemories: typeof import("./memory-ops").listMemories;
+    addMemory: typeof import("./memory-ops").addMemory;
+    removeMemory: typeof import("./memory-ops").removeMemory;
+  };
+};
+
+export type SlashCommand = {
+  name: string;
+  match: (value: string) => boolean;
+  run: () => Promise<CommandResult>;
+};

--- a/src/chat-commands-memory.ts
+++ b/src/chat-commands-memory.ts
@@ -1,0 +1,148 @@
+import type { CommandContext, CommandResult, SlashCommand } from "./chat-commands-contract";
+import { createRow } from "./chat-contract";
+import { formatUsage } from "./cli-help";
+import { t } from "./i18n";
+import type { MemoryScope } from "./memory-contract";
+import { addMemory, listMemories, removeMemory } from "./memory-ops";
+
+type MemoryContextScope = "all" | "user" | "project";
+
+function parseMemoryListScope(parts: string[]): MemoryContextScope | null {
+  if (parts.length === 1) return "all";
+  if (parts.length !== 2) return null;
+  const scope = parts[1];
+  if (scope === "all" || scope === "user" || scope === "project") return scope;
+  return null;
+}
+
+function scopeLabel(scope: MemoryContextScope): string {
+  if (scope === "user") return t("chat.scope.user");
+  if (scope === "project") return t("chat.scope.project");
+  return t("chat.scope.all");
+}
+
+export function resolveMemoryApi(ctx: CommandContext): {
+  listMemories: typeof listMemories;
+  addMemory: typeof addMemory;
+  removeMemory: typeof removeMemory;
+} {
+  return {
+    listMemories,
+    addMemory,
+    removeMemory,
+    ...ctx.memoryApi,
+  };
+}
+
+async function handleMemoryRm(
+  ctx: CommandContext,
+  memoryApi: ReturnType<typeof resolveMemoryApi>,
+): Promise<CommandResult> {
+  const { text, resolvedText } = ctx;
+  const parts = resolvedText.trim().split(/\s+/);
+  if (parts.length !== 3) {
+    ctx.setRows((current) => [...current, createRow("system", formatUsage("/memory rm <id-prefix>"))]);
+    return { stop: true, userText: text };
+  }
+  const prefix = parts[2];
+  try {
+    const removed = await memoryApi.removeMemory(prefix);
+    if (removed.kind === "not_found") {
+      ctx.setRows((current) => [...current, createRow("system", t("chat.memory.rm.not_found", { id: removed.id }))]);
+      return { stop: true, userText: text };
+    }
+    ctx.setRows((current) => [
+      ...current,
+      createRow("system", t("chat.memory.rm.removed", { scope: removed.entry.scope, id: removed.entry.id })),
+    ]);
+  } catch (error) {
+    ctx.setRows((current) => [
+      ...current,
+      createRow("system", error instanceof Error ? error.message : t("chat.memory.rm.failed")),
+    ]);
+  }
+  return { stop: true, userText: text };
+}
+
+async function handleMemoryList(
+  ctx: CommandContext,
+  memoryApi: ReturnType<typeof resolveMemoryApi>,
+): Promise<CommandResult> {
+  const { text, resolvedText } = ctx;
+  const parts = resolvedText.split(/\s+/);
+  const scope = parseMemoryListScope(parts);
+  if (!scope) {
+    ctx.setRows((current) => [...current, createRow("system", formatUsage("/memory [all|user|project]"))]);
+    return { stop: true, userText: text };
+  }
+  const memories = await memoryApi.listMemories({ scope: scope === "all" ? undefined : scope });
+  if (memories.length === 0) {
+    const emptyLabel = scope === "all" ? "" : `${scope} `;
+    ctx.setRows((current) => [...current, createRow("system", t("chat.memory.none", { scope: emptyLabel }))]);
+    return { stop: true, userText: text };
+  }
+  const list = memories.slice(0, 10).map((entry) => `${entry.scope}:${entry.id} ${entry.content}`);
+  const header =
+    scope === "all"
+      ? t("chat.memory.header.all", { count: memories.length })
+      : t("chat.memory.header.scope", { scope: scopeLabel(scope), count: memories.length });
+  ctx.setRows((current) => [...current, createRow("system", { header, sections: [], list })]);
+  return { stop: true, userText: text };
+}
+
+async function handleRemember(
+  ctx: CommandContext,
+  memoryApi: ReturnType<typeof resolveMemoryApi>,
+): Promise<CommandResult> {
+  const { text, resolvedText } = ctx;
+  const parts = resolvedText.split(/\s+/).slice(1);
+  let scope: MemoryScope = "user";
+  const contentParts: string[] = [];
+  for (const part of parts) {
+    if (part === "--project") {
+      scope = "project";
+      continue;
+    }
+    if (part === "--user") {
+      scope = "user";
+      continue;
+    }
+    contentParts.push(part);
+  }
+  const content = contentParts.join(" ").trim();
+  if (!content) {
+    ctx.setRows((current) => [
+      ...current,
+      createRow("system", formatUsage("/remember [--user|--project] <memory text>")),
+    ]);
+    return { stop: true, userText: text };
+  }
+  try {
+    const entry = await memoryApi.addMemory(content, { scope });
+    ctx.setRows((current) => [
+      ...current,
+      createRow("system", t("chat.remember.saved", { scope: entry.scope, content })),
+    ]);
+  } catch (error) {
+    ctx.setRows((current) => [
+      ...current,
+      createRow("system", error instanceof Error ? error.message : t("chat.remember.failed")),
+    ]);
+  }
+  return { stop: true, userText: text };
+}
+
+export function createMemoryCommands(
+  ctx: CommandContext,
+  memoryApi: ReturnType<typeof resolveMemoryApi>,
+): SlashCommand[] {
+  return [
+    { name: "memory.rm", match: (value) => value.startsWith("/memory rm"), run: () => handleMemoryRm(ctx, memoryApi) },
+    {
+      name: "memory.list",
+      match: (value) => value === "/memory" || value.startsWith("/memory "),
+      run: () => handleMemoryList(ctx, memoryApi),
+    },
+    { name: "remember", match: (value) => value.startsWith("/remember"), run: () => handleRemember(ctx, memoryApi) },
+  ];
+}

--- a/src/chat-commands-model.ts
+++ b/src/chat-commands-model.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import { setModel } from "./app-config";
+import type { CommandContext, CommandResult, SlashCommand } from "./chat-commands-contract";
+import { createRow } from "./chat-contract";
+import { formatUsage } from "./cli-help";
+import { setConfigValue } from "./config";
+import { nowIso } from "./datetime";
+import { t } from "./i18n";
+import { formatModel } from "./provider-config";
+import type { Session } from "./session-contract";
+
+const modelIdSchema = z.string().trim().min(1).regex(/^\S+$/);
+
+function parseModelCommand(resolvedText: string): string | null {
+  const parts = resolvedText.trim().split(/\s+/);
+  if (parts[0] !== "/model" || parts.length !== 2) return null;
+  const parsed = modelIdSchema.safeParse(parts[1]);
+  return parsed.success ? parsed.data : null;
+}
+
+async function handleModelPanel(ctx: CommandContext): Promise<CommandResult> {
+  ctx.openModelPanel();
+  return { stop: true, userText: ctx.text };
+}
+
+async function handleModelSet(ctx: CommandContext): Promise<CommandResult> {
+  const { text, resolvedText } = ctx;
+  const model = parseModelCommand(resolvedText);
+  if (!model) {
+    ctx.setRows((current) => [...current, createRow("system", formatUsage("/model <id>"))]);
+    return { stop: true, userText: text };
+  }
+  try {
+    if (ctx.persistModelConfig) {
+      await ctx.persistModelConfig("model", model, "project");
+    } else {
+      await setConfigValue("model", model, { scope: "project" });
+    }
+    setModel(model);
+    const nextSession: Session = {
+      ...ctx.currentSession,
+      model,
+      updatedAt: nowIso(),
+    };
+    ctx.setCurrentSession(nextSession);
+    ctx.setRows((current) => [...current, createRow("system", t("chat.model.changed", { model: formatModel(model) }))]);
+  } catch (error) {
+    ctx.setRows((current) => [
+      ...current,
+      createRow("system", error instanceof Error ? error.message : t("chat.model.failed")),
+    ]);
+  }
+  return { stop: true, userText: text };
+}
+
+export function createModelCommands(ctx: CommandContext): SlashCommand[] {
+  return [
+    { name: "model.panel", match: (value) => value === "/model", run: () => handleModelPanel(ctx) },
+    { name: "model.set", match: (value) => value.startsWith("/model "), run: () => handleModelSet(ctx) },
+  ];
+}

--- a/src/chat-commands-resume.test.ts
+++ b/src/chat-commands-resume.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { resolveResumeSession } from "./chat-commands-resume";
+import { createSession, createStore } from "./test-utils";
+
+function createUiStore() {
+  return createStore({
+    activeSessionId: "sess_aaaa1111",
+    sessions: [
+      createSession({ id: "sess_aaaa1111", title: "First" }),
+      createSession({ id: "sess_bbbb2222", title: "Second" }),
+    ],
+  });
+}
+
+describe("chat-commands-resume", () => {
+  test("resolveResumeSession reports usage when no prefix is provided", () => {
+    const resolved = resolveResumeSession(createUiStore(), "/resume");
+    expect(resolved.kind).toBe("usage");
+  });
+
+  test("resolveResumeSession reports not_found for unknown prefix", () => {
+    const resolved = resolveResumeSession(createUiStore(), "/resume sess_missing");
+    expect(resolved.kind).toBe("not_found");
+    if (resolved.kind === "not_found") expect(resolved.prefix).toBe("sess_missing");
+  });
+
+  test("resolveResumeSession reports ambiguous for multi-match prefix", () => {
+    const resolved = resolveResumeSession(createUiStore(), "/resume sess_");
+    expect(resolved.kind).toBe("ambiguous");
+    if (resolved.kind === "ambiguous") expect(resolved.matches).toHaveLength(2);
+  });
+
+  test("resolveResumeSession returns target session for exact-ish prefix", () => {
+    const resolved = resolveResumeSession(createUiStore(), "/resume sess_bbbb");
+    expect(resolved.kind).toBe("ok");
+    if (resolved.kind === "ok") expect(resolved.session.id).toBe("sess_bbbb2222");
+  });
+});

--- a/src/chat-commands-resume.ts
+++ b/src/chat-commands-resume.ts
@@ -1,0 +1,75 @@
+import type { CommandContext, CommandResult, SlashCommand } from "./chat-commands-contract";
+import { formatSessionList } from "./chat-commands-sessions";
+import { type ChatRow, createRow } from "./chat-contract";
+import { formatUsage } from "./cli-help";
+import { t } from "./i18n";
+import type { Session, SessionState } from "./session-contract";
+
+export type ResumeResolution =
+  | { kind: "usage" }
+  | { kind: "not_found"; prefix: string }
+  | { kind: "ambiguous"; prefix: string; matches: Session[] }
+  | { kind: "ok"; session: Session };
+
+export function resolveResumeSession(store: SessionState, text: string): ResumeResolution {
+  const parts = text.trim().split(/\s+/);
+  if (parts.length < 2) return { kind: "usage" };
+  const prefix = parts[1];
+  const matches = store.sessions.filter((item) => item.id.startsWith(prefix));
+  if (matches.length === 0) return { kind: "not_found", prefix };
+  if (matches.length > 1) return { kind: "ambiguous", prefix, matches };
+  return { kind: "ok", session: matches[0] };
+}
+
+function resumeUsageRows(store: SessionState): ChatRow[] {
+  const recent = formatSessionList(store, 6);
+  return [
+    createRow("system", formatUsage("/resume <session-id-prefix>")),
+    ...recent.map((line) => createRow("system", line)),
+  ];
+}
+
+async function handleResumePanel(ctx: CommandContext): Promise<CommandResult> {
+  ctx.openResumePanel();
+  return { stop: true, userText: ctx.text };
+}
+
+async function handleResume(ctx: CommandContext): Promise<CommandResult> {
+  const { text, resolvedText } = ctx;
+  const resolved = resolveResumeSession(ctx.store, resolvedText);
+  if (resolved.kind === "usage") {
+    ctx.setRows((current) => [...current, ...resumeUsageRows(ctx.store)]);
+    return { stop: true, userText: text };
+  }
+  if (resolved.kind === "not_found") {
+    ctx.setRows((current) => [
+      ...current,
+      createRow("system", t("chat.resume.not_found", { prefix: resolved.prefix })),
+    ]);
+    return { stop: true, userText: text };
+  }
+  if (resolved.kind === "ambiguous") {
+    const matches = resolved.matches.map((item) => item.id).join(", ");
+    ctx.setRows((current) => [
+      ...current,
+      createRow("system", t("chat.resume.ambiguous", { prefix: resolved.prefix, matches })),
+    ]);
+    return { stop: true, userText: text };
+  }
+  const target = resolved.session;
+  ctx.store.activeSessionId = target.id;
+  ctx.setCurrentSession(target);
+  ctx.setTokenUsage?.(() => target.tokenUsage);
+  ctx.clearTranscript(target.id);
+  ctx.setRows(() => ctx.toRows(target.messages));
+  ctx.setShowHelp(() => false);
+  await ctx.persist();
+  return { stop: true, userText: text };
+}
+
+export function createResumeCommands(ctx: CommandContext): SlashCommand[] {
+  return [
+    { name: "resume.panel", match: (value) => value === "/resume", run: () => handleResumePanel(ctx) },
+    { name: "resume", match: (value) => value.startsWith("/resume"), run: () => handleResume(ctx) },
+  ];
+}

--- a/src/chat-commands-sessions.test.ts
+++ b/src/chat-commands-sessions.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { formatSessionList, sessionsRows } from "./chat-commands-sessions";
+import { isCommandOutput } from "./chat-contract";
+import { createSession, createStore } from "./test-utils";
+
+describe("chat-commands-sessions", () => {
+  test("sessionsRows returns commandOutput with header and list", () => {
+    const store = createStore({
+      activeSessionId: "sess_aaaa1111",
+      sessions: [createSession({ id: "sess_aaaa1111", title: "First" })],
+    });
+    const [row] = sessionsRows(store, 10);
+    const content = row?.content;
+    expect(isCommandOutput(content) && content.header).toBe("Sessions 1");
+    expect(isCommandOutput(content) && content.list?.some((line) => line.includes("● sess_aaaa1111"))).toBe(true);
+    expect(isCommandOutput(content) && content.list?.some((line) => line.includes("First"))).toBe(true);
+  });
+
+  test("formatSessionList marks active session", () => {
+    const store = createStore({
+      activeSessionId: "sess_aaaa1111",
+      sessions: [
+        createSession({ id: "sess_aaaa1111", title: "First" }),
+        createSession({ id: "sess_bbbb2222", title: "Second" }),
+      ],
+    });
+    const lines = formatSessionList(store);
+    expect(lines[0]?.startsWith("● ")).toBe(true);
+    expect(lines[1]?.startsWith("  ")).toBe(true);
+  });
+});

--- a/src/chat-commands-sessions.ts
+++ b/src/chat-commands-sessions.ts
@@ -1,0 +1,21 @@
+import { type ChatRow, createRow } from "./chat-contract";
+import { alignCols } from "./chat-format";
+import { formatRelativeTime } from "./datetime";
+import { t } from "./i18n";
+import type { SessionState } from "./session-contract";
+
+export function formatSessionList(store: SessionState, limit = 10): string[] {
+  const rows = store.sessions.slice(0, limit).map((item) => {
+    const active = item.id === store.activeSessionId ? "●" : " ";
+    const title = item.title || t("chat.session.default_title");
+    return [`${active} ${item.id}`, title, formatRelativeTime(item.updatedAt)];
+  });
+  return alignCols(rows);
+}
+
+export function sessionsRows(store: SessionState, limit = 10): ChatRow[] {
+  const list = formatSessionList(store, limit);
+  return [
+    createRow("system", { header: t("chat.sessions.header", { count: store.sessions.length }), sections: [], list }),
+  ];
+}

--- a/src/chat-commands-skill.ts
+++ b/src/chat-commands-skill.ts
@@ -1,9 +1,9 @@
-import type { CommandContext, CommandResult, SlashCommand } from "./chat-commands-contract";
+import type { CommandContext, CommandResult } from "./chat-commands-contract";
 import { createRow } from "./chat-contract";
 import { t } from "./i18n";
 import { findSkillByName } from "./skills";
 
-async function handleSkillActivation(ctx: CommandContext): Promise<CommandResult | null> {
+export async function handleSkillActivation(ctx: CommandContext): Promise<CommandResult | null> {
   if (!ctx.activateSkill) return null;
   const [head, ...rest] = ctx.resolvedText.split(/\s+/);
   const skillName = (head ?? "").slice(1);
@@ -21,23 +21,4 @@ async function handleSkillActivation(ctx: CommandContext): Promise<CommandResult
     return { stop: true, userText: ctx.text };
   }
   return { stop: false, userText: runPrompt };
-}
-
-async function handleUnknownSlash(ctx: CommandContext): Promise<CommandResult> {
-  ctx.setRows((current) => [...current, createRow("system", t("chat.command.unknown", { command: ctx.text }))]);
-  return { stop: true, userText: ctx.text };
-}
-
-export function createSkillCommands(ctx: CommandContext): SlashCommand[] {
-  return [
-    {
-      name: "skill.or.unknown",
-      match: (value) => value.startsWith("/"),
-      run: async () => {
-        const handled = await handleSkillActivation(ctx);
-        if (handled) return handled;
-        return handleUnknownSlash(ctx);
-      },
-    },
-  ];
 }

--- a/src/chat-commands-skill.ts
+++ b/src/chat-commands-skill.ts
@@ -1,0 +1,43 @@
+import type { CommandContext, CommandResult, SlashCommand } from "./chat-commands-contract";
+import { createRow } from "./chat-contract";
+import { t } from "./i18n";
+import { findSkillByName } from "./skills";
+
+async function handleSkillActivation(ctx: CommandContext): Promise<CommandResult | null> {
+  if (!ctx.activateSkill) return null;
+  const [head, ...rest] = ctx.resolvedText.split(/\s+/);
+  const skillName = (head ?? "").slice(1);
+  const skill = findSkillByName(skillName);
+  if (!skill) return null;
+  const args = rest.join(" ").trim();
+  const ok = await ctx.activateSkill(skill.name, args);
+  if (!ok) {
+    ctx.setRows((current) => [...current, createRow("system", t("chat.skill.failed", { skill: skill.name }))]);
+    return { stop: true, userText: ctx.text };
+  }
+  const runPrompt = args || t("chat.skill.run_prompt", { skill: skill.name });
+  if (ctx.startAssistantTurn) {
+    void ctx.startAssistantTurn(runPrompt);
+    return { stop: true, userText: ctx.text };
+  }
+  return { stop: false, userText: runPrompt };
+}
+
+async function handleUnknownSlash(ctx: CommandContext): Promise<CommandResult> {
+  ctx.setRows((current) => [...current, createRow("system", t("chat.command.unknown", { command: ctx.text }))]);
+  return { stop: true, userText: ctx.text };
+}
+
+export function createSkillCommands(ctx: CommandContext): SlashCommand[] {
+  return [
+    {
+      name: "skill.or.unknown",
+      match: (value) => value.startsWith("/"),
+      run: async () => {
+        const handled = await handleSkillActivation(ctx);
+        if (handled) return handled;
+        return handleUnknownSlash(ctx);
+      },
+    },
+  ];
+}

--- a/src/chat-commands-status.test.ts
+++ b/src/chat-commands-status.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { statusRows } from "./chat-commands-status";
+import { isCommandOutput } from "./chat-contract";
+
+describe("chat-commands-status", () => {
+  test("statusRows returns commandOutput with labeled fields", () => {
+    const [row] = statusRows({
+      providers: ["openai"],
+      model: "gpt-5-mini",
+    });
+    const content = row?.content;
+    expect(isCommandOutput(content) && content.header).toBe("Status");
+    const pairs = isCommandOutput(content) ? (content.sections[0] ?? []) : [];
+    expect(pairs).toContainEqual(["Providers", "openai"]);
+    expect(pairs).toContainEqual(["Model", "gpt-5-mini"]);
+  });
+
+  test("statusRows returns empty array when payload has no visible fields", () => {
+    expect(statusRows({})).toHaveLength(0);
+  });
+});

--- a/src/chat-commands-status.ts
+++ b/src/chat-commands-status.ts
@@ -1,0 +1,9 @@
+import { type ChatRow, createRow } from "./chat-contract";
+import type { StatusFields } from "./status-contract";
+import { createStatusOutput } from "./status-format";
+
+export function statusRows(status: StatusFields): ChatRow[] {
+  const output = createStatusOutput(status);
+  if (!output) return [];
+  return [createRow("system", output)];
+}

--- a/src/chat-commands-usage.test.ts
+++ b/src/chat-commands-usage.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import { usageRows } from "./chat-commands-usage";
+import { isCommandOutput } from "./chat-contract";
+import type { SessionTokenUsageEntry } from "./session-contract";
+
+describe("chat-commands-usage", () => {
+  test("usageRows includes expected metric keys", () => {
+    const usage: SessionTokenUsageEntry = {
+      id: "row_1",
+      usage: {
+        inputTokens: 100,
+        outputTokens: 40,
+        totalTokens: 140,
+        inputBudgetTokens: 300,
+        inputTruncated: false,
+      },
+      promptBreakdown: {
+        budgetTokens: 300,
+        usedTokens: 100,
+        systemTokens: 40,
+        toolTokens: 30,
+        memoryTokens: 0,
+        messageTokens: 10,
+      },
+    };
+    const [row] = usageRows(usage);
+    const content = row?.content;
+    const allPairs = isCommandOutput(content) ? content.sections.flat() : [];
+    const keys = allPairs.map(([k]) => k);
+    expect(keys).toContain("Input");
+    expect(keys).toContain("Output");
+    expect(keys).toContain("System");
+    expect(keys).toContain("Tools");
+    expect(keys).toContain("Messages");
+  });
+
+  test("usageRows does not include budget warning", () => {
+    const usage: SessionTokenUsageEntry = {
+      id: "row_warn",
+      usage: {
+        inputTokens: 900,
+        outputTokens: 40,
+        totalTokens: 940,
+        inputBudgetTokens: 1000,
+        inputTruncated: true,
+      },
+    };
+    const [row] = usageRows(usage);
+    const content = row?.content;
+    const allPairs = isCommandOutput(content) ? content.sections.flat() : [];
+    expect(allPairs.every(([k]) => !k.toLowerCase().includes("warning"))).toBe(true);
+    expect(allPairs.every(([, v]) => !v.includes("context trimmed"))).toBe(true);
+  });
+
+  test("usageRows uses prompt breakdown total for percentages", () => {
+    const usage: SessionTokenUsageEntry = {
+      id: "row_1",
+      usage: { inputTokens: 50, outputTokens: 2, totalTokens: 52 },
+      promptBreakdown: {
+        budgetTokens: 1000,
+        usedTokens: 100,
+        systemTokens: 20,
+        toolTokens: 30,
+        memoryTokens: 0,
+        messageTokens: 40,
+      },
+    };
+    const [row] = usageRows(usage);
+    const content = row?.content;
+    const allPairs = isCommandOutput(content) ? content.sections.flat() : [];
+    const find = (key: string) => allPairs.find(([k]) => k === key)?.[1] ?? "";
+    expect(find("System")).toContain("20%");
+    expect(find("Tools")).toContain("30%");
+    expect(find("Messages")).toContain("40%");
+  });
+
+  test("usageRows returns fallback row when no usage data", () => {
+    const [row] = usageRows(null);
+    expect(row?.content).toBe("No usage data yet. Send a prompt first.");
+  });
+});

--- a/src/chat-commands-usage.ts
+++ b/src/chat-commands-usage.ts
@@ -1,0 +1,64 @@
+import { type ChatRow, createRow } from "./chat-contract";
+import { alignCols, formatCompactNumber } from "./chat-format";
+import { t } from "./i18n";
+import type { SessionTokenUsageEntry } from "./session-contract";
+
+function formatUsageValue(value: number): string {
+  return formatCompactNumber(value);
+}
+
+function formatShare(tokens: number, total: number): string {
+  if (total <= 0) return "0%";
+  return `${Math.round((tokens / total) * 100)}%`;
+}
+
+export function usageRows(last: SessionTokenUsageEntry | null, all: SessionTokenUsageEntry[] = []): ChatRow[] {
+  if (!last) return [createRow("system", t("chat.usage.none"))];
+  const totals = all.reduce(
+    (acc, entry) => {
+      acc.input += entry.usage.inputTokens;
+      acc.output += entry.usage.outputTokens;
+      acc.total += entry.usage.totalTokens;
+      return acc;
+    },
+    { input: 0, output: 0, total: 0 },
+  );
+  const hasSession = all.length > 1;
+  const summaryGrid: string[][] = [
+    hasSession
+      ? [formatUsageValue(last.usage.inputTokens), formatUsageValue(totals.input)]
+      : [formatUsageValue(last.usage.inputTokens)],
+    hasSession
+      ? [formatUsageValue(last.usage.outputTokens), formatUsageValue(totals.output)]
+      : [formatUsageValue(last.usage.outputTokens)],
+    hasSession
+      ? [formatUsageValue(last.usage.totalTokens), formatUsageValue(totals.total)]
+      : [formatUsageValue(last.usage.totalTokens)],
+  ];
+  const summaryLabels = [t("chat.usage.metric.input"), t("chat.usage.metric.output"), t("chat.usage.metric.total")];
+  const summaryAligned = alignCols(summaryGrid);
+  const summary: [string, string][] = summaryLabels.map((label, i) => [label, summaryAligned[i]]);
+  const breakdown: [string, string][] = [];
+  if (last.promptBreakdown) {
+    const bd = last.promptBreakdown;
+    const total = Math.max(bd.usedTokens, last.usage.inputTokens);
+    const breakdownGrid: string[][] = [];
+    const breakdownLabels: string[] = [];
+    for (const [label, tokens] of [
+      [t("chat.usage.metric.system"), bd.systemTokens],
+      [t("chat.usage.metric.tools"), bd.toolTokens],
+      [t("chat.usage.metric.memory"), bd.memoryTokens],
+      [t("chat.usage.metric.messages"), bd.messageTokens],
+    ] as [string, number][]) {
+      breakdownLabels.push(label);
+      breakdownGrid.push([formatUsageValue(tokens), formatShare(tokens, total)]);
+    }
+    const breakdownAligned = alignCols(breakdownGrid);
+    for (let i = 0; i < breakdownLabels.length; i++) {
+      breakdown.push([breakdownLabels[i], breakdownAligned[i]]);
+    }
+  }
+  const sections: [string, string][][] = [summary];
+  if (breakdown.length > 0) sections.push(breakdown);
+  return [createRow("system", { header: t("chat.usage.header"), sections })];
+}

--- a/src/chat-commands-workspaces.ts
+++ b/src/chat-commands-workspaces.ts
@@ -1,0 +1,182 @@
+import type { z } from "zod";
+import { appConfig } from "./app-config";
+import type { CommandContext, CommandResult, SlashCommand } from "./chat-commands-contract";
+import { createRow } from "./chat-contract";
+import { alignCols } from "./chat-format";
+import { formatUsage } from "./cli-help";
+import { t } from "./i18n";
+import { createSession } from "./storage";
+import { createGitWorktree, resolveGitRepoRoot, suggestWorkspaceName, workspaceNameSchema } from "./workspaces-ops";
+
+async function handleWorkspaces(ctx: CommandContext): Promise<CommandResult> {
+  const { text, resolvedText } = ctx;
+  if (!appConfig.features.parallelWorkspaces) {
+    ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.disabled"))]);
+    return { stop: true, userText: text };
+  }
+
+  const parts = resolvedText.trim().split(/\s+/);
+  const sub = parts[1] ?? "list";
+
+  if (sub === "list" && parts.length <= 2) {
+    const workspaces = ctx.store.sessions
+      .filter((s) => typeof s.workspaceName === "string" && s.workspaceName.length > 0)
+      .map((s) => ({
+        id: s.id,
+        name: s.workspaceName ?? "",
+        branch: s.workspaceBranch ?? "",
+        path: s.workspace ?? "",
+      }));
+    if (workspaces.length === 0) {
+      ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.list.none"))]);
+      return { stop: true, userText: text };
+    }
+    const grid = workspaces.map((ws) => {
+      const active = ws.id === ctx.store.activeSessionId ? "●" : " ";
+      const branch = ws.branch.length > 0 ? ws.branch : "—";
+      const path = ws.path.length > 0 ? ws.path : "—";
+      return [`${active} ${ws.name}`, branch, path];
+    });
+    const list = alignCols(grid);
+    ctx.setRows((current) => [
+      ...current,
+      createRow("system", { header: t("chat.workspaces.header", { count: workspaces.length }), sections: [], list }),
+    ]);
+    return { stop: true, userText: text };
+  }
+
+  if (sub === "new") {
+    const args = parts.slice(2);
+    const showUsage = (): CommandResult => {
+      ctx.setRows((current) => [
+        ...current,
+        createRow("system", formatUsage("/workspaces new <name> [-- <prompt>]")),
+        createRow("system", formatUsage("/workspaces new -- <prompt>")),
+      ]);
+      return { stop: true, userText: text };
+    };
+
+    if (args.length === 0) return showUsage();
+
+    const delimiterIndex = args.indexOf("--");
+    let baseName: z.infer<typeof workspaceNameSchema>;
+    let prompt = "";
+    let isExplicitName = false;
+
+    if (delimiterIndex === -1) {
+      if (args.length !== 1) return showUsage();
+      const parsedName = workspaceNameSchema.safeParse(args[0]);
+      if (!parsedName.success) return showUsage();
+      baseName = parsedName.data;
+      isExplicitName = true;
+    } else if (delimiterIndex === 0) {
+      prompt = args.slice(1).join(" ").trim();
+      if (prompt.length === 0) {
+        ctx.setRows((current) => [...current, createRow("system", formatUsage("/workspaces new -- <prompt>"))]);
+        return { stop: true, userText: text };
+      }
+      baseName = suggestWorkspaceName(prompt);
+    } else if (delimiterIndex === 1) {
+      const parsedName = workspaceNameSchema.safeParse(args[0]);
+      if (!parsedName.success) return showUsage();
+      baseName = parsedName.data;
+      isExplicitName = true;
+      prompt = args.slice(2).join(" ").trim();
+    } else {
+      ctx.setRows((current) => [
+        ...current,
+        createRow("system", formatUsage("/workspaces new <name> -- <prompt>")),
+        createRow("system", formatUsage("/workspaces new -- <prompt>")),
+      ]);
+      return { stop: true, userText: text };
+    }
+    const existing = new Set(
+      ctx.store.sessions
+        .map((s) => (typeof s.workspaceName === "string" && s.workspaceName.length > 0 ? s.workspaceName : null))
+        .filter((s): s is string => typeof s === "string"),
+    );
+    if (isExplicitName && existing.has(baseName)) {
+      ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.name_conflict"))]);
+      return { stop: true, userText: text };
+    }
+    let name = baseName;
+    if (!isExplicitName) {
+      for (let n = 2; existing.has(name) && n < 100; n++) {
+        const suffix = `-${n}`;
+        const trimmed = `${baseName}`.slice(0, Math.max(1, 40 - suffix.length));
+        const candidate = `${trimmed}${suffix}`;
+        const parsed = workspaceNameSchema.safeParse(candidate);
+        if (!parsed.success) continue;
+        name = parsed.data;
+      }
+      if (existing.has(name)) {
+        ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.name_conflict"))]);
+        return { stop: true, userText: text };
+      }
+    }
+    let created: { workspacePath: string; branch: string };
+    try {
+      const repoRoot = await resolveGitRepoRoot(ctx.currentSession.workspace ?? process.cwd());
+      created = await createGitWorktree({ repoRoot, name, baseRef: "HEAD" });
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : "unknown error";
+      ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.create_failed", { reason }))]);
+      return { stop: true, userText: text };
+    }
+    const next = createSession(appConfig.model);
+    next.workspaceName = name;
+    next.workspace = created.workspacePath;
+    next.workspaceBranch = created.branch;
+    next.title = prompt.length > 0 ? prompt : name;
+    ctx.store.sessions.unshift(next);
+    ctx.store.activeSessionId = next.id;
+    ctx.setCurrentSession(next);
+    ctx.setTokenUsage?.(() => []);
+    ctx.clearTranscript(next.id);
+    ctx.setRows(() => ctx.toRows(next.messages));
+    ctx.setShowHelp(() => false);
+    await ctx.persist();
+    ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.created", { name }))]);
+
+    if (prompt.length > 0 && ctx.startAssistantTurn) {
+      void ctx.startAssistantTurn(prompt);
+      return { stop: true, userText: prompt };
+    }
+    return { stop: true, userText: text };
+  }
+
+  if (sub === "switch") {
+    const name = workspaceNameSchema.safeParse(parts[2]);
+    if (!name.success || parts.length !== 3) {
+      ctx.setRows((current) => [...current, createRow("system", formatUsage("/workspaces switch <name>"))]);
+      return { stop: true, userText: text };
+    }
+    const target = ctx.store.sessions.find((s) => s.workspaceName === name.data);
+    if (!target) {
+      ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.not_found", { name: name.data }))]);
+      return { stop: true, userText: text };
+    }
+    ctx.store.activeSessionId = target.id;
+    ctx.setCurrentSession(target);
+    ctx.setTokenUsage?.(() => target.tokenUsage);
+    ctx.clearTranscript(target.id);
+    ctx.setRows(() => ctx.toRows(target.messages));
+    ctx.setShowHelp(() => false);
+    await ctx.persist();
+    ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.switched", { name: name.data }))]);
+    return { stop: true, userText: text };
+  }
+
+  ctx.setRows((current) => [...current, createRow("system", formatUsage("/workspaces [list|new|switch] ..."))]);
+  return { stop: true, userText: text };
+}
+
+export function createWorkspacesCommands(ctx: CommandContext): SlashCommand[] {
+  return [
+    {
+      name: "workspaces",
+      match: (value) => value === "/workspaces" || value.startsWith("/workspaces "),
+      run: () => handleWorkspaces(ctx),
+    },
+  ];
+}

--- a/src/chat-commands.test.ts
+++ b/src/chat-commands.test.ts
@@ -1,11 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { appConfig } from "./app-config";
-import { dispatchSlashCommand, sessionsRows, statusRows, usageRows } from "./chat-commands";
+import { dispatchSlashCommand } from "./chat-commands";
 import { isCommandOutput } from "./chat-contract";
 import type { ConfigScope } from "./config-contract";
 import type { MemoryEntry, MemoryScope, RemoveMemoryResult } from "./memory-contract";
 import type { MemoryOptions } from "./memory-ops";
-import type { SessionTokenUsageEntry } from "./session-contract";
 import { loadSkills, resetSkillCache } from "./skills";
 import { createCommandContext, createMessage, createSession, createStore, tempDir, writeSkill } from "./test-utils";
 
@@ -39,111 +38,8 @@ async function runCommand(text: string, overrides: Parameters<typeof createComma
 }
 
 describe("chat-commands", () => {
-  test("usageRows includes expected metric keys", () => {
-    const usage: SessionTokenUsageEntry = {
-      id: "row_1",
-      usage: {
-        inputTokens: 100,
-        outputTokens: 40,
-        totalTokens: 140,
-        inputBudgetTokens: 300,
-        inputTruncated: false,
-      },
-      promptBreakdown: {
-        budgetTokens: 300,
-        usedTokens: 100,
-        systemTokens: 40,
-        toolTokens: 30,
-        memoryTokens: 0,
-        messageTokens: 10,
-      },
-    };
-    const [row] = usageRows(usage);
-    const content = row?.content;
-    const allPairs = isCommandOutput(content) ? content.sections.flat() : [];
-    const keys = allPairs.map(([k]) => k);
-    expect(keys).toContain("Input");
-    expect(keys).toContain("Output");
-    expect(keys).toContain("System");
-    expect(keys).toContain("Tools");
-    expect(keys).toContain("Messages");
-  });
-
-  test("usageRows does not include budget warning", () => {
-    const usage: SessionTokenUsageEntry = {
-      id: "row_warn",
-      usage: {
-        inputTokens: 900,
-        outputTokens: 40,
-        totalTokens: 940,
-        inputBudgetTokens: 1000,
-        inputTruncated: true,
-      },
-    };
-    const [row] = usageRows(usage);
-    const content = row?.content;
-    const allPairs = isCommandOutput(content) ? content.sections.flat() : [];
-    expect(allPairs.every(([k]) => !k.toLowerCase().includes("warning"))).toBe(true);
-    expect(allPairs.every(([, v]) => !v.includes("context trimmed"))).toBe(true);
-  });
-
-  test("usageRows uses prompt breakdown total for percentages", () => {
-    const usage: SessionTokenUsageEntry = {
-      id: "row_1",
-      usage: { inputTokens: 50, outputTokens: 2, totalTokens: 52 },
-      promptBreakdown: {
-        budgetTokens: 1000,
-        usedTokens: 100,
-        systemTokens: 20,
-        toolTokens: 30,
-        memoryTokens: 0,
-        messageTokens: 40,
-      },
-    };
-    const [row] = usageRows(usage);
-    const content = row?.content;
-    const allPairs = isCommandOutput(content) ? content.sections.flat() : [];
-    const find = (key: string) => allPairs.find(([k]) => k === key)?.[1] ?? "";
-    expect(find("System")).toContain("20%");
-    expect(find("Tools")).toContain("30%");
-    expect(find("Messages")).toContain("40%");
-  });
-
-  test("statusRows returns commandOutput with labeled fields", () => {
-    const [row] = statusRows({
-      providers: ["openai"],
-      model: "gpt-5-mini",
-    });
-    const content = row?.content;
-    expect(isCommandOutput(content) && content.header).toBe("Status");
-    const pairs = isCommandOutput(content) ? (content.sections[0] ?? []) : [];
-    expect(pairs).toContainEqual(["Providers", "openai"]);
-    expect(pairs).toContainEqual(["Model", "gpt-5-mini"]);
-  });
-
-  test("statusRows returns empty array when payload has no visible fields", () => {
-    expect(statusRows({})).toHaveLength(0);
-  });
-
-  test("sessionsRows returns commandOutput with header and list", () => {
-    const store = createStore({
-      activeSessionId: "sess_aaaa1111",
-      sessions: [createSession({ id: "sess_aaaa1111", title: "First" })],
-    });
-    const [row] = sessionsRows(store, 10);
-    const content = row?.content;
-    expect(isCommandOutput(content) && content.header).toBe("Sessions 1");
-    expect(isCommandOutput(content) && content.list?.some((line) => line.includes("● sess_aaaa1111"))).toBe(true);
-    expect(isCommandOutput(content) && content.list?.some((line) => line.includes("First"))).toBe(true);
-  });
-
-  test("usageRows returns fallback row when no usage data", () => {
-    const [row] = usageRows(null);
-    expect(row?.content).toBe("No usage data yet. Send a prompt first.");
-  });
-
   test("dispatchSlashCommand handles /usage", async () => {
-    const tokenUsage: SessionTokenUsageEntry[] = [
+    const tokenUsage = [
       {
         id: "row_2",
         usage: {

--- a/src/chat-commands.ts
+++ b/src/chat-commands.ts
@@ -1,633 +1,140 @@
-import { z } from "zod";
-import { appConfig, setModel } from "./app-config";
-import { type ChatRow, createRow } from "./chat-contract";
-import { alignCols, formatCompactNumber } from "./chat-format";
-import { formatUsage } from "./cli-help";
-import type { Client } from "./client-contract";
-import { setConfigValue } from "./config";
-import type { ConfigScope } from "./config-contract";
-import { formatRelativeTime, nowIso } from "./datetime";
+import { appConfig } from "./app-config";
+import type { CommandContext, CommandResult, SlashCommand } from "./chat-commands-contract";
+import { createMemoryCommands, resolveMemoryApi } from "./chat-commands-memory";
+import { createModelCommands } from "./chat-commands-model";
+import { createResumeCommands } from "./chat-commands-resume";
+import { sessionsRows } from "./chat-commands-sessions";
+import { createSkillCommands } from "./chat-commands-skill";
+import { statusRows } from "./chat-commands-status";
+import { usageRows } from "./chat-commands-usage";
+import { createWorkspacesCommands } from "./chat-commands-workspaces";
+import { createRow } from "./chat-contract";
 import { t } from "./i18n";
-import type { MemoryScope } from "./memory-contract";
-import { addMemory, listMemories, removeMemory } from "./memory-ops";
-import { formatModel } from "./provider-config";
-import type { Session, SessionState, SessionTokenUsageEntry } from "./session-contract";
-import { findSkillByName } from "./skills";
-import type { StatusFields } from "./status-contract";
-import { createStatusOutput } from "./status-format";
 import { createSession } from "./storage";
-import { createGitWorktree, resolveGitRepoRoot, suggestWorkspaceName, workspaceNameSchema } from "./workspaces-ops";
 
-type MemoryContextScope = "all" | "user" | "project";
-
-export type ResumeResolution =
-  | { kind: "usage" }
-  | { kind: "not_found"; prefix: string }
-  | { kind: "ambiguous"; prefix: string; matches: Session[] }
-  | { kind: "ok"; session: Session };
-
-export function resolveResumeSession(store: SessionState, text: string): ResumeResolution {
-  const parts = text.trim().split(/\s+/);
-  if (parts.length < 2) return { kind: "usage" };
-  const prefix = parts[1];
-  const matches = store.sessions.filter((item) => item.id.startsWith(prefix));
-  if (matches.length === 0) return { kind: "not_found", prefix };
-  if (matches.length > 1) return { kind: "ambiguous", prefix, matches };
-  return { kind: "ok", session: matches[0] };
-}
-
-export function formatSessionList(store: SessionState, limit = 10): string[] {
-  const rows = store.sessions.slice(0, limit).map((item) => {
-    const active = item.id === store.activeSessionId ? "●" : " ";
-    const title = item.title || t("chat.session.default_title");
-    return [`${active} ${item.id}`, title, formatRelativeTime(item.updatedAt)];
-  });
-  return alignCols(rows);
-}
-
-function formatUsageValue(value: number): string {
-  return formatCompactNumber(value);
-}
-
-function formatShare(tokens: number, total: number): string {
-  if (total <= 0) return "0%";
-  return `${Math.round((tokens / total) * 100)}%`;
-}
-
-export function sessionsRows(store: SessionState, limit = 10): ChatRow[] {
-  const list = formatSessionList(store, limit);
-  return [
-    createRow("system", { header: t("chat.sessions.header", { count: store.sessions.length }), sections: [], list }),
-  ];
-}
-
-export function statusRows(status: StatusFields): ChatRow[] {
-  const output = createStatusOutput(status);
-  if (!output) return [];
-  return [createRow("system", output)];
-}
-
-export function usageRows(last: SessionTokenUsageEntry | null, all: SessionTokenUsageEntry[] = []): ChatRow[] {
-  if (!last) return [createRow("system", t("chat.usage.none"))];
-  const totals = all.reduce(
-    (acc, entry) => {
-      acc.input += entry.usage.inputTokens;
-      acc.output += entry.usage.outputTokens;
-      acc.total += entry.usage.totalTokens;
-      return acc;
+function createSessionsCommand(ctx: CommandContext): SlashCommand {
+  return {
+    name: "sessions",
+    match: (value) => value === "/sessions",
+    run: async () => {
+      ctx.setRows((current) => [...current, ...sessionsRows(ctx.store, 10)]);
+      return { stop: true, userText: ctx.text };
     },
-    { input: 0, output: 0, total: 0 },
-  );
-  const hasSession = all.length > 1;
-  const summaryGrid: string[][] = [
-    hasSession
-      ? [formatUsageValue(last.usage.inputTokens), formatUsageValue(totals.input)]
-      : [formatUsageValue(last.usage.inputTokens)],
-    hasSession
-      ? [formatUsageValue(last.usage.outputTokens), formatUsageValue(totals.output)]
-      : [formatUsageValue(last.usage.outputTokens)],
-    hasSession
-      ? [formatUsageValue(last.usage.totalTokens), formatUsageValue(totals.total)]
-      : [formatUsageValue(last.usage.totalTokens)],
-  ];
-  const summaryLabels = [t("chat.usage.metric.input"), t("chat.usage.metric.output"), t("chat.usage.metric.total")];
-  const summaryAligned = alignCols(summaryGrid);
-  const summary: [string, string][] = summaryLabels.map((label, i) => [label, summaryAligned[i]]);
-  const breakdown: [string, string][] = [];
-  if (last.promptBreakdown) {
-    const bd = last.promptBreakdown;
-    const total = Math.max(bd.usedTokens, last.usage.inputTokens);
-    const breakdownGrid: string[][] = [];
-    const breakdownLabels: string[] = [];
-    for (const [label, tokens] of [
-      [t("chat.usage.metric.system"), bd.systemTokens],
-      [t("chat.usage.metric.tools"), bd.toolTokens],
-      [t("chat.usage.metric.memory"), bd.memoryTokens],
-      [t("chat.usage.metric.messages"), bd.messageTokens],
-    ] as [string, number][]) {
-      breakdownLabels.push(label);
-      breakdownGrid.push([formatUsageValue(tokens), formatShare(tokens, total)]);
-    }
-    const breakdownAligned = alignCols(breakdownGrid);
-    for (let i = 0; i < breakdownLabels.length; i++) {
-      breakdown.push([breakdownLabels[i], breakdownAligned[i]]);
-    }
-  }
-  const sections: [string, string][][] = [summary];
-  if (breakdown.length > 0) sections.push(breakdown);
-  return [createRow("system", { header: t("chat.usage.header"), sections })];
+  };
 }
 
-type CommandResult = {
-  stop: boolean;
-  userText: string;
-};
-
-export type CommandContext = {
-  text: string;
-  resolvedText: string;
-  client: Client;
-  store: SessionState;
-  currentSession: Session;
-  setCurrentSession: (next: Session) => void;
-  setTokenUsage?: (updater: (current: SessionTokenUsageEntry[]) => SessionTokenUsageEntry[]) => void;
-  toRows: (messages: Session["messages"]) => ChatRow[];
-  setRows: (updater: (current: ChatRow[]) => ChatRow[]) => void;
-  setShowHelp: (updater: (current: boolean) => boolean) => void;
-  setValue: (next: string) => void;
-  persist: () => Promise<void>;
-  exit: () => void;
-  openSkillsPanel: () => Promise<void>;
-  openResumePanel: () => void;
-  openModelPanel: () => void | Promise<void>;
-  persistModelConfig?: (key: string, value: string, scope: ConfigScope) => Promise<void>;
-  activateSkill?: (skillName: string, args: string) => Promise<boolean>;
-  startAssistantTurn?: (userText: string) => Promise<void>;
-  clearTranscript: (sessionId?: string) => void;
-  tokenUsage: SessionTokenUsageEntry[];
-  memoryApi?: {
-    listMemories: typeof listMemories;
-    addMemory: typeof addMemory;
-    removeMemory: typeof removeMemory;
-  };
-};
-
-function parseMemoryListScope(parts: string[]): MemoryContextScope | null {
-  if (parts.length === 1) return "all";
-  if (parts.length !== 2) return null;
-  const scope = parts[1];
-  if (scope === "all" || scope === "user" || scope === "project") return scope;
-  return null;
-}
-
-function scopeLabel(scope: MemoryContextScope): string {
-  if (scope === "user") return t("chat.scope.user");
-  if (scope === "project") return t("chat.scope.project");
-  return t("chat.scope.all");
-}
-
-const modelIdSchema = z.string().trim().min(1).regex(/^\S+$/);
-
-function parseModelCommand(resolvedText: string): string | null {
-  const parts = resolvedText.trim().split(/\s+/);
-  if (parts[0] !== "/model" || parts.length !== 2) return null;
-  const parsed = modelIdSchema.safeParse(parts[1]);
-  return parsed.success ? parsed.data : null;
-}
-
-export async function dispatchSlashCommand(ctx: CommandContext): Promise<CommandResult> {
-  const { text, resolvedText } = ctx;
-  const memoryApi = {
-    listMemories,
-    addMemory,
-    removeMemory,
-    ...ctx.memoryApi,
-  };
-
-  type SlashCommand = {
-    name: string;
-    match: (value: string) => boolean;
-    run: () => Promise<CommandResult>;
-  };
-
-  const handleResumePanel = async (): Promise<CommandResult> => {
-    ctx.openResumePanel();
-    return { stop: true, userText: text };
-  };
-
-  const handleResume = async (): Promise<CommandResult> => {
-    const resolved = resolveResumeSession(ctx.store, resolvedText);
-    if (resolved.kind === "usage") {
-      const recent = formatSessionList(ctx.store, 6);
-      ctx.setRows((current) => [
-        ...current,
-        createRow("system", formatUsage("/resume <session-id-prefix>")),
-        ...recent.map((line) => createRow("system", line)),
-      ]);
-      return { stop: true, userText: text };
-    }
-    if (resolved.kind === "not_found") {
-      ctx.setRows((current) => [
-        ...current,
-        createRow("system", t("chat.resume.not_found", { prefix: resolved.prefix })),
-      ]);
-      return { stop: true, userText: text };
-    }
-    if (resolved.kind === "ambiguous") {
-      const matches = resolved.matches.map((item) => item.id).join(", ");
-      ctx.setRows((current) => [
-        ...current,
-        createRow("system", t("chat.resume.ambiguous", { prefix: resolved.prefix, matches })),
-      ]);
-      return { stop: true, userText: text };
-    }
-    const target = resolved.session;
-    ctx.store.activeSessionId = target.id;
-    ctx.setCurrentSession(target);
-    ctx.setTokenUsage?.(() => target.tokenUsage);
-    ctx.clearTranscript(target.id);
-    ctx.setRows(() => ctx.toRows(target.messages));
-    ctx.setShowHelp(() => false);
-    await ctx.persist();
-    return { stop: true, userText: text };
-  };
-
-  const handleSessions = async (): Promise<CommandResult> => {
-    ctx.setRows((current) => [...current, ...sessionsRows(ctx.store, 10)]);
-    return { stop: true, userText: text };
-  };
-
-  const handleWorkspaces = async (): Promise<CommandResult> => {
-    if (!appConfig.features.parallelWorkspaces) {
-      ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.disabled"))]);
-      return { stop: true, userText: text };
-    }
-
-    const parts = resolvedText.trim().split(/\s+/);
-    const sub = parts[1] ?? "list";
-
-    if (sub === "list" && parts.length <= 2) {
-      const workspaces = ctx.store.sessions
-        .filter((s) => typeof s.workspaceName === "string" && s.workspaceName.length > 0)
-        .map((s) => ({
-          id: s.id,
-          name: s.workspaceName ?? "",
-          branch: s.workspaceBranch ?? "",
-          path: s.workspace ?? "",
-        }));
-      if (workspaces.length === 0) {
-        ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.list.none"))]);
-        return { stop: true, userText: text };
-      }
-      const grid = workspaces.map((ws) => {
-        const active = ws.id === ctx.store.activeSessionId ? "●" : " ";
-        const branch = ws.branch.length > 0 ? ws.branch : "—";
-        const path = ws.path.length > 0 ? ws.path : "—";
-        return [`${active} ${ws.name}`, branch, path];
-      });
-      const list = alignCols(grid);
-      ctx.setRows((current) => [
-        ...current,
-        createRow("system", { header: t("chat.workspaces.header", { count: workspaces.length }), sections: [], list }),
-      ]);
-      return { stop: true, userText: text };
-    }
-
-    if (sub === "new") {
-      const args = parts.slice(2);
-      const showUsage = (): CommandResult => {
-        ctx.setRows((current) => [
-          ...current,
-          createRow("system", formatUsage("/workspaces new <name> [-- <prompt>]")),
-          createRow("system", formatUsage("/workspaces new -- <prompt>")),
-        ]);
-        return { stop: true, userText: text };
-      };
-
-      if (args.length === 0) return showUsage();
-
-      const delimiterIndex = args.indexOf("--");
-      let baseName: z.infer<typeof workspaceNameSchema>;
-      let prompt = "";
-      let isExplicitName = false;
-
-      if (delimiterIndex === -1) {
-        if (args.length !== 1) return showUsage();
-        const parsedName = workspaceNameSchema.safeParse(args[0]);
-        if (!parsedName.success) return showUsage();
-        baseName = parsedName.data;
-        isExplicitName = true;
-      } else if (delimiterIndex === 0) {
-        prompt = args.slice(1).join(" ").trim();
-        if (prompt.length === 0) {
-          ctx.setRows((current) => [...current, createRow("system", formatUsage("/workspaces new -- <prompt>"))]);
-          return { stop: true, userText: text };
-        }
-        baseName = suggestWorkspaceName(prompt);
-      } else if (delimiterIndex === 1) {
-        const parsedName = workspaceNameSchema.safeParse(args[0]);
-        if (!parsedName.success) return showUsage();
-        baseName = parsedName.data;
-        isExplicitName = true;
-        prompt = args.slice(2).join(" ").trim();
-      } else {
-        ctx.setRows((current) => [
-          ...current,
-          createRow("system", formatUsage("/workspaces new <name> -- <prompt>")),
-          createRow("system", formatUsage("/workspaces new -- <prompt>")),
-        ]);
-        return { stop: true, userText: text };
-      }
-      const existing = new Set(
-        ctx.store.sessions
-          .map((s) => (typeof s.workspaceName === "string" && s.workspaceName.length > 0 ? s.workspaceName : null))
-          .filter((s): s is string => typeof s === "string"),
-      );
-      if (isExplicitName && existing.has(baseName)) {
-        ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.name_conflict"))]);
-        return { stop: true, userText: text };
-      }
-      let name = baseName;
-      if (!isExplicitName) {
-        for (let n = 2; existing.has(name) && n < 100; n++) {
-          const suffix = `-${n}`;
-          const trimmed = `${baseName}`.slice(0, Math.max(1, 40 - suffix.length));
-          const candidate = `${trimmed}${suffix}`;
-          const parsed = workspaceNameSchema.safeParse(candidate);
-          if (!parsed.success) continue;
-          name = parsed.data;
-        }
-        if (existing.has(name)) {
-          ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.name_conflict"))]);
-          return { stop: true, userText: text };
-        }
-      }
-      let created: { workspacePath: string; branch: string };
+function createStatusCommand(ctx: CommandContext): SlashCommand {
+  return {
+    name: "status",
+    match: (value) => value === "/status",
+    run: async () => {
       try {
-        const repoRoot = await resolveGitRepoRoot(ctx.currentSession.workspace ?? process.cwd());
-        created = await createGitWorktree({ repoRoot, name, baseRef: "HEAD" });
+        const status = await ctx.client.status();
+        ctx.setRows((current) => [...current, ...statusRows(status)]);
       } catch (error) {
-        const reason = error instanceof Error ? error.message : "unknown error";
-        ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.create_failed", { reason }))]);
-        return { stop: true, userText: text };
+        ctx.setRows((current) => [
+          ...current,
+          createRow("system", error instanceof Error ? error.message : t("chat.status.check_failed")),
+        ]);
       }
+      return { stop: true, userText: ctx.text };
+    },
+  };
+}
+
+function createUsageCommand(ctx: CommandContext): SlashCommand {
+  return {
+    name: "usage",
+    match: (value) => value === "/usage",
+    run: async () => {
+      const last = ctx.tokenUsage.length > 0 ? ctx.tokenUsage[ctx.tokenUsage.length - 1] : null;
+      ctx.setRows((current) => [...current, ...usageRows(last, ctx.tokenUsage)]);
+      return { stop: true, userText: ctx.text };
+    },
+  };
+}
+
+function createSkillsCommand(ctx: CommandContext): SlashCommand {
+  return {
+    name: "skills.panel",
+    match: (value) => value === "/skills",
+    run: async () => {
+      await ctx.openSkillsPanel();
+      return { stop: true, userText: ctx.text };
+    },
+  };
+}
+
+function createNewCommand(ctx: CommandContext): SlashCommand {
+  return {
+    name: "new",
+    match: (value) => value === "/new",
+    run: async () => {
       const next = createSession(appConfig.model);
-      next.workspaceName = name;
-      next.workspace = created.workspacePath;
-      next.workspaceBranch = created.branch;
-      next.title = prompt.length > 0 ? prompt : name;
       ctx.store.sessions.unshift(next);
       ctx.store.activeSessionId = next.id;
       ctx.setCurrentSession(next);
       ctx.setTokenUsage?.(() => []);
       ctx.clearTranscript(next.id);
-      ctx.setRows(() => ctx.toRows(next.messages));
+      ctx.setValue("");
       ctx.setShowHelp(() => false);
       await ctx.persist();
-      ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.created", { name }))]);
+      return { stop: true, userText: ctx.text };
+    },
+  };
+}
 
-      if (prompt.length > 0 && ctx.startAssistantTurn) {
-        void ctx.startAssistantTurn(prompt);
-        return { stop: true, userText: prompt };
-      }
-      return { stop: true, userText: text };
-    }
-
-    if (sub === "switch") {
-      const name = workspaceNameSchema.safeParse(parts[2]);
-      if (!name.success || parts.length !== 3) {
-        ctx.setRows((current) => [...current, createRow("system", formatUsage("/workspaces switch <name>"))]);
-        return { stop: true, userText: text };
-      }
-      const target = ctx.store.sessions.find((s) => s.workspaceName === name.data);
-      if (!target) {
-        ctx.setRows((current) => [
-          ...current,
-          createRow("system", t("chat.workspaces.not_found", { name: name.data })),
-        ]);
-        return { stop: true, userText: text };
-      }
-      ctx.store.activeSessionId = target.id;
-      ctx.setCurrentSession(target);
-      ctx.setTokenUsage?.(() => target.tokenUsage);
-      ctx.clearTranscript(target.id);
-      ctx.setRows(() => ctx.toRows(target.messages));
-      ctx.setShowHelp(() => false);
+function createExitCommand(ctx: CommandContext): SlashCommand {
+  return {
+    name: "exit",
+    match: (value) => value === "/exit",
+    run: async () => {
       await ctx.persist();
-      ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.switched", { name: name.data }))]);
-      return { stop: true, userText: text };
-    }
-
-    ctx.setRows((current) => [...current, createRow("system", formatUsage("/workspaces [list|new|switch] ..."))]);
-    return { stop: true, userText: text };
-  };
-
-  const handleStatus = async (): Promise<CommandResult> => {
-    try {
-      const status = await ctx.client.status();
-      ctx.setRows((current) => [...current, ...statusRows(status)]);
-    } catch (error) {
-      ctx.setRows((current) => [
-        ...current,
-        createRow("system", error instanceof Error ? error.message : t("chat.status.check_failed")),
-      ]);
-    }
-    return { stop: true, userText: text };
-  };
-
-  const handleModelPanel = async (): Promise<CommandResult> => {
-    ctx.openModelPanel();
-    return { stop: true, userText: text };
-  };
-
-  const handleModelSet = async (): Promise<CommandResult> => {
-    const model = parseModelCommand(resolvedText);
-    if (!model) {
-      ctx.setRows((current) => [...current, createRow("system", formatUsage("/model <id>"))]);
-      return { stop: true, userText: text };
-    }
-    try {
-      if (ctx.persistModelConfig) {
-        await ctx.persistModelConfig("model", model, "project");
-      } else {
-        await setConfigValue("model", model, { scope: "project" });
-      }
-      setModel(model);
-      const nextSession: Session = {
-        ...ctx.currentSession,
-        model,
-        updatedAt: nowIso(),
-      };
-      ctx.setCurrentSession(nextSession);
-      ctx.setRows((current) => [
-        ...current,
-        createRow("system", t("chat.model.changed", { model: formatModel(model) })),
-      ]);
-    } catch (error) {
-      ctx.setRows((current) => [
-        ...current,
-        createRow("system", error instanceof Error ? error.message : t("chat.model.failed")),
-      ]);
-    }
-    return { stop: true, userText: text };
-  };
-
-  const handleMemoryRm = async (): Promise<CommandResult> => {
-    const parts = resolvedText.trim().split(/\s+/);
-    if (parts.length !== 3) {
-      ctx.setRows((current) => [...current, createRow("system", formatUsage("/memory rm <id-prefix>"))]);
-      return { stop: true, userText: text };
-    }
-    const prefix = parts[2];
-    try {
-      const removed = await memoryApi.removeMemory(prefix);
-      if (removed.kind === "not_found") {
-        ctx.setRows((current) => [...current, createRow("system", t("chat.memory.rm.not_found", { id: removed.id }))]);
-        return { stop: true, userText: text };
-      }
-      ctx.setRows((current) => [
-        ...current,
-        createRow("system", t("chat.memory.rm.removed", { scope: removed.entry.scope, id: removed.entry.id })),
-      ]);
-    } catch (error) {
-      ctx.setRows((current) => [
-        ...current,
-        createRow("system", error instanceof Error ? error.message : t("chat.memory.rm.failed")),
-      ]);
-    }
-    return { stop: true, userText: text };
-  };
-
-  const handleMemoryList = async (): Promise<CommandResult> => {
-    const parts = resolvedText.split(/\s+/);
-    const scope = parseMemoryListScope(parts);
-    if (!scope) {
-      ctx.setRows((current) => [...current, createRow("system", formatUsage("/memory [all|user|project]"))]);
-      return { stop: true, userText: text };
-    }
-    const memories = await memoryApi.listMemories({ scope: scope === "all" ? undefined : scope });
-    if (memories.length === 0) {
-      const emptyLabel = scope === "all" ? "" : `${scope} `;
-      ctx.setRows((current) => [...current, createRow("system", t("chat.memory.none", { scope: emptyLabel }))]);
-      return { stop: true, userText: text };
-    }
-    const list = memories.slice(0, 10).map((entry) => `${entry.scope}:${entry.id} ${entry.content}`);
-    const header =
-      scope === "all"
-        ? t("chat.memory.header.all", { count: memories.length })
-        : t("chat.memory.header.scope", { scope: scopeLabel(scope), count: memories.length });
-    ctx.setRows((current) => [...current, createRow("system", { header, sections: [], list })]);
-    return { stop: true, userText: text };
-  };
-
-  const handleUsage = async (): Promise<CommandResult> => {
-    const last = ctx.tokenUsage.length > 0 ? ctx.tokenUsage[ctx.tokenUsage.length - 1] : null;
-    ctx.setRows((current) => [...current, ...usageRows(last, ctx.tokenUsage)]);
-    return { stop: true, userText: text };
-  };
-
-  const handleRemember = async (): Promise<CommandResult> => {
-    const parts = resolvedText.split(/\s+/).slice(1);
-    let scope: MemoryScope = "user";
-    const contentParts: string[] = [];
-    for (const part of parts) {
-      if (part === "--project") {
-        scope = "project";
-        continue;
-      }
-      if (part === "--user") {
-        scope = "user";
-        continue;
-      }
-      contentParts.push(part);
-    }
-    const content = contentParts.join(" ").trim();
-    if (!content) {
-      ctx.setRows((current) => [
-        ...current,
-        createRow("system", formatUsage("/remember [--user|--project] <memory text>")),
-      ]);
-      return { stop: true, userText: text };
-    }
-    try {
-      const entry = await memoryApi.addMemory(content, { scope });
-      ctx.setRows((current) => [
-        ...current,
-        createRow("system", t("chat.remember.saved", { scope: entry.scope, content })),
-      ]);
-    } catch (error) {
-      ctx.setRows((current) => [
-        ...current,
-        createRow("system", error instanceof Error ? error.message : t("chat.remember.failed")),
-      ]);
-    }
-    return { stop: true, userText: text };
-  };
-
-  const handleSkills = async (): Promise<CommandResult> => {
-    await ctx.openSkillsPanel();
-    return { stop: true, userText: text };
-  };
-
-  const handleNew = async (): Promise<CommandResult> => {
-    const next = createSession(appConfig.model);
-    ctx.store.sessions.unshift(next);
-    ctx.store.activeSessionId = next.id;
-    ctx.setCurrentSession(next);
-    ctx.setTokenUsage?.(() => []);
-    ctx.clearTranscript(next.id);
-    ctx.setValue("");
-    ctx.setShowHelp(() => false);
-    await ctx.persist();
-    return { stop: true, userText: text };
-  };
-
-  const handleExit = async (): Promise<CommandResult> => {
-    await ctx.persist();
-    ctx.exit();
-    return { stop: true, userText: text };
-  };
-
-  const handleClear = async (): Promise<CommandResult> => {
-    ctx.clearTranscript();
-    return { stop: true, userText: text };
-  };
-
-  const handleSkillOrUnknown = async (): Promise<CommandResult> => {
-    const [head, ...rest] = resolvedText.split(/\s+/);
-    const skillName = (head ?? "").slice(1);
-    const skill = findSkillByName(skillName);
-    if (skill && ctx.activateSkill) {
-      const args = rest.join(" ").trim();
-      const ok = await ctx.activateSkill(skill.name, args);
-      if (!ok) {
-        ctx.setRows((current) => [...current, createRow("system", t("chat.skill.failed", { skill: skill.name }))]);
-        return { stop: true, userText: text };
-      }
-      const runPrompt = args || t("chat.skill.run_prompt", { skill: skill.name });
-      if (ctx.startAssistantTurn) {
-        void ctx.startAssistantTurn(runPrompt);
-        return { stop: true, userText: text };
-      }
-      return { stop: false, userText: runPrompt };
-    }
-
-    ctx.setRows((current) => [...current, createRow("system", t("chat.command.unknown", { command: text }))]);
-    return { stop: true, userText: text };
-  };
-
-  const commands: SlashCommand[] = [
-    { name: "resume.panel", match: (value) => value === "/resume", run: handleResumePanel },
-    { name: "resume", match: (value) => value.startsWith("/resume"), run: handleResume },
-    { name: "sessions", match: (value) => value === "/sessions", run: handleSessions },
-    {
-      name: "workspaces",
-      match: (value) => value === "/workspaces" || value.startsWith("/workspaces "),
-      run: handleWorkspaces,
+      ctx.exit();
+      return { stop: true, userText: ctx.text };
     },
-    { name: "status", match: (value) => value === "/status", run: handleStatus },
-    { name: "model.panel", match: (value) => value === "/model", run: handleModelPanel },
-    { name: "model.set", match: (value) => value.startsWith("/model "), run: handleModelSet },
-    { name: "memory.rm", match: (value) => value.startsWith("/memory rm"), run: handleMemoryRm },
-    {
-      name: "memory.list",
-      match: (value) => value === "/memory" || value.startsWith("/memory "),
-      run: handleMemoryList,
+  };
+}
+
+function createClearCommand(ctx: CommandContext): SlashCommand {
+  return {
+    name: "clear",
+    match: (value) => value === "/clear",
+    run: async () => {
+      ctx.clearTranscript();
+      return { stop: true, userText: ctx.text };
     },
-    { name: "usage", match: (value) => value === "/usage", run: handleUsage },
-    { name: "remember", match: (value) => value.startsWith("/remember"), run: handleRemember },
-    { name: "skills", match: (value) => value === "/skills", run: handleSkills },
-    { name: "new", match: (value) => value === "/new", run: handleNew },
-    { name: "exit", match: (value) => value === "/exit", run: handleExit },
-    { name: "clear", match: (value) => value === "/clear", run: handleClear },
+  };
+}
+
+function resolveSlashCommands(ctx: CommandContext): SlashCommand[] {
+  const memoryApi = resolveMemoryApi(ctx);
+  return [
+    ...createResumeCommands(ctx),
+    createSessionsCommand(ctx),
+    ...createWorkspacesCommands(ctx),
+    createStatusCommand(ctx),
+    ...createModelCommands(ctx),
+    ...createMemoryCommands(ctx, memoryApi),
+    createUsageCommand(ctx),
+    createSkillsCommand(ctx),
+    createNewCommand(ctx),
+    createExitCommand(ctx),
+    createClearCommand(ctx),
+    ...createSkillCommands(ctx),
   ];
+}
 
+export async function dispatchSlashCommand(ctx: CommandContext): Promise<CommandResult> {
+  const { text, resolvedText } = ctx;
+  const commands = resolveSlashCommands(ctx);
   for (const command of commands) {
     if (!command.match(resolvedText)) continue;
     return command.run();
   }
-
-  if (resolvedText.startsWith("/")) return handleSkillOrUnknown();
-
+  if (resolvedText.startsWith("/")) {
+    ctx.setRows((current) => [...current, createRow("system", t("chat.command.unknown", { command: text }))]);
+    return { stop: true, userText: text };
+  }
   return { stop: false, userText: text };
 }

--- a/src/chat-commands.ts
+++ b/src/chat-commands.ts
@@ -4,7 +4,7 @@ import { createMemoryCommands, resolveMemoryApi } from "./chat-commands-memory";
 import { createModelCommands } from "./chat-commands-model";
 import { createResumeCommands } from "./chat-commands-resume";
 import { sessionsRows } from "./chat-commands-sessions";
-import { createSkillCommands } from "./chat-commands-skill";
+import { handleSkillActivation } from "./chat-commands-skill";
 import { statusRows } from "./chat-commands-status";
 import { usageRows } from "./chat-commands-usage";
 import { createWorkspacesCommands } from "./chat-commands-workspaces";
@@ -121,7 +121,6 @@ function resolveSlashCommands(ctx: CommandContext): SlashCommand[] {
     createNewCommand(ctx),
     createExitCommand(ctx),
     createClearCommand(ctx),
-    ...createSkillCommands(ctx),
   ];
 }
 
@@ -133,6 +132,8 @@ export async function dispatchSlashCommand(ctx: CommandContext): Promise<Command
     return command.run();
   }
   if (resolvedText.startsWith("/")) {
+    const skillResult = await handleSkillActivation(ctx);
+    if (skillResult) return skillResult;
     ctx.setRows((current) => [...current, createRow("system", t("chat.command.unknown", { command: text }))]);
     return { stop: true, userText: text };
   }

--- a/src/chat-commands.ts
+++ b/src/chat-commands.ts
@@ -184,12 +184,18 @@ export async function dispatchSlashCommand(ctx: CommandContext): Promise<Command
     ...ctx.memoryApi,
   };
 
-  if (resolvedText === "/resume") {
+  type SlashCommand = {
+    name: string;
+    match: (value: string) => boolean;
+    run: () => Promise<CommandResult>;
+  };
+
+  const handleResumePanel = async (): Promise<CommandResult> => {
     ctx.openResumePanel();
     return { stop: true, userText: text };
-  }
+  };
 
-  if (resolvedText.startsWith("/resume")) {
+  const handleResume = async (): Promise<CommandResult> => {
     const resolved = resolveResumeSession(ctx.store, resolvedText);
     if (resolved.kind === "usage") {
       const recent = formatSessionList(ctx.store, 6);
@@ -224,14 +230,14 @@ export async function dispatchSlashCommand(ctx: CommandContext): Promise<Command
     ctx.setShowHelp(() => false);
     await ctx.persist();
     return { stop: true, userText: text };
-  }
+  };
 
-  if (resolvedText === "/sessions") {
+  const handleSessions = async (): Promise<CommandResult> => {
     ctx.setRows((current) => [...current, ...sessionsRows(ctx.store, 10)]);
     return { stop: true, userText: text };
-  }
+  };
 
-  if (resolvedText === "/workspaces" || resolvedText.startsWith("/workspaces ")) {
+  const handleWorkspaces = async (): Promise<CommandResult> => {
     if (!appConfig.features.parallelWorkspaces) {
       ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.disabled"))]);
       return { stop: true, userText: text };
@@ -394,9 +400,9 @@ export async function dispatchSlashCommand(ctx: CommandContext): Promise<Command
 
     ctx.setRows((current) => [...current, createRow("system", formatUsage("/workspaces [list|new|switch] ..."))]);
     return { stop: true, userText: text };
-  }
+  };
 
-  if (resolvedText === "/status") {
+  const handleStatus = async (): Promise<CommandResult> => {
     try {
       const status = await ctx.client.status();
       ctx.setRows((current) => [...current, ...statusRows(status)]);
@@ -407,14 +413,14 @@ export async function dispatchSlashCommand(ctx: CommandContext): Promise<Command
       ]);
     }
     return { stop: true, userText: text };
-  }
+  };
 
-  if (resolvedText === "/model") {
+  const handleModelPanel = async (): Promise<CommandResult> => {
     ctx.openModelPanel();
     return { stop: true, userText: text };
-  }
+  };
 
-  if (resolvedText.startsWith("/model ")) {
+  const handleModelSet = async (): Promise<CommandResult> => {
     const model = parseModelCommand(resolvedText);
     if (!model) {
       ctx.setRows((current) => [...current, createRow("system", formatUsage("/model <id>"))]);
@@ -444,9 +450,9 @@ export async function dispatchSlashCommand(ctx: CommandContext): Promise<Command
       ]);
     }
     return { stop: true, userText: text };
-  }
+  };
 
-  if (resolvedText.startsWith("/memory rm")) {
+  const handleMemoryRm = async (): Promise<CommandResult> => {
     const parts = resolvedText.trim().split(/\s+/);
     if (parts.length !== 3) {
       ctx.setRows((current) => [...current, createRow("system", formatUsage("/memory rm <id-prefix>"))]);
@@ -470,9 +476,9 @@ export async function dispatchSlashCommand(ctx: CommandContext): Promise<Command
       ]);
     }
     return { stop: true, userText: text };
-  }
+  };
 
-  if (resolvedText === "/memory" || resolvedText.startsWith("/memory ")) {
+  const handleMemoryList = async (): Promise<CommandResult> => {
     const parts = resolvedText.split(/\s+/);
     const scope = parseMemoryListScope(parts);
     if (!scope) {
@@ -492,15 +498,15 @@ export async function dispatchSlashCommand(ctx: CommandContext): Promise<Command
         : t("chat.memory.header.scope", { scope: scopeLabel(scope), count: memories.length });
     ctx.setRows((current) => [...current, createRow("system", { header, sections: [], list })]);
     return { stop: true, userText: text };
-  }
+  };
 
-  if (resolvedText === "/usage") {
+  const handleUsage = async (): Promise<CommandResult> => {
     const last = ctx.tokenUsage.length > 0 ? ctx.tokenUsage[ctx.tokenUsage.length - 1] : null;
     ctx.setRows((current) => [...current, ...usageRows(last, ctx.tokenUsage)]);
     return { stop: true, userText: text };
-  }
+  };
 
-  if (resolvedText.startsWith("/remember")) {
+  const handleRemember = async (): Promise<CommandResult> => {
     const parts = resolvedText.split(/\s+/).slice(1);
     let scope: MemoryScope = "user";
     const contentParts: string[] = [];
@@ -536,14 +542,14 @@ export async function dispatchSlashCommand(ctx: CommandContext): Promise<Command
       ]);
     }
     return { stop: true, userText: text };
-  }
+  };
 
-  if (resolvedText === "/skills") {
+  const handleSkills = async (): Promise<CommandResult> => {
     await ctx.openSkillsPanel();
     return { stop: true, userText: text };
-  }
+  };
 
-  if (resolvedText === "/new") {
+  const handleNew = async (): Promise<CommandResult> => {
     const next = createSession(appConfig.model);
     ctx.store.sessions.unshift(next);
     ctx.store.activeSessionId = next.id;
@@ -554,20 +560,20 @@ export async function dispatchSlashCommand(ctx: CommandContext): Promise<Command
     ctx.setShowHelp(() => false);
     await ctx.persist();
     return { stop: true, userText: text };
-  }
+  };
 
-  if (resolvedText === "/exit") {
+  const handleExit = async (): Promise<CommandResult> => {
     await ctx.persist();
     ctx.exit();
     return { stop: true, userText: text };
-  }
+  };
 
-  if (resolvedText === "/clear") {
+  const handleClear = async (): Promise<CommandResult> => {
     ctx.clearTranscript();
     return { stop: true, userText: text };
-  }
+  };
 
-  if (resolvedText.startsWith("/")) {
+  const handleSkillOrUnknown = async (): Promise<CommandResult> => {
     const [head, ...rest] = resolvedText.split(/\s+/);
     const skillName = (head ?? "").slice(1);
     const skill = findSkillByName(skillName);
@@ -588,7 +594,40 @@ export async function dispatchSlashCommand(ctx: CommandContext): Promise<Command
 
     ctx.setRows((current) => [...current, createRow("system", t("chat.command.unknown", { command: text }))]);
     return { stop: true, userText: text };
+  };
+
+  const commands: SlashCommand[] = [
+    { name: "resume.panel", match: (value) => value === "/resume", run: handleResumePanel },
+    { name: "resume", match: (value) => value.startsWith("/resume"), run: handleResume },
+    { name: "sessions", match: (value) => value === "/sessions", run: handleSessions },
+    {
+      name: "workspaces",
+      match: (value) => value === "/workspaces" || value.startsWith("/workspaces "),
+      run: handleWorkspaces,
+    },
+    { name: "status", match: (value) => value === "/status", run: handleStatus },
+    { name: "model.panel", match: (value) => value === "/model", run: handleModelPanel },
+    { name: "model.set", match: (value) => value.startsWith("/model "), run: handleModelSet },
+    { name: "memory.rm", match: (value) => value.startsWith("/memory rm"), run: handleMemoryRm },
+    {
+      name: "memory.list",
+      match: (value) => value === "/memory" || value.startsWith("/memory "),
+      run: handleMemoryList,
+    },
+    { name: "usage", match: (value) => value === "/usage", run: handleUsage },
+    { name: "remember", match: (value) => value.startsWith("/remember"), run: handleRemember },
+    { name: "skills", match: (value) => value === "/skills", run: handleSkills },
+    { name: "new", match: (value) => value === "/new", run: handleNew },
+    { name: "exit", match: (value) => value === "/exit", run: handleExit },
+    { name: "clear", match: (value) => value === "/clear", run: handleClear },
+  ];
+
+  for (const command of commands) {
+    if (!command.match(resolvedText)) continue;
+    return command.run();
   }
+
+  if (resolvedText.startsWith("/")) return handleSkillOrUnknown();
 
   return { stop: false, userText: text };
 }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -4,7 +4,7 @@ import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ChatResponse } from "./api";
-import type { CommandContext } from "./chat-commands";
+import type { CommandContext } from "./chat-commands-contract";
 import type { ChatMessage, ChatRow } from "./chat-contract";
 import { createMessageHandler } from "./chat-message-handler";
 import { type CreatePickerHandlersInput, createPickerHandlers } from "./chat-picker-handlers";


### PR DESCRIPTION
## Motivation

The slash command dispatcher has grown into a long chain of conditionals that is easy to break as the slash-command surface expands (exact vs prefix matches, subcommands, and feature gating).

## Summary
- refactor slash command dispatch to a table-driven registry of matchers + handlers
- split `src/chat-commands.ts` into focused modules (workspaces, memory, model, resume, etc.)
- split tests so each module has a matching `*.test.ts`
- keep behavior and tests unchanged

Closes #130
