### PR TITLE
feat(cloud): incremental session sync with gzip compression

### DIFF
--- a/src/chat-commands-model.ts
+++ b/src/chat-commands-model.ts
@@ -43,6 +43,7 @@ async function handleModelSet(ctx: CommandContext): Promise<CommandResult> {
       updatedAt: nowIso(),
     };
     ctx.setCurrentSession(nextSession);
+    await ctx.persist();
     ctx.setRows((current) => [...current, createRow("system", t("chat.model.changed", { model: formatModel(model) }))]);
   } catch (error) {
     ctx.setRows((current) => [

--- a/src/chat-commands.test.ts
+++ b/src/chat-commands.test.ts
@@ -315,6 +315,19 @@ describe("chat-commands", () => {
     }
   });
 
+  test("dispatchSlashCommand /model <id> persists session", async () => {
+    const previousModel = appConfig.model;
+    try {
+      const { persistCalls, stop } = await runCommand("/model gpt-5.2", {
+        persistModelConfig: async () => {},
+      });
+      expect(stop).toBe(true);
+      expect(persistCalls).toBe(1);
+    } finally {
+      (appConfig as { model: string }).model = previousModel;
+    }
+  });
+
   test("dispatchSlashCommand /new resets rows to new-session status", async () => {
     const session = createSession({ id: "sess_current" });
     const sessionState = createSessionState({ sessions: [session], activeSessionId: session.id });

--- a/src/chat-commands.test.ts
+++ b/src/chat-commands.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { appConfig } from "./app-config";
+import { appConfig, setModel } from "./app-config";
 import { dispatchSlashCommand } from "./chat-commands";
 import { isCommandOutput } from "./chat-contract";
 import type { ConfigScope } from "./config-contract";
@@ -311,7 +311,7 @@ describe("chat-commands", () => {
       expect(writes).toEqual([{ key: "model", value: "gpt-5.2", scope: "project" }]);
       expect(appConfig.model).toBe("gpt-5.2");
     } finally {
-      (appConfig as { model: string }).model = previousModel;
+      setModel(previousModel);
     }
   });
 
@@ -324,7 +324,7 @@ describe("chat-commands", () => {
       expect(stop).toBe(true);
       expect(persistCalls).toBe(1);
     } finally {
-      (appConfig as { model: string }).model = previousModel;
+      setModel(previousModel);
     }
   });
 

--- a/src/chat-picker-handlers.test.ts
+++ b/src/chat-picker-handlers.test.ts
@@ -65,4 +65,25 @@ describe("chat picker handlers", () => {
     expect(spies.currentSessions.at(-1)?.model).toBe("gpt-5.2");
     expect(spies.rows.some((row) => row.content === "Changed model to gpt-5.2.")).toBe(true);
   });
+
+  test("model change persists session", async () => {
+    const currentSession = createSession({ id: "sess_current", model: "gpt-5-mini" });
+    const sessionState = createSessionState({ sessions: [currentSession], activeSessionId: currentSession.id });
+    const { handlers, spies } = createPickerHandlerHarness({
+      sessionState,
+      currentSession,
+      persistConfig: async () => {},
+    });
+
+    await handlers.handlePickerSelect({
+      kind: "model",
+      items: [{ label: "gpt-5.2", value: "gpt-5.2" }],
+      filtered: [{ label: "gpt-5.2", value: "gpt-5.2" }],
+      query: "",
+      index: 0,
+      scrollOffset: 0,
+    });
+
+    expect(spies.persistCalls).toBe(1);
+  });
 });

