### PR TITLE
fix(config): crash on malformed config file

### DIFF
--- a/src/app-config.ts
+++ b/src/app-config.ts
@@ -1,9 +1,11 @@
 import { readResolvedConfigSync } from "./config";
 import { readCredentialsSync } from "./credentials";
 import { env } from "./env";
+import { setLocale } from "./i18n";
 
 const fileConfig = readResolvedConfigSync();
 const credentials = readCredentialsSync();
+setLocale(fileConfig.locale);
 
 export const appConfig = {
   locale: fileConfig.locale,

--- a/src/config.int.test.ts
+++ b/src/config.int.test.ts
@@ -89,23 +89,13 @@ describe("config store", () => {
     expect(loaded.model).toBe("google/gemini-2.5-pro");
   });
 
-  test("readConfigSync warns to stderr and falls back on parse errors", () => {
+  test("readConfigSync throws on malformed config with scope", () => {
     const home = createDir("acolyte-config-home-");
     const dataDir = join(home, ".acolyte");
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), "not valid toml = {", "utf8");
 
-    const warnings: string[] = [];
-    const origWarn = console.warn;
-    console.warn = (...args: unknown[]) => warnings.push(args.join(" "));
-    try {
-      const loaded = readConfigSync({ homeDir: home, cwd: home });
-      expect(loaded).toEqual({});
-      expect(warnings.length).toBe(1);
-      expect(warnings[0]).toContain("failed to parse config file");
-    } finally {
-      console.warn = origWarn;
-    }
+    expect(() => readConfigSync({ homeDir: home, cwd: home })).toThrow(/user config/);
   });
 
   test("setConfigValue updates TOML when config.toml exists", async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -176,8 +176,8 @@ export function readResolvedConfigSync(options?: ConfigOptions): ResolvedConfig 
   return resolveConfig(readConfigSync(options));
 }
 
-function wrapConfigError(scope: string, error: unknown): never {
-  throw new Error(t("cli.config.parse_failed", { scope, reason: errorMessage(error) }));
+function wrapError(scope: string, error: unknown): Error {
+  return new Error(t("cli.config.parse_failed", { scope, reason: errorMessage(error) }));
 }
 
 export async function readConfig(options?: ConfigOptions): Promise<Config> {
@@ -186,12 +186,12 @@ export async function readConfig(options?: ConfigOptions): Promise<Config> {
   try {
     userConfig = await readConfigForScope("user", options);
   } catch (error) {
-    wrapConfigError("user", error);
+    throw wrapError("user", error);
   }
   try {
     projectConfig = await readConfigForScope("project", options);
   } catch (error) {
-    wrapConfigError("project", error);
+    throw wrapError("project", error);
   }
   return shallowMerge(userConfig, projectConfig);
 }
@@ -202,12 +202,12 @@ export function readConfigSync(options?: ConfigOptions): Config {
   try {
     userConfig = readConfigForScopeSync("user", options);
   } catch (error) {
-    wrapConfigError("user", error);
+    throw wrapError("user", error);
   }
   try {
     projectConfig = readConfigForScopeSync("project", options);
   } catch (error) {
-    wrapConfigError("project", error);
+    throw wrapError("project", error);
   }
   return shallowMerge(userConfig, projectConfig);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ import {
   type ResolvedConfig,
   toConfig,
 } from "./config-contract";
+import { errorMessage } from "./error-contract";
 import { featureFlagsSchema, resolvedFeatureFlagsSchema } from "./feature-flags-contract";
 import { resolveHomeDir } from "./home-dir";
 import { t } from "./i18n";
@@ -175,28 +176,40 @@ export function readResolvedConfigSync(options?: ConfigOptions): ResolvedConfig 
   return resolveConfig(readConfigSync(options));
 }
 
+function wrapConfigError(scope: string, error: unknown): never {
+  throw new Error(t("cli.config.parse_failed", { scope, reason: errorMessage(error) }));
+}
+
 export async function readConfig(options?: ConfigOptions): Promise<Config> {
+  let userConfig: Config;
+  let projectConfig: Config;
   try {
-    const userConfig = await readConfigForScope("user", options);
-    const projectConfig = await readConfigForScope("project", options);
-    return shallowMerge(userConfig, projectConfig);
+    userConfig = await readConfigForScope("user", options);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(`Warning: failed to parse config file, using defaults. ${message}`);
-    return {};
+    wrapConfigError("user", error);
   }
+  try {
+    projectConfig = await readConfigForScope("project", options);
+  } catch (error) {
+    wrapConfigError("project", error);
+  }
+  return shallowMerge(userConfig, projectConfig);
 }
 
 export function readConfigSync(options?: ConfigOptions): Config {
+  let userConfig: Config;
+  let projectConfig: Config;
   try {
-    const userConfig = readConfigForScopeSync("user", options);
-    const projectConfig = readConfigForScopeSync("project", options);
-    return shallowMerge(userConfig, projectConfig);
+    userConfig = readConfigForScopeSync("user", options);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.warn(`Warning: failed to parse config file, using defaults. ${message}`);
-    return {};
+    wrapConfigError("user", error);
   }
+  try {
+    projectConfig = readConfigForScopeSync("project", options);
+  } catch (error) {
+    wrapConfigError("project", error);
+  }
+  return shallowMerge(userConfig, projectConfig);
 }
 
 export async function writeConfig(config: Config, options?: ConfigOptions): Promise<void> {

--- a/src/error-contract.ts
+++ b/src/error-contract.ts
@@ -41,3 +41,7 @@ export const ERROR_KINDS = {
   unknown: "unknown",
 } as const;
 export type ErrorKind = (typeof ERROR_KINDS)[keyof typeof ERROR_KINDS];
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/error-contract.ts
+++ b/src/error-contract.ts
@@ -42,6 +42,10 @@ export const ERROR_KINDS = {
 } as const;
 export type ErrorKind = (typeof ERROR_KINDS)[keyof typeof ERROR_KINDS];
 
+export function errorCode(error: unknown): string | undefined {
+  return error instanceof Error && "code" in error && typeof error.code === "string" ? error.code : undefined;
+}
+
 export function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }

--- a/src/error-utils.ts
+++ b/src/error-utils.ts
@@ -1,0 +1,3 @@
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/error-utils.ts
+++ b/src/error-utils.ts
@@ -1,3 +1,0 @@
-export function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
-}

--- a/src/git-toolkit.ts
+++ b/src/git-toolkit.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { errorMessage } from "./error-contract";
 import { gitAdd, gitCommit, gitDiff, gitLog, gitShow, gitStatusShort } from "./git-ops";
 import { t } from "./i18n";
 import type { ToolkitInput } from "./tool-contract";
@@ -47,7 +48,7 @@ async function runGitOp(operation: GitOp, execute: () => Promise<string>): Promi
   try {
     return await execute();
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     throw new Error(`[git-ops:${operation}] ${message}`);
   }
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,4 +1,3 @@
-import { appConfig } from "./app-config";
 import type { EN_MESSAGES } from "./i18n/en";
 import { TRANSLATIONS, type TranslationLocale } from "./i18n/locales";
 
@@ -40,9 +39,15 @@ export function createTranslator(locale: TranslationLocale): Translator {
   return (key, ...args) => translate(templates, key, args[0] as Record<string, TranslationValue> | undefined);
 }
 
+let activeLocale: TranslationLocale = "en";
+
+export function setLocale(locale: TranslationLocale): void {
+  activeLocale = locale;
+}
+
 export function t<K extends TranslationKey>(key: K, ...args: TranslationArgs<K>): string {
   return translate(
-    TRANSLATIONS[appConfig.locale] ?? TRANSLATIONS.en,
+    TRANSLATIONS[activeLocale] ?? TRANSLATIONS.en,
     key,
     args[0] as Record<string, TranslationValue> | undefined,
   );
@@ -50,5 +55,5 @@ export function t<K extends TranslationKey>(key: K, ...args: TranslationArgs<K>)
 
 /** Translate a dynamic key without compile-time key checking. Falls back to the key itself when not found. */
 export function tDynamic(key: string, vars?: Record<string, TranslationValue>): string {
-  return translate(TRANSLATIONS[appConfig.locale] ?? TRANSLATIONS.en, key, vars);
+  return translate(TRANSLATIONS[activeLocale] ?? TRANSLATIONS.en, key, vars);
 }

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -94,6 +94,7 @@ export const EN_MESSAGES = {
   "chat.worked": "Worked {duration}{suffix}",
   "cli.config.api_key_unsupported": "Config apiKey is not supported. Use ACOLYTE_API_KEY in .env instead.",
   "cli.config.invalid_value": "Invalid value for {key}: {reason}",
+  "cli.config.parse_failed": "Failed to parse {scope} config: {reason}",
   "cli.config.keys": "Keys: {keys}",
   "cli.config.removed": "Removed config {key} ({scope}).",
   "cli.config.saved": "Saved config {key} ({scope}).",

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -3,7 +3,7 @@ import { estimateTokens } from "./agent-input";
 import { createInstructions } from "./agent-instructions";
 import { createAgent } from "./agent-stream";
 import { appConfig } from "./app-config";
-import { errorMessage, LIFECYCLE_ERROR_CODES } from "./error-contract";
+import { errorCode, errorMessage, LIFECYCLE_ERROR_CODES } from "./error-contract";
 import {
   categoryFromErrorCode,
   categoryFromErrorKind,
@@ -131,11 +131,10 @@ export async function phaseGenerate(ctx: RunContext, opts: GenerateOptions): Pro
       text_chars: ctx.result.text.trim().length,
     });
   } catch (error) {
-    const errorMsg = errorMessage(error);
-    const errorCode =
-      error instanceof Error && "code" in error && typeof error.code === "string" ? error.code : undefined;
-    captureError(ctx, errorMsg, { source: "generate", code: errorCode });
-    ctx.debug("lifecycle.generate.error", { model: ctx.model, error: errorMsg });
+    const message = errorMessage(error);
+    const code = errorCode(error);
+    captureError(ctx, message, { source: "generate", code });
+    ctx.debug("lifecycle.generate.error", { model: ctx.model, error: message });
   }
 }
 

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -3,7 +3,7 @@ import { estimateTokens } from "./agent-input";
 import { createInstructions } from "./agent-instructions";
 import { createAgent } from "./agent-stream";
 import { appConfig } from "./app-config";
-import { LIFECYCLE_ERROR_CODES } from "./error-contract";
+import { errorMessage, LIFECYCLE_ERROR_CODES } from "./error-contract";
 import {
   categoryFromErrorCode,
   categoryFromErrorKind,
@@ -131,7 +131,7 @@ export async function phaseGenerate(ctx: RunContext, opts: GenerateOptions): Pro
       text_chars: ctx.result.text.trim().length,
     });
   } catch (error) {
-    const errorMsg = error instanceof Error ? error.message : String(error);
+    const errorMsg = errorMessage(error);
     const errorCode =
       error instanceof Error && "code" in error && typeof error.code === "string" ? error.code : undefined;
     captureError(ctx, errorMsg, { source: "generate", code: errorCode });

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,5 +1,5 @@
 import { ensureRealTokenEncoder, estimateTokens } from "./agent-input";
-import { LIFECYCLE_ERROR_CODES } from "./error-contract";
+import { errorMessage, LIFECYCLE_ERROR_CODES } from "./error-contract";
 import { createErrorStats } from "./error-handling";
 import { DEFAULT_FEATURE_FLAGS } from "./feature-flags-contract";
 import { t } from "./i18n";
@@ -81,7 +81,7 @@ export function scheduleMemoryCommit(
   }).catch((error) => {
     debug("lifecycle.memory.commit_failed", {
       ...debugFields,
-      message: error instanceof Error ? error.message : String(error),
+      message: errorMessage(error),
     });
   });
 }

