### PR TITLE
feat(memory): contradiction detection

### DIFF
--- a/src/memory-distiller-contradiction.int.test.ts
+++ b/src/memory-distiller-contradiction.int.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { MemoryRecord } from "./memory-contract";
+import { findContradictions } from "./memory-distiller";
+import { embeddingToBuffer } from "./memory-embedding";
+import { createSqliteMemoryStore } from "./memory-store";
+import { tempDb } from "./test-utils";
+
+const { create, cleanup } = tempDb("acolyte-contradiction-", createSqliteMemoryStore);
+afterEach(cleanup);
+
+describe("findContradictions with real store", () => {
+  test("supersedes similar observation with different content", async () => {
+    const store = create();
+    const oldRecord: MemoryRecord = {
+      id: "mem_old",
+      scopeKey: "proj_test",
+      kind: "observation",
+      content: "project uses Jest for testing",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      tokenEstimate: 5,
+    };
+    await store.write(oldRecord);
+    const vec = new Float32Array([0.9, 0.1, 0, 0]);
+    await store.writeEmbedding("mem_old", "proj_test", embeddingToBuffer(vec));
+
+    const similarVec = new Float32Array([0.9, 0.1, 0, 0]);
+    const result = await findContradictions(store, "proj_test", "project uses Vitest for testing", similarVec);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe("mem_old");
+  });
+
+  test("does not flag dissimilar observations", async () => {
+    const store = create();
+    const oldRecord: MemoryRecord = {
+      id: "mem_old",
+      scopeKey: "proj_test",
+      kind: "observation",
+      content: "project uses Bun runtime",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      tokenEstimate: 4,
+    };
+    await store.write(oldRecord);
+    await store.writeEmbedding("mem_old", "proj_test", embeddingToBuffer(new Float32Array([1, 0, 0, 0])));
+
+    const orthogonal = new Float32Array([0, 1, 0, 0]);
+    const result = await findContradictions(store, "proj_test", "user prefers dark mode", orthogonal);
+    expect(result).toHaveLength(0);
+  });
+
+  test("ignores stored memories, only checks observations", async () => {
+    const store = create();
+    const storedRecord: MemoryRecord = {
+      id: "mem_stored",
+      scopeKey: "proj_test",
+      kind: "stored",
+      content: "project uses Jest for testing",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      tokenEstimate: 5,
+    };
+    await store.write(storedRecord);
+    await store.writeEmbedding("mem_stored", "proj_test", embeddingToBuffer(new Float32Array([0.9, 0.1, 0, 0])));
+
+    const result = await findContradictions(
+      store,
+      "proj_test",
+      "project uses Vitest for testing",
+      new Float32Array([0.9, 0.1, 0, 0]),
+    );
+    expect(result).toHaveLength(0);
+  });
+});

--- a/src/memory-distiller.test.ts
+++ b/src/memory-distiller.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type { MemoryKind, MemoryRecord, MemoryStore } from "./memory-contract";
 import { createMemoryPolicy } from "./memory-contract";
-import { createMemoryDistiller, DISTILLER_PROMPT } from "./memory-distiller";
+import { createMemoryDistiller, DISTILLER_PROMPT, findContradictions } from "./memory-distiller";
+import { embeddingToBuffer } from "./memory-embedding";
 
 const testPolicy = createMemoryPolicy({ messageThreshold: 1, maxOutputTokens: 200 });
 
@@ -326,6 +327,73 @@ describe("memoryDistiller", () => {
         expect(metrics, fixture.name).toMatchObject(fixture.expectedMetrics);
         expect(store.written.length, fixture.name).toBe(fixture.expectedWriteCount);
       }
+    });
+  });
+
+  describe("findContradictions", () => {
+    test("detects semantically similar but different content", async () => {
+      const similar = new Float32Array([1, 0, 0, 0]);
+      const existing: MemoryRecord = {
+        id: "mem_old",
+        scopeKey: "proj_test",
+        kind: "observation",
+        content: "project uses Jest for testing",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        tokenEstimate: 5,
+      };
+      const store = createMockStore([existing]);
+      store.getEmbeddings = async () => new Map([["mem_old", embeddingToBuffer(similar)]]);
+      const result = await findContradictions(store, "proj_test", "project uses Vitest for testing", similar);
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe("mem_old");
+    });
+
+    test("skips exact duplicates", async () => {
+      const vec = new Float32Array([1, 0, 0, 0]);
+      const existing: MemoryRecord = {
+        id: "mem_old",
+        scopeKey: "proj_test",
+        kind: "observation",
+        content: "project uses Bun",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        tokenEstimate: 4,
+      };
+      const store = createMockStore([existing]);
+      store.getEmbeddings = async () => new Map([["mem_old", embeddingToBuffer(vec)]]);
+      const result = await findContradictions(store, "proj_test", "project uses Bun", vec);
+      expect(result).toHaveLength(0);
+    });
+
+    test("skips when embedding is null", async () => {
+      const store = createMockStore([
+        {
+          id: "mem_old",
+          scopeKey: "proj_test",
+          kind: "observation",
+          content: "fact",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          tokenEstimate: 1,
+        },
+      ]);
+      const result = await findContradictions(store, "proj_test", "new fact", null);
+      expect(result).toHaveLength(0);
+    });
+
+    test("skips dissimilar records", async () => {
+      const newVec = new Float32Array([1, 0, 0, 0]);
+      const oldVec = new Float32Array([0, 1, 0, 0]);
+      const existing: MemoryRecord = {
+        id: "mem_old",
+        scopeKey: "proj_test",
+        kind: "observation",
+        content: "unrelated fact",
+        createdAt: "2026-01-01T00:00:00.000Z",
+        tokenEstimate: 2,
+      };
+      const store = createMockStore([existing]);
+      store.getEmbeddings = async () => new Map([["mem_old", embeddingToBuffer(oldVec)]]);
+      const result = await findContradictions(store, "proj_test", "project uses Bun", newVec);
+      expect(result).toHaveLength(0);
     });
   });
 });

