### PR TITLE
fix(tui): harden chat renderer

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -21,6 +21,7 @@ Naming conventions and core terms used across Acolyte code and docs.
 | Term | Definition |
 |---|---|
 | Base Agent Input | Immutable prompt input created during `prepare` and used for the generation pass |
+| Chat Promotion | State transition that moves completed chat rows from the active (re-rendered) region to static (write-once scrollback) |
 | ChatRow | One display block in the chat transcript; may render as many visual lines (e.g. a usage summary or status panel) |
 | Cloud Sync | Feature that syncs memory and sessions to a hosted cloud API for portable agent identity across machines |
 | CloudClient | HTTP client that implements `MemoryStore` and `SessionStore` against the cloud API |
@@ -31,6 +32,7 @@ Naming conventions and core terms used across Acolyte code and docs.
 | Effect | Lifecycle-owned side-effect applied per-tool-result via callback (format, lint) |
 | Embedding | Provider-generated vector representation of a memory record used for semantic recall |
 | Entry | Runtime or pipeline item used during processing and not necessarily persisted |
+| Frozen Overflow | TUI renderer optimization where active content lines that exceed the viewport are written once to scrollback and excluded from subsequent re-renders |
 | Host | Runtime environment around the model that provides tools, lifecycle structure, and memory |
 | Hybrid Recall | Relevance-ranked memory selection using a weighted blend of cosine similarity and TF-IDF token overlap |
 | Lifecycle Policy | Centralized limits and defaults for lifecycle behavior |

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -28,12 +28,14 @@ React tree → reconciler → TUI DOM → serialize → terminal output
 - **reconciler:** React's `react-reconciler` drives updates against a TUI DOM tree
 - **TUI DOM:** lightweight node tree (`tui-root`, `tui-box`, `tui-text`, `tui-static`, `tui-virtual`, text nodes)
 - **serialize:** walks the DOM, resolves flex layout, applies ANSI styles, produces a string. `serializeSplit` separates static (scrollback) from active (re-rendered) regions
-- **render loop:** on each React commit: serialize, diff against last output, erase and rewrite the active region. Static items flush once to scrollback. When the active region overflows the viewport, top lines are flushed to scrollback and only the bottom portion is re-rendered
-- **resize:** terminal dimensions are read from `stdout.columns`/`stdout.rows` on each commit — no SIGWINCH handler needed
+- **render loop:** on each React commit: serialize, diff against last output, erase and rewrite the active region. Static items flush once to scrollback. When the active region overflows the viewport, top lines are frozen to scrollback and only the bottom portion is re-rendered (see [Frozen Overflow](glossary.md)). Erase and repaint are atomic within a single DEC 2026 synchronized output block to prevent flicker
+- **resize:** a debounced resize listener resets frozen overflow state and triggers a re-render with updated dimensions
+- **focus repair:** on terminal focus-in (tab switch), frozen overflow state is invalidated and the active region is repainted via the normal commit path
+- **DEC 2026:** synchronized output (BSU/ESU) wraps all terminal writes to prevent partial-frame rendering. Skipped in tmux where DEC 2026 is not supported
 
 ## Input handling
 
-Centralized in `input.ts`. Raw stdin bytes are parsed into `KeyEvent` objects with named flags (`return`, `tab`, `ctrl`, `meta`, `escape`, arrows, etc.). Prefers the [Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) for unambiguous modifier reporting, with fallback to legacy escape sequences for terminals that don't support it. The dispatcher fans out to all registered handlers via `InputContext`.
+Centralized in `input.ts`. Raw stdin bytes are parsed into `KeyEvent` objects with named flags (`return`, `tab`, `ctrl`, `meta`, `escape`, arrows, etc.). Supports the [Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) for unambiguous modifier reporting, enabled only on terminals with full support (kitty, WezTerm, ghostty, iTerm). The dispatcher fans out to all registered handlers via `InputContext`.
 
 Components register handlers through `useInput`. Only handlers with `isActive: true` receive events.
 

--- a/src/chat-content.test.ts
+++ b/src/chat-content.test.ts
@@ -17,6 +17,13 @@ describe("chat-content helpers", () => {
     expect(sanitizeAssistantContent(raw)).toBe("");
   });
 
