### PR TITLE
docs: fix docs review drift

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,7 @@ Developer documentation for Acolyte, a terminal-first AI coding agent. Reliable 
 - [Architecture](./architecture.md) — headless daemon with typed RPC connecting CLI, editors, and custom clients
 - [Workspace](./workspace.md) — workspace root resolution, sandboxing, and profile behavior
 - [Lifecycle](./lifecycle.md) — how each task flows through resolve, prepare, generate, and finalize
-- [Errors](./errors.md) — error contracts, runtime classes, and recovery boundaries
+- [Errors](./errors.md) — error contracts and runtime classes
 
 ## Runtime
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,8 +6,8 @@ The CLI is the primary interface for working with Acolyte.
 
 - `acolyte`: start interactive chat
 - `acolyte init [provider]`: initialize provider API key
-- `acolyte login`: authenticate with the cloud
-- `acolyte logout`: remove cloud credentials
+- `acolyte login`: authenticate with the cloud (feature-flagged: `features.cloudSync`)
+- `acolyte logout`: remove cloud credentials (feature-flagged: `features.cloudSync`)
 - `acolyte resume [id]`: continue a previous session
 - `acolyte run "<prompt>"`: one-shot execution
 - `acolyte run --file <path> "<prompt>"`: one-shot with file context

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -18,7 +18,9 @@ The CLI is the primary interface for working with Acolyte.
 - `acolyte config list|set|unset`: manage configuration
 - `acolyte skill <name> [prompt]`: run a prompt with an active skill
 - `acolyte logs`: view server logs
+- `acolyte tool <tool-id> [args...]`: run a tool directly
 - `acolyte trace list|task <id>`: inspect server lifecycle traces
+- `acolyte update`: update to latest version
 
 Run `acolyte <command> help` for detailed usage.
 

--- a/docs/cloud.md
+++ b/docs/cloud.md
@@ -27,20 +27,7 @@ Credentials are stored in the config directory as `credentials` (mode 0600). See
 
 ## Authentication
 
-EdDSA JWT tokens (Ed25519) with scope claims:
-
-- `sub` — user ID
-- `tid` — team ID (optional, for team-scoped access)
-- `oid` — org ID (optional, for org-scoped access)
-- `scope` — active scope (`user`, `team`, or `org`)
-
-All data is isolated by `owner_id` derived from the active scope:
-
-| Scope | Owner ID source |
-|-------|----------------|
-| `user` (default) | `sub` |
-| `team` | `tid` |
-| `org` | `oid` |
+EdDSA JWT tokens (Ed25519) with a `sub` claim identifying the user. All data is isolated by `owner_id` derived from the token subject.
 
 ## API
 
