### PR TITLE
feat(memory): hybrid retrieval scoring

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -61,7 +61,7 @@ The observation model is inspired by [Mastra's Observational Memory](https://mas
 - commit debug includes promotion counters (`project_promoted_facts`, `user_promoted_facts`, `session_scoped_facts`, `dropped_untagged_facts`)
 - repeated malformed-directive drops emit `lifecycle.memory.quality_warning` with `malformed_reject_streak` after 3 consecutive commits
 - distill record writes use SQLite with WAL mode for atomic persistence
-- semantic recall: memory records are embedded at write time using the provider embedding API. At query time, the search query is embedded and entries are ranked by cosine similarity. Records without embeddings fall back to recency ordering
+- hybrid recall: memory records are embedded at write time using the provider embedding API. At query time, entries are scored by a weighted blend of cosine similarity (0.8) and token overlap (0.2). Token overlap catches exact keyword matches that embeddings miss, such as proper nouns, tool names, and file paths. Records without embeddings fall back to recency ordering
 
 ## Storage
 

--- a/scripts/memory-bench-scenarios.ts
+++ b/scripts/memory-bench-scenarios.ts
@@ -138,6 +138,26 @@ const locomoQaSchema = z.object({
 const LOCOMO_URL = "https://raw.githubusercontent.com/snap-research/locomo/main/data/locomo10.json";
 const LOCOMO_FILE = "locomo10.json";
 
+function locomoSessionDate(conv: Record<string, unknown>, sessionNum: string): string {
+  const value = conv[`session_${sessionNum}_date_time`];
+  return typeof value === "string" ? value : "unknown";
+}
+
+function locomoQueries(
+  qa: z.infer<typeof locomoQaSchema>[],
+  convIdx: number,
+  resolveDiaId: (diaId: string) => string[],
+): NormalizedQuery[] {
+  return qa
+    .filter((q) => q.evidence.length > 0)
+    .map((q, qIdx) => ({
+      id: `conv${convIdx}_q${qIdx}`,
+      question: q.question,
+      relevantObservationIds: q.evidence.flatMap(resolveDiaId),
+    }))
+    .filter((q) => q.relevantObservationIds.length > 0);
+}
+
 function normalizeLoCoMo(raw: unknown[]): DatasetScenario[] {
   return raw.map((entry, convIdx) => {
     const parsed = z.object({ conversation: z.record(z.string(), z.any()), qa: z.array(locomoQaSchema) }).parse(entry);
@@ -145,14 +165,13 @@ function normalizeLoCoMo(raw: unknown[]): DatasetScenario[] {
     const observations: NormalizedObservation[] = [];
     const turnById = new Map<string, string>();
 
-    // Extract sessions from conversation object (session_1, session_2, ...)
     const sessionKeys = Object.keys(conv)
       .filter((k) => /^session_\d+$/.test(k))
       .sort((a, b) => Number(a.split("_")[1]) - Number(b.split("_")[1]));
 
     for (const sessionKey of sessionKeys) {
-      const dateKey = `${sessionKey}_date_time`;
-      const date = typeof conv[dateKey] === "string" ? (conv[dateKey] as string) : "unknown";
+      const sessionNum = sessionKey.split("_")[1];
+      const date = locomoSessionDate(conv, sessionNum);
       const turns = z.array(locomoTurnSchema).parse(conv[sessionKey]);
 
       for (const turn of turns) {
@@ -162,15 +181,10 @@ function normalizeLoCoMo(raw: unknown[]): DatasetScenario[] {
       }
     }
 
-    // Map QA evidence to observation IDs
-    const queries: NormalizedQuery[] = parsed.qa
-      .filter((qa) => qa.evidence.length > 0)
-      .map((qa, qIdx) => ({
-        id: `conv${convIdx}_q${qIdx}`,
-        question: qa.question,
-        relevantObservationIds: qa.evidence.map((e) => turnById.get(e)).filter((id): id is string => id !== undefined),
-      }))
-      .filter((q) => q.relevantObservationIds.length > 0);
+    const queries = locomoQueries(parsed.qa, convIdx, (diaId) => {
+      const id = turnById.get(diaId);
+      return id ? [id] : [];
+    });
 
     return { scenarioId: `conv${convIdx}`, observations, queries };
   });
@@ -216,8 +230,7 @@ function normalizeLoCoMoObservations(raw: unknown[]): DatasetScenario[] {
     let obsIndex = 0;
     for (const sessionKey of sessionKeys) {
       const sessionNum = sessionKey.match(/\d+/)?.[0] ?? "1";
-      const dateKey = `session_${sessionNum}_date_time`;
-      const date = typeof conv[dateKey] === "string" ? (conv[dateKey] as string) : "unknown";
+      const date = locomoSessionDate(conv, sessionNum);
       const speakers = obsData[sessionKey];
 
       for (const [speaker, facts] of Object.entries(speakers)) {
@@ -232,14 +245,7 @@ function normalizeLoCoMoObservations(raw: unknown[]): DatasetScenario[] {
       }
     }
 
-    const queries: NormalizedQuery[] = parsed.qa
-      .filter((qa) => qa.evidence.length > 0)
-      .map((qa, qIdx) => ({
-        id: `conv${convIdx}_q${qIdx}`,
-        question: qa.question,
-        relevantObservationIds: qa.evidence.flatMap((e) => diaIdToObsIds.get(e) ?? []),
-      }))
-      .filter((q) => q.relevantObservationIds.length > 0);
+    const queries = locomoQueries(parsed.qa, convIdx, (diaId) => diaIdToObsIds.get(diaId) ?? []);
 
     return { scenarioId: `conv${convIdx}`, observations, queries };
   });

--- a/scripts/run-memory-bench.test.ts
+++ b/scripts/run-memory-bench.test.ts
@@ -47,6 +47,7 @@ describe("parseDatasetId", () => {
   test("accepts valid ids", () => {
     expect(parseDatasetId("longmemeval")).toBe("longmemeval");
     expect(parseDatasetId("locomo")).toBe("locomo");
+    expect(parseDatasetId("locomo-observations")).toBe("locomo-observations");
   });
 
   test("rejects unknown id", () => {

--- a/src/memory-contract.ts
+++ b/src/memory-contract.ts
@@ -40,6 +40,8 @@ export type MemoryPolicy = {
   maxOutputTokens: number;
   contextMessageWindow: number;
   malformedStreakWarningThreshold: number;
+  cosineWeight: number;
+  tokenWeight: number;
 };
 
 export const defaultMemoryPolicy: MemoryPolicy = {
@@ -47,6 +49,8 @@ export const defaultMemoryPolicy: MemoryPolicy = {
   maxOutputTokens: 1_000,
   contextMessageWindow: 20,
   malformedStreakWarningThreshold: 3,
+  cosineWeight: 0.8,
+  tokenWeight: 0.2,
 };
 
 export function createMemoryPolicy(override?: Partial<MemoryPolicy>): MemoryPolicy {

--- a/src/memory-embedding.test.ts
+++ b/src/memory-embedding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bufferToEmbedding, cosineSimilarity, embeddingToBuffer } from "./memory-embedding";
+import { bufferToEmbedding, cosineSimilarity, embeddingToBuffer, tokenOverlap } from "./memory-embedding";
 
 describe("cosineSimilarity", () => {
   test("identical vectors return 1", () => {
@@ -30,6 +30,36 @@ describe("cosineSimilarity", () => {
     const a = new Float32Array([0, 0, 0]);
     const b = new Float32Array([1, 0, 0]);
     expect(cosineSimilarity(a, b)).toBe(0);
+  });
+});
+
+describe("tokenOverlap", () => {
+  test("exact query tokens in content scores 1", () => {
+    expect(tokenOverlap("bun test runner", "the project uses bun test runner")).toBeCloseTo(1);
+  });
+
+  test("partial overlap scores proportionally", () => {
+    expect(tokenOverlap("bun test runner", "bun is fast")).toBeCloseTo(1 / 3);
+  });
+
+  test("no overlap scores 0", () => {
+    expect(tokenOverlap("bun test runner", "python flask server")).toBe(0);
+  });
+
+  test("filters stopwords", () => {
+    expect(tokenOverlap("what is the test runner", "test runner is bun")).toBeCloseTo(1);
+  });
+
+  test("case insensitive", () => {
+    expect(tokenOverlap("Bun Test", "uses bun test")).toBeCloseTo(1);
+  });
+
+  test("empty query returns 0", () => {
+    expect(tokenOverlap("", "some content")).toBe(0);
+  });
+
+  test("stopwords-only query returns 0", () => {
+    expect(tokenOverlap("the a is", "some content")).toBe(0);
   });
 });
 

--- a/src/memory-embedding.ts
+++ b/src/memory-embedding.ts
@@ -74,6 +74,78 @@ function getEmbeddingModel() {
   return cachedModel;
 }
 
+const STOPWORDS = new Set([
+  "a",
+  "an",
+  "the",
+  "and",
+  "or",
+  "but",
+  "in",
+  "on",
+  "at",
+  "to",
+  "for",
+  "of",
+  "with",
+  "by",
+  "from",
+  "is",
+  "it",
+  "as",
+  "be",
+  "was",
+  "are",
+  "been",
+  "has",
+  "have",
+  "had",
+  "do",
+  "does",
+  "did",
+  "not",
+  "no",
+  "so",
+  "if",
+  "my",
+  "me",
+  "we",
+  "he",
+  "she",
+  "they",
+  "this",
+  "that",
+  "what",
+  "which",
+  "who",
+  "how",
+  "when",
+  "where",
+  "i",
+  "you",
+  "your",
+  "its",
+]);
+
+function tokenize(text: string): Set<string> {
+  const tokens = new Set<string>();
+  for (const raw of text.toLowerCase().split(/[\s\p{P}]+/u)) {
+    if (raw.length > 1 && !STOPWORDS.has(raw)) tokens.add(raw);
+  }
+  return tokens;
+}
+
+export function tokenOverlap(query: string, content: string): number {
+  const queryTokens = tokenize(query);
+  if (queryTokens.size === 0) return 0;
+  const contentTokens = tokenize(content);
+  let hits = 0;
+  for (const token of queryTokens) {
+    if (contentTokens.has(token)) hits++;
+  }
+  return hits / queryTokens.size;
+}
+
 export async function embedText(text: string): Promise<Float32Array | null> {
   const model = getEmbeddingModel();
   if (!model) return null;

--- a/src/memory-toolkit.ts
+++ b/src/memory-toolkit.ts
@@ -7,6 +7,9 @@ import type { ToolkitInput } from "./tool-contract";
 import { createTool } from "./tool-contract";
 import { runTool } from "./tool-execution";
 
+const COSINE_WEIGHT = 0.8;
+const TOKEN_WEIGHT = 0.2;
+
 export async function searchMemories(
   query: string,
   options?: { scope?: "user" | "project"; limit?: number; store?: MemoryStore },
@@ -27,8 +30,6 @@ export async function searchMemories(
   const ids = filtered.map((r) => r.id);
   const embeddings = store.getEmbeddings(ids);
 
-  const COSINE_WEIGHT = 0.8;
-  const TOKEN_WEIGHT = 0.2;
   const scored = filtered.map((record) => {
     const buf = embeddings.get(record.id);
     const cosine = buf ? cosineSimilarity(queryEmbedding, bufferToEmbedding(buf)) : 0;

--- a/src/memory-toolkit.ts
+++ b/src/memory-toolkit.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
-import { type MemoryRecord, type MemoryStore, memoryScopeSchema, scopeFromKey } from "./memory-contract";
+import {
+  createMemoryPolicy,
+  type MemoryPolicy,
+  type MemoryRecord,
+  type MemoryStore,
+  memoryScopeSchema,
+  scopeFromKey,
+} from "./memory-contract";
 import { bufferToEmbedding, cosineSimilarity, embedText, tokenOverlap } from "./memory-embedding";
 import { addMemory, removeMemory } from "./memory-ops";
 import { getDefaultMemoryStore } from "./memory-store";
@@ -7,15 +14,13 @@ import type { ToolkitInput } from "./tool-contract";
 import { createTool } from "./tool-contract";
 import { runTool } from "./tool-execution";
 
-const COSINE_WEIGHT = 0.8;
-const TOKEN_WEIGHT = 0.2;
-
 export async function searchMemories(
   query: string,
-  options?: { scope?: "user" | "project"; limit?: number; store?: MemoryStore },
+  options?: { scope?: "user" | "project"; limit?: number; store?: MemoryStore; policy?: MemoryPolicy },
 ): Promise<MemoryRecord[]> {
   const store = options?.store ?? getDefaultMemoryStore();
   const limit = options?.limit ?? 10;
+  const policy = options?.policy ?? createMemoryPolicy();
   const all = await store.list({ kind: "stored" });
   const filtered = options?.scope ? all.filter((r) => scopeFromKey(r.scopeKey) === options.scope) : all;
   if (filtered.length === 0) return [];
@@ -34,7 +39,7 @@ export async function searchMemories(
     const buf = embeddings.get(record.id);
     const cosine = buf ? cosineSimilarity(queryEmbedding, bufferToEmbedding(buf)) : 0;
     const overlap = tokenOverlap(query, record.content);
-    const score = cosine * COSINE_WEIGHT + overlap * TOKEN_WEIGHT;
+    const score = cosine * policy.cosineWeight + overlap * policy.tokenWeight;
     return { record, score };
   });
   scored.sort((a, b) => b.score - a.score);

--- a/src/memory-toolkit.ts
+++ b/src/memory-toolkit.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { type MemoryRecord, type MemoryStore, memoryScopeSchema, scopeFromKey } from "./memory-contract";
-import { bufferToEmbedding, cosineSimilarity, embedText } from "./memory-embedding";
+import { bufferToEmbedding, cosineSimilarity, embedText, tokenOverlap } from "./memory-embedding";
 import { addMemory, removeMemory } from "./memory-ops";
 import { getDefaultMemoryStore } from "./memory-store";
 import type { ToolkitInput } from "./tool-contract";
@@ -27,9 +27,13 @@ export async function searchMemories(
   const ids = filtered.map((r) => r.id);
   const embeddings = store.getEmbeddings(ids);
 
+  const COSINE_WEIGHT = 0.8;
+  const TOKEN_WEIGHT = 0.2;
   const scored = filtered.map((record) => {
     const buf = embeddings.get(record.id);
-    const score = buf ? cosineSimilarity(queryEmbedding, bufferToEmbedding(buf)) : 0;
+    const cosine = buf ? cosineSimilarity(queryEmbedding, bufferToEmbedding(buf)) : 0;
+    const overlap = tokenOverlap(query, record.content);
+    const score = cosine * COSINE_WEIGHT + overlap * TOKEN_WEIGHT;
     return { record, score };
   });
   scored.sort((a, b) => b.score - a.score);


### PR DESCRIPTION
## Motivation

Benchmark baseline shows pure cosine similarity misses queries that reference specific entities like names, dates, and technical terms. Token overlap catches exact keyword matches that embeddings miss.

## Results

LoCoMo observations (1650 queries, 2541 memories, text-embedding-3-small):

|  | Baseline | Hybrid (0.8/0.2) | Delta |
|---|---|---|---|
| R@5 | 0.650 | 0.669 | +1.9% |
| R@10 | 0.730 | 0.731 | +0.1% |
| NDCG@3 | 0.555 | 0.578 | +2.3% |
| NDCG@5 | 0.580 | 0.602 | +2.2% |

Biggest gains at low K where ranking matters most.

## Summary

- add `tokenOverlap` function that scores keyword overlap between query and memory content with stopword filtering
- blend cosine similarity and token overlap weights in `searchMemories` via `MemoryPolicy`
- extract shared LoCoMo adapter helpers to reduce duplication
- add `locomo-observations` to `parseDatasetId` test coverage
- update `docs/memory.md` to describe hybrid recall

Fixes #141