+  test("sanitizeAssistantContent strips @signal lines", () => {
+    expect(sanitizeAssistantContent("Done.\n\n@signal done")).toBe("Done.");
+    expect(sanitizeAssistantContent("Nothing to do.\n@signal no_op")).toBe("Nothing to do.");
+    expect(sanitizeAssistantContent("Cannot proceed.\n\n@signal blocked")).toBe("Cannot proceed.");
+    expect(sanitizeAssistantContent("@signal done")).toBe("");
+  });
+
   test("wrapText wraps long lines at word boundaries", () => {
     const text = "one two three four five six seven eight nine ten";
     const wrapped = wrapText(text, 30);

--- a/src/chat-content.ts
+++ b/src/chat-content.ts
@@ -1,7 +1,10 @@
 export { type MarkupToken, tokenize } from "./chat-tokenizer";
 
+import { stripSignalLine } from "./lifecycle-signal";
+
 export function sanitizeAssistantContent(content: string): string {
-  const cleaned = content
+  const stripped = stripSignalLine(content);
+  const cleaned = stripped
     .split("\n")
     .map((line) => line.replace(/^\s+(\d+\.\s)/, "$1"))
     .filter((line) => !/^\s*(Tools used:|Evidence:)/.test(line))

--- a/src/chat-contract.ts
+++ b/src/chat-contract.ts
@@ -7,7 +7,7 @@ import { toolOutputPartSchema } from "./tool-output-content";
 
 export const roleSchema = z.enum(["system", "user", "assistant"]);
 export type Role = z.infer<typeof roleSchema>;
-export const messageKindSchema = z.enum(["text", "tool_payload"]);
+export const messageKindSchema = z.enum(["text", "tool_payload", "status"]);
 export type MessageKind = z.infer<typeof messageKindSchema>;
 export const messageIdSchema = domainIdSchema("msg");
 export type MessageId = z.infer<typeof messageIdSchema>;

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -154,6 +154,13 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
       streamState.finalize();
 
       input.currentSession.messages.push(assistantMessage);
+      for (const row of turn.rows) {
+        if (row.kind === "status" && typeof row.content === "string") {
+          const msg = input.createMessage("system", row.content);
+          msg.kind = "status";
+          input.currentSession.messages.push(msg);
+        }
+      }
       input.currentSession.updatedAt = input.nowIso();
       // Clear the pending indicator in the same synchronous block as
       // adding the worked/status rows so React batches them into one

--- a/src/chat-session.ts
+++ b/src/chat-session.ts
@@ -1,6 +1,7 @@
 import type { ChatMessage, ChatRow } from "./chat-contract";
 import { nowIso } from "./datetime";
 import { remapDomainId } from "./id-contract";
+import { palette } from "./palette";
 import { createId } from "./short-id";
 
 export function createMessage(role: ChatMessage["role"], content: string): ChatMessage {
@@ -21,6 +22,13 @@ export function toRows(messages: ChatMessage[]): ChatRow[] {
         id: remapDomainId(message.id, "row"),
         kind: message.role,
         content: message.content,
+      });
+    } else if (message.kind === "status") {
+      rows.push({
+        id: remapDomainId(message.id, "row"),
+        kind: "status",
+        content: message.content,
+        style: { marker: palette.success, dim: true },
       });
     }
   }

--- a/src/lifecycle-signal.ts
+++ b/src/lifecycle-signal.ts
@@ -3,7 +3,10 @@ import type { LifecycleSignal } from "./lifecycle-contract";
 const SIGNAL_RE = /(?:^|\n)@signal\s+(done|no_op|blocked)\s*(?:\n|$)/;
 const SIGNAL_PREFIXES = ["@signal done", "@signal no_op", "@signal blocked"] as const;
 
-// Strip the @signal line and everything after it; return only the text before it.
+export function stripSignalLine(text: string): string {
+  return extractLifecycleSignal(text).text;
+}
+
 export function extractLifecycleSignal(text: string): { signal?: LifecycleSignal; text: string } {
   const match = text.match(SIGNAL_RE);
   if (!match) return { text };

--- a/src/tui/render.test.tsx
+++ b/src/tui/render.test.tsx
@@ -440,4 +440,26 @@ describe("render", () => {
     const resizeTestWrites = frameWrites.filter((w) => w.includes("resize test"));
     expect(resizeTestWrites.length).toBeGreaterThanOrEqual(2);
   });
+
+  test("syncWrite skips BSU/ESU when TMUX is set", async () => {
+    const savedTmux = process.env.TMUX;
+    process.env.TMUX = "/tmp/tmux-1000/default,12345,0";
+    try {
+      const writes = await withMockedStdout(async () => {
+        const { render } = await import("./render");
+        const app = render(h("tui-text", null, "tmux test"));
+        await new Promise((r) => setTimeout(r, 100));
+        app.unmount();
+      });
+      const renderWrites = writes.filter((w) => w.includes("tmux test"));
+      expect(renderWrites.length).toBeGreaterThan(0);
+      for (const w of renderWrites) {
+        expect(w.includes(ansi.syncStart)).toBe(false);
+        expect(w.includes(ansi.syncEnd)).toBe(false);
+      }
+    } finally {
+      if (savedTmux === undefined) delete process.env.TMUX;
+      else process.env.TMUX = savedTmux;
+    }
+  });
 });