@@ -63,9 +50,9 @@ The cloud API is versioned at `/api/v1/`. All endpoints require `Authorization: 
 | | GET | `/api/v1/sessions/active` | Get active session |
 | | PUT | `/api/v1/sessions/active` | Set active session |
 
-## Multi-tenant isolation
+## Data isolation
 
-Every table is keyed by `(owner_id, id)`. The auth middleware derives `owner_id` from JWT scope claims before any query runs. There is no cross-tenant data access path.
+Every table is keyed by `(owner_id, id)`. The auth middleware derives `owner_id` from the JWT subject before any query runs. There is no cross-user data access path.
 
 ## Self-hosting
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,7 +56,7 @@ acolyte config set --project model openai-compatible/<model>
 ## Localization
 
 - `locale`: active UI language (defaults to `en`).
-- Locale catalogs are loaded from `src/i18n/locales/*.json` at startup, with `en` fallback.
+- English messages are defined in `src/i18n/en.ts`. Additional locales are loaded from `src/i18n/locales/*.json` at startup.
 
 ## Logging
 
@@ -119,6 +119,8 @@ acolyte config set features.syncAgents true
 | `vercelBaseUrl` | Vercel AI Gateway base URL |
 | `logFormat` | log output format (`logfmt` or `json`) |
 | `embeddingModel` | embedding model for semantic recall |
+| `distillModel` | model used for memory distillation |
+| `replyTimeoutMs` | max reply wait time in ms (min 1000, default 180000) |
 | `features.syncAgents` | opt-in: sync `AGENTS.md` to project memory and omit it from prompt |
 | `features.undoCheckpoints` | opt-in: capture write-tool undo checkpoints |
 | `features.parallelWorkspaces` | opt-in: enable `/workspaces` chat commands |

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -4,7 +4,7 @@ Error handling in Acolyte is split by boundary, not bundled into one module.
 
 ## Contract model
 
-Error codes and kinds are generic contracts shared across tools, lifecycle, and transport-facing parsing. Tools include recovery guidance directly in error messages. The model reads the error and decides what to do.
+Error codes and kinds are generic contracts shared across tools, lifecycle, and transport-facing parsing. The model reads error messages and decides what to do.
 
 ## Runtime model
 
@@ -12,7 +12,7 @@ Runtime code throws coded errors, not untyped string failures, when the failure 
 
 ## Lifecycle boundary
 
-Lifecycle consumes tool errors generically through error categories. Step budget exhaustion uses `E_BUDGET_EXHAUSTED` code. The model sees all tool errors and makes recovery decisions.
+Lifecycle consumes tool errors generically through error categories. Step budget exhaustion uses `E_BUDGET_EXHAUSTED` code.
 
 ## Design rule
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -4,54 +4,55 @@ Shipped, user-visible capabilities.
 
 ## CLI
 
-- interactive chat and one-shot run/skill commands
+- interactive chat and one-shot `run`/`skill` commands
 - persistent daemon with automatic startup and lifecycle management
-- session resume and history
+- session resume by ID prefix with history
 - model picker that queries provider APIs for available models
 - fuzzy search and autocomplete for file paths, sessions, commands, and skills
-- file and directory attachments via @path
+- file and directory attachments via `@path`
 - slash commands and skill invocation
 - engineering skills for structured workflows (plan, build, review, ship)
 - configurable locale
 - multi-line input
 - custom terminal renderer with React reconciler and structured output
 - auto-update on startup with progress UI
-- update flags to force or skip auto-update (--update, --no-update)
+- update flags to force or skip auto-update (`--update`, `--no-update`)
 - XDG Base Directory support on Linux
 - one-line install script
 
 ## Agent execution
 
-- single-pass lifecycle with resolve/prepare/generate/finalize phases
-- explicit completion signals (done, no-op, blocked)
+- single-pass lifecycle with `resolve`/`prepare`/`generate`/`finalize` phases
+- explicit completion signals (`done`, `no_op`, `blocked`)
 - pre/post-tool-call effect pipeline (auto-install deps, format, lint)
-- workspace profile detection with auto-detected install, lint, format, and test commands
-- configurable model reasoning level (low, medium, high) with provider-specific mapping
-- multi-provider support (OpenAI, Anthropic, Google, Vercel)
-- provider rate limit awareness with sliding window pacing and exponential backoff
-- proactive token budgeting with system prompt reservation and priority-based allocation
-- step budget enforcement for cost protection
-- two-tier result cache for read-only and search tools with cross-task persistence
-- streaming progress output with real-time token usage
-- inline task checklist for multi-step tasks
+- Workspace profile detection with auto-detected install, lint, format, and test commands
+- Configurable model reasoning level (low, medium, high) with provider-specific mapping
+- Multi-provider support (OpenAI, Anthropic, Google, Vercel)
+- Provider rate limit awareness with sliding window pacing and exponential backoff
+- Proactive token budgeting with system prompt reservation and priority-based allocation
+- Step budget enforcement for cost protection
+- Two-tier result cache for read-only and search tools with cross-task persistence
+- Streaming progress output with real-time token usage
+- Inline task checklist for multi-step tasks
 
 ## Tools
 
 - find/search/read files with gitignore awareness
 - edit/create/delete files
 - AST-based structural code editing with workspace-wide scope
-- git status/diff/log/show/add/commit
-- shell and test execution
-- web search/fetch
+- Git status/diff/log/show/add/commit
+- Shell and test execution
+- Web search/fetch
 
 ## Memory
 
-- on-demand memory toolkit (search, add, remove)
+- on-demand memory toolkit (`memory-search`, `memory-add`, `memory-remove`)
 - three-scope persistent memory (session, project, user)
-- automatic observation via distiller with @observe directives
-- semantic recall with embeddings and cosine similarity ranking
-- hybrid retrieval scoring (cosine similarity + TF-IDF token overlap)
-- topic tags on observations for filtered recall
+- memory recalled on-demand via tools (not injected into the system prompt)
+- automatic observation via distiller with `@observe` directives
+- Semantic recall with embeddings and cosine similarity ranking
+- Hybrid retrieval scoring (cosine similarity + TF-IDF token overlap)
+- Topic tags on observations for filtered recall
 
 ## Safety and control
 
@@ -68,23 +69,9 @@ Shipped, user-visible capabilities.
 
 ## Feature-flagged
 
-These capabilities are implemented but gated behind feature flags.
+Implemented but gated behind feature flags. See [Configuration](configuration.md) for setup.
 
-### AGENTS.md sync (`syncAgents`)
-
-- sync AGENTS.md into project memory for on-demand recall
-
-### Undo checkpoints (`undoCheckpoints`)
-
-- session-level undo via write-tool checkpoints
-
-### Parallel workspaces (`parallelWorkspaces`)
-
-- git worktree management and workspace-scoped sessions
-
-### Cloud sync (`cloudSync`)
-
-- portable memory and sessions across machines
-- login/logout commands with browser-based OAuth
-- EdDSA JWT auth with user/team/org scope isolation
-- self-hostable via Vercel Edge + Neon Postgres
+- `syncAgents` — sync `AGENTS.md` into project memory for on-demand recall
+- `undoCheckpoints` — session-level undo via write-tool checkpoints
+- `parallelWorkspaces` — manage git worktrees and workspace-scoped sessions via `/workspaces`
+- `cloudSync` — portable memory and sessions across machines via `acolyte login` and `acolyte logout`

--- a/docs/features.md
+++ b/docs/features.md
@@ -40,9 +40,9 @@ Shipped, user-visible capabilities.
 - find/search/read files with gitignore awareness
 - edit/create/delete files
 - AST-based structural code editing with workspace-wide scope
-- Git status/diff/log/show/add/commit
-- Shell and test execution
-- Web search/fetch
+- git status/diff/log/show/add/commit
+- shell and test execution
+- web search/fetch
 
 ## Memory
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -31,7 +31,7 @@ Naming conventions and core terms used across Acolyte code and docs.
 | Effect | Lifecycle-owned side-effect applied per-tool-result via callback (format, lint) |
 | Embedding | Provider-generated vector representation of a memory record used for semantic recall |
 | Entry | Runtime or pipeline item used during processing and not necessarily persisted |
-| Host | Runtime environment around the model that provides tools, lifecycle structure, memory, and recovery |
+| Host | Runtime environment around the model that provides tools, lifecycle structure, and memory |
 | Hybrid Recall | Relevance-ranked memory selection using a weighted blend of cosine similarity and TF-IDF token overlap |
 | Lifecycle Policy | Centralized limits and defaults for lifecycle behavior |
 | Lifecycle Signal | Model-to-host control signal emitted at generation completion (`done`, `no_op`, `blocked`) |
@@ -60,7 +60,6 @@ Naming conventions and core terms used across Acolyte code and docs.
 | TF-IDF | Term Frequency–Inverse Document Frequency; weights token matches by rarity across the memory corpus so uncommon terms score higher |
 | Token Overlap | Keyword matching component of hybrid recall that catches exact term matches embeddings miss |
 | Tool Cache | Two-tier cache for read-only and search tool results across a task and session |
-| Tool Recovery | Structured recovery payload attached to a tool failure when the tool knows the corrective action |
 | Toolkit | Group of domain tools exposed through adapters and composition |
 | Workspace Command | Typed shell command descriptor used for lint, format, and test commands |
 | Workspace Profile | Cached per-workspace detection result containing ecosystem, package manager, and commands |

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -27,8 +27,8 @@ Keep user-facing copy translatable while keeping protocol and tool contracts lan
 ## Current behavior
 
 - Locale is configurable via config (`locale` key, for example `acolyte config set locale en`).
-- Locale files are discovered automatically from `src/i18n/locales/*.json`.
-- Adding a new locale requires only adding one JSON file named `<locale>.json` with a complete catalog.
+- English messages are defined in `src/i18n/en.ts`. Additional locales are discovered from `src/i18n/locales/*.json`.
+- Adding a new locale requires adding one JSON file named `<locale>.json` with a complete catalog matching the English key set.
 - Locale tags use BCP-47 style with `-` separators (for example `en`, `en-GB`, `fi-FI`).
 
 ## Key naming

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -22,15 +22,16 @@ Events are append-only and ordered per request.
 - `tool-output`: incremental tool output for the call id
 - `tool-result`: tool completion (success/error, structured error detail)
 - `text-delta`: assistant text stream chunks
+- `usage`: token usage for the current generation step
+- `checklist`: inline task checklist with group ID, title, and items
 - `error`: terminal stream error
-- `done`: terminal success with final reply
 
 ## Invariants
 
-- Every request has exactly one terminal event: `done` or `error`.
+- Every request completes with either a `chat.done` or `chat.error` RPC message.
 - `tool-output`/`tool-result` reference a prior `tool-call` id.
 - Unknown event fields are ignored by clients (forward compatibility).
-- Error detail payloads are structured and stable for recovery decisions.
+- Error detail payloads are structured and stable.
 
 ## Versioning
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -43,6 +43,7 @@ Components register handlers through `useInput`. Only handlers with `isActive: t
 - `/clear`: clear transcript
 - `/resume`: resume a previous session
 - `/sessions`: show sessions
+- `/workspaces`: manage parallel workspaces (feature-flagged)
 - `/model [id]`: change model
 - `/status`: show server status
 - `/usage`: show token usage


### PR DESCRIPTION
## Motivation

Reduce docs drift from recent code review changes and keep user-facing docs aligned with the current CLI and feature surface.

## Summary

- align `docs/features.md` with shipped one-line feature bullets
- document `acolyte login` and `acolyte logout` as feature-flagged commands
- refresh multiple docs pages to match current behavior
