### PR TITLE
fix: detect Vercel AI Gateway rate limits

### DIFF
--- a/src/client-contract.ts
+++ b/src/client-contract.ts
@@ -3,6 +3,7 @@ import { type ChatRequest, type ChatResponse, chatResponseStateSchema } from "./
 import { invariant } from "./assert";
 import { checklistItemSchema } from "./checklist-contract";
 import { rpcServerMessageSchema } from "./rpc-protocol";
+import { promptBreakdownSchema, tokenUsageSchema } from "./session-contract";
 import type { StatusFields } from "./status-contract";
 import { streamErrorSchema } from "./stream-error";
 import type { TaskId, TaskRecord } from "./task-contract";
@@ -19,44 +20,17 @@ export const pendingStateSchema = z.discriminatedUnion("kind", [
 ]);
 export type PendingState = z.infer<typeof pendingStateSchema>;
 
-type UsageLikePayload = {
-  inputTokens?: unknown;
-  outputTokens?: unknown;
-  totalTokens?: unknown;
-  inputBudgetTokens?: unknown;
-  inputTruncated?: unknown;
-};
-
-type ParsedUsagePayload = {
-  inputTokens: number;
-  outputTokens: number;
-  totalTokens: number;
-  inputBudgetTokens?: number;
-  inputTruncated?: boolean;
-};
-
 export interface ClientOptions {
   apiUrl: string;
   apiKey?: string;
   replyTimeoutMs?: number;
 }
 
-const streamUsageEventSchema = z
-  .object({
-    type: z.literal("usage"),
-    inputTokens: z.number().optional(),
-    outputTokens: z.number().optional(),
-    promptTokens: z.number().optional(),
-    completionTokens: z.number().optional(),
-  })
-  .refine(
-    (value) =>
-      (typeof value.inputTokens === "number" && typeof value.outputTokens === "number") ||
-      (typeof value.promptTokens === "number" && typeof value.completionTokens === "number"),
-    {
-      message: "usage event missing token counters",
-    },
-  );
+const streamUsageEventSchema = z.object({
+  type: z.literal("usage"),
+  inputTokens: z.number(),
+  outputTokens: z.number(),
+});
 
 export const streamEventSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("text-delta"), text: z.string() }),
@@ -173,69 +147,23 @@ export function parseRpcServerMessage(raw: unknown): z.infer<typeof rpcServerMes
 
 export function parseStreamEvent(raw: unknown): StreamEvent | null {
   const result = streamEventSchema.safeParse(raw);
-  if (!result.success) return null;
-  const event = result.data;
-  if (event.type === "usage") {
-    const parsed = parseUsagePayload(event);
-    return parsed ? { type: "usage", inputTokens: parsed.inputTokens, outputTokens: parsed.outputTokens } : null;
-  }
-  return event;
+  return result.success ? result.data : null;
 }
 
