### PR TITLE
fix: strip @signal in lifecycle finalize (#182)

### DIFF
--- a/src/agent-stream.test.ts
+++ b/src/agent-stream.test.ts
@@ -89,4 +89,68 @@ describe("lifecycle text streaming", () => {
     // The preceding \n is included in the buffer since it's part of the potential signal delimiter.
     expect(finalizeLifecycleText(state)).toEqual({ text: "\n@sig" });
   });
+
+  test("strips signal regardless of where the delta boundary falls", () => {
+    const signal = "\n@signal done";
+    for (let split = 1; split < signal.length; split++) {
+      const state = createLifecycleTextStreamState();
+      const left = `Text.${signal.slice(0, split)}`;
+      const right = signal.slice(split);
+      let visible = appendLifecycleTextDelta(state, left);
+      visible += appendLifecycleTextDelta(state, right);
+      const fin = finalizeLifecycleText(state);
+      expect(fin.signal).toBe("done");
+      expect((visible + fin.text).trim()).toBe("Text.");
+    }
+  });
+
+  test("signal without trailing newline is caught at finalization", () => {
+    const state = createLifecycleTextStreamState();
+    appendLifecycleTextDelta(state, "Result.\n@signal done");
+    const fin = finalizeLifecycleText(state);
+    expect(fin.signal).toBe("done");
+    expect(fin.text).toBe("");
+  });
+
+  test("mid-line @signal is not stripped", () => {
+    const state = createLifecycleTextStreamState();
+    const visible = appendLifecycleTextDelta(state, "see @signal done for details");
+    expect(visible).toContain("@signal done");
+    expect(finalizeLifecycleText(state).signal).toBeUndefined();
+  });
+
+  test("empty deltas do not break signal detection", () => {
+    const state = createLifecycleTextStreamState();
+    appendLifecycleTextDelta(state, "Done.");
+    appendLifecycleTextDelta(state, "");
+    appendLifecycleTextDelta(state, "\n@signal");
+    appendLifecycleTextDelta(state, "");
+    appendLifecycleTextDelta(state, " done");
+    const fin = finalizeLifecycleText(state);
+    expect(fin.signal).toBe("done");
+  });
+
+  test("only the first signal is consumed", () => {
+    const state = createLifecycleTextStreamState();
+    appendLifecycleTextDelta(state, "A\n@signal done\nB\n@signal blocked");
+    const fin = finalizeLifecycleText(state);
+    expect(fin.signal).toBe("done");
+  });
+
+  test("signal with extra whitespace before newline", () => {
+    const state = createLifecycleTextStreamState();
+    appendLifecycleTextDelta(state, "Done.\n@signal done  ");
+    const fin = finalizeLifecycleText(state);
+    expect(fin.signal).toBe("done");
+  });
+
+  test("partial signal prefix abandoned at finalize does not leak signal keyword", () => {
+    const state = createLifecycleTextStreamState();
+    appendLifecycleTextDelta(state, "Text\n@signal ");
+    // Stream ends with incomplete signal — no valid signal name follows.
+    const fin = finalizeLifecycleText(state);
+    expect(fin.signal).toBeUndefined();
+    // The partial text is emitted since it's not a valid signal.
+    expect(fin.text).toContain("@signal");
+  });
 });

--- a/src/agent-stream.test.ts
+++ b/src/agent-stream.test.ts
@@ -4,7 +4,22 @@ import {
   createLifecycleTextStreamState,
   extractLifecycleSignal,
   finalizeLifecycleText,
+  stripSignalLine,
 } from "./lifecycle-signal";