--- a/src/tui/render.test.tsx
+++ b/src/tui/render.test.tsx
@@ -379,4 +379,43 @@ describe("render", () => {
     const headerCount = allOutput.split("HEADER").length - 1;
     expect(headerCount).toBe(1);
   });
+
+  test("frozen-content reset and repaint happen in a single syncWrite", async () => {
+    const writes = await withMockedStdout(
+      async () => {
+        const { render } = await import("./render");
+
+        function App(): React.JSX.Element {
+          const [lines, setLines] = useState(["A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8"]);
+
+          useEffect(() => {
+            const t1 = setTimeout(() => setLines(["B1", "B2", "B3", "B4"]), 20);
+            const t2 = setTimeout(() => app.unmount(), 60);
+            return () => {
+              clearTimeout(t1);
+              clearTimeout(t2);
+            };
+          }, []);
+
+          return (
+            <tui-box flexDirection="column">
+              {lines.map((line) => (
+                <tui-text key={line}>{line}</tui-text>
+              ))}
+            </tui-box>
+          );
+        }
+
+        const app = render(<App />);
+        await app.waitUntilExit();
+      },
+      { columns: 20, rows: 6 },
+    );
+
+    const redrawWrite = writes.find((w) => w.includes("B1")) ?? "";
+    expect(redrawWrite).toContain("B1");
+    // Erase must be in the SAME write as B1 — atomic within one BSU/ESU block.
+    const hasErase = redrawWrite.includes(ansi.eraseDown) || redrawWrite.includes(`${ansi.cursorUp(1)}`);
+    expect(hasErase).toBe(true);
+  });
 });

--- a/src/tui/render.test.tsx
+++ b/src/tui/render.test.tsx
@@ -118,6 +118,32 @@ function replayVisibleScreen(writes: string[], rows: number, columns: number): s
   return screen.map((line) => line.join("").trimEnd());
 }
 