--- a/src/chat-picker-handlers.ts
+++ b/src/chat-picker-handlers.ts
@@ -107,6 +107,7 @@ export function createPickerHandlers(input: CreatePickerHandlersInput): {
           setModel(nextModel);
           const nextSession: Session = { ...input.currentSession, model: nextModel, updatedAt: input.nowIso() };
           input.setCurrentSession(nextSession);
+          await input.persist();
           input.setRows((current) => [
             ...current,
             createRow("system", t("chat.model.changed", { model: formatModel(nextModel) })),

--- a/src/chat-state.ts
+++ b/src/chat-state.ts
@@ -30,6 +30,7 @@ export interface ChatAppProps {
   session: Session;
   sessionState: SessionState;
   persist: () => Promise<void>;
+  onSessionChange?: (next: Session) => void;
   version: string;
   useMemory?: boolean;
 }
@@ -65,6 +66,13 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
   const { client, session, sessionState, persist, useMemory } = props;
 
   const [currentSession, setCurrentSession] = useState<Session>(session);
+  const updateSession = useCallback(
+    (next: Session) => {
+      setCurrentSession(next);
+      props.onSessionChange?.(next);
+    },
+    [props.onSessionChange],
+  );
   const [rows, setRows] = useState<ChatRow[]>([]);
 
   const {
@@ -156,7 +164,7 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
   const { openSkillsPanel, openResumePanel, openModelPanel, handlePickerSelect } = createPickerHandlers({
     sessionState,
     currentSession,
-    setCurrentSession,
+    setCurrentSession: updateSession,
     setTokenUsage,
     setRows,
     setRowsDirect: setRows,
@@ -175,7 +183,7 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
     client,
     sessionState,
     currentSession,
-    setCurrentSession,
+    setCurrentSession: updateSession,
     toRows,
     setRows,
     setShowHelp,

--- a/src/cli-chat.ts
+++ b/src/cli-chat.ts
@@ -98,9 +98,13 @@ export async function chatModeWithOptions(options: { resumeLatest: boolean; resu
   if (daemon.started) printDim(t("cli.server.started", { port: daemon.port, pid: daemon.pid }));
   else printDim(t("cli.server.already_running", { port: daemon.port, pid: daemon.pid }));
   const client = createClient({ apiUrl });
+  let activeSession = session;
   const persist = async (): Promise<void> => {
-    await sessionStore.saveSession(session);
+    await sessionStore.saveSession(activeSession);
     await sessionStore.setActiveSessionId(state.activeSessionId);
+  };
+  const onSessionChange = (next: Session): void => {
+    activeSession = next;
   };
 
   try {
@@ -110,6 +114,7 @@ export async function chatModeWithOptions(options: { resumeLatest: boolean; resu
       session,
       sessionState: state,
       persist,
+      onSessionChange,
       version: CLI_VERSION,
       useMemory: isResumed,
     });

--- a/src/cloud-client.test.ts
+++ b/src/cloud-client.test.ts
@@ -88,11 +88,76 @@ describe("cloud sync client", () => {
     expect(url).toContain("limit=10");
   });
 
-  test("session.saveSession sends POST", async () => {
+  test("session.saveSession sends POST on first save", async () => {
     const fn = jsonFetch(200, { ok: true });
     const client = new CloudClient("https://api.example.com", "t");
     await client.session.saveSession({ id: "sess_1" } as never);
     const [, init] = callArgs(fn);
     expect(init.method).toBe("POST");
+  });
+
+  test("session.saveSession sends PATCH append after first save", async () => {
+    const fn = jsonFetch(200, { ok: true });
+    const client = new CloudClient("https://api.example.com", "t");
+    const session = {
+      id: "sess_1",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      model: "gpt-5-mini",
+      title: "test",
+      messages: [{ id: "msg_1", role: "user", content: "hello", kind: "text", timestamp: "2026-01-01T00:00:00.000Z" }],
+      tokenUsage: [],
+    } as never;
+    await client.session.saveSession(session);
+    expect(callArgs(fn, 0)[1].method).toBe("POST");
+
+    (session as { updatedAt: string }).updatedAt = "2026-01-01T00:01:00.000Z";
+    await client.session.saveSession(session);
+    const [url, init] = callArgs(fn, 1);
+    expect(init.method).toBe("PATCH");
+    expect(url).toContain("/sess_1/append");
+  });
+
+  test("session.saveSession append sends only new messages", async () => {
+    const fn = jsonFetch(200, { ok: true });
+    const client = new CloudClient("https://api.example.com", "t");
+    const msg1 = { id: "msg_1", role: "user", content: "hello", kind: "text", timestamp: "2026-01-01T00:00:00.000Z" };
+    const msg2 = { id: "msg_2", role: "assistant", content: "hi", kind: "text", timestamp: "2026-01-01T00:00:01.000Z" };
+    const session = {
+      id: "sess_1",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-01T00:00:00.000Z",
+      model: "gpt-5-mini",
+      title: "test",
+      messages: [msg1],
+      tokenUsage: [],
+    };
+    await client.session.saveSession(session as never);
+
+    session.messages.push(msg2 as never);
+    session.updatedAt = "2026-01-01T00:01:00.000Z";
+    await client.session.saveSession(session as never);
+
+    const [, init] = callArgs(fn, 1);
+    const body = JSON.parse(init.body as string);
+    expect(body.messages).toHaveLength(1);
+    expect(body.messages[0].id).toBe("msg_2");
+  });
+
+  test("gzips large request bodies", async () => {
+    const fn = jsonFetch(200, { ok: true });
+    const client = new CloudClient("https://api.example.com", "t");
+    const largeContent = "x".repeat(2000);
+    const record = {
+      id: "mem_1",
+      scopeKey: "user_x",
+      kind: "stored" as const,
+      content: largeContent,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      tokenEstimate: 5,
+    };
+    await client.memory.write(record);
+    const [, init] = callArgs(fn);
+    expect((init.headers as Record<string, string>)["content-encoding"]).toBe("gzip");
   });
 });

--- a/src/cloud-client.ts
+++ b/src/cloud-client.ts
@@ -5,6 +5,8 @@ import { type MemoryRecord, type MemoryScope, type MemoryStore, memoryRecordSche
 import { embeddingToBuffer } from "./memory-embedding";
 import { type Session, type SessionId, type SessionStore, sessionIdSchema, sessionSchema } from "./session-contract";
 
+const GZIP_THRESHOLD = 1024;
+
 const ROUTES = {
   memories: {
     list: "/api/v1/memories",
@@ -23,6 +25,7 @@ const ROUTES = {
     save: "/api/v1/sessions",
     get: (id: string) => `/api/v1/sessions/${encodeURIComponent(id)}`,
     remove: (id: string) => `/api/v1/sessions/${encodeURIComponent(id)}`,
+    append: (id: string) => `/api/v1/sessions/${encodeURIComponent(id)}/append`,
     getActive: "/api/v1/sessions/active",
     setActive: "/api/v1/sessions/active",
   },
@@ -46,9 +49,12 @@ const sessionListSchema = z.array(sessionSchema);
 const embeddingsResponseSchema = z.object({ embeddings: z.record(z.string(), z.string()) });
 const activeSessionSchema = z.object({ id: z.string().nullable() });
 
+type SyncCursor = { messageCount: number; tokenUsageCount: number };
+
 export class CloudClient {
   private readonly base: string;
   private readonly token: string;
+  private readonly syncCursors = new Map<string, SyncCursor>();
 
   constructor(baseUrl: string, token: string) {
     this.base = baseUrl.replace(/\/$/, "");
@@ -150,18 +156,64 @@ export class CloudClient {
   }
 
   private async listSessions(options?: { limit?: number }): Promise<readonly Session[]> {
-    return this.get(ROUTES.sessions.list, {
+    const sessions = await this.get(ROUTES.sessions.list, {
       schema: sessionListSchema,
       params: { limit: options?.limit?.toString() },
     });
+    for (const s of sessions) {
+      this.syncCursors.set(s.id, { messageCount: s.messages.length, tokenUsageCount: s.tokenUsage.length });
+    }
+    return sessions;
   }
 
   private async getSession(id: SessionId): Promise<Session | null> {
-    return this.get(ROUTES.sessions.get(id), { schema: sessionSchema.nullable() });
+    const session = await this.get(ROUTES.sessions.get(id), { schema: sessionSchema.nullable() });
+    if (session) {
+      this.syncCursors.set(session.id, {
+        messageCount: session.messages.length,
+        tokenUsageCount: session.tokenUsage.length,
+      });
+    }
+    return session;
   }
 
   private async saveSession(session: Session): Promise<void> {
-    await this.post(ROUTES.sessions.save, { body: session });
+    const cursor = this.syncCursors.get(session.id);
+    if (cursor) {
+      const newMessages = session.messages.slice(cursor.messageCount);
+      const newTokenUsage = session.tokenUsage.slice(cursor.tokenUsageCount);
+      if (newMessages.length === 0 && newTokenUsage.length === 0) {
+        await this.patch(ROUTES.sessions.append(session.id), {
+          body: {
+            updatedAt: session.updatedAt,
+            model: session.model,
+            title: session.title,
+            workspace: session.workspace,
+            workspaceName: session.workspaceName,
+            workspaceBranch: session.workspaceBranch,
+          },
+        });
+      } else {
+        await this.patch(ROUTES.sessions.append(session.id), {
+          body: {
+            ...(newMessages.length > 0 ? { messages: newMessages } : {}),
+            ...(newTokenUsage.length > 0 ? { tokenUsage: newTokenUsage } : {}),
+            updatedAt: session.updatedAt,
+            model: session.model,
+            title: session.title,
+            workspace: session.workspace,
+            workspaceName: session.workspaceName,
+            workspaceBranch: session.workspaceBranch,
+          },
+        });
+      }
+    } else {
+      await this.post(ROUTES.sessions.save, { body: session });
+    }
+    this.syncCursors.set(session.id, {
+      messageCount: session.messages?.length ?? 0,
+      tokenUsageCount: session.tokenUsage?.length ?? 0,
+    });
   }
 
   private async removeSession(id: SessionId): Promise<void> {
@@ -191,14 +243,19 @@ export class CloudClient {
       const query = qs.toString();
       if (query) url = `${url}?${query}`;
     }
-    const res = await fetch(url, {
-      method,
-      headers: {
-        authorization: `Bearer ${this.token}`,
-        ...(options?.body !== undefined ? { "content-type": "application/json" } : {}),
-      },
-      body: options?.body !== undefined ? JSON.stringify(options.body) : undefined,
-    });
+    let body: BodyInit | undefined;
+    const headers: Record<string, string> = { authorization: `Bearer ${this.token}` };
+    if (options?.body !== undefined) {
+      const json = JSON.stringify(options.body);
+      headers["content-type"] = "application/json";
+      if (json.length >= GZIP_THRESHOLD) {
+        body = Bun.gzipSync(Buffer.from(json));
+        headers["content-encoding"] = "gzip";
+      } else {
+        body = json;
+      }
+    }
+    const res = await fetch(url, { method, headers, body });
     if (!res.ok) {
       const text = await res.text().catch(() => "");
       throw new CloudApiError(res.status, `Cloud API ${method} ${path} failed (${res.status}): ${text}`);
@@ -217,6 +274,10 @@ export class CloudClient {
 
   private post<T = void>(path: string, options?: { schema?: z.ZodType<T>; body?: unknown }): Promise<T> {
     return this.request("POST", path, options);
+  }
+
+  private patch(path: string, options?: { body?: unknown }): Promise<void> {
+    return this.request("PATCH", path, options);
   }
 
   private put(path: string, options?: { body?: unknown }): Promise<void> {

--- a/src/cloud-client.ts
+++ b/src/cloud-client.ts
@@ -182,31 +182,21 @@ export class CloudClient {
     if (cursor) {
       const newMessages = session.messages.slice(cursor.messageCount);
       const newTokenUsage = session.tokenUsage.slice(cursor.tokenUsageCount);
-      if (newMessages.length === 0 && newTokenUsage.length === 0) {
-        await this.patch(ROUTES.sessions.append(session.id), {
-          body: {
-            updatedAt: session.updatedAt,
-            model: session.model,
-            title: session.title,
-            workspace: session.workspace,
-            workspaceName: session.workspaceName,
-            workspaceBranch: session.workspaceBranch,
-          },
-        });
-      } else {
-        await this.patch(ROUTES.sessions.append(session.id), {
-          body: {
-            ...(newMessages.length > 0 ? { messages: newMessages } : {}),
-            ...(newTokenUsage.length > 0 ? { tokenUsage: newTokenUsage } : {}),
-            updatedAt: session.updatedAt,
-            model: session.model,
-            title: session.title,
-            workspace: session.workspace,
-            workspaceName: session.workspaceName,
-            workspaceBranch: session.workspaceBranch,
-          },
-        });
-      }
+      const metadata = {
+        updatedAt: session.updatedAt,
+        model: session.model,
+        title: session.title,
+        workspace: session.workspace,
+        workspaceName: session.workspaceName,
+        workspaceBranch: session.workspaceBranch,
+      };
+      await this.patch(ROUTES.sessions.append(session.id), {
+        body: {
+          ...(newMessages.length > 0 ? { messages: newMessages } : {}),
+          ...(newTokenUsage.length > 0 ? { tokenUsage: newTokenUsage } : {}),
+          ...metadata,
+        },
+      });
     } else {
       await this.post(ROUTES.sessions.save, { body: session });
     }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -392,6 +392,7 @@ export type PickerHandlerSpies = {
   currentSessions: Session[];
   rowsDirectSets: ChatRow[][];
   assistantTurnTexts: string[];
+  persistCalls: number;
 };
 
 export function createPickerHandlerHarness(overrides?: Partial<CreatePickerHandlersInput>): {
@@ -404,6 +405,7 @@ export function createPickerHandlerHarness(overrides?: Partial<CreatePickerHandl
     currentSessions: [],
     rowsDirectSets: [],
     assistantTurnTexts: [],
+    persistCalls: 0,
   };
   const handlers = createPickerHandlers({
     sessionState: createSessionState(),
@@ -424,7 +426,9 @@ export function createPickerHandlerHarness(overrides?: Partial<CreatePickerHandl
     },
     setShowHelp: () => {},
     setValue: () => {},
-    persist: async () => {},
+    persist: async () => {
+      spies.persistCalls++;
+    },
     toRows: () => [],
     nowIso: () => "2026-02-20T00:00:00.000Z",
     activateSkill: async () => true,
@@ -442,6 +446,7 @@ export type CommandContextSpies = {
   openedModel: boolean;
   currentSessionIds: string[];
   tokenUsageSets: SessionTokenUsageEntry[][];
+  persistCalls: number;
 };
 
 export function createLifecycleDeps(overrides?: Partial<LifecycleDeps>): LifecycleDeps {
@@ -543,6 +548,7 @@ export function createCommandContext(
     openedModel: false,
     currentSessionIds: [],
     tokenUsageSets: [],
+    persistCalls: 0,
   };
   const ctx: CommandContext = {
     text,
@@ -562,7 +568,9 @@ export function createCommandContext(
     },
     setShowHelp: () => {},
     setValue: () => {},
-    persist: async () => {},
+    persist: async () => {
+      spies.persistCalls++;
+    },
     exit: () => {},
     openSkillsPanel: async () => {},
     openResumePanel: () => {},


### PR DESCRIPTION
## Motivation

Session sync sends the entire session (all messages + token usage) on every persist call. For long sessions this is wasteful and will eventually hit Vercel's body size limit. Additionally, changing the model or resuming a session causes persist to save stale data because the closure captures the original session reference.

## Summary

- fix stale session reference: add `onSessionChange` callback so persist always saves the current session object
- persist session after model change via picker and `/model` command
- switch from full-session POST to incremental PATCH append after the first save
- track sync cursors (message count, token usage count) per session in the cloud client
- gzip request bodies above 1 KB threshold for all cloud API calls
- set sync cursors on session load so resumed sessions also use incremental append