--- a/src/tool-execution.ts
+++ b/src/tool-execution.ts
@@ -1,5 +1,5 @@
 import { invariant } from "./assert";
-import { ERROR_KINDS, LIFECYCLE_ERROR_CODES } from "./error-contract";
+import { ERROR_KINDS, errorMessage, LIFECYCLE_ERROR_CODES } from "./error-contract";
 import { parseError } from "./error-handling";
 import { field } from "./field";
 import { ToolError } from "./tool-error";
@@ -40,7 +40,7 @@ export async function withToolError<T>(toolId: string, task: () => Promise<T>): 
   try {
     return await task();
   } catch (error) {
-    const baseMessage = error instanceof Error ? error.message : String(error);
+    const baseMessage = errorMessage(error);
     const wrapped = new Error(`${toolId} failed: ${baseMessage}`) as Error & {
       code?: string;
       kind?: string;
@@ -81,7 +81,7 @@ export async function runTool(
           hook: "before",
           tool: toolId,
           tool_call_id: toolCallId,
-          message: error instanceof Error ? error.message : String(error),
+          message: errorMessage(error),
         });
       }
     }
@@ -111,7 +111,7 @@ export async function runTool(
               hook: "after",
               tool: toolId,
               tool_call_id: toolCallId,
-              message: error instanceof Error ? error.message : String(error),
+              message: errorMessage(error),
             });
           }
         }
@@ -169,7 +169,7 @@ export async function runTool(
             hook: "after",
             tool: toolId,
             tool_call_id: toolCallId,
-            message: error instanceof Error ? error.message : String(error),
+            message: errorMessage(error),
           });
         }
       }

--- a/src/update-ops.ts
+++ b/src/update-ops.ts
@@ -1,6 +1,7 @@
 import { access, chmod, copyFile, lstat, mkdir, readdir, rename, rm, unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { errorMessage } from "./error-contract";
 
 const FETCH_TIMEOUT_MS = 5_000;
 
@@ -116,7 +117,7 @@ export async function installUpdate(
 
     return { success: true };
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     try {
       await unlink(newBinaryPath);
     } catch {


### PR DESCRIPTION
## Motivation

Malformed config files were silently ignored, falling back to defaults with no feedback. A typo in `config.toml` could leave you debugging for an hour why your settings aren't taking effect.

## Summary

- break the `config → i18n → app-config → config` circular dependency via `setLocale` in `app-config`
- crash with a translated, scope-specific error on malformed config (`Failed to parse user config: ...`)
- add `errorMessage` and `errorCode` helpers to `error-contract`
- adopt `errorMessage` across 6 files that had the same inline pattern