### PR TITLE
refactor(rpc): adopt object args and zod parsing

### DIFF
--- a/scripts/run-perf.ts
+++ b/scripts/run-perf.ts
@@ -182,16 +182,16 @@ async function runScenario(
   const client = createClient({ apiUrl });
 
   try {
-    const reply = await client.replyStream(
-      {
+    const reply = await client.replyStream({
+      request: {
         message: scenario.prompt,
         history: [],
         model: PERF_MODEL,
         sessionId: buildPerfSessionId(scenario.id, run),
         workspace: workspaceDir,
       },
-      { onEvent: (_event: StreamEvent) => {} },
-    );
+      onEvent: (_event: StreamEvent) => {},
+    });
 
     return {
       scenarioId: scenario.id,

--- a/src/chat-message-handler-stream.int.test.ts
+++ b/src/chat-message-handler-stream.int.test.ts
@@ -15,21 +15,21 @@ describe("chat message handler stream behavior", () => {
   test("streams tool-call events into tool progress rows", async () => {
     const { handleMessage, rows, calls } = createMessageHandlerHarness({
       client: createClient({
-        replyStream: async (params) => {
-          params.onEvent({ type: "status", state: { kind: "running" } });
-          params.onEvent({
+        replyStream: async (input) => {
+          input.onEvent({ type: "status", state: { kind: "running" } });
+          input.onEvent({
             type: "tool-call",
             toolCallId: "call_1",
             toolName: "shell-run",
             args: { cmd: "echo", args: ["hi"] },
           });
-          params.onEvent({
+          input.onEvent({
             type: "tool-output",
             toolCallId: "call_1",
             toolName: "shell-run",
             content: { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "echo hi" },
           });
-          params.onEvent({ type: "text-delta", text: "done" });
+          input.onEvent({ type: "text-delta", text: "done" });
           return { state: "done" as const, model: "gpt-5-mini", output: "done" };
         },
         status: async () => ({}),
@@ -69,20 +69,20 @@ describe("chat message handler stream behavior", () => {
     const { handleMessage, rows, session } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (params) => {
-          params.onEvent({
+        replyStream: async (input) => {
+          input.onEvent({
             type: "tool-call",
             toolCallId: "call_search",
             toolName: "file-search",
             args: { pattern: "needle" },
           });
-          params.onEvent({
+          input.onEvent({
             type: "tool-result",
             toolCallId: "call_search",
             toolName: "file-search",
             isError: false,
           });
-          params.onEvent({ type: "text-delta", text: "No matches found." });
+          input.onEvent({ type: "text-delta", text: "No matches found." });
           return { state: "done" as const, model: "gpt-5-mini", output: "No matches found." };
         },
       }),
@@ -144,10 +144,10 @@ describe("chat message handler stream behavior", () => {
     } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (params) => {
+        replyStream: async (input) => {
           callCount += 1;
           if (callCount === 1) throw new Error("Remote server stream timed out after 120000ms");
-          params.onEvent({ type: "text-delta", text: "ok" });
+          input.onEvent({ type: "text-delta", text: "ok" });
           return { state: "done" as const, model: "gpt-5-mini", output: "ok" };
         },
       }),
@@ -410,11 +410,11 @@ describe("chat message handler stream behavior", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (params) => {
+        replyStream: async (input) => {
           const turn = replyCount++;
           const events = eventsByTurn[turn] ?? [];
           for (const event of events) {
-            params.onEvent(event);
+            input.onEvent(event);
           }
           return replies[turn] ?? { state: "done" as const, model: "gpt-5-mini", output: "done" };
         },
@@ -473,10 +473,10 @@ describe("chat message handler stream behavior", () => {
 
     const client = createClient({
       status: async () => ({}),
-      replyStream: async (params) => {
+      replyStream: async (input) => {
         replyCount += 1;
-        params.onEvent({ type: "status", state: { kind: "running" } });
-        params.onEvent({ type: "text-delta", text: `reply-${replyCount}` });
+        input.onEvent({ type: "status", state: { kind: "running" } });
+        input.onEvent({ type: "text-delta", text: `reply-${replyCount}` });
         return { state: "done" as const, model: "gpt-5-mini", output: `reply-${replyCount}` };
       },
     });
@@ -553,22 +553,22 @@ describe("chat message handler stream behavior", () => {
   test("assistant text row stays before tool rows after finalization", async () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
-        replyStream: async (params) => {
-          params.onEvent({ type: "status", state: { kind: "running" } });
-          params.onEvent({ type: "text-delta", text: "I will run the command." });
-          params.onEvent({
+        replyStream: async (input) => {
+          input.onEvent({ type: "status", state: { kind: "running" } });
+          input.onEvent({ type: "text-delta", text: "I will run the command." });
+          input.onEvent({
             type: "tool-call",
             toolCallId: "call_1",
             toolName: "shell-run",
             args: { cmd: "echo", args: ["hi"] },
           });
-          params.onEvent({
+          input.onEvent({
             type: "tool-output",
             toolCallId: "call_1",
             toolName: "shell-run",
             content: { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "echo hi" },
           });
-          params.onEvent({
+          input.onEvent({
             type: "tool-result",
             toolCallId: "call_1",
             toolName: "shell-run",
@@ -591,16 +591,16 @@ describe("chat message handler stream behavior", () => {
   test("batched tool calls each get their own tool row", async () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
-        replyStream: async (params) => {
-          params.onEvent({ type: "status", state: { kind: "running" } });
+        replyStream: async (input) => {
+          input.onEvent({ type: "status", state: { kind: "running" } });
           // Two tool calls in the same batch, different toolCallIds
-          params.onEvent({
+          input.onEvent({
             type: "tool-call",
             toolCallId: "call_A",
             toolName: "code-edit",
             args: { path: "a.ts" },
           });
-          params.onEvent({
+          input.onEvent({
             type: "tool-output",
             toolCallId: "call_A",
             toolName: "code-edit",
@@ -613,18 +613,18 @@ describe("chat message handler stream behavior", () => {
               removed: 1,
             },
           });
-          params.onEvent({
+          input.onEvent({
             type: "tool-result",
             toolCallId: "call_A",
             toolName: "code-edit",
           });
-          params.onEvent({
+          input.onEvent({
             type: "tool-call",
             toolCallId: "call_B",
             toolName: "code-edit",
             args: { path: "b.ts" },
           });
-          params.onEvent({
+          input.onEvent({
             type: "tool-output",
             toolCallId: "call_B",
             toolName: "code-edit",
@@ -637,7 +637,7 @@ describe("chat message handler stream behavior", () => {
               removed: 1,
             },
           });
-          params.onEvent({
+          input.onEvent({
             type: "tool-result",
             toolCallId: "call_B",
             toolName: "code-edit",

--- a/src/chat-message-handler-stream.int.test.ts
+++ b/src/chat-message-handler-stream.int.test.ts
@@ -15,21 +15,21 @@ describe("chat message handler stream behavior", () => {
   test("streams tool-call events into tool progress rows", async () => {
     const { handleMessage, rows, calls } = createMessageHandlerHarness({
       client: createClient({
-        replyStream: async (_input, options) => {
-          options.onEvent({ type: "status", state: { kind: "running" } });
-          options.onEvent({
+        replyStream: async (params) => {
+          params.onEvent({ type: "status", state: { kind: "running" } });
+          params.onEvent({
             type: "tool-call",
             toolCallId: "call_1",
             toolName: "shell-run",
             args: { cmd: "echo", args: ["hi"] },
           });
-          options.onEvent({
+          params.onEvent({
             type: "tool-output",
             toolCallId: "call_1",
             toolName: "shell-run",
             content: { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "echo hi" },
           });
-          options.onEvent({ type: "text-delta", text: "done" });
+          params.onEvent({ type: "text-delta", text: "done" });
           return { state: "done" as const, model: "gpt-5-mini", output: "done" };
         },
         status: async () => ({}),
@@ -49,7 +49,7 @@ describe("chat message handler stream behavior", () => {
   test("does not add generic tool rows when progress stream is empty", async () => {
     const { handleMessage, rows, session } = createMessageHandlerHarness({
       client: createClient({
-        reply: async () => ({
+        replyStream: async () => ({
           state: "done" as const,
           model: "gpt-5-mini",
           output: "done",
@@ -69,20 +69,20 @@ describe("chat message handler stream behavior", () => {
     const { handleMessage, rows, session } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (_input, options) => {
-          options.onEvent({
+        replyStream: async (params) => {
+          params.onEvent({
             type: "tool-call",
             toolCallId: "call_search",
             toolName: "file-search",
             args: { pattern: "needle" },
           });
-          options.onEvent({
+          params.onEvent({
             type: "tool-result",
             toolCallId: "call_search",
             toolName: "file-search",
             isError: false,
           });
-          options.onEvent({ type: "text-delta", text: "No matches found." });
+          params.onEvent({ type: "text-delta", text: "No matches found." });
           return { state: "done" as const, model: "gpt-5-mini", output: "No matches found." };
         },
       }),
@@ -98,7 +98,7 @@ describe("chat message handler stream behavior", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        reply: async () => {
+        replyStream: async () => {
           throw new Error("insufficient_quota: You exceeded your current quota");
         },
       }),
@@ -118,7 +118,7 @@ describe("chat message handler stream behavior", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        reply: async () => {
+        replyStream: async () => {
           throw new Error("Remote server stream timed out after 120000ms");
         },
       }),
@@ -144,10 +144,10 @@ describe("chat message handler stream behavior", () => {
     } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (_input, options) => {
+        replyStream: async (params) => {
           callCount += 1;
           if (callCount === 1) throw new Error("Remote server stream timed out after 120000ms");
-          options.onEvent({ type: "text-delta", text: "ok" });
+          params.onEvent({ type: "text-delta", text: "ok" });
           return { state: "done" as const, model: "gpt-5-mini", output: "ok" };
         },
       }),
@@ -172,7 +172,7 @@ describe("chat message handler stream behavior", () => {
     const { handleMessage, calls } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        reply: async () => {
+        replyStream: async () => {
           throw Object.assign(new Error("RPC stream closed before final reply"), { taskId: "rpc_task_1" });
         },
         taskStatus: async () => {
@@ -208,7 +208,7 @@ describe("chat message handler stream behavior", () => {
     const { handleMessage, allRows, sessionState, calls } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        reply: async () => {
+        replyStream: async () => {
           replyCalls += 1;
           throw new Error("Remote server stream timed out after 120000ms");
         },
@@ -240,7 +240,7 @@ describe("chat message handler stream behavior", () => {
     const { handleMessage, rows, allRows, calls } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        reply: async () => {
+        replyStream: async () => {
           replyCalls += 1;
           throw new Error("Remote server stream timed out after 120000ms");
         },
@@ -270,14 +270,13 @@ describe("chat message handler stream behavior", () => {
     const { handleMessage, session } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        events: [
-          { type: "text-delta", text: "This is a long streamed answer that should not be truncated at finalize." },
-        ],
-        reply: async () => ({
-          state: "done" as const,
-          model: "gpt-5-mini",
-          output: finalOutput,
-        }),
+        replyStream: async (input) => {
+          input.onEvent({
+            type: "text-delta",
+            text: "This is a long streamed answer that should not be truncated at finalize.",
+          });
+          return { state: "done" as const, model: "gpt-5-mini", output: finalOutput };
+        },
       }),
     });
 
@@ -292,22 +291,23 @@ describe("chat message handler stream behavior", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        events: [
-          { type: "tool-call", toolCallId: "call_1", toolName: "file-read", args: { paths: [{ path: "a.ts" }] } },
-          {
+        replyStream: async (input) => {
+          input.onEvent({
+            type: "tool-call",
+            toolCallId: "call_1",
+            toolName: "file-read",
+            args: { paths: [{ path: "a.ts" }] },
+          });
+          input.onEvent({
             type: "tool-result",
             toolCallId: "call_1",
             toolName: "file-read",
             isError: true,
             errorCode: "E_GUARD_BLOCKED",
             error: { code: "E_GUARD_BLOCKED", category: "budget-exhausted" },
-          },
-        ],
-        reply: async () => ({
-          state: "done" as const,
-          model: "gpt-5-mini",
-          output: "done",
-        }),
+          });
+          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+        },
       }),
     });
 
@@ -321,35 +321,36 @@ describe("chat message handler stream behavior", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        events: [
-          { type: "tool-call", toolCallId: "call_blocked", toolName: "file-read", args: { paths: [{ path: "a.ts" }] } },
-          {
+        replyStream: async (input) => {
+          input.onEvent({
+            type: "tool-call",
+            toolCallId: "call_blocked",
+            toolName: "file-read",
+            args: { paths: [{ path: "a.ts" }] },
+          });
+          input.onEvent({
             type: "tool-result",
             toolCallId: "call_blocked",
             toolName: "file-read",
             isError: true,
             errorCode: "E_GUARD_BLOCKED",
             error: { code: "E_GUARD_BLOCKED", category: "budget-exhausted" },
-          },
-          { type: "tool-call", toolCallId: "call_ok", toolName: "file-edit", args: { path: "b.ts" } },
-          {
+          });
+          input.onEvent({ type: "tool-call", toolCallId: "call_ok", toolName: "file-edit", args: { path: "b.ts" } });
+          input.onEvent({
             type: "tool-output",
             toolCallId: "call_ok",
             toolName: "file-edit",
             content: { kind: "tool-header", labelKey: "tool.label.file_edit", detail: "b.ts" },
-          },
-          {
+          });
+          input.onEvent({
             type: "tool-output",
             toolCallId: "call_ok",
             toolName: "file-edit",
             content: { kind: "diff", lineNumber: 2, marker: "add", text: "export const b = 2;" },
-          },
-        ],
-        reply: async () => ({
-          state: "done" as const,
-          model: "gpt-5-mini",
-          output: "done",
-        }),
+          });
+          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+        },
       }),
     });
 
@@ -409,11 +410,11 @@ describe("chat message handler stream behavior", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (_input, options) => {
+        replyStream: async (params) => {
           const turn = replyCount++;
           const events = eventsByTurn[turn] ?? [];
           for (const event of events) {
-            options.onEvent(event);
+            params.onEvent(event);
           }
           return replies[turn] ?? { state: "done" as const, model: "gpt-5-mini", output: "done" };
         },
@@ -436,7 +437,7 @@ describe("chat message handler stream behavior", () => {
     const { handleMessage, session, calls } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        reply: async () => ({
+        replyStream: async () => ({
           state: "done" as const,
           model: "gpt-5-mini",
           output: "done",
@@ -472,10 +473,10 @@ describe("chat message handler stream behavior", () => {
 
     const client = createClient({
       status: async () => ({}),
-      replyStream: async (_input, options) => {
+      replyStream: async (params) => {
         replyCount += 1;
-        options.onEvent({ type: "status", state: { kind: "running" } });
-        options.onEvent({ type: "text-delta", text: `reply-${replyCount}` });
+        params.onEvent({ type: "status", state: { kind: "running" } });
+        params.onEvent({ type: "text-delta", text: `reply-${replyCount}` });
         return { state: "done" as const, model: "gpt-5-mini", output: `reply-${replyCount}` };
       },
     });
@@ -552,22 +553,22 @@ describe("chat message handler stream behavior", () => {
   test("assistant text row stays before tool rows after finalization", async () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
-        replyStream: async (_input, options) => {
-          options.onEvent({ type: "status", state: { kind: "running" } });
-          options.onEvent({ type: "text-delta", text: "I will run the command." });
-          options.onEvent({
+        replyStream: async (params) => {
+          params.onEvent({ type: "status", state: { kind: "running" } });
+          params.onEvent({ type: "text-delta", text: "I will run the command." });
+          params.onEvent({
             type: "tool-call",
             toolCallId: "call_1",
             toolName: "shell-run",
             args: { cmd: "echo", args: ["hi"] },
           });
-          options.onEvent({
+          params.onEvent({
             type: "tool-output",
             toolCallId: "call_1",
             toolName: "shell-run",
             content: { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "echo hi" },
           });
-          options.onEvent({
+          params.onEvent({
             type: "tool-result",
             toolCallId: "call_1",
             toolName: "shell-run",
@@ -590,16 +591,16 @@ describe("chat message handler stream behavior", () => {
   test("batched tool calls each get their own tool row", async () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
-        replyStream: async (_input, options) => {
-          options.onEvent({ type: "status", state: { kind: "running" } });
+        replyStream: async (params) => {
+          params.onEvent({ type: "status", state: { kind: "running" } });
           // Two tool calls in the same batch, different toolCallIds
-          options.onEvent({
+          params.onEvent({
             type: "tool-call",
             toolCallId: "call_A",
             toolName: "code-edit",
             args: { path: "a.ts" },
           });
-          options.onEvent({
+          params.onEvent({
             type: "tool-output",
             toolCallId: "call_A",
             toolName: "code-edit",
@@ -612,18 +613,18 @@ describe("chat message handler stream behavior", () => {
               removed: 1,
             },
           });
-          options.onEvent({
+          params.onEvent({
             type: "tool-result",
             toolCallId: "call_A",
             toolName: "code-edit",
           });
-          options.onEvent({
+          params.onEvent({
             type: "tool-call",
             toolCallId: "call_B",
             toolName: "code-edit",
             args: { path: "b.ts" },
           });
-          options.onEvent({
+          params.onEvent({
             type: "tool-output",
             toolCallId: "call_B",
             toolName: "code-edit",
@@ -636,7 +637,7 @@ describe("chat message handler stream behavior", () => {
               removed: 1,
             },
           });
-          options.onEvent({
+          params.onEvent({
             type: "tool-result",
             toolCallId: "call_B",
             toolName: "code-edit",

--- a/src/chat-message-handler-task-followup.ts
+++ b/src/chat-message-handler-task-followup.ts
@@ -20,7 +20,7 @@ const POLL_INTERVAL_MS = 700;
 
 export async function startRemoteTaskFollowup(input: StartRemoteTaskFollowupInput): Promise<boolean> {
   try {
-    const task = await input.client.taskStatus(input.remoteTaskId);
+    const task = await input.client.taskStatus({ taskId: input.remoteTaskId });
     if (!task || (task.state !== "running" && task.state !== "detached")) return false;
   } catch {
     return false;
@@ -38,7 +38,7 @@ export async function startRemoteTaskFollowup(input: StartRemoteTaskFollowupInpu
           ]);
           return;
         }
-        const next = await input.client.taskStatus(input.remoteTaskId);
+        const next = await input.client.taskStatus({ taskId: input.remoteTaskId });
         if (!next || next.state === "running" || next.state === "detached") continue;
         if (next.state === "failed") {
           input.setRows((current) => [

--- a/src/chat-message-handler.int.test.ts
+++ b/src/chat-message-handler.int.test.ts
@@ -141,9 +141,9 @@ describe("chat message handler", () => {
     const { handleMessage } = createMessageHandlerHarness({
       session,
       client: createClient({
-        reply: async (input) => {
-          requestedModel = input.model;
-          return { state: "done" as const, model: input.model, output: "ok" };
+        replyStream: async (input) => {
+          requestedModel = input.request.model;
+          return { state: "done" as const, model: input.request.model, output: "ok" };
         },
       }),
     });
@@ -211,11 +211,11 @@ describe("chat message handler", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (_input, options) => {
+        replyStream: async (params) => {
           const turn = replyCount++;
           const events = eventsByTurn[turn] ?? [];
           for (const event of events) {
-            options.onEvent(event);
+            params.onEvent(event);
           }
           return replies[turn] ?? { state: "done" as const, model: "gpt-5-mini", output: "done" };
         },
@@ -269,18 +269,18 @@ describe("chat message handler", () => {
 
     const { handleSubmit } = createMessageHandler({
       client: createClient({
-        reply: async (_input, options) =>
+        replyStream: async (input) =>
           await new Promise((_, reject) => {
             const abort = (): void => {
               const error = new Error("Aborted");
               error.name = "AbortError";
               reject(error);
             };
-            if (options?.signal?.aborted) {
+            if (input.signal?.aborted) {
               abort();
               return;
             }
-            options?.signal?.addEventListener("abort", abort, { once: true });
+            input.signal?.addEventListener("abort", abort, { once: true });
           }),
         status: async () => ({}),
       }),
@@ -344,7 +344,7 @@ describe("chat message handler", () => {
 
     const { handleSubmit } = createMessageHandler({
       client: createClient({
-        replyStream: async (_input, options) => {
+        replyStream: async (params) => {
           const call = callCount++;
           if (call === 0) {
             return await new Promise((_, reject) => {
@@ -353,14 +353,14 @@ describe("chat message handler", () => {
                 error.name = "AbortError";
                 reject(error);
               };
-              if (options?.signal?.aborted) {
+              if (params.signal?.aborted) {
                 abort();
                 return;
               }
-              options?.signal?.addEventListener("abort", abort, { once: true });
+              params.signal?.addEventListener("abort", abort, { once: true });
             });
           }
-          options.onEvent({ type: "text-delta", text: "Second answer." });
+          params.onEvent({ type: "text-delta", text: "Second answer." });
           return { state: "done" as const, model: "gpt-5-mini", output: "Second answer." };
         },
         status: async () => ({}),
@@ -431,7 +431,7 @@ describe("chat message handler", () => {
 
     const { handleSubmit } = createMessageHandler({
       client: createClient({
-        reply: async () => {
+        replyStream: async () => {
           replyCalls += 1;
           return { state: "done" as const, model: "gpt-5-mini", output: "ok" };
         },
@@ -489,9 +489,9 @@ describe("chat message handler", () => {
 
       const { handleSubmit } = createMessageHandler({
         client: createClient({
-          replyStream: async (_input, options) => {
+          replyStream: async (params) => {
             replyCalls += 1;
-            options.onEvent({ type: "text-delta", text: "ok" });
+            params.onEvent({ type: "text-delta", text: "ok" });
             return { state: "done" as const, model: "gpt-5-mini", output: "ok" };
           },
           status: async () => ({}),

--- a/src/chat-message-handler.int.test.ts
+++ b/src/chat-message-handler.int.test.ts
@@ -211,11 +211,11 @@ describe("chat message handler", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (params) => {
+        replyStream: async (input) => {
           const turn = replyCount++;
           const events = eventsByTurn[turn] ?? [];
           for (const event of events) {
-            params.onEvent(event);
+            input.onEvent(event);
           }
           return replies[turn] ?? { state: "done" as const, model: "gpt-5-mini", output: "done" };
         },
@@ -344,7 +344,7 @@ describe("chat message handler", () => {
 
     const { handleSubmit } = createMessageHandler({
       client: createClient({
-        replyStream: async (params) => {
+        replyStream: async (input) => {
           const call = callCount++;
           if (call === 0) {
             return await new Promise((_, reject) => {
@@ -353,14 +353,14 @@ describe("chat message handler", () => {
                 error.name = "AbortError";
                 reject(error);
               };
-              if (params.signal?.aborted) {
+              if (input.signal?.aborted) {
                 abort();
                 return;
               }
-              params.signal?.addEventListener("abort", abort, { once: true });
+              input.signal?.addEventListener("abort", abort, { once: true });
             });
           }
-          params.onEvent({ type: "text-delta", text: "Second answer." });
+          input.onEvent({ type: "text-delta", text: "Second answer." });
           return { state: "done" as const, model: "gpt-5-mini", output: "Second answer." };
         },
         status: async () => ({}),
@@ -489,9 +489,9 @@ describe("chat message handler", () => {
 
       const { handleSubmit } = createMessageHandler({
         client: createClient({
-          replyStream: async (params) => {
+          replyStream: async (input) => {
             replyCalls += 1;
-            params.onEvent({ type: "text-delta", text: "ok" });
+            input.onEvent({ type: "text-delta", text: "ok" });
             return { state: "done" as const, model: "gpt-5-mini", output: "ok" };
           },
           status: async () => ({}),

--- a/src/chat-turn.ts
+++ b/src/chat-turn.ts
@@ -100,8 +100,8 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
   tokenEntry: SessionTokenUsageEntry;
   rows: ChatRow[];
 }> {
-  const reply = await params.client.replyStream(
-    {
+  const reply = await params.client.replyStream({
+    request: {
       message: params.userText,
       history: params.history,
       model: params.model,
@@ -109,8 +109,9 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
       useMemory: params.useMemory,
       ...createWorkspaceSpecifier(params.workspace ?? process.cwd()),
     },
-    { signal: params.signal, onEvent: params.onEvent ?? (() => {}) },
-  );
+    signal: params.signal,
+    onEvent: params.onEvent ?? (() => {}),
+  });
 
   const baseAssistantMessage = params.createMessage("assistant", reply.output);
   const assistantMessage: ChatMessage =

--- a/src/checklist.int.test.ts
+++ b/src/checklist.int.test.ts
@@ -10,9 +10,9 @@ describe("checklist integration", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (params) => {
-          params.onEvent({ type: "status", state: { kind: "running" } });
-          params.onEvent({
+        replyStream: async (input) => {
+          input.onEvent({ type: "status", state: { kind: "running" } });
+          input.onEvent({
             type: "checklist",
             groupId: "grp_1",
             groupTitle: "Refactoring auth module",
@@ -45,10 +45,10 @@ describe("checklist integration", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (params) => {
-          params.onEvent({ type: "status", state: { kind: "running" } });
+        replyStream: async (input) => {
+          input.onEvent({ type: "status", state: { kind: "running" } });
           // set-checklist creates with all pending
-          params.onEvent({
+          input.onEvent({
             type: "checklist",
             groupId: "grp_1",
             groupTitle: "Build pipeline",
@@ -58,7 +58,7 @@ describe("checklist integration", () => {
             ],
           });
           // checklist-update updates individual items
-          params.onEvent({
+          input.onEvent({
             type: "checklist",
             groupId: "grp_1",
             groupTitle: "Build pipeline",
@@ -88,15 +88,15 @@ describe("checklist integration", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (params) => {
-          params.onEvent({ type: "status", state: { kind: "running" } });
-          params.onEvent({
+        replyStream: async (input) => {
+          input.onEvent({ type: "status", state: { kind: "running" } });
+          input.onEvent({
             type: "checklist",
             groupId: "grp_a",
             groupTitle: "Phase A",
             items: [{ id: "a1", label: "step A1", status: "pending", order: 0 }],
           });
-          params.onEvent({
+          input.onEvent({
             type: "checklist",
             groupId: "grp_b",
             groupTitle: "Phase B",
@@ -121,21 +121,21 @@ describe("checklist integration", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (params) => {
-          params.onEvent({ type: "status", state: { kind: "running" } });
-          params.onEvent({
+        replyStream: async (input) => {
+          input.onEvent({ type: "status", state: { kind: "running" } });
+          input.onEvent({
             type: "checklist",
             groupId: "grp_1",
             groupTitle: "Steps",
             items: [{ id: "s1", label: "do thing", status: "pending", order: 0 }],
           });
-          params.onEvent({
+          input.onEvent({
             type: "tool-call",
             toolCallId: "call_1",
             toolName: "file-read",
             args: { path: "a.ts" },
           });
-          params.onEvent({
+          input.onEvent({
             type: "tool-output",
             toolCallId: "call_1",
             toolName: "file-read",
@@ -161,27 +161,27 @@ describe("checklist integration", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (params) => {
-          params.onEvent({ type: "status", state: { kind: "running" } });
-          params.onEvent({
+        replyStream: async (input) => {
+          input.onEvent({ type: "status", state: { kind: "running" } });
+          input.onEvent({
             type: "checklist",
             groupId: "grp_1",
             groupTitle: "Steps",
             items: [{ id: "s1", label: "edit file", status: "in_progress", order: 0 }],
           });
-          params.onEvent({
+          input.onEvent({
             type: "tool-call",
             toolCallId: "call_1",
             toolName: "file-edit",
             args: { path: "a.ts" },
           });
-          params.onEvent({
+          input.onEvent({
             type: "tool-output",
             toolCallId: "call_1",
             toolName: "file-edit",
             content: { kind: "tool-header", labelKey: "tool.label.file_edit", detail: "a.ts" },
           });
-          params.onEvent({
+          input.onEvent({
             type: "tool-result",
             toolCallId: "call_1",
             toolName: "file-edit",
@@ -204,9 +204,9 @@ describe("checklist integration", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (params) => {
-          params.onEvent({ type: "status", state: { kind: "running" } });
-          params.onEvent({
+        replyStream: async (input) => {
+          input.onEvent({ type: "status", state: { kind: "running" } });
+          input.onEvent({
             type: "checklist",
             groupId: "grp_1",
             groupTitle: "Steps",
@@ -227,9 +227,9 @@ describe("checklist integration", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (params) => {
-          params.onEvent({ type: "status", state: { kind: "running" } });
-          params.onEvent({
+        replyStream: async (input) => {
+          input.onEvent({ type: "status", state: { kind: "running" } });
+          input.onEvent({
             type: "checklist",
             groupId: "grp_1",
             groupTitle: "Steps",

--- a/src/checklist.int.test.ts
+++ b/src/checklist.int.test.ts
@@ -10,9 +10,9 @@ describe("checklist integration", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (_input, options) => {
-          options.onEvent({ type: "status", state: { kind: "running" } });
-          options.onEvent({
+        replyStream: async (params) => {
+          params.onEvent({ type: "status", state: { kind: "running" } });
+          params.onEvent({
             type: "checklist",
             groupId: "grp_1",
             groupTitle: "Refactoring auth module",
@@ -45,10 +45,10 @@ describe("checklist integration", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (_input, options) => {
-          options.onEvent({ type: "status", state: { kind: "running" } });
+        replyStream: async (params) => {
+          params.onEvent({ type: "status", state: { kind: "running" } });
           // set-checklist creates with all pending
-          options.onEvent({
+          params.onEvent({
             type: "checklist",
             groupId: "grp_1",
             groupTitle: "Build pipeline",
@@ -58,7 +58,7 @@ describe("checklist integration", () => {
             ],
           });
           // checklist-update updates individual items
-          options.onEvent({
+          params.onEvent({
             type: "checklist",
             groupId: "grp_1",
             groupTitle: "Build pipeline",
@@ -88,15 +88,15 @@ describe("checklist integration", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (_input, options) => {
-          options.onEvent({ type: "status", state: { kind: "running" } });
-          options.onEvent({
+        replyStream: async (params) => {
+          params.onEvent({ type: "status", state: { kind: "running" } });
+          params.onEvent({
             type: "checklist",
             groupId: "grp_a",
             groupTitle: "Phase A",
             items: [{ id: "a1", label: "step A1", status: "pending", order: 0 }],
           });
-          options.onEvent({
+          params.onEvent({
             type: "checklist",
             groupId: "grp_b",
             groupTitle: "Phase B",
@@ -121,21 +121,21 @@ describe("checklist integration", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (_input, options) => {
-          options.onEvent({ type: "status", state: { kind: "running" } });
-          options.onEvent({
+        replyStream: async (params) => {
+          params.onEvent({ type: "status", state: { kind: "running" } });
+          params.onEvent({
             type: "checklist",
             groupId: "grp_1",
             groupTitle: "Steps",
             items: [{ id: "s1", label: "do thing", status: "pending", order: 0 }],
           });
-          options.onEvent({
+          params.onEvent({
             type: "tool-call",
             toolCallId: "call_1",
             toolName: "file-read",
             args: { path: "a.ts" },
           });
-          options.onEvent({
+          params.onEvent({
             type: "tool-output",
             toolCallId: "call_1",
             toolName: "file-read",
@@ -161,27 +161,27 @@ describe("checklist integration", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (_input, options) => {
-          options.onEvent({ type: "status", state: { kind: "running" } });
-          options.onEvent({
+        replyStream: async (params) => {
+          params.onEvent({ type: "status", state: { kind: "running" } });
+          params.onEvent({
             type: "checklist",
             groupId: "grp_1",
             groupTitle: "Steps",
             items: [{ id: "s1", label: "edit file", status: "in_progress", order: 0 }],
           });
-          options.onEvent({
+          params.onEvent({
             type: "tool-call",
             toolCallId: "call_1",
             toolName: "file-edit",
             args: { path: "a.ts" },
           });
-          options.onEvent({
+          params.onEvent({
             type: "tool-output",
             toolCallId: "call_1",
             toolName: "file-edit",
             content: { kind: "tool-header", labelKey: "tool.label.file_edit", detail: "a.ts" },
           });
-          options.onEvent({
+          params.onEvent({
             type: "tool-result",
             toolCallId: "call_1",
             toolName: "file-edit",
@@ -204,9 +204,9 @@ describe("checklist integration", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (_input, options) => {
-          options.onEvent({ type: "status", state: { kind: "running" } });
-          options.onEvent({
+        replyStream: async (params) => {
+          params.onEvent({ type: "status", state: { kind: "running" } });
+          params.onEvent({
             type: "checklist",
             groupId: "grp_1",
             groupTitle: "Steps",
@@ -227,9 +227,9 @@ describe("checklist integration", () => {
     const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
-        replyStream: async (_input, options) => {
-          options.onEvent({ type: "status", state: { kind: "running" } });
-          options.onEvent({
+        replyStream: async (params) => {
+          params.onEvent({ type: "status", state: { kind: "running" } });
+          params.onEvent({
             type: "checklist",
             groupId: "grp_1",
             groupTitle: "Steps",

--- a/src/cli-prompt.test.ts
+++ b/src/cli-prompt.test.ts
@@ -21,8 +21,8 @@ function createTestSession(): Session {
 
 function createStreamingClient(events: StreamEvent[]): Client {
   return {
-    replyStream: async (_input, options) => {
-      for (const event of events) options.onEvent(event);
+    replyStream: async (params) => {
+      for (const event of events) params.onEvent(event);
       return { state: "done" as const, output: "done", model: "gpt-5-mini", toolCalls: ["code-edit"] };
     },
     status: async () => ({}),

--- a/src/cli-prompt.test.ts
+++ b/src/cli-prompt.test.ts
@@ -21,8 +21,8 @@ function createTestSession(): Session {
 
 function createStreamingClient(events: StreamEvent[]): Client {
   return {
-    replyStream: async (params) => {
-      for (const event of events) params.onEvent(event);
+    replyStream: async (input) => {
+      for (const event of events) input.onEvent(event);
       return { state: "done" as const, output: "done", model: "gpt-5-mini", toolCalls: ["code-edit"] };
     },
     status: async () => ({}),

--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -96,8 +96,8 @@ export async function handlePrompt(
     const snapshotByCallId = new Map<string, string>();
     let hasPrintedToolProgress = false;
 
-    const reply = await client.replyStream(
-      {
+    const reply = await client.replyStream({
+      request: {
         message: prompt,
         history: session.messages,
         model: session.model,
@@ -105,64 +105,60 @@ export async function handlePrompt(
         resourceId: options?.resourceId,
         ...createWorkspaceSpecifier(options?.workspace),
       },
-      {
-        onEvent: (event) => {
-          switch (event.type) {
-            case "text-delta":
-              agentRenderer.onDelta(event.text);
-              break;
-            case "tool-output": {
-              const update = toolOutput.push(event);
-              if (!update) break;
-              if (update.items.length === 1 && update.items[0]?.kind === "tool-header" && !update.items[0].detail)
-                break;
-              const rendered = formatToolOutput(update.items);
-              if (!rendered) break;
-              const previous = snapshotByCallId.get(event.toolCallId);
-              snapshotByCallId.set(event.toolCallId, rendered);
-              if (previous) {
-                const current = rendered.trimEnd();
-                const before = previous.trimEnd();
-                if (current === before) break;
-                if (current.startsWith(`${before}\n`)) {
-                  printIndentedDim(current.slice(before.length + 1));
-                  hasPrintedToolProgress = true;
-                  break;
-                }
-                // Padding or formatting changed earlier lines — print only new trailing lines.
-                const currentLines = current.split("\n");
-                const previousLines = before.split("\n");
-                if (currentLines.length > previousLines.length) {
-                  printIndentedDim(currentLines.slice(previousLines.length).join("\n"));
-                  hasPrintedToolProgress = true;
-                  break;
-                }
+      onEvent: (event) => {
+        switch (event.type) {
+          case "text-delta":
+            agentRenderer.onDelta(event.text);
+            break;
+          case "tool-output": {
+            const update = toolOutput.push(event);
+            if (!update) break;
+            if (update.items.length === 1 && update.items[0]?.kind === "tool-header" && !update.items[0].detail) break;
+            const rendered = formatToolOutput(update.items);
+            if (!rendered) break;
+            const previous = snapshotByCallId.get(event.toolCallId);
+            snapshotByCallId.set(event.toolCallId, rendered);
+            if (previous) {
+              const current = rendered.trimEnd();
+              const before = previous.trimEnd();
+              if (current === before) break;
+              if (current.startsWith(`${before}\n`)) {
+                printIndentedDim(current.slice(before.length + 1));
+                hasPrintedToolProgress = true;
                 break;
               }
-              printDim(`• ${rendered.split("\n")[0] ?? ""}`);
-              if (rendered.includes("\n")) printIndentedDim(rendered.slice(rendered.indexOf("\n") + 1));
-              hasPrintedToolProgress = true;
+              const currentLines = current.split("\n");
+              const previousLines = before.split("\n");
+              if (currentLines.length > previousLines.length) {
+                printIndentedDim(currentLines.slice(previousLines.length).join("\n"));
+                hasPrintedToolProgress = true;
+                break;
+              }
               break;
             }
-            case "checklist": {
-              const { header, items } = formatChecklist(event);
-              printDim(`• ${header}`);
-              for (const item of items) printIndentedDim(`${item.marker} ${item.label}`);
-              hasPrintedToolProgress = true;
-              break;
-            }
-            case "tool-result": {
-              const budgetExhausted =
-                event.isError === true &&
-                (event.errorCode === LIFECYCLE_ERROR_CODES.budgetExhausted ||
-                  event.error?.category === "budget-exhausted");
-              if (budgetExhausted) toolOutput.delete(event.toolCallId);
-              break;
-            }
+            printDim(`• ${rendered.split("\n")[0] ?? ""}`);
+            if (rendered.includes("\n")) printIndentedDim(rendered.slice(rendered.indexOf("\n") + 1));
+            hasPrintedToolProgress = true;
+            break;
           }
-        },
+          case "checklist": {
+            const { header, items } = formatChecklist(event);
+            printDim(`• ${header}`);
+            for (const item of items) printIndentedDim(`${item.marker} ${item.label}`);
+            hasPrintedToolProgress = true;
+            break;
+          }
+          case "tool-result": {
+            const budgetExhausted =
+              event.isError === true &&
+              (event.errorCode === LIFECYCLE_ERROR_CODES.budgetExhausted ||
+                event.error?.category === "budget-exhausted");
+            if (budgetExhausted) toolOutput.delete(event.toolCallId);
+            break;
+          }
+        }
       },
-    );
+    });
 
     if (reply.error) {
       printError(reply.error);

--- a/src/client-contract.ts
+++ b/src/client-contract.ts
@@ -117,15 +117,13 @@ export type StreamEvent =
   | ErrorEvent;
 
 export interface Client {
-  replyStream(
-    input: ChatRequest,
-    options: {
-      onEvent: (event: StreamEvent) => void;
-      signal?: AbortSignal;
-    },
-  ): Promise<ChatResponse>;
+  replyStream(input: {
+    request: ChatRequest;
+    onEvent: (event: StreamEvent) => void;
+    signal?: AbortSignal;
+  }): Promise<ChatResponse>;
   status(): Promise<StatusFields>;
-  taskStatus(params: { taskId: TaskId }): Promise<TaskRecord | null>;
+  taskStatus(input: { taskId: TaskId }): Promise<TaskRecord | null>;
 }
 
 export type RemoteErrorMetadata = {

--- a/src/client-contract.ts
+++ b/src/client-contract.ts
@@ -125,7 +125,7 @@ export interface Client {
     },
   ): Promise<ChatResponse>;
   status(): Promise<StatusFields>;
-  taskStatus(taskId: TaskId): Promise<TaskRecord | null>;
+  taskStatus(params: { taskId: TaskId }): Promise<TaskRecord | null>;
 }
 
 export type RemoteErrorMetadata = {

--- a/src/client-rpc.test.ts
+++ b/src/client-rpc.test.ts
@@ -275,7 +275,7 @@ describe("rpc websocket lifecycle", () => {
 
     globalThis.WebSocket = MockWebSocket as unknown as typeof WebSocket;
     const client = createClient({ apiUrl: "http://localhost:6767" });
-    const task = await client.taskStatus("task_123");
+    const task = await client.taskStatus({ taskId: "task_123" });
     expect(task?.id).toBe("task_123");
     expect(task?.state).toBe("running");
   });

--- a/src/client-rpc.test.ts
+++ b/src/client-rpc.test.ts
@@ -74,14 +74,12 @@ describe("rpc websocket lifecycle", () => {
 
     const client = createClient({ apiUrl: "http://localhost:6767" });
     const receivedEventTypes: string[] = [];
-    const reply = await client.replyStream(
-      { message: "hi", history: [], model: "gpt-5-mini", sessionId: "sess_rpc" },
-      {
-        onEvent: (event) => {
-          receivedEventTypes.push(event.type);
-        },
+    const reply = await client.replyStream({
+      request: { message: "hi", history: [], model: "gpt-5-mini", sessionId: "sess_rpc" },
+      onEvent: (event) => {
+        receivedEventTypes.push(event.type);
       },
-    );
+    });
 
     expect(reply.output).toBe("done");
     expect(receivedEventTypes).toEqual(["status", "status", "status", "status", "tool-call"]);
@@ -128,10 +126,11 @@ describe("rpc websocket lifecycle", () => {
     const client = createClient({ apiUrl: "http://localhost:6767" });
     const controller = new AbortController();
 
-    const run = client.replyStream(
-      { message: "hi", history: [], model: "gpt-5-mini", sessionId: "sess_rpcabort" },
-      { onEvent: () => {}, signal: controller.signal },
-    );
+    const run = client.replyStream({
+      request: { message: "hi", history: [], model: "gpt-5-mini", sessionId: "sess_rpcabort" },
+      onEvent: () => {},
+      signal: controller.signal,
+    });
 
     for (let i = 0; i < 100 && !sent.some((msg) => msg.type === "chat.start"); i++) {
       await Promise.resolve();
@@ -204,14 +203,12 @@ describe("rpc websocket lifecycle", () => {
     const receivedEventTypes: string[] = [];
 
     try {
-      await client.replyStream(
-        { message: "hi", history: [], model: "gpt-5-mini", sessionId: "sess_rpcdisconnect" },
-        {
-          onEvent: (event) => {
-            receivedEventTypes.push(event.type);
-          },
+      await client.replyStream({
+        request: { message: "hi", history: [], model: "gpt-5-mini", sessionId: "sess_rpcdisconnect" },
+        onEvent: (event) => {
+          receivedEventTypes.push(event.type);
         },
-      );
+      });
       throw new Error("expected replyStream to reject");
     } catch (error) {
       const rpcError = error as Error & { taskId?: string };

--- a/src/client-rpc.ts
+++ b/src/client-rpc.ts
@@ -161,9 +161,9 @@ export class RpcClient implements Client {
     });
   }
 
-  async taskStatus(params: { taskId: TaskId }): Promise<TaskRecord | null> {
+  async taskStatus(input: { taskId: TaskId }): Promise<TaskRecord | null> {
     return await this.runUnaryRequest<TaskRecord | null>({
-      request: (id) => ({ id, type: "task.status", payload: { taskId: params.taskId } }),
+      request: (id) => ({ id, type: "task.status", payload: { taskId: input.taskId } }),
       closeError: "RPC connection closed before task status response",
       resolve: (msg) => {
         if (msg.type === "task.status.result") {
@@ -176,13 +176,12 @@ export class RpcClient implements Client {
     });
   }
 
-  async replyStream(
-    input: ChatRequest,
-    options: {
-      onEvent: (event: import("./client-contract").StreamEvent) => void;
-      signal?: AbortSignal;
-    },
-  ): Promise<ChatResponse> {
+  async replyStream(input: {
+    request: ChatRequest;
+    onEvent: (event: import("./client-contract").StreamEvent) => void;
+    signal?: AbortSignal;
+  }): Promise<ChatResponse> {
+    const { request, onEvent, signal } = input;
     const ws = await this.openSocket();
     const id = createRpcRequestId();
     let acceptedTaskId: TaskId | undefined;
@@ -206,7 +205,7 @@ export class RpcClient implements Client {
         ws.removeEventListener("message", onMessage);
         ws.removeEventListener("close", onClose);
         ws.removeEventListener("error", onError);
-        if (options.signal) options.signal.removeEventListener("abort", onAbort);
+        if (signal) signal.removeEventListener("abort", onAbort);
       };
       const onAbort = () => {
         try {
@@ -242,21 +241,21 @@ export class RpcClient implements Client {
         if (!msg || msg.id !== id) return;
         if (msg.type === "chat.accepted") {
           acceptedTaskId = msg.taskId;
-          options.onEvent({ type: "status", state: { kind: "accepted" } });
+          onEvent({ type: "status", state: { kind: "accepted" } });
           return;
         }
         if (msg.type === "chat.queued") {
-          options.onEvent({ type: "status", state: { kind: "queued", position: msg.position } });
+          onEvent({ type: "status", state: { kind: "queued", position: msg.position } });
           return;
         }
         if (msg.type === "chat.started") {
-          options.onEvent({ type: "status", state: { kind: "running" } });
+          onEvent({ type: "status", state: { kind: "running" } });
           return;
         }
         if (msg.type === "chat.abort.result") return;
         if (msg.type === "chat.event") {
           const parsed = parseStreamEvent(msg.event);
-          if (parsed) options.onEvent(parsed);
+          if (parsed) onEvent(parsed);
           return;
         }
         cleanup();
@@ -279,14 +278,14 @@ export class RpcClient implements Client {
       ws.addEventListener("message", onMessage);
       ws.addEventListener("close", onClose);
       ws.addEventListener("error", onError);
-      if (options.signal) {
-        if (options.signal.aborted) {
+      if (signal) {
+        if (signal.aborted) {
           onAbort();
           return;
         }
-        options.signal.addEventListener("abort", onAbort, { once: true });
+        signal.addEventListener("abort", onAbort, { once: true });
       }
-      ws.send(JSON.stringify({ id, type: "chat.start", payload: { request: input } }));
+      ws.send(JSON.stringify({ id, type: "chat.start", payload: { request } }));
     });
   }
 }

--- a/src/client-rpc.ts
+++ b/src/client-rpc.ts
@@ -11,7 +11,7 @@ import {
 import { connectionHelpMessage } from "./error-messages";
 import { field } from "./field";
 import { createRpcRequestId } from "./rpc-protocol";
-import type { StatusFields } from "./status-contract";
+import { parseStatusFields, type StatusFields } from "./status-contract";
 import type { TaskId, TaskRecord } from "./task-contract";
 
 type RpcServerMessage = NonNullable<ReturnType<typeof parseRpcServerMessage>>;
@@ -152,18 +152,8 @@ export class RpcClient implements Client {
       closeError: "RPC connection closed before status response",
       resolve: (msg) => {
         if (msg.type === "status.result") {
-          const fields: StatusFields = {};
-          for (const [key, value] of Object.entries(msg.status)) {
-            if (key === "ok") continue;
-            if (typeof value === "string" || typeof value === "number") {
-              fields[key] = value;
-              continue;
-            }
-            if (Array.isArray(value) && value.every((entry) => typeof entry === "string")) {
-              fields[key] = value;
-            }
-          }
-          return fields;
+          const fields = parseStatusFields(msg.status);
+          return fields ?? new Error("Invalid status response");
         }
         if (msg.type === "error") return new Error(msg.error);
         return new Error(`Unexpected RPC response: ${msg.type}`);

--- a/src/client-rpc.ts
+++ b/src/client-rpc.ts
@@ -161,9 +161,9 @@ export class RpcClient implements Client {
     });
   }
 
-  async taskStatus(taskId: TaskId): Promise<TaskRecord | null> {
+  async taskStatus(params: { taskId: TaskId }): Promise<TaskRecord | null> {
     return await this.runUnaryRequest<TaskRecord | null>({
-      request: (id) => ({ id, type: "task.status", payload: { taskId } }),
+      request: (id) => ({ id, type: "task.status", payload: { taskId: params.taskId } }),
       closeError: "RPC connection closed before task status response",
       resolve: (msg) => {
         if (msg.type === "task.status.result") {

--- a/src/client-rpc.ts
+++ b/src/client-rpc.ts
@@ -12,7 +12,7 @@ import { connectionHelpMessage } from "./error-messages";
 import { field } from "./field";
 import { createRpcRequestId } from "./rpc-protocol";
 import { parseStatusFields, type StatusFields } from "./status-contract";
-import type { TaskId, TaskRecord } from "./task-contract";
+import { parseTaskRecord, type TaskId, type TaskRecord } from "./task-contract";
 
 type RpcServerMessage = NonNullable<ReturnType<typeof parseRpcServerMessage>>;
 
@@ -166,7 +166,10 @@ export class RpcClient implements Client {
       request: (id) => ({ id, type: "task.status", payload: { taskId } }),
       closeError: "RPC connection closed before task status response",
       resolve: (msg) => {
-        if (msg.type === "task.status.result") return msg.task;
+        if (msg.type === "task.status.result") {
+          if (msg.task === null || msg.task === undefined) return null;
+          return parseTaskRecord(msg.task) ?? new Error("Invalid task record");
+        }
         if (msg.type === "error") return new Error(msg.error);
         return new Error(`Unexpected RPC response: ${msg.type}`);
       },

--- a/src/status-contract.test.ts
+++ b/src/status-contract.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { parseStatusFields } from "./status-contract";
+
+describe("parseStatusFields", () => {
+  test("returns fields for valid status payload", () => {
+    const fields = parseStatusFields({
+      ok: true,
+      providers: ["openai"],
+      model: "gpt-5-mini",
+      protocol_version: "1",
+      capabilities: "chat",
+      service: "acolyte",
+      tasks_total: 0,
+      tasks_running: 0,
+      tasks_detached: 0,
+      rpc_queue_length: 0,
+    });
+    expect(fields).not.toBeNull();
+    expect(fields?.providers).toEqual(["openai"]);
+    expect(fields?.model).toBe("gpt-5-mini");
+    expect(fields).not.toHaveProperty("ok");
+  });
+
+  test("returns null for invalid payload", () => {
+    expect(parseStatusFields({})).toBeNull();
+    expect(parseStatusFields(null)).toBeNull();
+  });
+});

--- a/src/status-contract.ts
+++ b/src/status-contract.ts
@@ -18,3 +18,15 @@ export const statusPayloadSchema = z
 
 export type StatusFields = Record<string, string | number | string[]>;
 export type StatusPayload = z.infer<typeof statusPayloadSchema>;
+
+export function parseStatusFields(payload: unknown): StatusFields | null {
+  const result = statusPayloadSchema.safeParse(payload);
+  if (!result.success) return null;
+  const fields: StatusFields = {};
+  for (const [key, value] of Object.entries(result.data)) {
+    if (key === "ok") continue;
+    if (typeof value === "string" || typeof value === "number") fields[key] = value;
+    else if (Array.isArray(value)) fields[key] = value;
+  }
+  return fields;
+}

--- a/src/task-contract.test.ts
+++ b/src/task-contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isTerminalTaskState, taskRecordSchema, taskStateSchema } from "./task-contract";
+import { isTerminalTaskState, parseTaskRecord, taskRecordSchema, taskStateSchema } from "./task-contract";
 
 describe("task state contract", () => {
   test("accepts all planned task states", () => {
@@ -31,6 +31,23 @@ describe("task state contract", () => {
       updatedAt: "2026-02-28T00:00:01.000Z",
     });
     expect(parsed.success).toBe(false);
+  });
+
+  test("parseTaskRecord returns record for valid input", () => {
+    const record = parseTaskRecord({
+      id: "task_123",
+      state: "running",
+      createdAt: "2026-02-28T00:00:00.000Z",
+      updatedAt: "2026-02-28T00:00:01.000Z",
+    });
+    expect(record?.id).toBe("task_123");
+    expect(record?.state).toBe("running");
+  });
+
+  test("parseTaskRecord returns null for invalid input", () => {
+    expect(parseTaskRecord({})).toBeNull();
+    expect(parseTaskRecord(null)).toBeNull();
+    expect(parseTaskRecord({ id: "bad", state: "running" })).toBeNull();
   });
 
   test("detects terminal vs non-terminal states", () => {

--- a/src/task-contract.ts
+++ b/src/task-contract.ts
@@ -36,6 +36,11 @@ export const taskRecordSchema = z.object({
 
 export type TaskRecord = Readonly<z.infer<typeof taskRecordSchema>>;
 
+export function parseTaskRecord(payload: unknown): TaskRecord | null {
+  const result = taskRecordSchema.safeParse(payload);
+  return result.success ? result.data : null;
+}
+
 export function isTerminalTaskState(state: TaskState): boolean {
   return TERMINAL_TASK_STATES.includes(state as (typeof TERMINAL_TASK_STATES)[number]);
 }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -246,32 +246,21 @@ export function createSessionState(overrides: Partial<SessionState> = {}): Sessi
 }
 
 export function createClient(overrides?: {
-  reply?: (
-    input: Parameters<Client["replyStream"]>[0],
-    options?: { signal?: AbortSignal },
-  ) => ReturnType<Client["replyStream"]>;
   replyStream?: Client["replyStream"];
   status?: Client["status"];
   events?: StreamEvent[];
   taskStatus?: Client["taskStatus"];
 }): Client {
-  const reply =
-    overrides?.reply ??
-    (async () => ({
-      model: "gpt-5-mini",
-      output: "ok",
-      state: "done" as const,
-    }));
   const replyStream =
     overrides?.replyStream ??
-    (async (input, options) => {
+    (async (input) => {
       const events = overrides?.events;
       if (events) {
         for (const event of events) {
-          options.onEvent(event);
+          input.onEvent(event);
         }
       }
-      return reply(input, { signal: options.signal });
+      return { model: "gpt-5-mini", output: "ok", state: "done" as const };
     });
   return {
     replyStream,


### PR DESCRIPTION
## Motivation

`RpcClient` used positional args and type assertions for response handling, while `CloudClient` uses object args and zod validation at the boundary. Aligning the patterns improves consistency and catches malformed server responses early.

## Summary

- validate `status()` response with `statusPayloadSchema` via `parseStatusFields` helper
- validate `taskStatus()` response with `taskRecordSchema` via `parseTaskRecord` helper
- adopt `input:` object args for `taskStatus` and `replyStream` to match repo conventions
- update all callers and test mocks to use the new signatures

Fixes #159