### PR TITLE
feat(memory): TF-IDF weighted token overlap

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -47,7 +47,9 @@ Naming conventions and core terms used across Acolyte code and docs.
 | Record | Persisted entity object stored by a persistence backend |
 | Registry | Composition layer that wires implementations into an agent-facing surface under shared contracts |
 | Resource ID | Typed cross-session identity key used for memory and execution scoping |
-| Semantic Recall | Relevance-ranked memory selection using embeddings and cosine similarity |
+| Hybrid Recall | Relevance-ranked memory selection using a weighted blend of cosine similarity and TF-IDF token overlap |
+| TF-IDF | Term Frequency–Inverse Document Frequency; weights token matches by rarity across the memory corpus so uncommon terms score higher |
+| Token Overlap | Keyword matching component of hybrid recall that catches exact term matches embeddings miss |
 | Session | One chat session in memory, including messages, model, token usage, and timestamps |
 | SessionRecord | One stored session record |
 | SessionState | Aggregate session state (`sessions[]`, `activeSessionId`) |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -26,18 +26,19 @@ Naming conventions and core terms used across Acolyte code and docs.
 | Context Budgeting | Token allocation strategy that reserves system space first and fills the remaining budget by priority |
 | Directive | Model-to-host structured annotation emitted via `@` prefix (e.g. `@signal done`, `@observe project`) |
 | Distill | Memory source that extracts observations from conversations at project, user, or session scope |
-| Embedding | Provider-generated vector representation of a memory record used for semantic recall |
 | Ecosystem Detector | Pluggable rule that identifies the workspace type and resolves available tooling |
-| Entry | Runtime or pipeline item used during processing and not necessarily persisted |
 | Effect | Lifecycle-owned side-effect applied per-tool-result via callback (format, lint) |
+| Embedding | Provider-generated vector representation of a memory record used for semantic recall |
+| Entry | Runtime or pipeline item used during processing and not necessarily persisted |
 | Host | Runtime environment around the model that provides tools, lifecycle structure, memory, and recovery |
+| Hybrid Recall | Relevance-ranked memory selection using a weighted blend of cosine similarity and TF-IDF token overlap |
 | Lifecycle Policy | Centralized limits and defaults for lifecycle behavior |
 | Lifecycle Signal | Model-to-host control signal emitted at generation completion (`done`, `no_op`, `blocked`) |
 | Lifecycle State | Internal task-scoped runtime state used during the lifecycle pass |
+| Memory Distiller | Extracts and commits observations from conversations after each request |
 | Memory Engine | Top-level memory capability that maintains continuity across turns |
 | Memory Pipeline | Internal memory flow from ingest through commit |
 | Memory Policy | Centralized limits and defaults for memory behavior |
-| Memory Distiller | Extracts and commits observations from conversations after each request |
 | Memory Toolkit | On-demand tools (`memory-search`, `memory-add`, `memory-remove`) the model invokes to access memory at runtime |
 | Message Kind | Semantic message classification used by history handling (`text`, `tool_payload`) |
 | Model Judgment | The model's responsibility for deciding how to complete the task within host constraints |
@@ -47,9 +48,6 @@ Naming conventions and core terms used across Acolyte code and docs.
 | Record | Persisted entity object stored by a persistence backend |
 | Registry | Composition layer that wires implementations into an agent-facing surface under shared contracts |
 | Resource ID | Typed cross-session identity key used for memory and execution scoping |
-| Hybrid Recall | Relevance-ranked memory selection using a weighted blend of cosine similarity and TF-IDF token overlap |
-| TF-IDF | Term Frequency–Inverse Document Frequency; weights token matches by rarity across the memory corpus so uncommon terms score higher |
-| Token Overlap | Keyword matching component of hybrid recall that catches exact term matches embeddings miss |
 | Session | One chat session in memory, including messages, model, token usage, and timestamps |
 | SessionRecord | One stored session record |
 | SessionState | Aggregate session state (`sessions[]`, `activeSessionId`) |
@@ -58,6 +56,8 @@ Naming conventions and core terms used across Acolyte code and docs.
 | Step Budget | Per-cycle and total tool-call limit inlined into tool execution to prevent runaway loops |
 | Task | Lifecycle work request moving through accept, queue, run, and terminal states |
 | Task Queue | Runtime queue policy that orders accepted tasks and enforces capacity and cancellation boundaries |