--- a/src/memory-distiller.ts
+++ b/src/memory-distiller.ts
@@ -11,7 +11,7 @@ import {
   type MemoryRecord,
   type MemoryStore,
 } from "./memory-contract";
-import { embeddingToBuffer, embedText } from "./memory-embedding";
+import { bufferToEmbedding, cosineSimilarity, embeddingToBuffer, embedText } from "./memory-embedding";
 import { getMemoryStore } from "./memory-store";
 import { createModel } from "./model-factory";
 import { normalizeModel, providerFromModel } from "./provider-config";
@@ -41,15 +41,6 @@ async function getCachedStore(): Promise<MemoryStore> {
 }
 
 type DistillScope = "session" | "project" | "user";
-
-async function embedAndStore(ds: MemoryStore, id: string, scope: string, content: string): Promise<void> {
-  try {
-    const vec = await embedText(content);
-    if (vec) await ds.writeEmbedding(id, scope, embeddingToBuffer(vec));
-  } catch (error) {
-    log.warn("memory.distill.embed_failed", { id, error: String(error) });
-  }
-}
 
 const CHARS_PER_TOKEN_ESTIMATE = 4;
 const TEXT_SHRINK_RATIO = 0.9;
@@ -179,10 +170,44 @@ function resolveDistillScopeKey(
   return DISTILL_SCOPE_KEY_RESOLVERS[scope](ctx);
 }
 