+function extractFrameWrites(writes: string[]): string[] {
+  const cleanupStart = writes.findIndex((write) => write.includes(ansi.cursorShow));
+  return cleanupStart >= 0 ? writes.slice(0, cleanupStart) : writes;
+}
+
+function OverflowShrinkApp(props: { onUnmount: () => void }): React.JSX.Element {
+  const [lines, setLines] = useState(["A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8"]);
+
+  useEffect(() => {
+    const t1 = setTimeout(() => setLines(["B1", "B2", "B3", "B4"]), 20);
+    const t2 = setTimeout(() => props.onUnmount(), 60);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+  }, [props.onUnmount]);
+
+  return (
+    <tui-box flexDirection="column">
+      {lines.map((line) => (
+        <tui-text key={line}>{line}</tui-text>
+      ))}
+    </tui-box>
+  );
+}
+
 describe("render", () => {
   test("commitRender wraps output in sync markers", async () => {
     const writes = await withMockedStdout(async () => {
@@ -152,41 +178,13 @@ describe("render", () => {
     const writes = await withMockedStdout(
       async () => {
         const { render } = await import("./render");
-
-        function App(): React.JSX.Element {
-          const [lines, setLines] = useState(["A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8"]);
-
-          useEffect(() => {
-            const updateTimer = setTimeout(() => {
-              setLines(["B1", "B2", "B3", "B4"]);
-            }, 20);
-            const unmountTimer = setTimeout(() => {
-              app.unmount();
-            }, 60);
-            return () => {
-              clearTimeout(updateTimer);
-              clearTimeout(unmountTimer);
-            };
-          }, []);
-
-          return (
-            <tui-box flexDirection="column">
-              {lines.map((line) => (
-                <tui-text key={line}>{line}</tui-text>
-              ))}
-            </tui-box>
-          );
-        }
-
-        const app = render(<App />);
+        const app = render(<OverflowShrinkApp onUnmount={() => app.unmount()} />);
         await app.waitUntilExit();
       },
       { columns: 20, rows: 6 },
     );
 
-    const cleanupStart = writes.findIndex((write) => write.includes(ansi.cursorShow));
-    const frameWrites = cleanupStart >= 0 ? writes.slice(0, cleanupStart) : writes;
-    const visible = replayVisibleScreen(frameWrites, 6, 20);
+    const visible = replayVisibleScreen(extractFrameWrites(writes), 6, 20);
     const joined = visible.join("\n");
 
     expect(joined).toContain("B1");
@@ -201,33 +199,7 @@ describe("render", () => {
     const writes = await withMockedStdout(
       async () => {
         const { render } = await import("./render");
-
-        function App(): React.JSX.Element {
-          const [lines, setLines] = useState(["A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8"]);
-
-          useEffect(() => {
-            const updateTimer = setTimeout(() => {
-              setLines(["B1", "B2", "B3", "B4"]);
-            }, 20);
-            const unmountTimer = setTimeout(() => {
-              app.unmount();
-            }, 60);
-            return () => {
-              clearTimeout(updateTimer);
-              clearTimeout(unmountTimer);
-            };
-          }, []);
-
-          return (
-            <tui-box flexDirection="column">
-              {lines.map((line) => (
-                <tui-text key={line}>{line}</tui-text>
-              ))}
-            </tui-box>
-          );
-        }
-
-        const app = render(<App />);
+        const app = render(<OverflowShrinkApp onUnmount={() => app.unmount()} />);
         await app.waitUntilExit();
       },
       { columns: 20, rows: 6 },
@@ -307,8 +279,7 @@ describe("render", () => {
       { columns: 80, rows: 24 },
     );
 
-    const cleanupStart = writes.findIndex((write) => write.includes(ansi.cursorShow));
-    const frameWrites = cleanupStart >= 0 ? writes.slice(0, cleanupStart) : writes;
+    const frameWrites = extractFrameWrites(writes);
     const visible = replayVisibleScreen(frameWrites, 24, 80);
     const joined = visible.join("\n");
 
@@ -371,8 +342,7 @@ describe("render", () => {
       { columns: 40, rows: 12 },
     );
 
-    const cleanupStart = writes.findIndex((write) => write.includes(ansi.cursorShow));
-    const frameWrites = cleanupStart >= 0 ? writes.slice(0, cleanupStart) : writes;
+    const frameWrites = extractFrameWrites(writes);
     const allOutput = frameWrites.join("");
 
     // HEADER must appear exactly once — never duplicated by forceRedraw.
@@ -435,8 +405,7 @@ describe("render", () => {
       { columns: 80, rows: 24 },
     );
 
-    const cleanupStart = writes.findIndex((write) => write.includes(ansi.cursorShow));
-    const frameWrites = cleanupStart >= 0 ? writes.slice(0, cleanupStart) : writes;
+    const frameWrites = extractFrameWrites(writes);
     const resizeTestWrites = frameWrites.filter((w) => w.includes("resize test"));
     expect(resizeTestWrites.length).toBeGreaterThanOrEqual(2);
   });

--- a/src/tui/render.test.tsx
+++ b/src/tui/render.test.tsx
@@ -418,4 +418,26 @@ describe("render", () => {
     const hasErase = redrawWrite.includes(ansi.eraseDown) || redrawWrite.includes(`${ansi.cursorUp(1)}`);
     expect(hasErase).toBe(true);
   });
+
+  test("resize triggers a re-render with updated dimensions", async () => {
+    const writes = await withMockedStdout(
+      async () => {
+        const { render } = await import("./render");
+
+        const app = render(h("tui-text", null, "resize test"));
+        await new Promise((r) => setTimeout(r, 30));
+
+        Object.defineProperty(process.stdout, "columns", { value: 60, configurable: true });
+        process.stdout.emit("resize");
+        await new Promise((r) => setTimeout(r, 50));
+        app.unmount();
+      },
+      { columns: 80, rows: 24 },
+    );
+
+    const cleanupStart = writes.findIndex((write) => write.includes(ansi.cursorShow));
+    const frameWrites = cleanupStart >= 0 ? writes.slice(0, cleanupStart) : writes;
+    const resizeTestWrites = frameWrites.filter((w) => w.includes("resize test"));
+    expect(resizeTestWrites.length).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -135,16 +135,22 @@ export function render(node: ReactNode): RenderInstance {
     return visible === 0 ? 1 : Math.ceil(visible / cols);
   }
 
+  const useSyncOutput = stdout.isTTY && !process.env.TMUX;
+
   function syncWrite(data: string) {
-    if (stdout.isTTY) {
-      const normalized = data.replace(/\r?\n/g, "\r\n");
-      // Trailing \r defuses auto-margin pending-wrap state left when a
-      // line fills exactly `columns` characters.  Without it, the next
-      // cursorUp may overshoot (pending-wrap counts as the next row in
-      // some terminals), causing eraseSequence to eat into static content.
+    if (!stdout.isTTY) {
+      stdout.write(data);
+      return;
+    }
+    const normalized = data.replace(/\r?\n/g, "\r\n");
+    // Trailing \r defuses auto-margin pending-wrap state left when a
+    // line fills exactly `columns` characters.  Without it, the next
+    // cursorUp may overshoot (pending-wrap counts as the next row in
+    // some terminals), causing eraseSequence to eat into static content.
+    if (useSyncOutput) {
       stdout.write(`${ansi.syncStart}${normalized}\r${ansi.syncEnd}`);
     } else {
-      stdout.write(data);
+      stdout.write(`${normalized}\r`);
     }
   }
 

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -201,12 +201,6 @@ export function render(node: ReactNode): RenderInstance {
 
     const allLines = active.split("\n");
 
-    // If content shrank or rewrote the previously frozen prefix, the
-    // append-only overflow assumption no longer holds.  Erase the full
-    // viewport (frozen lines may still be visible at the top) and reset
-    // tracking so the normal render path treats all lines as live.
-    // We intentionally avoid forceRedraw here because it re-emits all
-    // static items, duplicating content already in the scrollback buffer.
     // If the frozen prefix was invalidated (content shrank or changed),
     // defer the viewport erase into the render syncWrite below so
     // erase+paint is atomic within one BSU/ESU block.

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -154,29 +154,23 @@ export function render(node: ReactNode): RenderInstance {
     }
   }
 
-  /** Full-screen erase and re-render.  Called on terminal focus-in to
-   *  repair display corruption caused by xterm resolving auto-margin
-   *  pending-wrap state during tab switches.  Re-flushes static items
-   *  (header, completed messages) because the erase may have cleared
-   *  them from the visible area. */
+  /** Repaint the active region on focus-in.  Static items are already in
+   *  terminal scrollback — re-emitting them would cause the output to
+   *  exceed the viewport and scroll, duplicating content on each tab
+   *  switch.  The trailing \r in syncWrite defuses the auto-margin
+   *  pending-wrap state that would otherwise make relative cursor-up
+   *  unreliable after tab switches. */
   function forceRedraw() {
     if (exited || !stdout.isTTY) return;
     const { staticItems, active } = serializeSplit(root);
     const cols = stdout.columns ?? DEFAULT_COLUMNS;
-    const rows = stdout.rows ?? 24;
-    const maxLiveRows = rows - 1;
+    const maxLiveRows = (stdout.rows ?? 24) - 1;
 
-    // Move to the visible origin and erase everything. Absolute positioning is
-    // more robust than relative cursor-up when prior output left terminals in
-    // ambiguous wrap states.
-    let buf = `${ansi.cursorTo(0, 0)}${ansi.eraseDown}`;
-    for (const item of staticItems) buf += `${item}\n`;
-    buf += active;
-
-    syncWrite(buf);
-    flushedStaticCount = staticItems.length;
     frozenLineCount = 0;
     frozenOverflowText = "";
+    flushedStaticCount = staticItems.length;
+
+    syncWrite(eraseSequence() + active);
     lastActive = active;
     lastActiveLineCount = Math.min(physicalRowCount(active, cols), maxLiveRows);
   }

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -13,6 +13,8 @@ import { reconciler } from "./reconciler";
 import { serializeSplit, stripAnsiLength } from "./serialize";
 import { ansi, kitty } from "./styles";
 
+const KITTY_TERMINALS = ["kitty", "WezTerm", "ghostty", "iTerm.app"];
+
 function clientLogPath(): string {
   return join(stateDir(), "client.log");
 }
@@ -50,6 +52,8 @@ export function render(node: ReactNode): RenderInstance {
   const root = createElement("tui-root", {});
   const stdout = process.stdout;
   const stdin = process.stdin;
+  const termProgram = process.env.TERM_PROGRAM ?? "";
+  const useKittyProtocol = stdout.isTTY && KITTY_TERMINALS.includes(termProgram);
   let lastActive = "";
   let lastActiveLineCount = 0;
   let flushedStaticCount = 0;
@@ -113,7 +117,7 @@ export function render(node: ReactNode): RenderInstance {
   };
 
   if (stdout.isTTY) {
-    stdout.write(kitty.enable(1));
+    if (useKittyProtocol) stdout.write(kitty.enable(1));
     stdout.write(ansi.cursorHide);
     stdout.write(ansi.bracketedPasteEnable);
     stdout.write(ansi.focusReportEnable);
@@ -293,7 +297,7 @@ export function render(node: ReactNode): RenderInstance {
       stdout.removeListener("resize", onResize);
       stdout.write(ansi.focusReportDisable);
       stdout.write(ansi.bracketedPasteDisable);
-      stdout.write(kitty.disable);
+      if (useKittyProtocol) stdout.write(kitty.disable);
       stdout.write(ansi.cursorShow);
       stdout.write("\n");
     }
@@ -310,7 +314,7 @@ export function render(node: ReactNode): RenderInstance {
     if (stdout.isTTY) {
       stdout.write(ansi.focusReportDisable);
       stdout.write(ansi.bracketedPasteDisable);
-      stdout.write(kitty.disable);
+      if (useKittyProtocol) stdout.write(kitty.disable);
       stdout.write(ansi.cursorShow);
       stdout.write("\n");
     }

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -154,25 +154,15 @@ export function render(node: ReactNode): RenderInstance {
     }
   }
 
-  /** Repaint the active region on focus-in.  Static items are already in
-   *  terminal scrollback — re-emitting them would cause the output to
-   *  exceed the viewport and scroll, duplicating content on each tab
-   *  switch.  The trailing \r in syncWrite defuses the auto-margin
-   *  pending-wrap state that would otherwise make relative cursor-up
-   *  unreliable after tab switches. */
+  /** Repaint the active region on focus-in.  Invalidates frozen overflow
+   *  state (may be stale after tab switch) and delegates to commitRender
+   *  which handles viewport overflow correctly. */
   function forceRedraw() {
     if (exited || !stdout.isTTY) return;
-    const { staticItems, active } = serializeSplit(root);
-    const cols = stdout.columns ?? DEFAULT_COLUMNS;
-    const maxLiveRows = (stdout.rows ?? 24) - 1;
-
     frozenLineCount = 0;
     frozenOverflowText = "";
-    flushedStaticCount = staticItems.length;
-
-    syncWrite(eraseSequence() + active);
-    lastActive = active;
-    lastActiveLineCount = Math.min(physicalRowCount(active, cols), maxLiveRows);
+    lastActive = "";
+    commitRender();
   }
 
   function commitRender() {

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -99,11 +99,25 @@ export function render(node: ReactNode): RenderInstance {
     stdin.on("data", onStdinData);
   }
 
+  let resizeTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const onResize = () => {
+    if (resizeTimer) clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => {
+      resizeTimer = null;
+      frozenLineCount = 0;
+      frozenOverflowText = "";
+      lastActive = "";
+      commitRender();
+    }, 16);
+  };
+
   if (stdout.isTTY) {
     stdout.write(kitty.enable(1));
     stdout.write(ansi.cursorHide);
     stdout.write(ansi.bracketedPasteEnable);
     stdout.write(ansi.focusReportEnable);
+    stdout.on("resize", onResize);
   }
 
   function countRows(output: string): number {
@@ -276,6 +290,7 @@ export function render(node: ReactNode): RenderInstance {
   function cleanup() {
     setLogSink(null);
     setOnCommit(null);
+    if (resizeTimer) clearTimeout(resizeTimer);
     process.removeListener("SIGINT", onSignal);
     process.removeListener("SIGTERM", onSignal);
     process.removeListener("exit", onExit);
@@ -285,6 +300,7 @@ export function render(node: ReactNode): RenderInstance {
       stdin.pause();
     }
     if (stdout.isTTY) {
+      stdout.removeListener("resize", onResize);
       stdout.write(ansi.focusReportDisable);
       stdout.write(ansi.bracketedPasteDisable);
       stdout.write(kitty.disable);

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -199,20 +199,22 @@ export function render(node: ReactNode): RenderInstance {
     // tracking so the normal render path treats all lines as live.
     // We intentionally avoid forceRedraw here because it re-emits all
     // static items, duplicating content already in the scrollback buffer.
+    // If the frozen prefix was invalidated (content shrank or changed),
+    // defer the viewport erase into the render syncWrite below so
+    // erase+paint is atomic within one BSU/ESU block.
+    let frozenResetErase = "";
     if (
       frozenLineCount > 0 &&
       (allLines.length < frozenLineCount || (frozenOverflowText.length > 0 && !active.startsWith(frozenOverflowText)))
     ) {
-      syncWrite(`${ansi.cursorUp(maxLiveRows)}\r${ansi.eraseDown}`);
+      frozenResetErase = `${ansi.cursorUp(maxLiveRows)}\r${ansi.eraseDown}`;
       lastActiveLineCount = 0;
       frozenLineCount = 0;
       frozenOverflowText = "";
     }
 
-    // Determine the live (on-screen, erasable) portion of the active output.
     const liveLines = allLines.slice(frozenLineCount);
 
-    // Count physical rows from the bottom to find what fits on screen.
     let physRows = 0;
     let splitIdx = 0;
     for (let i = liveLines.length - 1; i >= 0; i--) {
@@ -224,19 +226,18 @@ export function render(node: ReactNode): RenderInstance {
       physRows += rows;
     }
 
+    const erase = frozenResetErase || eraseSequence();
+
     if (splitIdx === 0) {
-      syncWrite(eraseSequence() + liveLines.join("\n"));
+      syncWrite(erase + liveLines.join("\n"));
       lastActiveLineCount = physRows > 0 ? physRows - 1 : 0;
     } else {
-      // Overflow: flush top lines to scrollback (they are stable during
-      // streaming — content is append-only), then re-render only the
-      // bottom portion that fits on screen.
       const overflow = liveLines.slice(0, splitIdx);
       const onScreen = liveLines.slice(splitIdx);
       frozenLineCount += splitIdx;
       const overflowText = overflow.join("\n");
       frozenOverflowText += `${overflowText}\n`;
-      syncWrite(`${eraseSequence()}${overflowText}\n${onScreen.join("\n")}`);
+      syncWrite(`${erase}${overflowText}\n${onScreen.join("\n")}`);
       lastActiveLineCount = physRows > 0 ? physRows - 1 : 0;
     }
 

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -69,5 +69,5 @@ export function printError(content: string): void {
 }
 
 export function clearScreen(): void {
-  write("\x1b[2J\x1b[H");
+  write("\x1b[2J\x1b[3J\x1b[H");
 }


### PR DESCRIPTION
## Motivation

Terminal tab switching, resize, streaming overflow, and resume transitions cause visible flicker, content duplication, and missing UI state in the chat renderer.

## Summary

- make frozen-content reset atomic within a single BSU/ESU block to eliminate blank frame between erase and repaint
- add debounced resize handler that resets frozen state and re-renders with correct dimensions
- skip DEC 2026 synchronized output in tmux where it is silently ignored
- repaint only the active region on focus-in instead of re-emitting all content
- delegate forceRedraw to commitRender so viewport overflow is handled correctly
- strip leaked `@signal` lines from rendered assistant content via shared lifecycle utility
- persist status rows (worked, awaiting-input) so they appear on resume
- skip Kitty keyboard protocol on terminals without full support to restore Cmd+C
- clear scrollback buffer on screen clear to prevent content accumulation across resumes