+| TF-IDF | Term Frequency–Inverse Document Frequency; weights token matches by rarity across the memory corpus so uncommon terms score higher |
+| Token Overlap | Keyword matching component of hybrid recall that catches exact term matches embeddings miss |
 | Tool Cache | Two-tier cache for read-only and search tool results across a task and session |
 | Tool Recovery | Structured recovery payload attached to a tool failure when the tool knows the corrective action |
 | Toolkit | Group of domain tools exposed through adapters and composition |

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -61,7 +61,18 @@ The observation model is inspired by [Mastra's Observational Memory](https://mas
 - commit debug includes promotion counters (`project_promoted_facts`, `user_promoted_facts`, `session_scoped_facts`, `dropped_untagged_facts`)
 - repeated malformed-directive drops emit `lifecycle.memory.quality_warning` with `malformed_reject_streak` after 3 consecutive commits
 - distill record writes use the configured storage backend (SQLite or Postgres) for atomic persistence
-- hybrid recall: memory records are embedded at write time using the provider embedding API. At query time, entries are scored by a weighted blend of cosine similarity (0.8) and TF-IDF weighted token overlap (0.2). Token overlap catches exact keyword matches that embeddings miss, and TF-IDF weighting ensures rare tokens like proper nouns and tool names score higher than common words. Both the SQLite and Postgres backends use this hybrid scoring. Records without embeddings fall back to recency ordering
+- hybrid recall: entries scored by cosine similarity + TF-IDF weighted token overlap (see below). Falls back to recency when embeddings are unavailable
+
+## Recall
+
+Memory records are embedded at write time using the provider embedding API. At query time, entries are scored by a weighted blend of two signals:
+
+- **Cosine similarity** (weight 0.8) — semantic relevance via embedding distance
+- **TF-IDF token overlap** (weight 0.2) — exact keyword matching where rare tokens like proper nouns and tool names score higher than common words
+
+Both the SQLite and Postgres backends use this hybrid scoring. The Postgres path uses native pgvector cosine distance to pre-filter candidates, then applies token overlap to re-rank the shortlist.
+
+Weights are defined in `MemoryPolicy` (`cosineWeight`, `tokenWeight`).
 
 ## Storage
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -61,7 +61,7 @@ The observation model is inspired by [Mastra's Observational Memory](https://mas
 - commit debug includes promotion counters (`project_promoted_facts`, `user_promoted_facts`, `session_scoped_facts`, `dropped_untagged_facts`)
 - repeated malformed-directive drops emit `lifecycle.memory.quality_warning` with `malformed_reject_streak` after 3 consecutive commits
 - distill record writes use the configured storage backend (SQLite or Postgres) for atomic persistence
-- semantic recall: memory records are embedded at write time using the provider embedding API. At query time, the SQLite backend scores entries by a weighted blend of cosine similarity (0.8) and token overlap (0.2). The Postgres backend uses native pgvector cosine distance (`<=>` operator) for similarity search. Records without embeddings fall back to recency ordering
+- hybrid recall: memory records are embedded at write time using the provider embedding API. At query time, entries are scored by a weighted blend of cosine similarity (0.8) and TF-IDF weighted token overlap (0.2). Token overlap catches exact keyword matches that embeddings miss, and TF-IDF weighting ensures rare tokens like proper nouns and tool names score higher than common words. Both the SQLite and Postgres backends use this hybrid scoring. Records without embeddings fall back to recency ordering
 
 ## Storage
 

--- a/src/memory-embedding.test.ts
+++ b/src/memory-embedding.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bufferToEmbedding, cosineSimilarity, embeddingToBuffer, tokenOverlap } from "./memory-embedding";
+import { bufferToEmbedding, computeIdf, cosineSimilarity, embeddingToBuffer, tokenOverlap } from "./memory-embedding";
 
 describe("cosineSimilarity", () => {
   test("identical vectors return 1", () => {
@@ -60,6 +60,27 @@ describe("tokenOverlap", () => {
 
   test("stopwords-only query returns 0", () => {
     expect(tokenOverlap("the a is", "some content")).toBe(0);
+  });
+
+  test("idf-weighted overlap favors rare tokens", () => {
+    const corpus = ["project uses bun", "project uses typescript", "project has tests", "pgvector is configured"];
+    const idf = computeIdf(corpus);
+    const common = tokenOverlap("project tools", "project uses bun", idf);
+    const rare = tokenOverlap("pgvector tools", "pgvector is configured", idf);
+    expect(rare).toBeGreaterThan(common);
+  });
+});
+
+describe("computeIdf", () => {
+  test("rare tokens get higher scores", () => {
+    const idf = computeIdf(["bun test", "bun build", "pgvector setup"]);
+    const bunScore = idf.get("bun") ?? 0;
+    const pgvectorScore = idf.get("pgvector") ?? 0;
+    expect(pgvectorScore).toBeGreaterThan(bunScore);
+  });
+
+  test("empty corpus returns empty map", () => {
+    expect(computeIdf([]).size).toBe(0);
   });
 });
 

--- a/src/memory-embedding.ts
+++ b/src/memory-embedding.ts
@@ -135,15 +135,41 @@ function tokenize(text: string): Set<string> {
   return tokens;
 }
 
-export function tokenOverlap(query: string, content: string): number {
+export function tokenOverlap(query: string, content: string, idf?: ReadonlyMap<string, number>): number {
   const queryTokens = tokenize(query);
   if (queryTokens.size === 0) return 0;
   const contentTokens = tokenize(content);
-  let hits = 0;
-  for (const token of queryTokens) {
-    if (contentTokens.has(token)) hits++;
+  if (!idf) {
+    let hits = 0;
+    for (const token of queryTokens) {
+      if (contentTokens.has(token)) hits++;
+    }
+    return hits / queryTokens.size;
   }
-  return hits / queryTokens.size;
+  let weightedHits = 0;
+  let totalWeight = 0;
+  for (const token of queryTokens) {
+    const w = idf.get(token) ?? 1;
+    totalWeight += w;
+    if (contentTokens.has(token)) weightedHits += w;
+  }
+  return totalWeight === 0 ? 0 : weightedHits / totalWeight;
+}
+
+export function computeIdf(documents: readonly string[]): Map<string, number> {
+  const n = documents.length;
+  if (n === 0) return new Map();
+  const df = new Map<string, number>();
+  for (const doc of documents) {
+    for (const token of tokenize(doc)) {
+      df.set(token, (df.get(token) ?? 0) + 1);
+    }
+  }
+  const idf = new Map<string, number>();
+  for (const [token, count] of df) {
+    idf.set(token, Math.log(n / count) + 1);
+  }
+  return idf;
 }
 
 export async function embedText(text: string): Promise<Float32Array | null> {

--- a/src/memory-toolkit.ts
+++ b/src/memory-toolkit.ts
@@ -7,7 +7,7 @@ import {
   memoryScopeSchema,
   scopeFromKey,
 } from "./memory-contract";
-import { bufferToEmbedding, cosineSimilarity, embedText, tokenOverlap } from "./memory-embedding";
+import { bufferToEmbedding, computeIdf, cosineSimilarity, embedText, tokenOverlap } from "./memory-embedding";
 import { addMemory, removeMemory } from "./memory-ops";
 import { getMemoryStore } from "./memory-store";
 import type { ToolkitInput } from "./tool-contract";
@@ -43,11 +43,12 @@ export async function searchMemories(
 
   const ids = filtered.map((r) => r.id);
   const embeddings = await store.getEmbeddings(ids);
+  const idf = computeIdf(filtered.map((r) => r.content));
 
   const scored = filtered.map((record) => {
     const buf = embeddings.get(record.id);
     const cosine = buf ? cosineSimilarity(queryEmbedding, bufferToEmbedding(buf)) : 0;
-    const overlap = tokenOverlap(query, record.content);
+    const overlap = tokenOverlap(query, record.content, idf);
     const score = cosine * policy.cosineWeight + overlap * policy.tokenWeight;
     return { record, score };
   });

--- a/src/memory-toolkit.ts
+++ b/src/memory-toolkit.ts
@@ -33,10 +33,17 @@ export async function searchMemories(
   }
 
   if (store.searchByEmbedding) {
-    const oversample = options?.scope ? limit * 2 : limit;
+    const oversample = (options?.scope ? limit * 2 : limit) * 2;
     const raw = await store.searchByEmbedding(queryEmbedding, { kind: "stored", limit: oversample });
     const scoped = options?.scope ? raw.filter((r) => scopeFromKey(r.scopeKey) === options.scope) : raw;
-    const results = scoped.slice(0, limit);
+    const idf = computeIdf(scoped.map((r) => r.content));
+    const rescored = scoped.map((record, rank) => {
+      const positionScore = 1 - rank / scoped.length;
+      const overlap = tokenOverlap(query, record.content, idf);
+      return { record, score: positionScore * policy.cosineWeight + overlap * policy.tokenWeight };
+    });
+    rescored.sort((a, b) => b.score - a.score);
+    const results = rescored.slice(0, limit).map((s) => s.record);
     await store.touchRecalled(results.map((r) => r.id));
     return results;
   }


### PR DESCRIPTION
## Motivation

The token overlap component of hybrid scoring treats all non-stopword tokens equally. Rare tokens like "pgvector" are far more informative than common ones like "project". TF-IDF weighting makes token overlap more precise.

## Results

LoCoMo observations (3 conversations, 405 queries, 677 memories, text-embedding-3-small):

| | Uniform tokens | TF-IDF weighted | Delta |
|---|---|---|---|
| R@5 | 0.691 | 0.705 | +1.4% |
| R@10 | 0.747 | 0.764 | +1.7% |
| NDCG@5 | 0.631 | 0.651 | +2.0% |

## Summary

- add `computeIdf` function that computes inverse document frequency across the memory corpus
- extend `tokenOverlap` to accept optional IDF weights for scoring matches
- compute IDF at search time in `searchMemories` and pass to token overlap
- add hybrid scoring to the Postgres `searchByEmbedding` path so pgvector users get the same benefit

Fixes #149