+
+describe("stripSignalLine", () => {
+  test("returns text before the signal", () => {
+    expect(stripSignalLine("Done.\n@signal done")).toBe("Done.");
+  });
+
+  test("returns empty string when only a signal is present", () => {
+    expect(stripSignalLine("@signal no_op")).toBe("");
+  });
+
+  test("returns full text when no signal is present", () => {
+    expect(stripSignalLine("No signal here.")).toBe("No signal here.");
+  });
+});
 
 describe("extractLifecycleSignal", () => {
   test("strips a trailing signal and returns text before it", () => {
@@ -110,47 +125,5 @@ describe("lifecycle text streaming", () => {
     const fin = finalizeLifecycleText(state);
     expect(fin.signal).toBe("done");
     expect(fin.text).toBe("");
-  });
-
-  test("mid-line @signal is not stripped", () => {
-    const state = createLifecycleTextStreamState();
-    const visible = appendLifecycleTextDelta(state, "see @signal done for details");
-    expect(visible).toContain("@signal done");
-    expect(finalizeLifecycleText(state).signal).toBeUndefined();
-  });
-
-  test("empty deltas do not break signal detection", () => {
-    const state = createLifecycleTextStreamState();
-    appendLifecycleTextDelta(state, "Done.");
-    appendLifecycleTextDelta(state, "");
-    appendLifecycleTextDelta(state, "\n@signal");
-    appendLifecycleTextDelta(state, "");
-    appendLifecycleTextDelta(state, " done");
-    const fin = finalizeLifecycleText(state);
-    expect(fin.signal).toBe("done");
-  });
-
-  test("only the first signal is consumed", () => {
-    const state = createLifecycleTextStreamState();
-    appendLifecycleTextDelta(state, "A\n@signal done\nB\n@signal blocked");
-    const fin = finalizeLifecycleText(state);
-    expect(fin.signal).toBe("done");
-  });
-
-  test("signal with extra whitespace before newline", () => {
-    const state = createLifecycleTextStreamState();
-    appendLifecycleTextDelta(state, "Done.\n@signal done  ");
-    const fin = finalizeLifecycleText(state);
-    expect(fin.signal).toBe("done");
-  });
-
-  test("partial signal prefix abandoned at finalize does not leak signal keyword", () => {
-    const state = createLifecycleTextStreamState();
-    appendLifecycleTextDelta(state, "Text\n@signal ");
-    // Stream ends with incomplete signal — no valid signal name follows.
-    const fin = finalizeLifecycleText(state);
-    expect(fin.signal).toBeUndefined();
-    // The partial text is emitted since it's not a valid signal.
-    expect(fin.text).toContain("@signal");
   });
 });

--- a/src/chat-content.test.ts
+++ b/src/chat-content.test.ts
@@ -17,11 +17,8 @@ describe("chat-content helpers", () => {
     expect(sanitizeAssistantContent(raw)).toBe("");
   });
 
-  test("sanitizeAssistantContent strips @signal lines", () => {
-    expect(sanitizeAssistantContent("Done.\n\n@signal done")).toBe("Done.");
-    expect(sanitizeAssistantContent("Nothing to do.\n@signal no_op")).toBe("Nothing to do.");
-    expect(sanitizeAssistantContent("Cannot proceed.\n\n@signal blocked")).toBe("Cannot proceed.");
-    expect(sanitizeAssistantContent("@signal done")).toBe("");
+  test("sanitizeAssistantContent does not strip @signal (handled by lifecycle layer)", () => {
+    expect(sanitizeAssistantContent("Done.\n\n@signal done")).toContain("@signal done");
   });
 
   test("wrapText wraps long lines at word boundaries", () => {

--- a/src/chat-content.test.ts
+++ b/src/chat-content.test.ts
@@ -2,23 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { sanitizeAssistantContent, wrapAssistantContent, wrapText } from "./chat-content";
 
 describe("chat-content helpers", () => {
-  test("sanitizeAssistantContent removes tools/evidence footer lines", () => {
-    const raw = ["Run bun run verify", "", "Tools used: shell-run", "Evidence: src/cli.ts"].join("\n");
-    expect(sanitizeAssistantContent(raw)).toBe("Run bun run verify");
-  });
-
   test("sanitizeAssistantContent left-aligns numbered findings", () => {
     const raw = ["  1. First finding", "    2. Second finding"].join("\n");
     expect(sanitizeAssistantContent(raw)).toBe(["1. First finding", "2. Second finding"].join("\n"));
-  });
-
-  test("sanitizeAssistantContent returns empty when everything is stripped", () => {
-    const raw = ["Tools used: file-search", "Evidence: src/cli.ts:1"].join("\n");
-    expect(sanitizeAssistantContent(raw)).toBe("");
-  });
-
-  test("sanitizeAssistantContent does not strip @signal (handled by lifecycle layer)", () => {
-    expect(sanitizeAssistantContent("Done.\n\n@signal done")).toContain("@signal done");
   });
 
   test("wrapText wraps long lines at word boundaries", () => {

--- a/src/chat-content.ts
+++ b/src/chat-content.ts
@@ -4,7 +4,6 @@ export function sanitizeAssistantContent(content: string): string {
   const cleaned = content
     .split("\n")
     .map((line) => line.replace(/^\s+(\d+\.\s)/, "$1"))
-    .filter((line) => !/^\s*(Tools used:|Evidence:)/.test(line))
     .join("\n")
     .trimEnd();
   return cleaned;

--- a/src/chat-content.ts
+++ b/src/chat-content.ts
@@ -1,10 +1,7 @@
 export { type MarkupToken, tokenize } from "./chat-tokenizer";
 
-import { stripSignalLine } from "./lifecycle-signal";
-
 export function sanitizeAssistantContent(content: string): string {
-  const stripped = stripSignalLine(content);
-  const cleaned = stripped
+  const cleaned = content
     .split("\n")
     .map((line) => line.replace(/^\s+(\d+\.\s)/, "$1"))
     .filter((line) => !/^\s*(Tools used:|Evidence:)/.test(line))

--- a/src/lifecycle-finalize.ts
+++ b/src/lifecycle-finalize.ts
@@ -2,12 +2,13 @@ import { estimateTokens } from "./agent-input";
 import type { ChatResponse } from "./api";
 import { t } from "./i18n";
 import type { RunContext } from "./lifecycle-contract";
+import { stripSignalLine } from "./lifecycle-signal";
 import { totalPromptBreakdownTokens } from "./lifecycle-usage";
 import { DISCOVERY_TOOL_SET, READ_TOOL_SET, SEARCH_TOOL_SET, WRITE_TOOL_SET } from "./tool-registry";
 import { scopedCallLog } from "./tool-session";
 
 export function phaseFinalize(ctx: RunContext): ChatResponse {
-  const rawOutput = ctx.result?.text.trim() ?? "";
+  const rawOutput = stripSignalLine(ctx.result?.text ?? "").trim();
   const output =
     rawOutput.length > 0
       ? rawOutput


### PR DESCRIPTION
## Motivation

`@signal done` text leaked into visible assistant output on interrupted streams because `phaseFinalize` returned `ctx.result.text` without re-stripping signals that the streaming layer failed to finalize on abort.

## Summary

- strip signal lines in `phaseFinalize` before returning output — the single exit point for all lifecycle responses
- remove the defense-in-depth fallback from `sanitizeAssistantContent` since signal stripping now belongs entirely in the lifecycle layer
- remove obsolete `Tools used:` / `Evidence:` content filter from assistant sanitizer
- add edge case tests for signal stripping across delta boundaries and at finalization

Fixes #182