### PR TITLE
refactor(paths): replace homeDir with env injection

### DIFF
--- a/src/cli-login.ts
+++ b/src/cli-login.ts
@@ -9,7 +9,7 @@ type LoginModeDeps = {
   printDim: (message: string) => void;
   printError: (message: string) => void;
   promptHidden: (question: string) => Promise<string | undefined>;
-  writeCredential: (key: keyof Credentials, value: string, homeDir?: string) => Promise<void>;
+  writeCredential: (key: keyof Credentials, value: string) => Promise<void>;
   commandError: (name: string, message?: string) => void;
   commandHelp: (name: string) => void;
   createId: () => string;
@@ -75,7 +75,7 @@ export async function loginMode(args: string[], deps: LoginModeDeps): Promise<vo
 type LogoutModeDeps = {
   hasHelpFlag: (args: string[]) => boolean;
   printDim: (message: string) => void;
-  removeCredential: (key: keyof Credentials, homeDir?: string) => Promise<void>;
+  removeCredential: (key: keyof Credentials) => Promise<void>;
   commandError: (name: string, message?: string) => void;
   commandHelp: (name: string) => void;
 };

--- a/src/cli-visual.int.test.ts
+++ b/src/cli-visual.int.test.ts
@@ -203,7 +203,7 @@ describe("cli visual regression", () => {
     await withCliTestEnv(async ({ run, homeDir, dataDir }) => {
       const dbPath = join(dataDir, "memory.db");
       const store = createSqliteMemoryStore(dbPath);
-      const scopeKey = defaultUserResourceId(homeDir);
+      const scopeKey = defaultUserResourceId({ HOME: homeDir });
       await store.write(
         {
           id: "mem_abc123",

--- a/src/config.int.test.ts
+++ b/src/config.int.test.ts
@@ -26,7 +26,7 @@ describe("config store", () => {
       "utf8",
     );
 
-    const loaded = await readConfig({ homeDir: home, cwd: home });
+    const loaded = await readConfig({ env: { HOME: home }, cwd: home });
     expect(loaded).toEqual({
       model: "anthropic/claude-sonnet-4",
       port: 7777,
@@ -43,7 +43,7 @@ describe("config store", () => {
       "utf8",
     );
 
-    const loaded = await readConfig({ homeDir: home, cwd: home });
+    const loaded = await readConfig({ env: { HOME: home }, cwd: home });
     expect(loaded).toEqual({
       model: "openai/gpt-5-mini",
       port: 7777,
@@ -57,7 +57,7 @@ describe("config store", () => {
     writeFileSync(join(dataDir, "config.toml"), 'model = "google/gemini-2.5-pro"', "utf8");
     writeFileSync(join(dataDir, "config.json"), JSON.stringify({ model: "openai/gpt-5-mini" }, null, 2), "utf8");
 
-    const loaded = await readConfig({ homeDir: home, cwd: home });
+    const loaded = await readConfig({ env: { HOME: home }, cwd: home });
     expect(loaded.model).toBe("google/gemini-2.5-pro");
   });
 
@@ -71,7 +71,7 @@ describe("config store", () => {
       "utf8",
     );
 
-    const loaded = await readConfig({ homeDir: home, cwd: home });
+    const loaded = await readConfig({ env: { HOME: home }, cwd: home });
     expect(loaded).toEqual({
       model: "openai/gpt-5-mini",
       port: 7777,
@@ -85,7 +85,7 @@ describe("config store", () => {
     writeFileSync(join(dataDir, "config.toml"), 'model = "google/gemini-2.5-pro"', "utf8");
     writeFileSync(join(dataDir, "config.json"), JSON.stringify({ model: "openai/gpt-5-mini" }, null, 2), "utf8");
 
-    const loaded = readConfigSync({ homeDir: home, cwd: home });
+    const loaded = readConfigSync({ env: { HOME: home }, cwd: home });
     expect(loaded.model).toBe("google/gemini-2.5-pro");
   });
 
@@ -95,7 +95,7 @@ describe("config store", () => {
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), "not valid toml = {", "utf8");
 
-    expect(() => readConfigSync({ homeDir: home, cwd: home })).toThrow(/user config/);
+    expect(() => readConfigSync({ env: { HOME: home }, cwd: home })).toThrow(/user config/);
   });
 
   test("setConfigValue updates TOML when config.toml exists", async () => {
@@ -104,7 +104,7 @@ describe("config store", () => {
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), 'model = "openai/gpt-5-mini"\n', "utf8");
 
-    await setConfigValue("port", "7777", { homeDir: home, cwd: home });
+    await setConfigValue("port", "7777", { env: { HOME: home }, cwd: home });
     const rawToml = readFileSync(join(dataDir, "config.toml"), "utf8");
     expect(rawToml).toContain('model = "openai/gpt-5-mini"');
     expect(rawToml).toContain("port = 7777");
@@ -116,7 +116,7 @@ describe("config store", () => {
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), 'model = "openai/gpt-5-mini"\nport = 7777\n', "utf8");
 
-    await unsetConfigValue("port", { homeDir: home, cwd: home });
+    await unsetConfigValue("port", { env: { HOME: home }, cwd: home });
     const rawToml = readFileSync(join(dataDir, "config.toml"), "utf8");
     expect(rawToml).toContain('model = "openai/gpt-5-mini"');
     expect(rawToml).not.toContain("port =");
@@ -134,7 +134,7 @@ describe("config store", () => {
         port: 7777,
         ...({ apiKey: "secret-should-not-persist" } as unknown as Record<string, string>),
       } as unknown as { model: string; port: number; apiKey: string },
-      { homeDir: home, cwd: home },
+      { env: { HOME: home }, cwd: home },
     );
     const rawToml = readFileSync(join(dataDir, "config.toml"), "utf8");
     expect(rawToml).toContain('model = "openai/gpt-5-mini"');
@@ -153,7 +153,7 @@ describe("config store", () => {
         model: "openai/gpt-5-mini",
         port: 7777,
       },
-      { homeDir: home, cwd: home },
+      { env: { HOME: home }, cwd: home },
     );
 
     expect(existsSync(join(dataDir, "config.toml"))).toBe(true);
@@ -183,7 +183,7 @@ describe("config store", () => {
       "utf8",
     );
 
-    const loaded = readConfigSync({ homeDir: home, cwd: home });
+    const loaded = readConfigSync({ env: { HOME: home }, cwd: home });
     expect(loaded.port).toBe(7777);
     expect(loaded.locale).toBe("en");
     expect(loaded.model).toBe("openai/gpt-5-mini");
@@ -199,10 +199,10 @@ describe("config store", () => {
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), ["[features]", "syncAgents = true"].join("\n"), "utf8");
 
-    const loaded = readConfigSync({ homeDir: home, cwd: home });
+    const loaded = readConfigSync({ env: { HOME: home }, cwd: home });
     expect(loaded.features).toEqual({ syncAgents: true });
 
-    const resolved = readResolvedConfigSync({ homeDir: home, cwd: home });
+    const resolved = readResolvedConfigSync({ env: { HOME: home }, cwd: home });
     expect(resolved.features.syncAgents).toBe(true);
   });
 
@@ -212,7 +212,7 @@ describe("config store", () => {
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), 'model = "anthropic/claude-sonnet-4"\n', "utf8");
 
-    const resolved = readResolvedConfigSync({ homeDir: home, cwd: home });
+    const resolved = readResolvedConfigSync({ env: { HOME: home }, cwd: home });
     expect(resolved.port).toBe(6767);
     expect(resolved.locale).toBe("en");
     expect(resolved.model).toBe("anthropic/claude-sonnet-4");
@@ -230,7 +230,7 @@ describe("config store", () => {
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), 'model = "anthropic/claude-sonnet-4"\n\ntemperature = 0.2\n', "utf8");
 
-    const resolved = readResolvedConfigSync({ homeDir: home, cwd: home });
+    const resolved = readResolvedConfigSync({ env: { HOME: home }, cwd: home });
     expect(resolved.model).toBe("anthropic/claude-sonnet-4");
     expect(resolved.temperature).toBe(0.2);
     expect(resolved.distillModel).toBe("anthropic/claude-sonnet-4");
@@ -242,7 +242,7 @@ describe("config store", () => {
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), 'model = "anthropic/claude-sonnet-4"\n\ntemperature = 0.1\n', "utf8");
 
-    const resolved = readResolvedConfigSync({ homeDir: home, cwd: home });
+    const resolved = readResolvedConfigSync({ env: { HOME: home }, cwd: home });
     expect(resolved.model).toBe("anthropic/claude-sonnet-4");
     expect(resolved.temperature).toBe(0.1);
   });
@@ -253,7 +253,9 @@ describe("config store", () => {
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), "", "utf8");
 
-    await expect(setConfigValue("bogus", "value", { homeDir: home, cwd: home })).rejects.toThrow("Unknown config key");
+    await expect(setConfigValue("bogus", "value", { env: { HOME: home }, cwd: home })).rejects.toThrow(
+      "Unknown config key",
+    );
   });
 
   test("setConfigValue supports locale", async () => {
@@ -262,8 +264,8 @@ describe("config store", () => {
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), "", "utf8");
 
-    await setConfigValue("locale", "en", { homeDir: home, cwd: home });
-    const loaded = readConfigSync({ homeDir: home, cwd: home });
+    await setConfigValue("locale", "en", { env: { HOME: home }, cwd: home });
+    const loaded = readConfigSync({ env: { HOME: home }, cwd: home });
     expect(loaded.locale).toBe("en");
   });
 
@@ -273,12 +275,12 @@ describe("config store", () => {
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), "", "utf8");
 
-    await setConfigValue("features.syncAgents", "true", { homeDir: home, cwd: home });
+    await setConfigValue("features.syncAgents", "true", { env: { HOME: home }, cwd: home });
     const rawToml = readFileSync(join(dataDir, "config.toml"), "utf8");
     expect(rawToml).toContain("[features]");
     expect(rawToml).toContain("syncAgents = true");
 
-    const resolved = readResolvedConfigSync({ homeDir: home, cwd: home });
+    const resolved = readResolvedConfigSync({ env: { HOME: home }, cwd: home });
     expect(resolved.features.syncAgents).toBe(true);
   });
 
@@ -288,11 +290,11 @@ describe("config store", () => {
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), ["[features]", "syncAgents = true"].join("\n"), "utf8");
 
-    await unsetConfigValue("features.syncAgents", { homeDir: home, cwd: home });
+    await unsetConfigValue("features.syncAgents", { env: { HOME: home }, cwd: home });
     const rawToml = readFileSync(join(dataDir, "config.toml"), "utf8");
     expect(rawToml).not.toContain("[features]");
 
-    const resolved = readResolvedConfigSync({ homeDir: home, cwd: home });
+    const resolved = readResolvedConfigSync({ env: { HOME: home }, cwd: home });
     expect(resolved.features.syncAgents).toBe(false);
   });
 
@@ -307,7 +309,7 @@ describe("config store", () => {
     writeFileSync(join(userDataDir, "config.toml"), ["[features]", "syncAgents = true"].join("\n"), "utf8");
     writeFileSync(join(projectDataDir, "config.toml"), ["[features]", "cloudSync = true"].join("\n"), "utf8");
 
-    const loaded = await readConfig({ homeDir: home, cwd: project });
+    const loaded = await readConfig({ env: { HOME: home }, cwd: project });
     expect(loaded.features?.syncAgents).toBe(true);
     expect(loaded.features?.cloudSync).toBe(true);
   });
@@ -331,7 +333,7 @@ describe("config store", () => {
       "utf8",
     );
 
-    const loaded = await readConfig({ homeDir: home, cwd: project });
+    const loaded = await readConfig({ env: { HOME: home }, cwd: project });
     expect(loaded.model).toBe("anthropic/claude-sonnet-4");
     expect(loaded.replyTimeoutMs).toBe(200000);
   });
@@ -347,7 +349,7 @@ describe("config store", () => {
     writeFileSync(join(userDataDir, "config.toml"), ["port = 7777", 'model = "openai/gpt-5-mini"'].join("\n"), "utf8");
     writeFileSync(join(projectDataDir, "config.toml"), 'model = "anthropic/claude-sonnet-4"\n', "utf8");
 
-    const loaded = await readConfig({ homeDir: home, cwd: project });
+    const loaded = await readConfig({ env: { HOME: home }, cwd: project });
     expect(loaded.model).toBe("anthropic/claude-sonnet-4");
     expect(loaded.port).toBe(7777);
   });
@@ -361,7 +363,7 @@ describe("config store", () => {
     mkdirSync(projectDataDir, { recursive: true });
 
     writeFileSync(join(userDataDir, "config.toml"), 'model = "openai/gpt-5-mini"\n', "utf8");
-    await setConfigValue("model", "anthropic/claude-sonnet-4", { homeDir: home, cwd: project, scope: "project" });
+    await setConfigValue("model", "anthropic/claude-sonnet-4", { env: { HOME: home }, cwd: project, scope: "project" });
 
     const userToml = readFileSync(join(userDataDir, "config.toml"), "utf8");
     const projectToml = readFileSync(join(projectDataDir, "config.toml"), "utf8");
@@ -372,14 +374,14 @@ describe("config store", () => {
   test("setConfigValue validates external values with zod", async () => {
     const home = createDir("acolyte-config-home-");
     const project = createDir("acolyte-config-project-");
-    await expect(setConfigValue("port", "not-a-number", { homeDir: home, cwd: project })).rejects.toThrow(
+    await expect(setConfigValue("port", "not-a-number", { env: { HOME: home }, cwd: project })).rejects.toThrow(
       "Invalid value for port",
     );
 
-    await expect(setConfigValue("temperature", "3", { homeDir: home, cwd: project })).rejects.toThrow(
+    await expect(setConfigValue("temperature", "3", { env: { HOME: home }, cwd: project })).rejects.toThrow(
       "Invalid value for temperature",
     );
-    await expect(setConfigValue("locale", "xx", { homeDir: home, cwd: project })).rejects.toThrow(
+    await expect(setConfigValue("locale", "xx", { env: { HOME: home }, cwd: project })).rejects.toThrow(
       "Invalid value for locale",
     );
   });
@@ -390,9 +392,9 @@ describe("config store", () => {
     const projectDataDir = join(project, ".acolyte");
     mkdirSync(projectDataDir, { recursive: true });
 
-    await setConfigValue("temperature", "0.2", { homeDir: home, cwd: project, scope: "project" });
+    await setConfigValue("temperature", "0.2", { env: { HOME: home }, cwd: project, scope: "project" });
 
-    const loaded = await readConfigForScope("project", { homeDir: home, cwd: project });
+    const loaded = await readConfigForScope("project", { env: { HOME: home }, cwd: project });
     expect(loaded.temperature).toBe(0.2);
   });
 
@@ -402,10 +404,10 @@ describe("config store", () => {
     const projectDataDir = join(project, ".acolyte");
     mkdirSync(projectDataDir, { recursive: true });
 
-    await setConfigValue("temperature", "0.4", { homeDir: home, cwd: project, scope: "project" });
-    await unsetConfigValue("temperature", { homeDir: home, cwd: project, scope: "project" });
+    await setConfigValue("temperature", "0.4", { env: { HOME: home }, cwd: project, scope: "project" });
+    await unsetConfigValue("temperature", { env: { HOME: home }, cwd: project, scope: "project" });
 
-    const loaded = await readConfigForScope("project", { homeDir: home, cwd: project });
+    const loaded = await readConfigForScope("project", { env: { HOME: home }, cwd: project });
     expect(loaded.temperature).toBeUndefined();
   });
 
@@ -420,7 +422,7 @@ describe("config store", () => {
     writeFileSync(join(userDataDir, "config.toml"), "port = 6767\n", "utf8");
     writeFileSync(join(projectDataDir, "config.toml"), "port = 7777\n", "utf8");
 
-    await unsetConfigValue("port", { homeDir: home, cwd: project, scope: "project" });
+    await unsetConfigValue("port", { env: { HOME: home }, cwd: project, scope: "project" });
 
     const userToml = readFileSync(join(userDataDir, "config.toml"), "utf8");
     const projectToml = readFileSync(join(projectDataDir, "config.toml"), "utf8");

--- a/src/config.int.test.ts
+++ b/src/config.int.test.ts
@@ -10,6 +10,7 @@ import {
   unsetConfigValue,
   writeConfig,
 } from "./config";
+import { configDir } from "./paths";
 import { tempDir } from "./test-utils";
 
 const { createDir, cleanupDirs } = tempDir();
@@ -18,7 +19,7 @@ afterEach(cleanupDirs);
 describe("config store", () => {
   test("reads non-secret settings from config.toml", async () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(
       join(dataDir, "config.toml"),
@@ -35,7 +36,7 @@ describe("config store", () => {
 
   test("ignores apiKey in file config (secrets are env-only)", async () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(
       join(dataDir, "config.toml"),
@@ -52,7 +53,7 @@ describe("config store", () => {
 
   test("prefers config.toml when both TOML and JSON exist", async () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), 'model = "google/gemini-2.5-pro"', "utf8");
     writeFileSync(join(dataDir, "config.json"), JSON.stringify({ model: "openai/gpt-5-mini" }, null, 2), "utf8");
@@ -63,7 +64,7 @@ describe("config store", () => {
 
   test("falls back to JSON when TOML is absent", async () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(
       join(dataDir, "config.json"),
@@ -80,7 +81,7 @@ describe("config store", () => {
 
   test("readConfigSync prefers TOML over JSON", () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), 'model = "google/gemini-2.5-pro"', "utf8");
     writeFileSync(join(dataDir, "config.json"), JSON.stringify({ model: "openai/gpt-5-mini" }, null, 2), "utf8");
@@ -91,7 +92,7 @@ describe("config store", () => {
 
   test("readConfigSync throws on malformed config with scope", () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), "not valid toml = {", "utf8");
 
@@ -100,7 +101,7 @@ describe("config store", () => {
 
   test("setConfigValue updates TOML when config.toml exists", async () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), 'model = "openai/gpt-5-mini"\n', "utf8");
 
@@ -112,7 +113,7 @@ describe("config store", () => {
 
   test("unsetConfigValue removes field from TOML when config.toml exists", async () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), 'model = "openai/gpt-5-mini"\nport = 7777\n', "utf8");
 
@@ -124,7 +125,7 @@ describe("config store", () => {
 
   test("writeConfig sanitizes unexpected secret fields before persisting", async () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), 'model = "openai/gpt-5-mini"\n', "utf8");
 
@@ -144,7 +145,7 @@ describe("config store", () => {
 
   test("writeConfig writes TOML by default when only JSON existed", async () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.json"), JSON.stringify({ model: "openai/gpt-5-mini" }, null, 2), "utf8");
 
@@ -164,7 +165,7 @@ describe("config store", () => {
 
   test("reads non-secret runtime knobs from config.toml", () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(
       join(dataDir, "config.toml"),
@@ -195,7 +196,7 @@ describe("config store", () => {
 
   test("reads feature flags from [features] section in config.toml", () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), ["[features]", "syncAgents = true"].join("\n"), "utf8");
 
@@ -208,7 +209,7 @@ describe("config store", () => {
 
   test("readResolvedConfigSync applies defaults and model fallbacks", () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), 'model = "anthropic/claude-sonnet-4"\n', "utf8");
 
@@ -226,7 +227,7 @@ describe("config store", () => {
 
   test("readResolvedConfigSync uses top-level temperature when set", () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), 'model = "anthropic/claude-sonnet-4"\n\ntemperature = 0.2\n', "utf8");
 
@@ -238,7 +239,7 @@ describe("config store", () => {
 
   test("readResolvedConfigSync uses top-level temperature from config", () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), 'model = "anthropic/claude-sonnet-4"\n\ntemperature = 0.1\n', "utf8");
 
@@ -249,7 +250,7 @@ describe("config store", () => {
 
   test("setConfigValue rejects internal config keys", async () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), "", "utf8");
 
@@ -260,7 +261,7 @@ describe("config store", () => {
 
   test("setConfigValue supports locale", async () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), "", "utf8");
 
@@ -271,7 +272,7 @@ describe("config store", () => {
 
   test("setConfigValue supports dotted feature flags keys", async () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), "", "utf8");
 
@@ -286,7 +287,7 @@ describe("config store", () => {
 
   test("unsetConfigValue supports dotted feature flags keys", async () => {
     const home = createDir("acolyte-config-home-");
-    const dataDir = join(home, ".acolyte");
+    const dataDir = configDir({ HOME: home });
     mkdirSync(dataDir, { recursive: true });
     writeFileSync(join(dataDir, "config.toml"), ["[features]", "syncAgents = true"].join("\n"), "utf8");
 
@@ -301,7 +302,7 @@ describe("config store", () => {
   test("project features merge with user features instead of replacing", async () => {
     const home = createDir("acolyte-config-home-");
     const project = createDir("acolyte-config-project-");
-    const userDataDir = join(home, ".acolyte");
+    const userDataDir = configDir({ HOME: home });
     const projectDataDir = join(project, ".acolyte");
     mkdirSync(userDataDir, { recursive: true });
     mkdirSync(projectDataDir, { recursive: true });
@@ -317,7 +318,7 @@ describe("config store", () => {
   test("project config overrides user config", async () => {
     const home = createDir("acolyte-config-home-");
     const project = createDir("acolyte-config-project-");
-    const userDataDir = join(home, ".acolyte");
+    const userDataDir = configDir({ HOME: home });
     const projectDataDir = join(project, ".acolyte");
     mkdirSync(userDataDir, { recursive: true });
     mkdirSync(projectDataDir, { recursive: true });
@@ -341,7 +342,7 @@ describe("config store", () => {
   test("project config does not clear user values when project key is missing", async () => {
     const home = createDir("acolyte-config-home-");
     const project = createDir("acolyte-config-project-");
-    const userDataDir = join(home, ".acolyte");
+    const userDataDir = configDir({ HOME: home });
     const projectDataDir = join(project, ".acolyte");
     mkdirSync(userDataDir, { recursive: true });
     mkdirSync(projectDataDir, { recursive: true });
@@ -357,7 +358,7 @@ describe("config store", () => {
   test("setConfigValue writes to project scope without mutating user scope", async () => {
     const home = createDir("acolyte-config-home-");
     const project = createDir("acolyte-config-project-");
-    const userDataDir = join(home, ".acolyte");
+    const userDataDir = configDir({ HOME: home });
     const projectDataDir = join(project, ".acolyte");
     mkdirSync(userDataDir, { recursive: true });
     mkdirSync(projectDataDir, { recursive: true });
@@ -414,7 +415,7 @@ describe("config store", () => {
   test("unsetConfigValue removes key only from targeted project scope", async () => {
     const home = createDir("acolyte-config-home-");
     const project = createDir("acolyte-config-project-");
-    const userDataDir = join(home, ".acolyte");
+    const userDataDir = configDir({ HOME: home });
     const projectDataDir = join(project, ".acolyte");
     mkdirSync(userDataDir, { recursive: true });
     mkdirSync(projectDataDir, { recursive: true });

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,7 @@ import {
 import { errorMessage } from "./error-contract";
 import { featureFlagsSchema, resolvedFeatureFlagsSchema } from "./feature-flags-contract";
 import { t } from "./i18n";
-import { configDirFromHome } from "./paths";
+import { configDir, type Env } from "./paths";
 
 function createDefaultConfig() {
   return {
@@ -31,7 +31,7 @@ function createDefaultConfig() {
 }
 
 export type ConfigOptions = {
-  homeDir?: string;
+  env?: Env;
   cwd?: string;
   scope?: ConfigScope;
 };
@@ -65,7 +65,7 @@ function resolvePaths(options?: ConfigOptions): {
   projectJsonPath: string;
   projectTomlPath: string;
 } {
-  const userDataDir = configDirFromHome(options?.homeDir);
+  const userDataDir = configDir(options?.env);
   const projectDataDir = join(options?.cwd ?? process.cwd(), ".acolyte");
   return {
     userDataDir,

--- a/src/credentials.int.test.ts
+++ b/src/credentials.int.test.ts
@@ -8,6 +8,7 @@ import {
   removeCredential,
   writeCredential,
 } from "./credentials";
+import { configDir } from "./paths";
 import { tempDir } from "./test-utils";
 
 const dirs = tempDir();
@@ -59,7 +60,7 @@ describe("credentials", () => {
     const env = { HOME: home };
     await writeCredential("cloudToken", "tok_abc123", env);
     await removeCredential("cloudToken", env);
-    expect(existsSync(join(home, ".acolyte", "credentials"))).toBe(false);
+    expect(existsSync(join(configDir(env), "credentials"))).toBe(false);
   });
 
   test("readCredentialsSync reads file correctly", async () => {
@@ -84,18 +85,18 @@ describe("credentials", () => {
     const home = createTempHome();
     const env = { HOME: home };
     await writeCredential("cloudToken", "tok_private", env);
-    const filePath = join(home, ".acolyte", "credentials");
+    const filePath = join(configDir(env), "credentials");
     const mode = statSync(filePath).mode & 0o777;
     expect(mode).toBe(0o600);
   });
 
   test("ignores comments and blank lines", async () => {
-    const home = createTempHome();
-    const dir = join(home, ".acolyte");
+    const env = { HOME: createTempHome() };
+    const dir = configDir(env);
     mkdirSync(dir, { recursive: true });
     const { writeFile } = await import("node:fs/promises");
     await writeFile(join(dir, "credentials"), "# comment\n\nACOLYTE_CLOUD_TOKEN=tok\n", "utf8");
-    const creds = await readCredentials({ HOME: home });
+    const creds = await readCredentials(env);
     expect(creds).toEqual({ cloudToken: "tok" });
   });
 });

--- a/src/credentials.int.test.ts
+++ b/src/credentials.int.test.ts
@@ -19,52 +19,53 @@ function createTempHome(): string {
 
 describe("credentials", () => {
   test("readCredentialsSync returns empty when no file exists", () => {
-    expect(readCredentialsSync("/nonexistent")).toEqual({});
+    expect(readCredentialsSync({ HOME: "/nonexistent" })).toEqual({});
   });
 
   test("writeCredential creates file and readCredentials reads it", async () => {
-    const home = createTempHome();
-    await writeCredential("cloudToken", "tok_abc123", home);
-    const creds = await readCredentials(home);
+    const env = { HOME: createTempHome() };
+    await writeCredential("cloudToken", "tok_abc123", env);
+    const creds = await readCredentials(env);
     expect(creds).toEqual({ cloudToken: "tok_abc123" });
   });
 
   test("writeCredential preserves existing credentials", async () => {
-    const home = createTempHome();
-    await writeCredential("cloudUrl", "https://cloud.example.com", home);
-    await writeCredential("cloudToken", "tok_abc123", home);
-    const creds = await readCredentials(home);
+    const env = { HOME: createTempHome() };
+    await writeCredential("cloudUrl", "https://cloud.example.com", env);
+    await writeCredential("cloudToken", "tok_abc123", env);
+    const creds = await readCredentials(env);
     expect(creds).toEqual({ cloudUrl: "https://cloud.example.com", cloudToken: "tok_abc123" });
   });
 
   test("writeCredential overwrites existing value", async () => {
-    const home = createTempHome();
-    await writeCredential("cloudToken", "old", home);
-    await writeCredential("cloudToken", "new", home);
-    const creds = await readCredentials(home);
+    const env = { HOME: createTempHome() };
+    await writeCredential("cloudToken", "old", env);
+    await writeCredential("cloudToken", "new", env);
+    const creds = await readCredentials(env);
     expect(creds).toEqual({ cloudToken: "new" });
   });
 
   test("removeCredential removes a single credential", async () => {
-    const home = createTempHome();
-    await writeCredential("cloudUrl", "https://cloud.example.com", home);
-    await writeCredential("cloudToken", "tok_abc123", home);
-    await removeCredential("cloudToken", home);
-    const creds = await readCredentials(home);
+    const env = { HOME: createTempHome() };
+    await writeCredential("cloudUrl", "https://cloud.example.com", env);
+    await writeCredential("cloudToken", "tok_abc123", env);
+    await removeCredential("cloudToken", env);
+    const creds = await readCredentials(env);
     expect(creds).toEqual({ cloudUrl: "https://cloud.example.com" });
   });
 
   test("removeCredential deletes file when last credential removed", async () => {
     const home = createTempHome();
-    await writeCredential("cloudToken", "tok_abc123", home);
-    await removeCredential("cloudToken", home);
+    const env = { HOME: home };
+    await writeCredential("cloudToken", "tok_abc123", env);
+    await removeCredential("cloudToken", env);
     expect(existsSync(join(home, ".acolyte", "credentials"))).toBe(false);
   });
 
   test("readCredentialsSync reads file correctly", async () => {
-    const home = createTempHome();
-    await writeCredential("cloudToken", "tok_sync", home);
-    const creds = readCredentialsSync(home);
+    const env = { HOME: createTempHome() };
+    await writeCredential("cloudToken", "tok_sync", env);
+    const creds = readCredentialsSync(env);
     expect(creds).toEqual({ cloudToken: "tok_sync" });
   });
 
@@ -81,7 +82,8 @@ describe("credentials", () => {
 
   test("credential file is written with 0o600 permissions", async () => {
     const home = createTempHome();
-    await writeCredential("cloudToken", "tok_private", home);
+    const env = { HOME: home };
+    await writeCredential("cloudToken", "tok_private", env);
     const filePath = join(home, ".acolyte", "credentials");
     const mode = statSync(filePath).mode & 0o777;
     expect(mode).toBe(0o600);
@@ -93,7 +95,7 @@ describe("credentials", () => {
     mkdirSync(dir, { recursive: true });
     const { writeFile } = await import("node:fs/promises");
     await writeFile(join(dir, "credentials"), "# comment\n\nACOLYTE_CLOUD_TOKEN=tok\n", "utf8");
-    const creds = await readCredentials(home);
+    const creds = await readCredentials({ HOME: home });
     expect(creds).toEqual({ cloudToken: "tok" });
   });
 });

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -3,7 +3,7 @@ import { chmod, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { getDotenvValue, parseDotenv, removeDotenvKey, upsertDotenvValue } from "./dotenv";
 import { PRIVATE_FILE_MODE } from "./file-ops";
-import { configDirFromHome } from "./paths";
+import { configDir, type Env } from "./paths";
 
 const CREDENTIALS_FILE = "credentials";
 
@@ -17,8 +17,8 @@ export type Credentials = {
   cloudToken?: string;
 };
 
-function credentialsPath(homeDir?: string): string {
-  return join(configDirFromHome(homeDir), CREDENTIALS_FILE);
+function credentialsPath(env?: Env): string {
+  return join(configDir(env), CREDENTIALS_FILE);
 }
 
 function parseCredentials(content: string): Credentials {
@@ -31,8 +31,8 @@ function parseCredentials(content: string): Credentials {
   return creds;
 }
 
-export function readCredentialsSync(homeDir?: string): Credentials {
-  const path = credentialsPath(homeDir);
+export function readCredentialsSync(env?: Env): Credentials {
+  const path = credentialsPath(env);
   if (!existsSync(path)) return {};
   try {
     return parseCredentials(readFileSync(path, "utf8"));
@@ -41,8 +41,8 @@ export function readCredentialsSync(homeDir?: string): Credentials {
   }
 }
 
-export async function readCredentials(homeDir?: string): Promise<Credentials> {
-  const path = credentialsPath(homeDir);
+export async function readCredentials(env?: Env): Promise<Credentials> {
+  const path = credentialsPath(env);
   if (!existsSync(path)) return {};
   try {
     return parseCredentials(await readFile(path, "utf8"));
@@ -51,14 +51,14 @@ export async function readCredentials(homeDir?: string): Promise<Credentials> {
   }
 }
 
-export async function writeCredential(key: keyof Credentials, value: string, homeDir?: string): Promise<void> {
-  const path = credentialsPath(homeDir);
+export async function writeCredential(key: keyof Credentials, value: string, env?: Env): Promise<void> {
+  const path = credentialsPath(env);
   let content = "";
   try {
     content = await readFile(path, "utf8");
   } catch {}
   const next = upsertDotenvValue(content, KEY_MAP[key], value);
-  const dir = configDirFromHome(homeDir);
+  const dir = configDir(env);
   await mkdir(dir, { recursive: true });
   await writeFile(path, next, { encoding: "utf8", mode: PRIVATE_FILE_MODE });
   await chmod(path, PRIVATE_FILE_MODE);
@@ -75,8 +75,8 @@ export function decodeTokenSubject(token: string): string | undefined {
   }
 }
 
-export async function removeCredential(key: keyof Credentials, homeDir?: string): Promise<void> {
-  const path = credentialsPath(homeDir);
+export async function removeCredential(key: keyof Credentials, env?: Env): Promise<void> {
+  const path = credentialsPath(env);
   let content = "";
   try {
     content = await readFile(path, "utf8");

--- a/src/daemon-ops.test.ts
+++ b/src/daemon-ops.test.ts
@@ -3,11 +3,11 @@ import { isProcessAlive, parseServerLock, serverLogPath } from "./daemon-ops";
 
 describe("daemon ops", () => {
   test("serverLogPath uses server.log for default port", () => {
-    expect(serverLogPath(6767, "/tmp/acolyte-home")).toBe("/tmp/acolyte-home/.acolyte/daemons/server.log");
+    expect(serverLogPath(6767, { HOME: "/tmp/acolyte-home" })).toBe("/tmp/acolyte-home/.acolyte/daemons/server.log");
   });
 
   test("serverLogPath uses port number for non-default port", () => {
-    expect(serverLogPath(8080, "/tmp/acolyte-home")).toBe("/tmp/acolyte-home/.acolyte/daemons/8080.log");
+    expect(serverLogPath(8080, { HOME: "/tmp/acolyte-home" })).toBe("/tmp/acolyte-home/.acolyte/daemons/8080.log");
   });
 
   test("parseServerLock accepts valid payload", () => {

--- a/src/daemon-ops.test.ts
+++ b/src/daemon-ops.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
 import { isProcessAlive, parseServerLock, serverLogPath } from "./daemon-ops";
+import { stateDir } from "./paths";
 
 describe("daemon ops", () => {
   test("serverLogPath uses server.log for default port", () => {
-    expect(serverLogPath(6767, { HOME: "/tmp/acolyte-home" })).toBe("/tmp/acolyte-home/.acolyte/daemons/server.log");
+    const env = { HOME: "/tmp/acolyte-home" };
+    expect(serverLogPath(6767, env)).toBe(join(stateDir(env), "daemons", "server.log"));
   });
 
   test("serverLogPath uses port number for non-default port", () => {
-    expect(serverLogPath(8080, { HOME: "/tmp/acolyte-home" })).toBe("/tmp/acolyte-home/.acolyte/daemons/8080.log");
+    const env = { HOME: "/tmp/acolyte-home" };
+    expect(serverLogPath(8080, env)).toBe(join(stateDir(env), "daemons", "8080.log"));
   });
 
   test("parseServerLock accepts valid payload", () => {

--- a/src/daemon-ops.ts
+++ b/src/daemon-ops.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { z } from "zod";
 import { type IsoDateTimeString, isoDateTimeSchema } from "./datetime";
 import { PRIVATE_FILE_MODE } from "./file-ops";
-import { stateDirFromHome } from "./paths";
+import { type Env, stateDir } from "./paths";
 
 // 6        7
 // \_(ᴗ _ᴗ)_/
@@ -33,24 +33,24 @@ const startupLockSchema = z.object({
   startedAt: isoDateTimeSchema,
 });
 
-export function daemonsDir(homeDir?: string): string {
-  return join(stateDirFromHome(homeDir), "daemons");
+export function daemonsDir(env?: Env): string {
+  return join(stateDir(env), "daemons");
 }
 
 function daemonFileName(port: number, suffix: string): string {
   return port === DEFAULT_PORT ? `server${suffix}` : `${port}${suffix}`;
 }
 
-export function serverLockPath(port: number, homeDir?: string): string {
-  return join(daemonsDir(homeDir), daemonFileName(port, ".lock"));
+export function serverLockPath(port: number, env?: Env): string {
+  return join(daemonsDir(env), daemonFileName(port, ".lock"));
 }
 
-export function startupLockPath(port: number, homeDir?: string): string {
-  return join(daemonsDir(homeDir), daemonFileName(port, ".start.lock"));
+export function startupLockPath(port: number, env?: Env): string {
+  return join(daemonsDir(env), daemonFileName(port, ".start.lock"));
 }
 
-export function serverLogPath(port: number, homeDir?: string): string {
-  return join(daemonsDir(homeDir), daemonFileName(port, ".log"));
+export function serverLogPath(port: number, env?: Env): string {
+  return join(daemonsDir(env), daemonFileName(port, ".log"));
 }
 
 export function parseServerLock(raw: string): ServerLock | null {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -41,11 +41,3 @@ export function stateDir(env: Env = process.env, platform: Platform = resolvePla
   }
   return join(resolveHomeDir(env), ".acolyte");
 }
-
-export function configDirFromHome(homeDir?: string): string {
-  return homeDir ? join(homeDir, ".acolyte") : configDir();
-}
-
-export function stateDirFromHome(homeDir?: string): string {
-  return homeDir ? join(homeDir, ".acolyte") : stateDir();
-}

--- a/src/resource-diagnostics.test.ts
+++ b/src/resource-diagnostics.test.ts
@@ -21,7 +21,7 @@ describe("resource diagnostics", () => {
     writeFileSync(join(projectConfig, "config.toml"), 'model = "gpt-5-mini"\n', "utf8");
     writeFileSync(join(projectConfig, "config.json"), '{"model":"gpt-5"}\n', "utf8");
 
-    const diagnostics = collectResourceDiagnostics({ cwd, homeDir: home });
+    const diagnostics = collectResourceDiagnostics({ cwd, env: { HOME: home } });
     expect(diagnostics["resources.config.collisions"]).toBe("project");
   });
 
@@ -29,7 +29,7 @@ describe("resource diagnostics", () => {
     const cwd = createDir("acolyte-resdiag-prompts-");
     const home = createDir("acolyte-resdiag-home-");
 
-    const diagnostics = collectResourceDiagnostics({ cwd, homeDir: home });
+    const diagnostics = collectResourceDiagnostics({ cwd, env: { HOME: home } });
     expect(diagnostics["resources.prompt.agents"]).toBe("missing_or_unreadable");
   });
 
@@ -39,7 +39,7 @@ describe("resource diagnostics", () => {
     writeSkill(cwd, "bad", "---\nname: Bad\ndescription: Invalid skill name\n---");
 
     await loadSkills(cwd);
-    const diagnostics = collectResourceDiagnostics({ cwd, homeDir: home });
+    const diagnostics = collectResourceDiagnostics({ cwd, env: { HOME: home } });
     expect(diagnostics["resources.skills.invalid"]).toBe(1);
     expect(diagnostics["resources.skills.status"]).toBeUndefined();
   });
@@ -51,7 +51,7 @@ describe("resource diagnostics", () => {
     writeSkill(cwd, "demo", "---\nname: demo\ndescription: Demo skill\n---");
 
     await loadSkills(cwd);
-    const diagnostics = collectResourceDiagnostics({ cwd, homeDir: home });
+    const diagnostics = collectResourceDiagnostics({ cwd, env: { HOME: home } });
     expect(diagnostics).toEqual({});
   });
 });

--- a/src/resource-diagnostics.ts
+++ b/src/resource-diagnostics.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { configDirFromHome } from "./paths";
+import { configDir, type Env } from "./paths";
 import { getLoadedSkills, getSkillLoadDiagnostics } from "./skills";
 import { loadAgentsPrompt } from "./soul";
 import type { StatusFields } from "./status-contract";
@@ -9,9 +9,9 @@ function hasConfigFileCollision(scopeDir: string): boolean {
   return existsSync(join(scopeDir, "config.toml")) && existsSync(join(scopeDir, "config.json"));
 }
 
-export function collectResourceDiagnostics(options?: { cwd?: string; homeDir?: string }): StatusFields {
+export function collectResourceDiagnostics(options?: { cwd?: string; env?: Env }): StatusFields {
   const cwd = options?.cwd ?? process.cwd();
-  const userConfigDir = configDirFromHome(options?.homeDir);
+  const userConfigDir = configDir(options?.env);
   const diagnostics: StatusFields = {};
 
   const collisionScopes: string[] = [];

--- a/src/resource-id.test.ts
+++ b/src/resource-id.test.ts
@@ -25,8 +25,8 @@ describe("resource id", () => {
   });
 
   test("defaultUserResourceId is deterministic for homeDir", () => {
-    const a = defaultUserResourceId("/home/test-user");
-    const b = defaultUserResourceId("/home/test-user");
+    const a = defaultUserResourceId({ HOME: "/home/test-user" });
+    const b = defaultUserResourceId({ HOME: "/home/test-user" });
     expect(a).toBe(b);
     expect(a.startsWith("user_")).toBe(true);
   });

--- a/src/resource-id.ts
+++ b/src/resource-id.ts
@@ -1,7 +1,7 @@
 import { resolve as resolvePath } from "node:path";
 import { z } from "zod";
 import { domainIdSchema } from "./id-contract";
-import { resolveHomeDir } from "./paths";
+import { type Env, resolveHomeDir } from "./paths";
 
 export const userResourceIdSchema = domainIdSchema("user");
 export type UserResourceId = z.infer<typeof userResourceIdSchema>;
@@ -29,8 +29,8 @@ export function projectResourceIdFromWorkspace(workspace: string): ProjectResour
   return projectResourceIdSchema.parse(`proj_${hashValue(normalized)}`);
 }
 
-export function defaultUserResourceId(homeDir = resolveHomeDir()): UserResourceId {
-  return userResourceIdSchema.parse(`user_${hashValue(resolvePath(homeDir))}`);
+export function defaultUserResourceId(env?: Env): UserResourceId {
+  return userResourceIdSchema.parse(`user_${hashValue(resolvePath(resolveHomeDir(env)))}`);
 }
 
 export function userResourceIdFor(context: string, sessionId: string): UserResourceId {

--- a/src/server-daemon.int.test.ts
+++ b/src/server-daemon.int.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { mkdir, utimes, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { clearStaleStartupLock, daemonsDir, isProcessAlive, serverLockPath, startupLockPath } from "./daemon-ops";
+import type { Env } from "./paths";
 import { PROTOCOL_VERSION } from "./protocol";
 import {
   ensureLocalServer,
@@ -17,6 +18,10 @@ afterEach(dirs.cleanupDirs);
 
 function compatibleStatusResponse(): Response {
   return Response.json({ ok: true, protocol_version: PROTOCOL_VERSION });
+}
+
+function testEnv(homeDir: string): Env {
+  return { HOME: homeDir };
 }
 
 describe("server daemon", () => {
@@ -37,8 +42,8 @@ describe("server daemon", () => {
   });
 
   test("localServerStatus removes stale server lock when endpoint is not healthy", async () => {
-    const home = dirs.createDir("acolyte-daemon-home-");
-    const lockPath = serverLockPath(9, home);
+    const env = testEnv(dirs.createDir("acolyte-daemon-home-"));
+    const lockPath = serverLockPath(9, env);
     await mkdir(join(lockPath, ".."), { recursive: true });
     await writeFile(
       lockPath,
@@ -49,7 +54,7 @@ describe("server daemon", () => {
       }),
       "utf8",
     );
-    await expect(localServerStatus({ port: 9, homeDir: home })).resolves.toEqual({
+    await expect(localServerStatus({ port: 9, env })).resolves.toEqual({
       running: false,
       pid: null,
       port: 9,
@@ -58,9 +63,9 @@ describe("server daemon", () => {
   });
 
   test("localServerStatus reports running when lock and server are healthy", async () => {
-    const home = dirs.createDir("acolyte-daemon-home-");
+    const env = testEnv(dirs.createDir("acolyte-daemon-home-"));
     const server = startTestServer(() => compatibleStatusResponse());
-    const lockPath = serverLockPath(server.port, home);
+    const lockPath = serverLockPath(server.port, env);
     await mkdir(join(lockPath, ".."), { recursive: true });
     await writeFile(
       lockPath,
@@ -72,7 +77,7 @@ describe("server daemon", () => {
       "utf8",
     );
     try {
-      await expect(localServerStatus({ port: server.port, homeDir: home })).resolves.toEqual({
+      await expect(localServerStatus({ port: server.port, env })).resolves.toEqual({
         running: true,
         pid: process.pid,
         port: server.port,
@@ -83,9 +88,9 @@ describe("server daemon", () => {
   });
 
   test("localServerStatus removes lock when pid is dead", async () => {
-    const home = dirs.createDir("acolyte-daemon-home-");
+    const env = testEnv(dirs.createDir("acolyte-daemon-home-"));
     const server = startTestServer(() => compatibleStatusResponse());
-    const lockPath = serverLockPath(server.port, home);
+    const lockPath = serverLockPath(server.port, env);
     await mkdir(join(lockPath, ".."), { recursive: true });
     await writeFile(
       lockPath,
@@ -97,8 +102,7 @@ describe("server daemon", () => {
       "utf8",
     );
     try {
-      // Lock is cleared because pid 999999 is dead, but server is healthy so it reports running with null pid
-      await expect(localServerStatus({ port: server.port, homeDir: home })).resolves.toEqual({
+      await expect(localServerStatus({ port: server.port, env })).resolves.toEqual({
         running: true,
         pid: null,
         port: server.port,
@@ -110,8 +114,8 @@ describe("server daemon", () => {
   });
 
   test("localServerStatus reports not running when no lock and no server", async () => {
-    const home = dirs.createDir("acolyte-daemon-home-");
-    await expect(localServerStatus({ port: 9, homeDir: home })).resolves.toEqual({
+    const env = testEnv(dirs.createDir("acolyte-daemon-home-"));
+    await expect(localServerStatus({ port: 9, env })).resolves.toEqual({
       running: false,
       pid: null,
       port: 9,
@@ -119,9 +123,9 @@ describe("server daemon", () => {
   });
 
   test("ensureLocalServer reuses healthy locked server", async () => {
-    const home = dirs.createDir("acolyte-daemon-home-");
+    const env = testEnv(dirs.createDir("acolyte-daemon-home-"));
     const server = startTestServer(() => compatibleStatusResponse());
-    const lockPath = serverLockPath(server.port, home);
+    const lockPath = serverLockPath(server.port, env);
     await mkdir(join(lockPath, ".."), { recursive: true });
     await writeFile(
       lockPath,
@@ -138,7 +142,7 @@ describe("server daemon", () => {
           port: server.port,
           apiKey: undefined,
           serverEntry: join(process.cwd(), "src/server.ts"),
-          homeDir: home,
+          env,
         }),
       ).resolves.toEqual({ port: server.port, pid: process.pid, started: false });
     } finally {
@@ -147,7 +151,7 @@ describe("server daemon", () => {
   });
 
   test("ensureLocalServer reuses healthy server without lock", async () => {
-    const home = dirs.createDir("acolyte-daemon-home-");
+    const env = testEnv(dirs.createDir("acolyte-daemon-home-"));
     const server = startTestServer(() => compatibleStatusResponse());
     try {
       await expect(
@@ -155,7 +159,7 @@ describe("server daemon", () => {
           port: server.port,
           apiKey: undefined,
           serverEntry: join(process.cwd(), "src/server.ts"),
-          homeDir: home,
+          env,
         }),
       ).resolves.toEqual({ port: server.port, pid: 0, started: false });
     } finally {
@@ -165,10 +169,11 @@ describe("server daemon", () => {
 
   test("ensureLocalServer recovers from a stale startup lock with a live owner pid", async () => {
     const home = dirs.createDir("acolyte-daemon-home-");
+    const env = testEnv(home);
     const reservation = startTestServer(() => new Response("reserved"));
     const port = reservation.port;
     reservation.stop();
-    const startLockPath = startupLockPath(port, home);
+    const startLockPath = startupLockPath(port, env);
     await mkdir(join(startLockPath, ".."), { recursive: true });
     await writeFile(startLockPath, String(process.pid), "utf8");
     const staleAt = new Date(Date.now() - 60_000);
@@ -197,7 +202,7 @@ describe("server daemon", () => {
         port,
         apiKey: undefined,
         serverEntry,
-        homeDir: home,
+        env,
         timeoutMs: 1_500,
       });
       startedPid = result.pid;
@@ -207,13 +212,14 @@ describe("server daemon", () => {
       await expect(Bun.file(startLockPath).exists()).resolves.toBe(false);
     } finally {
       if (startedPid !== null && startedPid > 0) {
-        await stopLocalServer({ port, homeDir: home });
+        await stopLocalServer({ port, env });
       }
     }
   });
 
   test("ensureLocalServer fails fast when spawned process exits immediately", async () => {
     const home = dirs.createDir("acolyte-daemon-home-");
+    const env = testEnv(home);
     const reservation = startTestServer(() => new Response("reserved"));
     const port = reservation.port;
     reservation.stop();
@@ -226,7 +232,7 @@ describe("server daemon", () => {
         port,
         apiKey: undefined,
         serverEntry,
-        homeDir: home,
+        env,
         timeoutMs: 5_000,
       }),
     ).rejects.toThrow(/exited before becoming healthy/);
@@ -234,22 +240,22 @@ describe("server daemon", () => {
 
   test("ensureLocalServer releases startup lock when spawn throws", async () => {
     const home = dirs.createDir("acolyte-daemon-home-");
+    const env = testEnv(home);
     const reservation = startTestServer(() => new Response("reserved"));
     const port = reservation.port;
     reservation.stop();
 
-    const startLockPath = startupLockPath(port, home);
+    const startLockPath = startupLockPath(port, env);
     const origExecPath = process.execPath;
 
     try {
-      // Force Bun.spawn to throw ENOENT by using a nonexistent binary
       Object.defineProperty(process, "execPath", { value: "/nonexistent/binary", configurable: true });
       await expect(
         ensureLocalServer({
           port,
           apiKey: undefined,
           serverEntry: "server.ts",
-          homeDir: home,
+          env,
           timeoutMs: 5_000,
         }),
       ).rejects.toThrow();
@@ -261,7 +267,7 @@ describe("server daemon", () => {
   });
 
   test("stopLocalServer stops a healthy server even without a lock file", async () => {
-    const home = dirs.createDir("acolyte-daemon-home-");
+    const env = testEnv(dirs.createDir("acolyte-daemon-home-"));
     const server = startTestServer((req) => {
       const url = new URL(req.url);
       if (url.pathname === "/v1/status") return compatibleStatusResponse();
@@ -271,14 +277,13 @@ describe("server daemon", () => {
       }
       return new Response("ok");
     });
-    // No lock file written — server is running but lock is missing
-    const result = await stopLocalServer({ port: server.port, homeDir: home });
+    const result = await stopLocalServer({ port: server.port, env });
     expect(result.stopped).toBe(true);
   });
 
   test("stopLocalServer cleans up lock when pid is dead and endpoint is not healthy", async () => {
-    const home = dirs.createDir("acolyte-daemon-home-");
-    const lockPath = serverLockPath(9, home);
+    const env = testEnv(dirs.createDir("acolyte-daemon-home-"));
+    const lockPath = serverLockPath(9, env);
     await mkdir(join(lockPath, ".."), { recursive: true });
     await writeFile(
       lockPath,
@@ -289,12 +294,12 @@ describe("server daemon", () => {
       }),
       "utf8",
     );
-    await expect(stopLocalServer({ port: 9, homeDir: home })).resolves.toEqual({ stopped: true, pid: 999999 });
+    await expect(stopLocalServer({ port: 9, env })).resolves.toEqual({ stopped: true, pid: 999999 });
     await expect(Bun.file(lockPath).exists()).resolves.toBe(false);
   });
 
   test("stopLocalServer shuts down healthy server when lock pid is dead", async () => {
-    const home = dirs.createDir("acolyte-daemon-home-");
+    const env = testEnv(dirs.createDir("acolyte-daemon-home-"));
     let shutdownCalled = false;
     const server = startTestServer((req) => {
       const url = new URL(req.url);
@@ -306,24 +311,22 @@ describe("server daemon", () => {
       }
       return new Response("ok");
     });
-    // Lock exists but its PID is dead — server is actually running on the port
-    const lockPath = serverLockPath(server.port, home);
+    const lockPath = serverLockPath(server.port, env);
     await mkdir(join(lockPath, ".."), { recursive: true });
     await writeFile(
       lockPath,
       JSON.stringify({ pid: 999999, port: server.port, startedAt: "2026-02-28T00:00:00.000Z" }),
       "utf8",
     );
-    const result = await stopLocalServer({ port: server.port, homeDir: home });
+    const result = await stopLocalServer({ port: server.port, env });
     expect(result.stopped).toBe(true);
     expect(shutdownCalled).toBe(true);
   });
 
   test("stopLocalServer kills alive process even when endpoint is unhealthy", async () => {
-    const home = dirs.createDir("acolyte-daemon-home-");
-    // Start a subprocess that just sleeps
+    const env = testEnv(dirs.createDir("acolyte-daemon-home-"));
     const proc = Bun.spawn(["sleep", "60"], { detached: true });
-    const lockPath = serverLockPath(9, home);
+    const lockPath = serverLockPath(9, env);
     await mkdir(join(lockPath, ".."), { recursive: true });
     await writeFile(
       lockPath,
@@ -335,10 +338,9 @@ describe("server daemon", () => {
       "utf8",
     );
     try {
-      const result = await stopLocalServer({ port: 9, homeDir: home });
+      const result = await stopLocalServer({ port: 9, env });
       expect(result).toEqual({ stopped: true, pid: proc.pid });
       await expect(Bun.file(lockPath).exists()).resolves.toBe(false);
-      // Give SIGTERM a moment to land
       await Bun.sleep(50);
       expect(isProcessAlive(proc.pid)).toBe(false);
     } finally {
@@ -349,28 +351,25 @@ describe("server daemon", () => {
 
   test("ensureLocalServer gives up after max startup retries", async () => {
     const home = dirs.createDir("acolyte-daemon-home-");
+    const env = testEnv(home);
     const reservation = startTestServer(() => new Response("not acolyte"));
     const port = reservation.port;
     reservation.stop();
 
-    // Create a stale startup lock owned by a dead process so each attempt clears it and retries
-    const startLockPath = startupLockPath(port, home);
+    const startLockPath = startupLockPath(port, env);
     await mkdir(join(startLockPath, ".."), { recursive: true });
 
-    // Use a server entry that creates a new startup lock on each spawn (simulating contention)
     const serverEntry = join(home, "lock-stealer.ts");
     await writeFile(
       serverEntry,
       [
         `import { writeFileSync } from "node:fs";`,
         `writeFileSync(${JSON.stringify(startLockPath)}, JSON.stringify({ pid: process.pid, port: ${port}, startedAt: new Date().toISOString() }));`,
-        `// Never become healthy — just hold the lock and exit`,
         `process.exit(1);`,
       ].join("\n"),
       "utf8",
     );
 
-    // Pre-create a stale lock so the first attempt can't claim it and enters the wait/retry path
     await writeFile(
       startLockPath,
       JSON.stringify({ pid: 999999, port, startedAt: new Date(Date.now() - 60_000).toISOString() }),
@@ -383,16 +382,16 @@ describe("server daemon", () => {
         port,
         apiKey: undefined,
         serverEntry,
-        homeDir: home,
+        env,
         timeoutMs: 2_000,
       }),
     ).rejects.toThrow();
   });
 
   test("localServerStatus removes lock when status payload is protocol-incompatible", async () => {
-    const home = dirs.createDir("acolyte-daemon-home-");
+    const env = testEnv(dirs.createDir("acolyte-daemon-home-"));
     const staleServer = startTestServer(() => Response.json({ ok: true, protocolVersion: "1" }));
-    const lockPath = serverLockPath(staleServer.port, home);
+    const lockPath = serverLockPath(staleServer.port, env);
     await mkdir(join(lockPath, ".."), { recursive: true });
     await writeFile(
       lockPath,
@@ -404,7 +403,7 @@ describe("server daemon", () => {
       "utf8",
     );
     try {
-      await expect(localServerStatus({ port: staleServer.port, homeDir: home })).resolves.toEqual({
+      await expect(localServerStatus({ port: staleServer.port, env })).resolves.toEqual({
         running: false,
         pid: null,
         port: staleServer.port,
@@ -416,23 +415,23 @@ describe("server daemon", () => {
   });
 
   test("stopAllLocalServers stops multiple daemons by lock", async () => {
-    const home = dirs.createDir("acolyte-daemon-home-");
-    const dir = daemonsDir(home);
+    const env = testEnv(dirs.createDir("acolyte-daemon-home-"));
+    const dir = daemonsDir(env);
     await mkdir(dir, { recursive: true });
 
     const procA = Bun.spawn(["sleep", "60"], { detached: true });
     const procB = Bun.spawn(["sleep", "60"], { detached: true });
     try {
       await writeFile(
-        serverLockPath(9001, home),
+        serverLockPath(9001, env),
         JSON.stringify({ pid: procA.pid, port: 9001, startedAt: "2026-01-01T00:00:00.000Z" }),
       );
       await writeFile(
-        serverLockPath(9002, home),
+        serverLockPath(9002, env),
         JSON.stringify({ pid: procB.pid, port: 9002, startedAt: "2026-01-01T00:00:00.000Z" }),
       );
 
-      const stopped = await stopAllLocalServers({ homeDir: home });
+      const stopped = await stopAllLocalServers({ env });
       expect(stopped).toHaveLength(2);
       expect(stopped.map((s) => s.port).sort()).toEqual([9001, 9002]);
     } finally {
@@ -444,28 +443,25 @@ describe("server daemon", () => {
   });
 
   test("listRunningDaemons returns alive daemons and cleans dead locks", async () => {
-    const home = dirs.createDir("acolyte-daemon-home-");
-    const dir = daemonsDir(home);
+    const env = testEnv(dirs.createDir("acolyte-daemon-home-"));
+    const dir = daemonsDir(env);
     await mkdir(dir, { recursive: true });
 
-    // Alive daemon
     const proc = Bun.spawn(["sleep", "60"], { detached: true });
     await writeFile(
-      serverLockPath(9001, home),
+      serverLockPath(9001, env),
       JSON.stringify({ pid: proc.pid, port: 9001, startedAt: "2026-01-01T00:00:00.000Z" }),
     );
-    // Dead daemon
     await writeFile(
-      serverLockPath(9002, home),
+      serverLockPath(9002, env),
       JSON.stringify({ pid: 999999, port: 9002, startedAt: "2026-01-01T00:00:00.000Z" }),
     );
 
     try {
-      const daemons = await listRunningDaemons({ homeDir: home });
+      const daemons = await listRunningDaemons({ env });
       expect(daemons).toHaveLength(1);
       expect(daemons[0]?.pid).toBe(proc.pid);
-      // Dead lock should be cleaned up
-      await expect(Bun.file(serverLockPath(9002, home)).exists()).resolves.toBe(false);
+      await expect(Bun.file(serverLockPath(9002, env)).exists()).resolves.toBe(false);
     } finally {
       proc.kill();
       await proc.exited.catch(() => {});

--- a/src/server-daemon.int.test.ts
+++ b/src/server-daemon.int.test.ts
@@ -102,6 +102,7 @@ describe("server daemon", () => {
       "utf8",
     );
     try {
+      // Lock is cleared because pid 999999 is dead, but server is healthy so it reports running with null pid
       await expect(localServerStatus({ port: server.port, env })).resolves.toEqual({
         running: true,
         pid: null,
@@ -277,6 +278,7 @@ describe("server daemon", () => {
       }
       return new Response("ok");
     });
+    // No lock file written — server is running but lock is missing
     const result = await stopLocalServer({ port: server.port, env });
     expect(result.stopped).toBe(true);
   });
@@ -311,6 +313,7 @@ describe("server daemon", () => {
       }
       return new Response("ok");
     });
+    // Lock exists but its PID is dead — server is actually running on the port
     const lockPath = serverLockPath(server.port, env);
     await mkdir(join(lockPath, ".."), { recursive: true });
     await writeFile(

--- a/src/server-daemon.ts
+++ b/src/server-daemon.ts
@@ -16,6 +16,7 @@ import {
 import { field } from "./field";
 import { PRIVATE_FILE_MODE } from "./file-ops";
 import { t } from "./i18n";
+import type { Env } from "./paths";
 import { PROTOCOL_VERSION } from "./protocol";
 
 const SERVER_START_TIMEOUT_MS = 10_000;
@@ -26,7 +27,7 @@ type EnsureLocalServerInput = {
   port: number;
   apiKey?: string;
   serverEntry: string;
-  homeDir?: string;
+  env?: Env;
   timeoutMs?: number;
 };
 
@@ -157,11 +158,11 @@ export async function ensureLocalServer(
   input: EnsureLocalServerInput,
   retryCount = 0,
 ): Promise<EnsureLocalServerResult> {
-  const { port, apiKey, serverEntry, homeDir, timeoutMs: inputTimeoutMs } = input;
+  const { port, apiKey, serverEntry, env, timeoutMs: inputTimeoutMs } = input;
   const apiUrl = apiUrlForPort(port);
   const timeoutMs = inputTimeoutMs ?? SERVER_START_TIMEOUT_MS;
-  const lockPath = serverLockPath(port, homeDir);
-  const startLockPath = startupLockPath(port, homeDir);
+  const lockPath = serverLockPath(port, env);
+  const startLockPath = startupLockPath(port, env);
 
   const lock = await readServerLock(lockPath);
   if (lock) {
@@ -189,7 +190,7 @@ export async function ensureLocalServer(
     return { port, pid: waitedLock?.pid ?? 0, started: false };
   }
 
-  const logPath = serverLogPath(port, homeDir);
+  const logPath = serverLogPath(port, env);
   await mkdir(join(logPath, ".."), { recursive: true });
 
   let proc: ReturnType<typeof Bun.spawn> | undefined;
@@ -228,11 +229,11 @@ export async function ensureLocalServer(
 export async function localServerStatus(input: {
   port: number;
   apiKey?: string;
-  homeDir?: string;
+  env?: Env;
 }): Promise<LocalServerStatus> {
-  const { port, apiKey, homeDir } = input;
+  const { port, apiKey, env } = input;
   const apiUrl = apiUrlForPort(port);
-  const lockPath = serverLockPath(port, homeDir);
+  const lockPath = serverLockPath(port, env);
   const lock = await readServerLock(lockPath);
 
   if (lock) {
@@ -252,10 +253,10 @@ export async function localServerStatus(input: {
   return { running: false, pid: null, port };
 }
 
-export async function stopLocalServer(input: { port: number; apiKey?: string; homeDir?: string }): Promise<StopResult> {
-  const { port, apiKey, homeDir } = input;
+export async function stopLocalServer(input: { port: number; apiKey?: string; env?: Env }): Promise<StopResult> {
+  const { port, apiKey, env } = input;
   const apiUrl = apiUrlForPort(port);
-  const lockPath = serverLockPath(port, homeDir);
+  const lockPath = serverLockPath(port, env);
   const lock = await readServerLock(lockPath);
 
   if (!lock) {
@@ -284,9 +285,9 @@ function portFromLockEntry(entry: string): number | undefined {
 
 export async function stopAllLocalServers(input?: {
   apiKey?: string;
-  homeDir?: string;
+  env?: Env;
 }): Promise<Array<{ port: number; pid: number }>> {
-  const dir = daemonsDir(input?.homeDir);
+  const dir = daemonsDir(input?.env);
   let entries: string[];
   try {
     entries = await readdir(dir);
@@ -298,7 +299,7 @@ export async function stopAllLocalServers(input?: {
   for (const entry of entries) {
     const port = portFromLockEntry(entry);
     if (port === undefined) continue;
-    const result = await stopLocalServer({ port, apiKey: input?.apiKey, homeDir: input?.homeDir });
+    const result = await stopLocalServer({ port, apiKey: input?.apiKey, env: input?.env });
     if (result.stopped && result.pid !== null) {
       stopped.push({ port, pid: result.pid });
     }
@@ -307,9 +308,9 @@ export async function stopAllLocalServers(input?: {
 }
 
 export async function listRunningDaemons(input?: {
-  homeDir?: string;
+  env?: Env;
 }): Promise<Array<{ port: number; pid: number; startedAt: string }>> {
-  const dir = daemonsDir(input?.homeDir);
+  const dir = daemonsDir(input?.env);
   let entries: string[];
   try {
     entries = await readdir(dir);
@@ -321,7 +322,7 @@ export async function listRunningDaemons(input?: {
   for (const entry of entries) {
     const port = portFromLockEntry(entry);
     if (port === undefined) continue;
-    const lockPath = serverLockPath(port, input?.homeDir);
+    const lockPath = serverLockPath(port, input?.env);
     const lock = await readServerLock(lockPath);
     if (!lock) continue;
     if (!isProcessAlive(lock.pid)) {

--- a/src/session-lock.int.test.ts
+++ b/src/session-lock.int.test.ts
@@ -10,44 +10,47 @@ afterEach(cleanupDirs);
 
 describe("session lock", () => {
   test("allows re-acquire by same process", () => {
-    const homeDir = createTempHome();
-    const first = acquireSessionLock("sess_test", { homeDir });
-    const second = acquireSessionLock("sess_test", { homeDir });
+    const env = { HOME: createTempHome() };
+    const first = acquireSessionLock("sess_test", { env });
+    const second = acquireSessionLock("sess_test", { env });
     expect(first.ok).toBe(true);
     expect(second.ok).toBe(true);
-    releaseSessionLock("sess_test", { homeDir });
+    releaseSessionLock("sess_test", { env });
   });
 
   test("reclaims stale lock from non-running pid", () => {
     const homeDir = createTempHome();
+    const env = { HOME: homeDir };
     const locksDir = join(homeDir, ".acolyte", "locks");
     mkdirSync(locksDir, { recursive: true });
     const lockPath = join(homeDir, ".acolyte", "locks", "sess_test.lock");
     writeFileSync(lockPath, "999999");
-    const result = acquireSessionLock("sess_test", { homeDir });
+    const result = acquireSessionLock("sess_test", { env });
     expect(result.ok).toBe(true);
-    releaseSessionLock("sess_test", { homeDir });
+    releaseSessionLock("sess_test", { env });
   });
 
   test("blocks when lock is owned by a live different pid", () => {
     const homeDir = createTempHome();
+    const env = { HOME: homeDir };
     const sleeper = Bun.spawn(["sleep", "2"], { stdout: "ignore", stderr: "ignore" });
     try {
       const locksDir = join(homeDir, ".acolyte", "locks");
       mkdirSync(locksDir, { recursive: true });
       const lockPath = join(homeDir, ".acolyte", "locks", "sess_test.lock");
       writeFileSync(lockPath, String(sleeper.pid));
-      const result = acquireSessionLock("sess_test", { homeDir });
+      const result = acquireSessionLock("sess_test", { env });
       expect(result.ok).toBe(false);
       if (!result.ok) expect(result.ownerPid).toBe(sleeper.pid);
     } finally {
       sleeper.kill();
-      releaseSessionLock("sess_test", { homeDir });
+      releaseSessionLock("sess_test", { env });
     }
   });
 
   test("sweepStaleSessionLocks removes dead and malformed locks, keeps live locks", () => {
     const homeDir = createTempHome();
+    const env = { HOME: homeDir };
     const locksDir = join(homeDir, ".acolyte", "locks");
     mkdirSync(locksDir, { recursive: true });
 
@@ -61,7 +64,7 @@ describe("session lock", () => {
     writeFileSync(livePath, String(sleeper.pid));
 
     try {
-      const summary = sweepStaleSessionLocks({ homeDir });
+      const summary = sweepStaleSessionLocks({ env });
       expect(summary.removed).toBe(2);
       expect(summary.kept).toBe(1);
       expect(existsSync(livePath)).toBe(true);
@@ -70,7 +73,7 @@ describe("session lock", () => {
     } finally {
       sleeper.kill();
       try {
-        releaseSessionLock("sess_live", { homeDir });
+        releaseSessionLock("sess_live", { env });
       } catch {
         // best effort
       }

--- a/src/session-lock.int.test.ts
+++ b/src/session-lock.int.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { stateDir } from "./paths";
 import { acquireSessionLock, releaseSessionLock, sweepStaleSessionLocks } from "./session-lock";
 import { tempDir } from "./test-utils";
 
@@ -21,9 +22,9 @@ describe("session lock", () => {
   test("reclaims stale lock from non-running pid", () => {
     const homeDir = createTempHome();
     const env = { HOME: homeDir };
-    const locksDir = join(homeDir, ".acolyte", "locks");
+    const locksDir = join(stateDir(env), "locks");
     mkdirSync(locksDir, { recursive: true });
-    const lockPath = join(homeDir, ".acolyte", "locks", "sess_test.lock");
+    const lockPath = join(stateDir(env), "locks", "sess_test.lock");
     writeFileSync(lockPath, "999999");
     const result = acquireSessionLock("sess_test", { env });
     expect(result.ok).toBe(true);
@@ -35,9 +36,9 @@ describe("session lock", () => {
     const env = { HOME: homeDir };
     const sleeper = Bun.spawn(["sleep", "2"], { stdout: "ignore", stderr: "ignore" });
     try {
-      const locksDir = join(homeDir, ".acolyte", "locks");
+      const locksDir = join(stateDir(env), "locks");
       mkdirSync(locksDir, { recursive: true });
-      const lockPath = join(homeDir, ".acolyte", "locks", "sess_test.lock");
+      const lockPath = join(stateDir(env), "locks", "sess_test.lock");
       writeFileSync(lockPath, String(sleeper.pid));
       const result = acquireSessionLock("sess_test", { env });
       expect(result.ok).toBe(false);
@@ -51,7 +52,7 @@ describe("session lock", () => {
   test("sweepStaleSessionLocks removes dead and malformed locks, keeps live locks", () => {
     const homeDir = createTempHome();
     const env = { HOME: homeDir };
-    const locksDir = join(homeDir, ".acolyte", "locks");
+    const locksDir = join(stateDir(env), "locks");
     mkdirSync(locksDir, { recursive: true });
 
     const stalePath = join(locksDir, "sess_stale.lock");

--- a/src/session-lock.ts
+++ b/src/session-lock.ts
@@ -10,10 +10,10 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { PRIVATE_FILE_MODE } from "./file-ops";
-import { stateDirFromHome } from "./paths";
+import { type Env, stateDir } from "./paths";
 
 type LockOptions = {
-  homeDir?: string;
+  env?: Env;
 };
 
 function isProcessAlive(pid: number): boolean {
@@ -28,7 +28,7 @@ function isProcessAlive(pid: number): boolean {
 const MAX_LOCK_ATTEMPTS = 2;
 
 function locksDir(options?: LockOptions): string {
-  return join(stateDirFromHome(options?.homeDir), "locks");
+  return join(stateDir(options?.env), "locks");
 }
 
 function lockPathForSession(sessionId: string, options?: LockOptions): string {


### PR DESCRIPTION
## Motivation

Every production function in `credentials.ts`, `daemon-ops.ts`, `session-lock.ts`, `config.ts`, `resource-diagnostics.ts`, and `server-daemon.ts` carries an optional `homeDir` parameter that no production caller ever uses. The `configDirFromHome` / `stateDirFromHome` helpers bypass XDG resolution and the name is misleading now that paths resolve through XDG on Linux.

## Summary

- delete `configDirFromHome` and `stateDirFromHome` from `paths.ts`
- replace `homeDir?: string` with `env?: Env` in all production function signatures across 9 files
- update ~80 test call sites to pass `{ HOME: tempDir }` env objects
- remove `homeDir` from DI type signatures in `cli-login.ts`
- use `configDir(env)` / `stateDir(env)` in tests to derive fixture paths for Linux XDG compat

Fixes #171