-function parseUsageNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
-}
-
-function parseUsagePayload(raw: unknown): ParsedUsagePayload | undefined {
-  if (!raw || typeof raw !== "object") return undefined;
-  const usage = raw as UsageLikePayload;
-  const inputTokens = parseUsageNumber(usage.inputTokens);
-  const outputTokens = parseUsageNumber(usage.outputTokens);
-  if (typeof inputTokens !== "number" || typeof outputTokens !== "number") return undefined;
-  return {
-    inputTokens,
-    outputTokens,
-    totalTokens: parseUsageNumber(usage.totalTokens) ?? inputTokens + outputTokens,
-    ...(typeof usage.inputBudgetTokens === "number" ? { inputBudgetTokens: usage.inputBudgetTokens } : {}),
-    ...(typeof usage.inputTruncated === "boolean" ? { inputTruncated: usage.inputTruncated } : {}),
-  };
-}
+const chatResponseSchema = z.object({
+  output: z.string(),
+  model: z.string().min(1),
+  state: chatResponseStateSchema.catch("done"),
+  usage: tokenUsageSchema.optional(),
+  promptBreakdown: promptBreakdownSchema.optional(),
+  toolCalls: z.array(z.string()).optional(),
+  modelCalls: z.number().optional(),
+  error: z.string().optional(),
+});
 
 export function parseChatResponse(payload: unknown): ChatResponse | null {
-  if (!payload || typeof payload !== "object") return null;
-  const json = payload as Partial<ChatResponse>;
-  if (typeof json.output !== "string") return null;
-  if (typeof json.model !== "string" || json.model.trim().length === 0) return null;
-  const parsedUsage = json.usage ? parseUsagePayload(json.usage) : undefined;
-  return {
-    output: json.output,
-    model: json.model,
-    modelCalls: typeof json.modelCalls === "number" ? json.modelCalls : undefined,
-    toolCalls: Array.isArray((json as { toolCalls?: unknown }).toolCalls)
-      ? ((json as { toolCalls?: unknown[] }).toolCalls ?? []).filter((item): item is string => typeof item === "string")
-      : undefined,
-    usage: parsedUsage,
-    promptBreakdown:
-      json.promptBreakdown &&
-      typeof json.promptBreakdown === "object" &&
-      typeof (json.promptBreakdown as { budgetTokens?: unknown }).budgetTokens === "number" &&
-      typeof (json.promptBreakdown as { usedTokens?: unknown }).usedTokens === "number" &&
-      typeof (json.promptBreakdown as { systemTokens?: unknown }).systemTokens === "number" &&
-      typeof (json.promptBreakdown as { toolTokens?: unknown }).toolTokens === "number" &&
-      typeof (json.promptBreakdown as { memoryTokens?: unknown }).memoryTokens === "number" &&
-      typeof (json.promptBreakdown as { messageTokens?: unknown }).messageTokens === "number"
-        ? {
-            budgetTokens: (json.promptBreakdown as { budgetTokens: number }).budgetTokens,
-            usedTokens: (json.promptBreakdown as { usedTokens: number }).usedTokens,
-            systemTokens: (json.promptBreakdown as { systemTokens: number }).systemTokens,
-            toolTokens: (json.promptBreakdown as { toolTokens: number }).toolTokens,
-            memoryTokens: (json.promptBreakdown as { memoryTokens: number }).memoryTokens,
-            messageTokens: (json.promptBreakdown as { messageTokens: number }).messageTokens,
-          }
-        : undefined,
-    state: chatResponseStateSchema.catch("done").parse(json.state),
-    error: typeof json.error === "string" ? json.error : undefined,
-  };
+  const result = chatResponseSchema.safeParse(payload);
+  return result.success ? result.data : null;
 }
 
 export function validateFinalChatResponse(payload: unknown, message: string): ChatResponse {

--- a/src/client-rpc.ts
+++ b/src/client-rpc.ts
@@ -9,6 +9,7 @@ import {
   validateFinalChatResponse,
 } from "./client-contract";
 import { connectionHelpMessage } from "./error-messages";
+import { field } from "./field";
 import { createRpcRequestId } from "./rpc-protocol";
 import type { StatusFields } from "./status-contract";
 import type { TaskId, TaskRecord } from "./task-contract";
@@ -115,7 +116,7 @@ export class RpcClient implements Client {
       const onMessage = (event: MessageEvent) => {
         const raw = this.parseRawSocketData(event);
         if (!raw || typeof raw !== "object") return;
-        const rawId = "id" in raw ? (raw as { id?: unknown }).id : undefined;
+        const rawId = field(raw, "id");
         if (rawId !== id) return;
         const msg = parseRpcServerMessage(raw);
         if (!msg) {

--- a/src/field.ts
+++ b/src/field.ts
@@ -1,0 +1,4 @@
+export function field(obj: unknown, key: string): unknown {
+  if (typeof obj !== "object" || obj === null) return undefined;
+  return key in obj ? (obj as Record<string, unknown>)[key] : undefined;
+}

--- a/src/http-status.ts
+++ b/src/http-status.ts
@@ -1,0 +1,7 @@
+export const HTTP_STATUS = {
+  ok: 200,
+  badRequest: 400,
+  unauthorized: 401,
+  notFound: 404,
+  tooManyRequests: 429,
+} as const;

--- a/src/lifecycle-finalize.test.ts
+++ b/src/lifecycle-finalize.test.ts
@@ -23,14 +23,13 @@ describe("ChatResponse error field", () => {
     expect(response?.error).toBeUndefined();
   });
 
-  test("parseChatResponse ignores non-string error", () => {
+  test("parseChatResponse rejects non-string error", () => {
     const response = parseChatResponse({
       output: "Hello",
       model: "gpt-5-mini",
       error: 42,
     });
-    expect(response).not.toBeNull();
-    expect(response?.error).toBeUndefined();
+    expect(response).toBeNull();
   });
 });
 

--- a/src/rate-limiter.test.ts
+++ b/src/rate-limiter.test.ts
@@ -16,6 +16,10 @@ describe("isRateLimitError", () => {
     expect(isRateLimitError({ status: 429 })).toBe(true);
   });
 
+  test("detects 429 statusCode (AI SDK format)", () => {
+    expect(isRateLimitError({ statusCode: 429 })).toBe(true);
+  });
+
   test("detects rate_limit_exceeded code", () => {
     expect(isRateLimitError({ code: "rate_limit_exceeded" })).toBe(true);
     expect(isRateLimitError({ code: "RATE_LIMIT_EXCEEDED" })).toBe(true);

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -25,19 +25,21 @@ function jitter(ms: number): number {
   return ms * (0.5 + Math.random() * 0.5);
 }
 
+function field(obj: unknown, key: string): unknown {
+  if (typeof obj !== "object" || obj === null) return undefined;
+  return key in obj ? (obj as Record<string, unknown>)[key] : undefined;
+}
+
 function isRateLimitError(error: unknown): boolean {
-  if (typeof error !== "object" || error === null) return false;
-  const status = "status" in error ? (error as { status?: unknown }).status : undefined;
-  if (status === 429) return true;
-  const code = "code" in error ? (error as { code?: unknown }).code : undefined;
-  return code === "rate_limit_exceeded" || code === "RATE_LIMIT_EXCEEDED";
+  if (field(error, "status") === 429) return true;
+  if (field(error, "statusCode") === 429) return true;
+  const code = field(error, "code");
+  return typeof code === "string" && code.toLowerCase() === "rate_limit_exceeded";
 }
 
 function retryAfterMs(error: unknown): number | undefined {
-  if (typeof error !== "object" || error === null) return undefined;
-  const headers = "headers" in error ? (error as { headers?: unknown }).headers : undefined;
-  if (typeof headers !== "object" || headers === null) return undefined;
-  const retryAfter = "retry-after" in headers ? (headers as Record<string, unknown>)["retry-after"] : undefined;
+  const headers = field(error, "headers");
+  const retryAfter = field(headers, "retry-after");
   if (typeof retryAfter === "string") {
     const seconds = Number.parseFloat(retryAfter);
     if (Number.isFinite(seconds) && seconds > 0) return seconds * 1_000;

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -1,3 +1,5 @@
+import { field } from "./field";
+import { HTTP_STATUS } from "./http-status";
 import type { Provider } from "./provider-contract";
 
 export type RateLimiterConfig = {
@@ -24,9 +26,6 @@ export function clearSharedRateLimiters(): void {
 function jitter(ms: number): number {
   return ms * (0.5 + Math.random() * 0.5);
 }
-
-import { field } from "./field";
-import { HTTP_STATUS } from "./http-status";
 
 function isRateLimitError(error: unknown): boolean {
   if (field(error, "status") === HTTP_STATUS.tooManyRequests) return true;

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -25,10 +25,7 @@ function jitter(ms: number): number {
   return ms * (0.5 + Math.random() * 0.5);
 }
 
-function field(obj: unknown, key: string): unknown {
-  if (typeof obj !== "object" || obj === null) return undefined;
-  return key in obj ? (obj as Record<string, unknown>)[key] : undefined;
-}
+import { field } from "./field";
 
 function isRateLimitError(error: unknown): boolean {
   if (field(error, "status") === 429) return true;

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -26,10 +26,11 @@ function jitter(ms: number): number {
 }
 
 import { field } from "./field";
+import { HTTP_STATUS } from "./http-status";
 
 function isRateLimitError(error: unknown): boolean {
-  if (field(error, "status") === 429) return true;
-  if (field(error, "statusCode") === 429) return true;
+  if (field(error, "status") === HTTP_STATUS.tooManyRequests) return true;
+  if (field(error, "statusCode") === HTTP_STATUS.tooManyRequests) return true;
   const code = field(error, "code");
   return typeof code === "string" && code.toLowerCase() === "rate_limit_exceeded";
 }

--- a/src/server-chat-runtime.ts
+++ b/src/server-chat-runtime.ts
@@ -6,6 +6,7 @@ import { appConfig } from "./app-config";
 import { readResolvedConfigSync } from "./config";
 import { createDebugLogger } from "./debug-flags";
 import { createStreamError, errorIdSchema, parseError } from "./error-handling";
+import { field } from "./field";
 import { runLifecycle } from "./lifecycle";
 import { errorToLogFields, log } from "./log";
 import { isProviderAvailable, providerFromModel } from "./provider-config";
@@ -215,12 +216,12 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
       runControl,
       onEvent: (event) => {
         if (runControl?.isCancelled()) return;
-        if ((event as { type?: string }).type === "tool-output")
+        if (field(event, "type") === "tool-output")
           debug.log("tool-stream-forward", {
             task_id: handlers.taskId ?? null,
             type: "tool-output",
-            tool: (event as { toolName?: unknown }).toolName,
-            tool_call_id: (event as { toolCallId?: unknown }).toolCallId,
+            tool: field(event, "toolName"),
+            tool_call_id: field(event, "toolCallId"),
           });
         handlers.onEvent(event as Record<string, unknown>);
       },

--- a/src/server-daemon.ts
+++ b/src/server-daemon.ts
@@ -3,6 +3,7 @@ import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises"
 import { join } from "node:path";
 import { z } from "zod";
 import { type IsoDateTimeString, isoDateTimeSchema } from "./datetime";
+import { field } from "./field";
 import { PRIVATE_FILE_MODE } from "./file-ops";
 import { resolveHomeDir } from "./home-dir";
 import { t } from "./i18n";
@@ -134,8 +135,7 @@ async function isServerHealthy(apiUrl: string, apiKey?: string, timeoutMs = HEAL
     if (!response.ok) return false;
     const payload = await response.json().catch(() => null);
     if (!payload || typeof payload !== "object") return false;
-    const protocolVersion =
-      "protocol_version" in payload ? (payload as { protocol_version?: unknown }).protocol_version : undefined;
+    const protocolVersion = field(payload, "protocol_version");
     return protocolVersion === PROTOCOL_VERSION;
   } catch {
     return false;

--- a/src/server-http.ts
+++ b/src/server-http.ts
@@ -1,4 +1,5 @@
 import type { ChatRequest } from "./api";
+import { HTTP_STATUS } from "./http-status";
 import { log } from "./log";
 import type { RunChatHandlers, StatusPayload } from "./server-contract";
 
@@ -25,14 +26,14 @@ type RouteContext = {
 type RouteHandler = (ctx: RouteContext) => Promise<Response | undefined | null>;
 
 function unauthorized(): Response {
-  return new Response("Unauthorized", { status: 401 });
+  return new Response("Unauthorized", { status: HTTP_STATUS.unauthorized });
 }
 
 function badRequest(message: string): Response {
-  return new Response(message, { status: 400 });
+  return new Response(message, { status: HTTP_STATUS.badRequest });
 }
 
-export function json<T>(body: T, status = 200): Response {
+export function json<T>(body: T, status: number = HTTP_STATUS.ok): Response {
   return new Response(JSON.stringify(body), {
     status,
     headers: { "content-type": "application/json" },
@@ -172,6 +173,6 @@ export function createServerFetchHandler(deps: ServerHttpDeps): (req: Request) =
       const response = await routeHandler(ctx);
       if (response !== null && response !== undefined) return response;
     }
-    return new Response("Not Found", { status: 404 });
+    return new Response("Not Found", { status: HTTP_STATUS.notFound });
   };
 }

--- a/src/session-contract.ts
+++ b/src/session-contract.ts
@@ -7,7 +7,7 @@ import { domainIdSchema } from "./id-contract";
 export const sessionIdSchema = domainIdSchema("sess");
 export type SessionId = z.infer<typeof sessionIdSchema>;
 
-const tokenUsageSchema = z.object({
+export const tokenUsageSchema = z.object({
   inputTokens: z.number(),
   outputTokens: z.number(),
   totalTokens: z.number(),

--- a/src/tool-arg-paths.ts
+++ b/src/tool-arg-paths.ts
@@ -1,3 +1,5 @@
+import { field } from "./field";
+
 export const WORKSPACE_SCOPE = "__workspace__";
 
 export function normalizePath(p: string): string {
@@ -12,7 +14,7 @@ export function extractReadPaths(args: Record<string, unknown>, opts?: { normali
   const out: string[] = [];
   for (const entry of paths) {
     if (!entry || typeof entry !== "object") continue;
-    const path = (entry as { path?: unknown }).path;
+    const path = field(entry, "path");
     if (typeof path === "string" && path.trim().length > 0) {
       out.push(shouldNormalize ? normalizePath(path.trim()) : path.trim());
     }

--- a/src/tool-execution.ts
+++ b/src/tool-execution.ts
@@ -1,6 +1,7 @@
 import { invariant } from "./assert";
 import { ERROR_KINDS, LIFECYCLE_ERROR_CODES } from "./error-contract";
 import { parseError } from "./error-handling";
+import { field } from "./field";
 import { ToolError } from "./tool-error";
 import { checkStepBudget, recordCall, type SessionContext } from "./tool-session";
 
@@ -44,14 +45,10 @@ export async function withToolError<T>(toolId: string, task: () => Promise<T>): 
       code?: string;
       kind?: string;
     };
-    if (typeof error === "object" && error !== null && "code" in error) {
-      const code = (error as { code?: unknown }).code;
-      if (typeof code === "string" && code.length > 0) wrapped.code = code;
-    }
-    if (typeof error === "object" && error !== null && "kind" in error) {
-      const kind = (error as { kind?: unknown }).kind;
-      if (typeof kind === "string" && kind.length > 0) wrapped.kind = kind;
-    }
+    const code = field(error, "code");
+    if (typeof code === "string" && code.length > 0) wrapped.code = code;
+    const kind = field(error, "kind");
+    if (typeof kind === "string" && kind.length > 0) wrapped.kind = kind;
     throw wrapped;
   }
 }

--- a/src/workspace-sandbox.ts
+++ b/src/workspace-sandbox.ts
@@ -1,6 +1,7 @@
 import { lstatSync, realpathSync } from "node:fs";
 import { dirname, isAbsolute, relative, resolve } from "node:path";
 import { ERROR_KINDS, TOOL_ERROR_CODES } from "./error-contract";
+import { field } from "./field";
 import { createToolError } from "./tool-error";
 
 const sandboxRootCache = new Map<string, string>();
@@ -14,9 +15,7 @@ const SANDBOX_VIOLATION_MESSAGES = {
 type SandboxViolationMessageKey = keyof typeof SANDBOX_VIOLATION_MESSAGES;
 
 function isNotFoundError(error: unknown): boolean {
-  return (
-    typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "ENOENT"
-  );
+  return field(error, "code") === "ENOENT";
 }
 
 function pathEntryExists(pathInput: string): boolean {


### PR DESCRIPTION
## Motivation

Vercel AI Gateway rate limit errors weren't detected by the rate limiter because the AI SDK uses `statusCode` (not `status`). While fixing this, cleaned up related code: unsafe property access patterns, magic HTTP status numbers, and a hand-rolled `parseChatResponse` that should have been a zod schema.

## Summary

- add `statusCode` check to `isRateLimitError` for AI SDK error objects
- case-insensitive error code matching
- extract `field()` helper for safe property access on `unknown` (replaces `as` casts across 7 files)
- extract `HTTP_STATUS` constants (replaces magic numbers in rate-limiter and server-http)
- replace manual `parseChatResponse` with `chatResponseSchema.safeParse()`
- reuse `tokenUsageSchema` and `promptBreakdownSchema` from session-contract
- remove legacy `promptTokens`/`completionTokens` alias handling
- remove redundant `streamUsageEventSchema` refine