+export const CONTRADICTION_SIMILARITY_THRESHOLD = 0.85;
+
+export async function findContradictions(
+  ds: MemoryStore,
+  key: string,
+  newContent: string,
+  newEmbedding: Float32Array | null,
+): Promise<MemoryRecord[]> {
+  if (!newEmbedding) return [];
+  const existing = (await ds.list({ scopeKey: key })).filter((e) => e.kind === "observation");
+  if (existing.length === 0) return [];
+  const ids = existing.map((e) => e.id);
+  const embeddings = await ds.getEmbeddings(ids);
+  const normalized = normalizeMemoryText(newContent);
+  const contradictions: MemoryRecord[] = [];
+  for (const record of existing) {
+    const buf = embeddings.get(record.id);
+    if (!buf) continue;
+    const similarity = cosineSimilarity(newEmbedding, bufferToEmbedding(buf));
+    if (similarity >= CONTRADICTION_SIMILARITY_THRESHOLD && normalizeMemoryText(record.content) !== normalized) {
+      contradictions.push(record);
+    }
+  }
+  return contradictions;
+}
+
 async function commitDistillForKey(ds: MemoryStore, key: string, observed: string): Promise<number> {
   const existingEntries = await ds.list({ scopeKey: key });
   const latestObservation = existingEntries.filter((e) => e.kind === "observation").slice(-1)[0];
   if (latestObservation && normalizeMemoryText(latestObservation.content) === normalizeMemoryText(observed)) return 0;
+
+  const vec = await embedText(observed);
+  const contradictions = await findContradictions(ds, key, observed, vec);
+  for (const stale of contradictions) {
+    await ds.remove(stale.id);
+    await ds.removeEmbedding(stale.id);
+    log.debug("memory.distill.contradiction_superseded", { key, staleId: stale.id, staleContent: stale.content });
+  }
 
   const observation: MemoryRecord = {
     id: `mem_${createId()}`,
@@ -193,8 +218,13 @@ async function commitDistillForKey(ds: MemoryStore, key: string, observed: strin
     tokenEstimate: estimateTokens(observed),
   };
   await ds.write(observation);
-  await embedAndStore(ds, observation.id, key, observed);
-  log.debug("memory.distill.observation_written", { key, id: observation.id, tokens: observation.tokenEstimate });
+  if (vec) await ds.writeEmbedding(observation.id, key, embeddingToBuffer(vec));
+  log.debug("memory.distill.observation_written", {
+    key,
+    id: observation.id,
+    tokens: observation.tokenEstimate,
+    superseded: contradictions.length,
+  });
   return observation.tokenEstimate;
 }
 

--- a/src/memory-toolkit.int.test.ts
+++ b/src/memory-toolkit.int.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import type { MemoryRecord } from "./memory-contract";
 import { embeddingToBuffer } from "./memory-embedding";
-import { addMemory } from "./memory-ops";
 import { createSqliteMemoryStore } from "./memory-store";
 import { searchMemories } from "./memory-toolkit";
 import { tempDb } from "./test-utils";
@@ -8,19 +8,23 @@ import { tempDb } from "./test-utils";
 const { create: createStore, cleanup: cleanupStores } = tempDb("acolyte-toolkit-", createSqliteMemoryStore);
 afterEach(cleanupStores);
 
+function makeRecord(id: string, scopeKey: string, content: string): MemoryRecord {
+  return { id, scopeKey, kind: "stored", content, createdAt: "2026-01-01T00:00:00.000Z", tokenEstimate: 4 };
+}
+
 describe("searchMemories", () => {
   test("returns entries up to the limit", async () => {
     const store = createStore();
-    await addMemory("alpha fact", { scope: "user", store });
-    await addMemory("beta fact", { scope: "user", store });
-    await addMemory("gamma fact", { scope: "user", store });
+    await store.write(makeRecord("mem_a", "user_test", "alpha fact"));
+    await store.write(makeRecord("mem_b", "user_test", "beta fact"));
+    await store.write(makeRecord("mem_c", "user_test", "gamma fact"));
     const result = await searchMemories("anything", { limit: 2, store });
     expect(result).toHaveLength(2);
   });
 
   test("returns all entries when limit exceeds count", async () => {
     const store = createStore();
-    await addMemory("only fact", { scope: "user", store });
+    await store.write(makeRecord("mem_a", "user_test", "only fact"));
     const result = await searchMemories("only", { limit: 10, store });
     expect(result).toHaveLength(1);
   });
@@ -33,8 +37,8 @@ describe("searchMemories", () => {
 
   test("filters by scope", async () => {
     const store = createStore();
-    await addMemory("user preference", { scope: "user", store });
-    await addMemory("project convention", { scope: "project", store });
+    await store.write(makeRecord("mem_u", "user_test", "user preference"));
+    await store.write(makeRecord("mem_p", "proj_test", "project convention"));
     const userOnly = await searchMemories("anything", { scope: "user", store });
     expect(userOnly).toHaveLength(1);
     expect(userOnly[0]?.content).toBe("user preference");
@@ -45,9 +49,9 @@ describe("searchMemories", () => {
 
   test("scope filter applies before limit", async () => {
     const store = createStore();
-    await addMemory("user a", { scope: "user", store });
-    await addMemory("user b", { scope: "user", store });
-    await addMemory("project a", { scope: "project", store });
+    await store.write(makeRecord("mem_u1", "user_test", "user a"));
+    await store.write(makeRecord("mem_u2", "user_test", "user b"));
+    await store.write(makeRecord("mem_p1", "proj_test", "project a"));
     const result = await searchMemories("anything", { scope: "user", limit: 5, store });
     expect(result).toHaveLength(2);
     for (const r of result) {
@@ -57,18 +61,14 @@ describe("searchMemories", () => {
 
   test("stores and retrieves pre-computed embeddings", async () => {
     const store = createStore();
-    const a = await addMemory("tool execution uses runTool", { scope: "user", store });
-    const b = await addMemory("unrelated weather fact", { scope: "user", store });
-    // Manually write embeddings: a is close to query, b is orthogonal
+    await store.write(makeRecord("mem_a", "user_test", "tool execution uses runTool"));
+    await store.write(makeRecord("mem_b", "user_test", "unrelated weather fact"));
     const closeVec = new Float32Array([0.9, 0.1, 0]);
     const farVec = new Float32Array([0, 0, 1]);
-    await store.writeEmbedding(a.id, `user_test`, embeddingToBuffer(closeVec));
-    await store.writeEmbedding(b.id, `user_test`, embeddingToBuffer(farVec));
-    // Mock embedText by searching with a store that has embeddings
-    // searchMemories calls embedText for the query — if it returns null, falls back to recency
-    // Since we can't mock embedText easily, we verify the embedding lookup path works
-    const embA = await store.getEmbedding(a.id);
-    const embB = await store.getEmbedding(b.id);
+    await store.writeEmbedding("mem_a", "user_test", embeddingToBuffer(closeVec));
+    await store.writeEmbedding("mem_b", "user_test", embeddingToBuffer(farVec));
+    const embA = await store.getEmbedding("mem_a");
+    const embB = await store.getEmbedding("mem_b");
     expect(embA).not.toBeNull();
     expect(embB).not.toBeNull();
   });


### PR DESCRIPTION
## Motivation

Over time, the distiller accumulates conflicting observations. "Project uses Jest" and "Project switched to Vitest" both live in the store. Search returns both, and the model has to guess which is current.

## Summary

- detect semantically similar but different observations at distill time using cosine similarity (threshold 0.85)
- supersede stale observations by removing them before writing the new one
- embed once per observation and reuse the vector for both contradiction check and storage
- remove unused `embedAndStore` helper
- unit tests for `findContradictions` with mock embeddings
- integration tests against real SQLite store

Fixes #148