### PR TITLE
test: rewrite int tests with registry dispatch

### DIFF
--- a/docs/skills/tests.md
+++ b/docs/skills/tests.md
@@ -27,7 +27,6 @@ Review test adequacy for changed code.
 - tests duplicating coverage without distinct scenarios
 - fragile tests (timing, ordering, absolute paths)
 - using the wrong test type (filesystem/process/network in unit tests) — move those to integration tests
-- calling tool functions directly in integration tests instead of dispatching through the tool registry
 - missing cleanup (temp files, cache state)
 - mocking internals instead of testing through the real contract — mock at boundaries only
 - test names that don't read as specifications

--- a/docs/skills/tests.md
+++ b/docs/skills/tests.md
@@ -27,6 +27,7 @@ Review test adequacy for changed code.
 - tests duplicating coverage without distinct scenarios
 - fragile tests (timing, ordering, absolute paths)
 - using the wrong test type (filesystem/process/network in unit tests) — move those to integration tests
+- calling tool functions directly in integration tests instead of dispatching through the tool registry
 - missing cleanup (temp files, cache state)
 - mocking internals instead of testing through the real contract — mock at boundaries only
 - test names that don't read as specifications

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -15,6 +15,12 @@ Use the smallest test type that gives strong confidence.
 - If a test needs real fs/process/network behavior, use `*.int.test.ts` instead.
 - Prefer mocks for UI/layout-focused unit tests.
 
+## Integration test boundary
+
+- Tool integration tests must dispatch through `toolsForAgent({ workspace })` and call `tools.<name>.execute()`, not the underlying function directly. This exercises budget checks, hooks, caching, and call logging — the same path production uses.
+- Effect integration tests must wire handlers via `attachLifecycleEffectHandlers(ctx, session)` and verify behavior through debug events, not call `effect.run()` directly.
+- Direct function calls (e.g., `editFile()`, `runShellCommand()`) belong in unit tests when testing the function contract itself. Integration tests test wiring.
+
 ## Commands
 
 - Full baseline: `bun run verify`

--- a/src/code-ops.int.test.ts
+++ b/src/code-ops.int.test.ts
@@ -16,7 +16,10 @@ describe("editCode", () => {
     const { tools } = toolsForAgent({ workspace });
     await expect(
       tools.editCode.execute(
-        { path: "/etc/hosts", edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.debug($ARG)" }] },
+        {
+          path: "/etc/hosts",
+          edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.debug($ARG)" }],
+        },
         "call_1",
       ),
     ).rejects.toMatchObject({
@@ -33,7 +36,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.debug($ARG)" }] },
       "call_2",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('logger.debug("hello")');
     expect(content).not.toContain("console.log");
@@ -73,7 +76,7 @@ describe("editCode", () => {
       },
       "call_3",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("const result = 1;");
     expect(content).toContain("return result;");
@@ -115,7 +118,7 @@ describe("editCode", () => {
       },
       "call_4",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("for (const patternResult of items)");
     expect(content).toContain("output.push(patternResult.toUpperCase());");
@@ -156,7 +159,7 @@ describe("editCode", () => {
       },
       "call_5",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("for (const patternResult of items)");
     expect(content).toContain("output.push(patternResult.toUpperCase());");
@@ -183,7 +186,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "rename", from: "item", to: "entry", withinSymbol: "Processor" }] },
       "call_6",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("(entry) => entry.toUpperCase()");
   });
@@ -208,7 +211,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "rename", from: "result", to: "patternResult", withinSymbol: "scanFile" }] },
       "call_7",
     );
-    expect(result.result.matches).toBe(5);
+    expect((result.result as Record<string, unknown>).matches).toBe(5);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("const patternResult = items[0] ?? '';");
     expect(content).toContain("const { result: alias, other = patternResult } = source;");
@@ -251,7 +254,7 @@ describe("editCode", () => {
       },
       "call_8",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('defaultAlias = "acolyte-mini";');
     expect(content).toContain("return this.defaultAlias + config.alias;");
@@ -281,7 +284,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "rename", from: "label", to: "displayLabel", withinSymbol: "ProviderConfig" }] },
       "call_9",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("displayLabel() {");
     expect(content).toContain("return this.labelText + config.label;");
@@ -314,7 +317,7 @@ describe("editCode", () => {
       },
       "call_10",
     );
-    expect(result.result.matches).toBe(3);
+    expect((result.result as Record<string, unknown>).matches).toBe(3);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('defaultAlias = "x";');
     expect(content).toContain("const alias = this.defaultAlias;");
@@ -347,7 +350,7 @@ describe("editCode", () => {
       },
       "call_11",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("const localAlias = this.alias;");
     expect(content).toContain("return { alias: localAlias, member: this.alias, other: config.alias };");
@@ -428,7 +431,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "rename", from: "result", to: "patternResult", withinSymbol: "scanFile" }] },
       "call_14",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("const scanFile = ({ result: patternResult }: { result: string }) => {");
     expect(content).toContain("return patternResult.toUpperCase();");
@@ -454,7 +457,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "rename", from: "result", to: "patternResult", withinSymbol: "scanFile" }] },
       "call_15",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("const patternResult = items[0] ?? '';");
     expect(content).toContain("return [patternResult, String(resultCount)];");
@@ -494,7 +497,7 @@ describe("editCode", () => {
       },
       "call_16",
     );
-    expect(result.result.matches).toBe(1);
+    expect((result.result as Record<string, unknown>).matches).toBe(1);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('defaultAlias = "acolyte-mini";');
     expect(content).toContain('const alias = "outside";');
@@ -525,7 +528,7 @@ describe("editCode", () => {
       },
       "call_17",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('logger.debug("first");');
     expect(content).toContain('logger.debug("second");');
@@ -577,7 +580,7 @@ describe("editCode", () => {
       },
       "call_18",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('logger.debug("first");');
     expect(content).toContain('logger.debug("second");');
@@ -626,7 +629,7 @@ describe("editCode", () => {
       },
       "call_19",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('logger.debug("inner");');
     expect(content).toContain('logger.debug("outer");');
@@ -680,9 +683,9 @@ describe("editCode", () => {
       { path: workspace, edits: [{ op: "rename", from: "oldName", to: "newName" }] },
       "call_22",
     );
-    expect(result.result.matches).toBe(2);
-    expect(result.result.output).toContain("a.ts");
-    expect(result.result.output).toContain("b.ts");
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect((result.result as Record<string, unknown>).output).toContain("a.ts");
+    expect((result.result as Record<string, unknown>).output).toContain("b.ts");
     const aContent = await readFile(join(workspace, "a.ts"), "utf8");
     const bContent = await readFile(join(workspace, "b.ts"), "utf8");
     expect(aContent).toContain("newName");
@@ -695,10 +698,13 @@ describe("editCode", () => {
     await writeFile(join(workspace, "main.ts"), "import { oldName } from './lib';\noldName();\n", "utf8");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.editCode.execute(
-      { path: join(workspace, "lib.ts"), edits: [{ op: "rename", from: "oldName", to: "newName", scope: "workspace" }] },
+      {
+        path: join(workspace, "lib.ts"),
+        edits: [{ op: "rename", from: "oldName", to: "newName", scope: "workspace" }],
+      },
       "call_23",
     );
-    expect(result.result.matches).toBeGreaterThanOrEqual(3);
+    expect((result.result as Record<string, unknown>).matches).toBeGreaterThanOrEqual(3);
     const libContent = await readFile(join(workspace, "lib.ts"), "utf8");
     const mainContent = await readFile(join(workspace, "main.ts"), "utf8");
     expect(libContent).toContain("newName");
@@ -718,7 +724,7 @@ describe("editCode", () => {
       },
       "call_24",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const aContent = await readFile(join(workspace, "a.ts"), "utf8");
     const bContent = await readFile(join(workspace, "b.ts"), "utf8");
     expect(aContent).toContain("logger.info");
@@ -762,7 +768,10 @@ describe("editCode", () => {
     const { tools } = toolsForAgent({ workspace });
     await expect(
       tools.editCode.execute(
-        { path: filePath, edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.debug($MISSING)" }] },
+        {
+          path: filePath,
+          edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.debug($MISSING)" }],
+        },
         "call_27",
       ),
     ).rejects.toMatchObject({
@@ -779,7 +788,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "replace", rule: "sum($$$ARGS)", replacement: "total($$$ARGS)" }] },
       "call_28",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("total(a, b);");
     expect(content).toContain("total(c);");
@@ -795,7 +804,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "replace", rule: "print($ARG)", replacement: "log($ARG)" }] },
       "call_29",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('log("hello")');
     expect(content).not.toContain("print");
@@ -810,7 +819,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "replace", rule: "println!($ARGS)", replacement: "eprintln!($ARGS)" }] },
       "call_30",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("eprintln!");
     expect(content).not.toMatch(/(?<!e)println!/);
@@ -825,7 +834,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "replace", rule: "println($ARG)", replacement: "print($ARG)" }] },
       "call_31",
     );
-    expect(result.result.matches).toBe(2);
+    expect((result.result as Record<string, unknown>).matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("print(");
     expect(content).not.toContain("println(");
@@ -851,7 +860,7 @@ describe("editCode", () => {
       },
       "call_32",
     );
-    expect(result.result.affectedSymbols).toEqual(["processItems"]);
+    expect((result.result as Record<string, unknown>).affectedSymbols).toEqual(["processItems"]);
   });
 });
 
@@ -884,7 +893,7 @@ describe("scanCode", () => {
     await writeFile(filePath, 'console.log("hello");\nconsole.log("world");\nconst x = 1;\n', "utf8");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.scanCode.execute({ paths: [filePath], patterns: ["console.log($ARG)"] }, "call_35");
-    const output = result.result.output;
+    const output = (result.result as Record<string, unknown>).output;
     expect(output).toContain("scanned=1 matches=2");
     expect(output).toContain('{$ARG="hello"}');
   });
@@ -895,7 +904,7 @@ describe("scanCode", () => {
     await writeFile(filePath, "const x = 1;\n", "utf8");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.scanCode.execute({ paths: [filePath], patterns: ["console.log($ARG)"] }, "call_36");
-    const output = result.result.output;
+    const output = (result.result as Record<string, unknown>).output;
     expect(output).toContain("scanned=1 matches=0");
     expect(output).toContain("No matches.");
   });
@@ -907,7 +916,7 @@ describe("scanCode", () => {
     await writeFile(join(workspace, "sub", "b.ts"), 'console.log("b");\nconst y = 2;\n', "utf8");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.scanCode.execute({ paths: [workspace], patterns: ["console.log($ARG)"] }, "call_37");
-    const output = result.result.output;
+    const output = (result.result as Record<string, unknown>).output;
     expect(output).toContain("scanned=2 matches=2");
   });
 
@@ -921,7 +930,7 @@ describe("scanCode", () => {
       { paths: [filePath], patterns: ["console.log($ARG)"], maxResults: 3 },
       "call_38",
     );
-    const output = result.result.output;
+    const output = (result.result as Record<string, unknown>).output;
     expect(output).toContain("matches=3");
   });
 
@@ -934,7 +943,7 @@ describe("scanCode", () => {
       { paths: [filePath], patterns: ["export function $NAME() {}", "console.log($ARG)"] },
       "call_39",
     );
-    const output = result.result.output;
+    const output = (result.result as Record<string, unknown>).output;
     expect(output).toContain("matches=2");
     expect(output).toContain("{$NAME=hello}");
     expect(output).toContain('{$ARG="test"}');
@@ -950,7 +959,7 @@ describe("scanCode", () => {
     );
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.scanCode.execute({ paths: [filePath], patterns: ["console.log($ARG)"] }, "call_40");
-    const output = result.result.output;
+    const output = (result.result as Record<string, unknown>).output;
     expect(output).toContain("[processItems]");
   });
 
@@ -964,7 +973,7 @@ describe("scanCode", () => {
     );
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.scanCode.execute({ paths: [filePath], patterns: ["console.log($ARG)"] }, "call_41");
-    const output = result.result.output;
+    const output = (result.result as Record<string, unknown>).output;
     expect(output).toContain("[run]");
   });
 
@@ -974,7 +983,7 @@ describe("scanCode", () => {
     await writeFile(filePath, "console.log('top-level');\n", "utf8");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.scanCode.execute({ paths: [filePath], patterns: ["console.log($ARG)"] }, "call_42");
-    const output = result.result.output;
+    const output = (result.result as Record<string, unknown>).output;
     expect(output).not.toMatch(/\[.*\]/);
     expect(output).toContain("console.log('top-level')");
   });
@@ -985,7 +994,7 @@ describe("scanCode", () => {
     await writeFile(filePath, 'type Status = "active" | "inactive";\n', "utf8");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.scanCode.execute({ paths: [filePath], patterns: ['"active"'] }, "call_43");
-    const output = result.result.output;
+    const output = (result.result as Record<string, unknown>).output;
     expect(output).toContain("[Status]");
   });
 });

--- a/src/code-ops.int.test.ts
+++ b/src/code-ops.int.test.ts
@@ -1,51 +1,47 @@
-import { afterAll, describe, expect, test } from "bun:test";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
-import { editCode, scanCode } from "./code-ops";
-import { ERROR_KINDS, TOOL_ERROR_CODES } from "./error-contract";
-import { testUuid } from "./test-utils";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { TOOL_ERROR_CODES } from "./error-contract";
+import { tempDir } from "./test-utils";
+import { toolsForAgent } from "./tool-registry";
 
-const WORKSPACE = resolve(process.cwd());
-const tempFiles: string[] = [];
-const tempDirs: string[] = [];
-
-afterAll(async () => {
-  await Promise.all(tempFiles.map(async (filePath) => rm(filePath, { force: true })));
-  await Promise.all(tempDirs.map(async (dirPath) => rm(dirPath, { recursive: true, force: true })));
-});
+const dirs = tempDir();
+afterEach(dirs.cleanupDirs);
 
 describe("editCode", () => {
-  test("blocks paths outside workspace", async () => {
+  test("rejects paths outside sandbox via dispatch", async () => {
+    const workspace = dirs.createDir("acolyte-test-sandbox-edit-");
+    const filePath = join(workspace, "file.ts");
+    await writeFile(filePath, "const x = 1;\n", "utf8");
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editCode({
-        workspace: WORKSPACE,
-        path: "/etc/hosts",
-        edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.debug($ARG)" }],
-      }),
+      tools.editCode.execute(
+        { path: "/etc/hosts", edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.debug($ARG)" }] },
+        "call_1",
+      ),
     ).rejects.toMatchObject({
       code: TOOL_ERROR_CODES.sandboxViolation,
-      kind: ERROR_KINDS.sandboxViolation,
     });
   });
 
   test("replaces pattern matches with metavariable capture", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(filePath, 'console.log("hello");\nconsole.log("world");\n', "utf8");
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.debug($ARG)" }],
-    });
-    expect(result.matches).toBe(2);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      { path: filePath, edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.debug($ARG)" }] },
+      "call_2",
+    );
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('logger.debug("hello")');
     expect(content).not.toContain("console.log");
   });
 
   test("scopes replacements with within", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-within-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-within-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(
       filePath,
       [
@@ -62,19 +58,22 @@ describe("editCode", () => {
       ].join("\n"),
       "utf8",
     );
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [
-        {
-          op: "replace",
-          rule: "result",
-          replacement: "value",
-          within: "function second() { $$$BODY }",
-        },
-      ],
-    });
-    expect(result.matches).toBe(2);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      {
+        path: filePath,
+        edits: [
+          {
+            op: "replace",
+            rule: "result",
+            replacement: "value",
+            within: "function second() { $$$BODY }",
+          },
+        ],
+      },
+      "call_3",
+    );
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("const result = 1;");
     expect(content).toContain("return result;");
@@ -83,8 +82,8 @@ describe("editCode", () => {
   });
 
   test("scopes replacements with withinSymbol", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-within-symbol-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-within-symbol-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(
       filePath,
       [
@@ -101,19 +100,22 @@ describe("editCode", () => {
       ].join("\n"),
       "utf8",
     );
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [
-        {
-          op: "replace",
-          rule: "result",
-          replacement: "patternResult",
-          withinSymbol: "scanFile",
-        },
-      ],
-    });
-    expect(result.matches).toBe(2);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      {
+        path: filePath,
+        edits: [
+          {
+            op: "replace",
+            rule: "result",
+            replacement: "patternResult",
+            withinSymbol: "scanFile",
+          },
+        ],
+      },
+      "call_4",
+    );
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("for (const patternResult of items)");
     expect(content).toContain("output.push(patternResult.toUpperCase());");
@@ -121,8 +123,8 @@ describe("editCode", () => {
   });
 
   test("supports structured rename edits with withinSymbol", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-rename-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-rename-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(
       filePath,
       [
@@ -139,19 +141,22 @@ describe("editCode", () => {
       ].join("\n"),
       "utf8",
     );
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [
-        {
-          op: "rename",
-          from: "result",
-          to: "patternResult",
-          withinSymbol: "scanFile",
-        },
-      ],
-    });
-    expect(result.matches).toBe(2);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      {
+        path: filePath,
+        edits: [
+          {
+            op: "rename",
+            from: "result",
+            to: "patternResult",
+            withinSymbol: "scanFile",
+          },
+        ],
+      },
+      "call_5",
+    );
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("for (const patternResult of items)");
     expect(content).toContain("output.push(patternResult.toUpperCase());");
@@ -159,8 +164,8 @@ describe("editCode", () => {
   });
 
   test("scoped local rename handles arrow function parameters", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-arrow-param-rename-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-arrow-param-rename-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(
       filePath,
       [
@@ -173,19 +178,19 @@ describe("editCode", () => {
       ].join("\n"),
       "utf8",
     );
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [{ op: "rename", from: "item", to: "entry", withinSymbol: "Processor" }],
-    });
-    expect(result.matches).toBe(2);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      { path: filePath, edits: [{ op: "rename", from: "item", to: "entry", withinSymbol: "Processor" }] },
+      "call_6",
+    );
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("(entry) => entry.toUpperCase()");
   });
 
   test("scoped local rename rewrites shorthand references without renaming object properties", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-local-rename-scope-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-local-rename-scope-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(
       filePath,
       [
@@ -198,12 +203,12 @@ describe("editCode", () => {
       ].join("\n"),
       "utf8",
     );
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [{ op: "rename", from: "result", to: "patternResult", withinSymbol: "scanFile" }],
-    });
-    expect(result.matches).toBe(5);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      { path: filePath, edits: [{ op: "rename", from: "result", to: "patternResult", withinSymbol: "scanFile" }] },
+      "call_7",
+    );
+    expect(result.result.matches).toBe(5);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("const patternResult = items[0] ?? '';");
     expect(content).toContain("const { result: alias, other = patternResult } = source;");
@@ -214,8 +219,8 @@ describe("editCode", () => {
   });
 
   test("supports structured rename edits within a class declaration", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-class-rename-${testUuid()}.js`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-class-rename-");
+    const filePath = join(workspace, "file.js");
     await writeFile(
       filePath,
       [
@@ -231,19 +236,22 @@ describe("editCode", () => {
       ].join("\n"),
       "utf8",
     );
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [
-        {
-          op: "rename",
-          from: "alias",
-          to: "defaultAlias",
-          withinSymbol: "ProviderConfig",
-        },
-      ],
-    });
-    expect(result.matches).toBe(2);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      {
+        path: filePath,
+        edits: [
+          {
+            op: "rename",
+            from: "alias",
+            to: "defaultAlias",
+            withinSymbol: "ProviderConfig",
+          },
+        ],
+      },
+      "call_8",
+    );
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('defaultAlias = "acolyte-mini";');
     expect(content).toContain("return this.defaultAlias + config.alias;");
@@ -251,8 +259,8 @@ describe("editCode", () => {
   });
 
   test("scoped member rename updates declared methods and this-method calls only", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-class-method-rename-${testUuid()}.js`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-class-method-rename-");
+    const filePath = join(workspace, "file.js");
     await writeFile(
       filePath,
       [
@@ -268,12 +276,12 @@ describe("editCode", () => {
       ].join("\n"),
       "utf8",
     );
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [{ op: "rename", from: "label", to: "displayLabel", withinSymbol: "ProviderConfig" }],
-    });
-    expect(result.matches).toBe(2);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      { path: filePath, edits: [{ op: "rename", from: "label", to: "displayLabel", withinSymbol: "ProviderConfig" }] },
+      "call_9",
+    );
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("displayLabel() {");
     expect(content).toContain("return this.labelText + config.label;");
@@ -282,8 +290,8 @@ describe("editCode", () => {
   });
 
   test("ambiguous scoped rename can target the member explicitly", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-ambiguous-member-rename-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-ambiguous-member-rename-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(
       filePath,
       [
@@ -298,12 +306,15 @@ describe("editCode", () => {
       ].join("\n"),
       "utf8",
     );
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [{ op: "rename", from: "alias", to: "defaultAlias", withinSymbol: "ProviderConfig", target: "member" }],
-    });
-    expect(result.matches).toBe(3);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      {
+        path: filePath,
+        edits: [{ op: "rename", from: "alias", to: "defaultAlias", withinSymbol: "ProviderConfig", target: "member" }],
+      },
+      "call_10",
+    );
+    expect(result.result.matches).toBe(3);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('defaultAlias = "x";');
     expect(content).toContain("const alias = this.defaultAlias;");
@@ -312,8 +323,8 @@ describe("editCode", () => {
   });
 
   test("ambiguous scoped rename can target the local symbol explicitly", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-ambiguous-local-rename-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-ambiguous-local-rename-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(
       filePath,
       [
@@ -328,12 +339,15 @@ describe("editCode", () => {
       ].join("\n"),
       "utf8",
     );
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [{ op: "rename", from: "alias", to: "localAlias", withinSymbol: "ProviderConfig", target: "local" }],
-    });
-    expect(result.matches).toBe(2);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      {
+        path: filePath,
+        edits: [{ op: "rename", from: "alias", to: "localAlias", withinSymbol: "ProviderConfig", target: "local" }],
+      },
+      "call_11",
+    );
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("const localAlias = this.alias;");
     expect(content).toContain("return { alias: localAlias, member: this.alias, other: config.alias };");
@@ -341,8 +355,8 @@ describe("editCode", () => {
   });
 
   test("ambiguous scoped rename fails with recovery when target is omitted", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-ambiguous-rename-auto-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-ambiguous-rename-auto-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(
       filePath,
       [
@@ -357,12 +371,15 @@ describe("editCode", () => {
       ].join("\n"),
       "utf8",
     );
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editCode({
-        workspace: WORKSPACE,
-        path: filePath,
-        edits: [{ op: "rename", from: "alias", to: "defaultAlias", withinSymbol: "ProviderConfig" }],
-      }),
+      tools.editCode.execute(
+        {
+          path: filePath,
+          edits: [{ op: "rename", from: "alias", to: "defaultAlias", withinSymbol: "ProviderConfig" }],
+        },
+        "call_12",
+      ),
     ).rejects.toMatchObject({
       code: TOOL_ERROR_CODES.editCodeNoMatch,
       message: expect.stringContaining('target: "local" or target: "member"'),
@@ -370,8 +387,8 @@ describe("editCode", () => {
   });
 
   test("scoped rename fails when explicit target has no matches in scope", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-invalid-target-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-invalid-target-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(
       filePath,
       [
@@ -383,12 +400,15 @@ describe("editCode", () => {
       ].join("\n"),
       "utf8",
     );
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editCode({
-        workspace: WORKSPACE,
-        path: filePath,
-        edits: [{ op: "rename", from: "result", to: "patternResult", withinSymbol: "scanFile", target: "member" }],
-      }),
+      tools.editCode.execute(
+        {
+          path: filePath,
+          edits: [{ op: "rename", from: "result", to: "patternResult", withinSymbol: "scanFile", target: "member" }],
+        },
+        "call_13",
+      ),
     ).rejects.toMatchObject({
       code: TOOL_ERROR_CODES.editCodeNoMatch,
       message: expect.stringContaining("target: member"),
@@ -396,27 +416,27 @@ describe("editCode", () => {
   });
 
   test("scoped local rename rewrites shorthand destructuring bindings", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-local-rename-destructure-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-local-rename-destructure-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(
       filePath,
       ["const scanFile = ({ result }: { result: string }) => {", "  return result.toUpperCase();", "};", ""].join("\n"),
       "utf8",
     );
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [{ op: "rename", from: "result", to: "patternResult", withinSymbol: "scanFile" }],
-    });
-    expect(result.matches).toBe(2);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      { path: filePath, edits: [{ op: "rename", from: "result", to: "patternResult", withinSymbol: "scanFile" }] },
+      "call_14",
+    );
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("const scanFile = ({ result: patternResult }: { result: string }) => {");
     expect(content).toContain("return patternResult.toUpperCase();");
   });
 
   test("rename matches exact identifiers only", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-rename-exact-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-rename-exact-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(
       filePath,
       [
@@ -429,12 +449,12 @@ describe("editCode", () => {
       ].join("\n"),
       "utf8",
     );
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [{ op: "rename", from: "result", to: "patternResult", withinSymbol: "scanFile" }],
-    });
-    expect(result.matches).toBe(2);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      { path: filePath, edits: [{ op: "rename", from: "result", to: "patternResult", withinSymbol: "scanFile" }] },
+      "call_15",
+    );
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("const patternResult = items[0] ?? '';");
     expect(content).toContain("return [patternResult, String(resultCount)];");
@@ -442,8 +462,8 @@ describe("editCode", () => {
   });
 
   test("supports structured replace patterns with context and selector", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-pattern-object-${testUuid()}.js`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-pattern-object-");
+    const filePath = join(workspace, "file.js");
     await writeFile(
       filePath,
       [
@@ -457,21 +477,24 @@ describe("editCode", () => {
       ].join("\n"),
       "utf8",
     );
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [
-        {
-          op: "replace",
-          rule: {
-            context: "class ProviderConfig { alias = $VALUE }",
-            selector: "field_definition",
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      {
+        path: filePath,
+        edits: [
+          {
+            op: "replace",
+            rule: {
+              context: "class ProviderConfig { alias = $VALUE }",
+              selector: "field_definition",
+            },
+            replacement: "defaultAlias = $VALUE",
           },
-          replacement: "defaultAlias = $VALUE",
-        },
-      ],
-    });
-    expect(result.matches).toBe(1);
+        ],
+      },
+      "call_16",
+    );
+    expect(result.result.matches).toBe(1);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('defaultAlias = "acolyte-mini";');
     expect(content).toContain('const alias = "outside";');
@@ -479,27 +502,30 @@ describe("editCode", () => {
   });
 
   test("supports recursive rule objects for replacements", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-rule-object-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-rule-object-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(
       filePath,
       ['console.log("first");', 'console.info("second");', 'console.warn("third");', ""].join("\n"),
       "utf8",
     );
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [
-        {
-          op: "replace",
-          rule: {
-            any: ["console.log($ARG)", "console.info($ARG)"],
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      {
+        path: filePath,
+        edits: [
+          {
+            op: "replace",
+            rule: {
+              any: ["console.log($ARG)", "console.info($ARG)"],
+            },
+            replacement: "logger.debug($ARG)",
           },
-          replacement: "logger.debug($ARG)",
-        },
-      ],
-    });
-    expect(result.matches).toBe(2);
+        ],
+      },
+      "call_17",
+    );
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('logger.debug("first");');
     expect(content).toContain('logger.debug("second");');
@@ -507,8 +533,8 @@ describe("editCode", () => {
   });
 
   test("supports nested all/any/inside rule combinations", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-nested-rules-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-nested-rules-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(
       filePath,
       [
@@ -524,31 +550,34 @@ describe("editCode", () => {
       ].join("\n"),
       "utf8",
     );
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [
-        {
-          op: "replace",
-          rule: {
-            all: [
-              { any: ["console.log($ARG)", "console.info($ARG)"] },
-              {
-                inside: {
-                  pattern: {
-                    context: "function logMessages() { $$$BODY }",
-                    selector: "function_declaration",
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      {
+        path: filePath,
+        edits: [
+          {
+            op: "replace",
+            rule: {
+              all: [
+                { any: ["console.log($ARG)", "console.info($ARG)"] },
+                {
+                  inside: {
+                    pattern: {
+                      context: "function logMessages() { $$$BODY }",
+                      selector: "function_declaration",
+                    },
+                    stopBy: "end",
                   },
-                  stopBy: "end",
                 },
-              },
-            ],
+              ],
+            },
+            replacement: "logger.debug($ARG)",
           },
-          replacement: "logger.debug($ARG)",
-        },
-      ],
-    });
-    expect(result.matches).toBe(2);
+        ],
+      },
+      "call_18",
+    );
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('logger.debug("first");');
     expect(content).toContain('logger.debug("second");');
@@ -556,8 +585,8 @@ describe("editCode", () => {
   });
 
   test("supports relational stopBy rule objects", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-stop-by-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-stop-by-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(
       filePath,
       [
@@ -571,186 +600,186 @@ describe("editCode", () => {
       ].join("\n"),
       "utf8",
     );
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [
-        {
-          op: "replace",
-          rule: {
-            pattern: "console.log($ARG)",
-            inside: {
-              kind: "function_declaration",
-              stopBy: {
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      {
+        path: filePath,
+        edits: [
+          {
+            op: "replace",
+            rule: {
+              pattern: "console.log($ARG)",
+              inside: {
                 kind: "function_declaration",
-                pattern: {
-                  context: "function outer() { $$$BODY }",
-                  selector: "function_declaration",
+                stopBy: {
+                  kind: "function_declaration",
+                  pattern: {
+                    context: "function outer() { $$$BODY }",
+                    selector: "function_declaration",
+                  },
                 },
               },
             },
+            replacement: "logger.debug($ARG)",
           },
-          replacement: "logger.debug($ARG)",
-        },
-      ],
-    });
-    expect(result.matches).toBe(2);
+        ],
+      },
+      "call_19",
+    );
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('logger.debug("inner");');
     expect(content).toContain('logger.debug("outer");');
   });
 
   test("throws when no matches found", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-nomatch-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-nomatch-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(filePath, "const x = 1;\n", "utf8");
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editCode({
-        workspace: WORKSPACE,
-        path: filePath,
-        edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.debug($ARG)" }],
-      }),
+      tools.editCode.execute(
+        { path: filePath, edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.debug($ARG)" }] },
+        "call_20",
+      ),
     ).rejects.toMatchObject({
       code: TOOL_ERROR_CODES.editCodeNoMatch,
     });
   });
 
   test("formats no-match errors with readable rule summaries", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-readable-error-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-readable-error-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(filePath, "const x = 1;\n", "utf8");
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editCode({
-        workspace: WORKSPACE,
-        path: filePath,
-        edits: [
-          {
-            op: "replace",
-            rule: { any: ["console.log($ARG)", "console.info($ARG)"] },
-            replacement: "logger.debug($ARG)",
-          },
-        ],
-      }),
+      tools.editCode.execute(
+        {
+          path: filePath,
+          edits: [
+            {
+              op: "replace",
+              rule: { any: ["console.log($ARG)", "console.info($ARG)"] },
+              replacement: "logger.debug($ARG)",
+            },
+          ],
+        },
+        "call_21",
+      ),
     ).rejects.toMatchObject({
       message: expect.stringContaining("No AST matches found for rule: any(2)"),
     });
   });
 
   test("applies edits across directory", async () => {
-    const dirPath = join(WORKSPACE, `acolyte-test-ast-dir-${testUuid()}`);
-    tempDirs.push(dirPath);
-    await mkdir(dirPath, { recursive: true });
-    await writeFile(join(dirPath, "a.ts"), "const x = oldName();\n", "utf8");
-    await writeFile(join(dirPath, "b.ts"), "const y = oldName();\n", "utf8");
-    tempFiles.push(join(dirPath, "a.ts"), join(dirPath, "b.ts"));
-    const result = await editCode({
-      workspace: dirPath,
-      path: dirPath,
-      edits: [{ op: "rename", from: "oldName", to: "newName" }],
-    });
-    expect(result.matches).toBe(2);
-    expect(result.diff).toContain("a.ts");
-    expect(result.diff).toContain("b.ts");
-    const aContent = await readFile(join(dirPath, "a.ts"), "utf8");
-    const bContent = await readFile(join(dirPath, "b.ts"), "utf8");
+    const workspace = dirs.createDir("acolyte-test-ast-dir-");
+    await writeFile(join(workspace, "a.ts"), "const x = oldName();\n", "utf8");
+    await writeFile(join(workspace, "b.ts"), "const y = oldName();\n", "utf8");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      { path: workspace, edits: [{ op: "rename", from: "oldName", to: "newName" }] },
+      "call_22",
+    );
+    expect(result.result.matches).toBe(2);
+    expect(result.result.output).toContain("a.ts");
+    expect(result.result.output).toContain("b.ts");
+    const aContent = await readFile(join(workspace, "a.ts"), "utf8");
+    const bContent = await readFile(join(workspace, "b.ts"), "utf8");
     expect(aContent).toContain("newName");
     expect(bContent).toContain("newName");
   });
 
   test("workspace scope renames across all project files", async () => {
-    const dirPath = join(WORKSPACE, `acolyte-test-ast-ws-${testUuid()}`);
-    tempDirs.push(dirPath);
-    await mkdir(dirPath, { recursive: true });
-    await writeFile(join(dirPath, "lib.ts"), "export function oldName() { return 1; }\n", "utf8");
-    await writeFile(join(dirPath, "main.ts"), "import { oldName } from './lib';\noldName();\n", "utf8");
-    tempFiles.push(join(dirPath, "lib.ts"), join(dirPath, "main.ts"));
-    const result = await editCode({
-      workspace: dirPath,
-      path: join(dirPath, "lib.ts"),
-      edits: [{ op: "rename", from: "oldName", to: "newName", scope: "workspace" }],
-    });
-    expect(result.matches).toBeGreaterThanOrEqual(3);
-    const libContent = await readFile(join(dirPath, "lib.ts"), "utf8");
-    const mainContent = await readFile(join(dirPath, "main.ts"), "utf8");
+    const workspace = dirs.createDir("acolyte-test-ast-ws-");
+    await writeFile(join(workspace, "lib.ts"), "export function oldName() { return 1; }\n", "utf8");
+    await writeFile(join(workspace, "main.ts"), "import { oldName } from './lib';\noldName();\n", "utf8");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      { path: join(workspace, "lib.ts"), edits: [{ op: "rename", from: "oldName", to: "newName", scope: "workspace" }] },
+      "call_23",
+    );
+    expect(result.result.matches).toBeGreaterThanOrEqual(3);
+    const libContent = await readFile(join(workspace, "lib.ts"), "utf8");
+    const mainContent = await readFile(join(workspace, "main.ts"), "utf8");
     expect(libContent).toContain("newName");
     expect(mainContent).toContain("newName");
     expect(mainContent).not.toContain("oldName");
   });
 
   test("workspace scope replaces across all project files", async () => {
-    const dirPath = join(WORKSPACE, `acolyte-test-ast-ws-replace-${testUuid()}`);
-    tempDirs.push(dirPath);
-    await mkdir(dirPath, { recursive: true });
-    await writeFile(join(dirPath, "a.ts"), "console.log('hello');\n", "utf8");
-    await writeFile(join(dirPath, "b.ts"), "console.log('world');\n", "utf8");
-    tempFiles.push(join(dirPath, "a.ts"), join(dirPath, "b.ts"));
-    const result = await editCode({
-      workspace: dirPath,
-      path: join(dirPath, "a.ts"),
-      edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.info($ARG)", scope: "workspace" }],
-    });
-    expect(result.matches).toBe(2);
-    const aContent = await readFile(join(dirPath, "a.ts"), "utf8");
-    const bContent = await readFile(join(dirPath, "b.ts"), "utf8");
+    const workspace = dirs.createDir("acolyte-test-ast-ws-replace-");
+    await writeFile(join(workspace, "a.ts"), "console.log('hello');\n", "utf8");
+    await writeFile(join(workspace, "b.ts"), "console.log('world');\n", "utf8");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      {
+        path: join(workspace, "a.ts"),
+        edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.info($ARG)", scope: "workspace" }],
+      },
+      "call_24",
+    );
+    expect(result.result.matches).toBe(2);
+    const aContent = await readFile(join(workspace, "a.ts"), "utf8");
+    const bContent = await readFile(join(workspace, "b.ts"), "utf8");
     expect(aContent).toContain("logger.info");
     expect(bContent).toContain("logger.info");
   });
 
   test("rejects unsupported non-code files", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-md-${testUuid()}.md`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-md-");
+    const filePath = join(workspace, "file.md");
     await writeFile(filePath, "# Title\n", "utf8");
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editCode({
-        workspace: WORKSPACE,
-        path: filePath,
-        edits: [{ op: "replace", rule: "Title", replacement: "Heading" }],
-      }),
+      tools.editCode.execute(
+        { path: filePath, edits: [{ op: "replace", rule: "Title", replacement: "Heading" }] },
+        "call_25",
+      ),
     ).rejects.toMatchObject({
       code: TOOL_ERROR_CODES.editCodeUnsupportedFile,
     });
   });
 
   test("rejects unknown single-file extensions without falling back", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-yaml-${testUuid()}.yaml`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-yaml-");
+    const filePath = join(workspace, "file.yaml");
     await writeFile(filePath, "foo: bar\n", "utf8");
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editCode({
-        workspace: WORKSPACE,
-        path: filePath,
-        edits: [{ op: "replace", rule: "foo: $VALUE", replacement: "bar: $VALUE" }],
-      }),
+      tools.editCode.execute(
+        { path: filePath, edits: [{ op: "replace", rule: "foo: $VALUE", replacement: "bar: $VALUE" }] },
+        "call_26",
+      ),
     ).rejects.toMatchObject({
       code: TOOL_ERROR_CODES.editCodeUnsupportedFile,
     });
   });
 
   test("rejects replacement metavariables that are not present in the pattern", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-missing-meta-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-missing-meta-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(filePath, 'console.log("hello");\n', "utf8");
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editCode({
-        workspace: WORKSPACE,
-        path: filePath,
-        edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.debug($MISSING)" }],
-      }),
+      tools.editCode.execute(
+        { path: filePath, edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.debug($MISSING)" }] },
+        "call_27",
+      ),
     ).rejects.toMatchObject({
       code: TOOL_ERROR_CODES.editCodeReplacementMetaMismatch,
     });
   });
 
   test("supports variadic metavariables in replacements", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-variadic-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-variadic-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(filePath, "sum(a, b);\nsum(c);\n", "utf8");
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [{ op: "replace", rule: "sum($$$ARGS)", replacement: "total($$$ARGS)" }],
-    });
-    expect(result.matches).toBe(2);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      { path: filePath, edits: [{ op: "replace", rule: "sum($$$ARGS)", replacement: "total($$$ARGS)" }] },
+      "call_28",
+    );
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("total(a, b);");
     expect(content).toContain("total(c);");
@@ -758,53 +787,53 @@ describe("editCode", () => {
   });
 
   test("replaces in Python files", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-py-${testUuid()}.py`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-py-");
+    const filePath = join(workspace, "file.py");
     await writeFile(filePath, 'print("hello")\nprint("world")\n', "utf8");
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [{ op: "replace", rule: "print($ARG)", replacement: "log($ARG)" }],
-    });
-    expect(result.matches).toBe(2);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      { path: filePath, edits: [{ op: "replace", rule: "print($ARG)", replacement: "log($ARG)" }] },
+      "call_29",
+    );
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('log("hello")');
     expect(content).not.toContain("print");
   });
 
   test("replaces in Rust files", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-rs-${testUuid()}.rs`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-rs-");
+    const filePath = join(workspace, "file.rs");
     await writeFile(filePath, 'println!("hello");\nprintln!("world");\n', "utf8");
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [{ op: "replace", rule: "println!($ARGS)", replacement: "eprintln!($ARGS)" }],
-    });
-    expect(result.matches).toBe(2);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      { path: filePath, edits: [{ op: "replace", rule: "println!($ARGS)", replacement: "eprintln!($ARGS)" }] },
+      "call_30",
+    );
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("eprintln!");
     expect(content).not.toMatch(/(?<!e)println!/);
   });
 
   test("replaces in Go files", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-go-${testUuid()}.go`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-go-");
+    const filePath = join(workspace, "file.go");
     await writeFile(filePath, 'package main\n\nfunc main() {\n\tprintln("hello")\n\tprintln("world")\n}\n', "utf8");
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [{ op: "replace", rule: "println($ARG)", replacement: "print($ARG)" }],
-    });
-    expect(result.matches).toBe(2);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      { path: filePath, edits: [{ op: "replace", rule: "println($ARG)", replacement: "print($ARG)" }] },
+      "call_31",
+    );
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("print(");
     expect(content).not.toContain("println(");
   });
 
   test("includes affectedSymbols in result", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-ast-affected-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-ast-affected-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(
       filePath,
       ['function processItems() { console.log("processing"); }', 'function other() { console.log("other"); }', ""].join(
@@ -812,133 +841,151 @@ describe("editCode", () => {
       ),
       "utf8",
     );
-    const result = await editCode({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [
-        { op: "replace", rule: "console.log($ARG)", replacement: "logger.info($ARG)", withinSymbol: "processItems" },
-      ],
-    });
-    expect(result.affectedSymbols).toEqual(["processItems"]);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editCode.execute(
+      {
+        path: filePath,
+        edits: [
+          { op: "replace", rule: "console.log($ARG)", replacement: "logger.info($ARG)", withinSymbol: "processItems" },
+        ],
+      },
+      "call_32",
+    );
+    expect(result.result.affectedSymbols).toEqual(["processItems"]);
   });
 });
 
 describe("scanCode", () => {
-  test("blocks paths outside workspace", async () => {
-    await expect(scanCode({ workspace: WORKSPACE, paths: ["/etc/hosts"], pattern: "const $X" })).rejects.toMatchObject({
+  test("rejects paths outside sandbox via dispatch", async () => {
+    const workspace = dirs.createDir("acolyte-test-sandbox-scan-");
+    const { tools } = toolsForAgent({ workspace });
+    await expect(
+      tools.scanCode.execute({ paths: ["/etc/hosts"], patterns: ["const $X"] }, "call_33"),
+    ).rejects.toMatchObject({
       code: TOOL_ERROR_CODES.sandboxViolation,
-      kind: ERROR_KINDS.sandboxViolation,
     });
   });
 
   test("rejects unsupported single-file types", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-scan-unsupported-${testUuid()}.yaml`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-scan-unsupported-");
+    const filePath = join(workspace, "file.yaml");
     await writeFile(filePath, "foo: bar\n", "utf8");
-    await expect(scanCode({ workspace: WORKSPACE, paths: [filePath], pattern: "const $X" })).rejects.toMatchObject({
+    const { tools } = toolsForAgent({ workspace });
+    await expect(
+      tools.scanCode.execute({ paths: [filePath], patterns: ["const $X"] }, "call_34"),
+    ).rejects.toMatchObject({
       code: TOOL_ERROR_CODES.scanCodeUnsupportedFile,
     });
   });
 
   test("finds matches with metavariable captures", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-scan-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-scan-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(filePath, 'console.log("hello");\nconsole.log("world");\nconst x = 1;\n', "utf8");
-    const result = await scanCode({ workspace: WORKSPACE, paths: [filePath], pattern: "console.log($ARG)" });
-    expect(result.scanned).toBe(1);
-    expect(result.matches).toBe(2);
-    expect(result.patterns).toHaveLength(1);
-    expect(result.patterns[0]?.matches[0]?.captures.$ARG).toBe('"hello"');
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.scanCode.execute({ paths: [filePath], patterns: ["console.log($ARG)"] }, "call_35");
+    const output = result.result.output;
+    expect(output).toContain("scanned=1 matches=2");
+    expect(output).toContain('{$ARG="hello"}');
   });
 
   test("returns no matches when pattern is absent", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-scan-nomatch-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-scan-nomatch-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(filePath, "const x = 1;\n", "utf8");
-    const result = await scanCode({ workspace: WORKSPACE, paths: [filePath], pattern: "console.log($ARG)" });
-    expect(result.scanned).toBe(1);
-    expect(result.matches).toBe(0);
-    expect(result.patterns[0]?.matches).toEqual([]);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.scanCode.execute({ paths: [filePath], patterns: ["console.log($ARG)"] }, "call_36");
+    const output = result.result.output;
+    expect(output).toContain("scanned=1 matches=0");
+    expect(output).toContain("No matches.");
   });
 
   test("scans a directory recursively", async () => {
-    const dirPath = join(WORKSPACE, `acolyte-test-scan-dir-${testUuid()}`);
-    tempDirs.push(dirPath);
-    await mkdir(join(dirPath, "sub"), { recursive: true });
-    await writeFile(join(dirPath, "a.ts"), 'console.log("a");\n', "utf8");
-    await writeFile(join(dirPath, "sub", "b.ts"), 'console.log("b");\nconst y = 2;\n', "utf8");
-    const result = await scanCode({ workspace: WORKSPACE, paths: [dirPath], pattern: "console.log($ARG)" });
-    expect(result.scanned).toBe(2);
-    expect(result.matches).toBe(2);
+    const workspace = dirs.createDir("acolyte-test-scan-dir-");
+    await mkdir(join(workspace, "sub"), { recursive: true });
+    await writeFile(join(workspace, "a.ts"), 'console.log("a");\n', "utf8");
+    await writeFile(join(workspace, "sub", "b.ts"), 'console.log("b");\nconst y = 2;\n', "utf8");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.scanCode.execute({ paths: [workspace], patterns: ["console.log($ARG)"] }, "call_37");
+    const output = result.result.output;
+    expect(output).toContain("scanned=2 matches=2");
   });
 
   test("respects maxResults limit", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-scan-limit-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-scan-limit-");
+    const filePath = join(workspace, "file.ts");
     const lines = `${Array.from({ length: 10 }, (_, i) => `console.log("line${i}");`).join("\n")}\n`;
     await writeFile(filePath, lines, "utf8");
-    const result = await scanCode({
-      workspace: WORKSPACE,
-      paths: [filePath],
-      pattern: "console.log($ARG)",
-      maxResults: 3,
-    });
-    expect(result.matches).toBe(3);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.scanCode.execute(
+      { paths: [filePath], patterns: ["console.log($ARG)"], maxResults: 3 },
+      "call_38",
+    );
+    const output = result.result.output;
+    expect(output).toContain("matches=3");
   });
 
   test("batches multiple patterns", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-scan-batch-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-scan-batch-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(filePath, 'export function hello() {}\nexport const x = 1;\nconsole.log("test");\n', "utf8");
-    const result = await scanCode({
-      workspace: WORKSPACE,
-      paths: [filePath],
-      pattern: ["export function $NAME() {}", "console.log($ARG)"],
-    });
-    expect(result.matches).toBe(2);
-    expect(result.patterns).toHaveLength(2);
-    expect(result.patterns[0]?.matches[0]?.captures.$NAME).toBe("hello");
-    expect(result.patterns[1]?.matches[0]?.captures.$ARG).toBe('"test"');
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.scanCode.execute(
+      { paths: [filePath], patterns: ["export function $NAME() {}", "console.log($ARG)"] },
+      "call_39",
+    );
+    const output = result.result.output;
+    expect(output).toContain("matches=2");
+    expect(output).toContain("{$NAME=hello}");
+    expect(output).toContain('{$ARG="test"}');
   });
 
   test("includes enclosingSymbol for match inside a function", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-scan-enclosing-fn-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-scan-enclosing-fn-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(
       filePath,
       ["function processItems() {", "  console.log('processing');", "}", ""].join("\n"),
       "utf8",
     );
-    const result = await scanCode({ workspace: WORKSPACE, paths: [filePath], pattern: "console.log($ARG)" });
-    expect(result.patterns[0]?.matches[0]?.enclosingSymbol).toBe("processItems");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.scanCode.execute({ paths: [filePath], patterns: ["console.log($ARG)"] }, "call_40");
+    const output = result.result.output;
+    expect(output).toContain("[processItems]");
   });
 
   test("includes enclosingSymbol for match inside a class", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-scan-enclosing-class-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-scan-enclosing-class-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(
       filePath,
       ["class MyService {", "  run() {", "    console.log('run');", "  }", "}", ""].join("\n"),
       "utf8",
     );
-    const result = await scanCode({ workspace: WORKSPACE, paths: [filePath], pattern: "console.log($ARG)" });
-    const match = result.patterns[0]?.matches[0];
-    expect(match?.enclosingSymbol).toBe("run");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.scanCode.execute({ paths: [filePath], patterns: ["console.log($ARG)"] }, "call_41");
+    const output = result.result.output;
+    expect(output).toContain("[run]");
   });
 
   test("enclosingSymbol is undefined at top-level", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-scan-enclosing-top-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-scan-enclosing-top-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(filePath, "console.log('top-level');\n", "utf8");
-    const result = await scanCode({ workspace: WORKSPACE, paths: [filePath], pattern: "console.log($ARG)" });
-    expect(result.patterns[0]?.matches[0]?.enclosingSymbol).toBeUndefined();
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.scanCode.execute({ paths: [filePath], patterns: ["console.log($ARG)"] }, "call_42");
+    const output = result.result.output;
+    expect(output).not.toMatch(/\[.*\]/);
+    expect(output).toContain("console.log('top-level')");
   });
 
   test("includes enclosingSymbol for match inside a TypeScript type alias", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-scan-enclosing-type-${testUuid()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-test-scan-enclosing-type-");
+    const filePath = join(workspace, "file.ts");
     await writeFile(filePath, 'type Status = "active" | "inactive";\n', "utf8");
-    const result = await scanCode({ workspace: WORKSPACE, paths: [filePath], pattern: '"active"' });
-    expect(result.patterns[0]?.matches[0]?.enclosingSymbol).toBe("Status");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.scanCode.execute({ paths: [filePath], patterns: ['"active"'] }, "call_43");
+    const output = result.result.output;
+    expect(output).toContain("[Status]");
   });
 });

--- a/src/file-ops.int.test.ts
+++ b/src/file-ops.int.test.ts
@@ -16,7 +16,7 @@ describe("path validation — fs", () => {
     await writeFile(filePath, "hello from workspace", "utf8");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.readFile.execute({ paths: [{ path: filePath }] }, "call_read_ws");
-    expect(result.result.output).toContain("hello from workspace");
+    expect((result.result as Record<string, unknown>).output).toContain("hello from workspace");
   });
 
   test("readFileContent rejects files exceeding maxLines", async () => {
@@ -54,7 +54,7 @@ describe("path validation — fs", () => {
       { path: filePath, edits: [{ find: "beta", replace: "gamma" }] },
       "call_edit_ws",
     );
-    expect(result.result.output).toContain("edits=1");
+    expect((result.result as Record<string, unknown>).output).toContain("edits=1");
     expect(session.callLog[0]?.toolName).toBe("file-edit");
   });
 });
@@ -69,7 +69,7 @@ describe("editFile", () => {
       { path: filePath, edits: [{ find: "beta", replace: "gamma" }] },
       "call_edit_fr",
     );
-    expect(result.result.output).toContain("edits=1");
+    expect((result.result as Record<string, unknown>).output).toContain("edits=1");
     expect(session.callLog).toHaveLength(1);
   });
 
@@ -122,7 +122,7 @@ describe("editFile", () => {
       },
       "call_edit_snippet",
     );
-    expect(result.result.output).toContain("edits=1");
+    expect((result.result as Record<string, unknown>).output).toContain("edits=1");
     await expect(readFile(filePath, "utf8")).resolves.toContain("docs/contributing.md");
   });
 
@@ -206,7 +206,7 @@ describe("editFile", () => {
       { path: filePath, edits: [{ startLine: 2, endLine: 3, replace: "replaced2\nreplaced3\n" }] },
       "call_edit_lr",
     );
-    expect(result.result.output).toContain("edits=1");
+    expect((result.result as Record<string, unknown>).output).toContain("edits=1");
     const content = await readFile(filePath, "utf8");
     expect(content).toBe("line1\nreplaced2\nreplaced3\nline4\nline5\n");
   });
@@ -217,10 +217,7 @@ describe("editFile", () => {
     await writeFile(filePath, "a\nb\nc\n", "utf8");
     const { tools } = toolsForAgent({ workspace });
     await expect(
-      tools.editFile.execute(
-        { path: filePath, edits: [{ startLine: 5, endLine: 3, replace: "x" }] },
-        "call_edit_lr2",
-      ),
+      tools.editFile.execute({ path: filePath, edits: [{ startLine: 5, endLine: 3, replace: "x" }] }, "call_edit_lr2"),
     ).rejects.toThrow("startLine (5) must be <= endLine (3)");
   });
 
@@ -243,10 +240,7 @@ describe("editFile", () => {
     await writeFile(filePath, "a\nb\n", "utf8");
     const { tools } = toolsForAgent({ workspace });
     await expect(
-      tools.editFile.execute(
-        { path: filePath, edits: [{ startLine: 0, endLine: 1, replace: "x" }] },
-        "call_edit_lr4",
-      ),
+      tools.editFile.execute({ path: filePath, edits: [{ startLine: 0, endLine: 1, replace: "x" }] }, "call_edit_lr4"),
     ).rejects.toThrow("Line numbers must be >= 1");
   });
 
@@ -265,7 +259,7 @@ describe("editFile", () => {
       },
       "call_edit_lr5",
     );
-    expect(result.result.output).toContain("edits=2");
+    expect((result.result as Record<string, unknown>).output).toContain("edits=2");
     const content = await readFile(filePath, "utf8");
     expect(content).toBe("AAA\nbbb\nccc\nDDD\nEEE\n");
   });
@@ -298,7 +292,7 @@ describe("editFile", () => {
       { path: filePath, edits: [{ startLine: 1, endLine: 5, replace: "entirely\nnew\ncontent\n" }] },
       "call_edit_lr7",
     );
-    expect(result.result.output).toContain("edits=1");
+    expect((result.result as Record<string, unknown>).output).toContain("edits=1");
     const content = await readFile(filePath, "utf8");
     expect(content).toBe("entirely\nnew\ncontent\n");
   });
@@ -309,10 +303,7 @@ describe("editFile", () => {
     await writeFile(filePath, "line1\nline2\nline3\n", "utf8");
     const { tools } = toolsForAgent({ workspace });
     await expect(
-      tools.editFile.execute(
-        { path: filePath, edits: [{ startLine: 1, endLine: 99, replace: "" }] },
-        "call_edit_lr8",
-      ),
+      tools.editFile.execute({ path: filePath, edits: [{ startLine: 1, endLine: 99, replace: "" }] }, "call_edit_lr8"),
     ).rejects.toMatchObject({ code: TOOL_ERROR_CODES.editFileLineRangeTooLarge });
   });
 });
@@ -343,8 +334,8 @@ describe("searchFiles", () => {
       { patterns: ["needle"], maxResults: 20, paths: [first] },
       "call_search_scope",
     );
-    expect(result.result.output).toContain("first.ts:1:");
-    expect(result.result.output).not.toContain("second.ts");
+    expect((result.result as Record<string, unknown>).output).toContain("first.ts:1:");
+    expect((result.result as Record<string, unknown>).output).not.toContain("second.ts");
     expect(session.callLog[0]?.toolName).toBe("file-search");
   });
 
@@ -359,8 +350,8 @@ describe("searchFiles", () => {
       { patterns: ["needle"], maxResults: 20, paths: [join(workspace, "sub")] },
       "call_search_dir",
     );
-    expect(result.result.output).toContain("inside.ts:1:");
-    expect(result.result.output).not.toContain("outside");
+    expect((result.result as Record<string, unknown>).output).toContain("inside.ts:1:");
+    expect((result.result as Record<string, unknown>).output).not.toContain("outside");
   });
 
   test("accepts canonical absolute paths inside a symlinked workspace root", async () => {
@@ -376,7 +367,7 @@ describe("searchFiles", () => {
       { patterns: ["needle"], maxResults: 20, paths: [filePath] },
       "call_search_symlink",
     );
-    expect(result.result.output).toContain("inside.ts:1:");
+    expect((result.result as Record<string, unknown>).output).toContain("inside.ts:1:");
   });
 });
 
@@ -386,7 +377,7 @@ describe("createFile", () => {
     const filePath = join(workspace, `test-write-${testUuid()}.txt`);
     const { tools, session } = toolsForAgent({ workspace });
     const result = await tools.createFile.execute({ path: filePath, content: "hello" }, "call_create_ws");
-    expect(result.result.output).toContain("bytes=5");
+    expect((result.result as Record<string, unknown>).output).toContain("bytes=5");
     expect(session.callLog[0]?.toolName).toBe("file-create");
   });
 });
@@ -398,11 +389,9 @@ describe("deleteFile", () => {
     await writeFile(filePath, "alpha\nbeta\n", "utf8");
     const { tools, session } = toolsForAgent({ workspace });
     const result = await tools.deleteFile.execute({ paths: [filePath] }, "call_delete_ws");
-    expect(result.result.output).toContain("bytes=");
+    expect((result.result as Record<string, unknown>).output).toContain("bytes=");
     expect(session.callLog[0]?.toolName).toBe("file-delete");
     const { tools: tools2 } = toolsForAgent({ workspace });
-    await expect(
-      tools2.readFile.execute({ paths: [{ path: filePath }] }, "call_delete_verify"),
-    ).rejects.toThrow();
+    await expect(tools2.readFile.execute({ paths: [{ path: filePath }] }, "call_delete_verify")).rejects.toThrow();
   });
 });

--- a/src/file-ops.int.test.ts
+++ b/src/file-ops.int.test.ts
@@ -1,336 +1,366 @@
-import { afterAll, afterEach, describe, expect, test } from "bun:test";
-import { mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { TOOL_ERROR_CODES } from "./error-contract";
-import { deleteTextFile, editFile, readFileContent, readFileContents, searchFiles, writeTextFile } from "./file-ops";
+import { readFileContent, readFileContents } from "./file-ops";
 import { tempDir, testUuid } from "./test-utils";
+import { toolsForAgent } from "./tool-registry";
 
-const WORKSPACE = resolve(process.cwd());
-const tempFiles: string[] = [];
-const tempDirs: string[] = [];
 const dirs = tempDir();
-
-afterAll(async () => {
-  await Promise.all(tempFiles.map(async (f) => rm(f, { force: true })));
-  await Promise.all(tempDirs.map(async (d) => rm(d, { recursive: true, force: true })));
-});
-
 afterEach(dirs.cleanupDirs);
 
 describe("path validation — fs", () => {
-  test("readFileContent allows workspace files", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-read-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+  test("readFile allows workspace files", async () => {
+    const workspace = dirs.createDir("acolyte-read-ws-");
+    const filePath = join(workspace, `test-read-${testUuid()}.txt`);
     await writeFile(filePath, "hello from workspace", "utf8");
-    const output = await readFileContent(WORKSPACE, filePath);
-    expect(output).toContain("hello from workspace");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.readFile.execute({ paths: [{ path: filePath }] }, "call_read_ws");
+    expect(result.result.output).toContain("hello from workspace");
   });
 
   test("readFileContent rejects files exceeding maxLines", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-large-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-read-maxlines-");
+    const filePath = join(workspace, `test-large-${testUuid()}.txt`);
     const lines = Array.from({ length: 11 }, (_, i) => `line ${i + 1}`).join("\n");
     await writeFile(filePath, lines, "utf8");
-    await expect(readFileContent(WORKSPACE, filePath, 10)).rejects.toThrow(/too large/);
+    await expect(readFileContent(workspace, filePath, 10)).rejects.toThrow(/too large/);
   });
 
   test("readFileContent allows files at exactly maxLines", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-exact-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-read-exact-");
+    const filePath = join(workspace, `test-exact-${testUuid()}.txt`);
     const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join("\n");
     await writeFile(filePath, lines, "utf8");
-    const output = await readFileContent(WORKSPACE, filePath, 10);
+    const output = await readFileContent(workspace, filePath, 10);
     expect(output).toContain("line 1");
   });
 
   test("readFileContents rejects batch when any file exceeds maxLines", async () => {
-    const small = join(WORKSPACE, `acolyte-test-small-${testUuid()}.txt`);
-    const large = join(WORKSPACE, `acolyte-test-large-${testUuid()}.txt`);
-    tempFiles.push(small, large);
+    const workspace = dirs.createDir("acolyte-read-batch-");
+    const small = join(workspace, `test-small-${testUuid()}.txt`);
+    const large = join(workspace, `test-large-${testUuid()}.txt`);
     await writeFile(small, "ok", "utf8");
     await writeFile(large, Array.from({ length: 11 }, (_, i) => `line ${i + 1}`).join("\n"), "utf8");
-    await expect(readFileContents(WORKSPACE, [small, large], 10)).rejects.toThrow(/too large/);
+    await expect(readFileContents(workspace, [small, large], 10)).rejects.toThrow(/too large/);
   });
 
   test("editFile allows workspace files", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-edit-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-ws-");
+    const filePath = join(workspace, `test-edit-${testUuid()}.txt`);
     await writeFile(filePath, "alpha beta", "utf8");
-    const output = await editFile({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [{ find: "beta", replace: "gamma" }],
-    });
-    expect(output).toContain("edits=1");
+    const { tools, session } = toolsForAgent({ workspace });
+    const result = await tools.editFile.execute(
+      { path: filePath, edits: [{ find: "beta", replace: "gamma" }] },
+      "call_edit_ws",
+    );
+    expect(result.result.output).toContain("edits=1");
+    expect(session.callLog[0]?.toolName).toBe("file-edit");
   });
 });
 
 describe("editFile", () => {
   test("find/replace in workspace file", async () => {
-    const filePath = join(WORKSPACE, `tmp-edit-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-fr-");
+    const filePath = join(workspace, `tmp-edit-${testUuid()}.txt`);
     await writeFile(filePath, "alpha beta", "utf8");
-    const result = await editFile({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [{ find: "beta", replace: "gamma" }],
-    });
-    expect(result).toContain("edits=1");
+    const { tools, session } = toolsForAgent({ workspace });
+    const result = await tools.editFile.execute(
+      { path: filePath, edits: [{ find: "beta", replace: "gamma" }] },
+      "call_edit_fr",
+    );
+    expect(result.result.output).toContain("edits=1");
+    expect(session.callLog).toHaveLength(1);
   });
 
   test("rejects multi-match find text", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-multi-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-multi-");
+    const filePath = join(workspace, `test-multi-${testUuid()}.txt`);
     await writeFile(filePath, "foo bar foo baz foo", "utf8");
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editFile({ workspace: WORKSPACE, path: filePath, edits: [{ find: "foo", replace: "qux" }] }),
+      tools.editFile.execute({ path: filePath, edits: [{ find: "foo", replace: "qux" }] }, "call_edit_multi"),
     ).rejects.toThrow("matched 3 locations");
   });
 
   test("rejects missing find text with a structured error code", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-not-found-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-nf-");
+    const filePath = join(workspace, `test-not-found-${testUuid()}.txt`);
     await writeFile(filePath, "alpha beta", "utf8");
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editFile({ workspace: WORKSPACE, path: filePath, edits: [{ find: "gamma", replace: "delta" }] }),
+      tools.editFile.execute({ path: filePath, edits: [{ find: "gamma", replace: "delta" }] }, "call_edit_nf"),
     ).rejects.toMatchObject({ code: TOOL_ERROR_CODES.editFileFindNotFound });
   });
 
   test("emits structured recovery metadata for bounded edit failures", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-recovery-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-recovery-");
+    const filePath = join(workspace, `test-recovery-${testUuid()}.txt`);
     await writeFile(filePath, "alpha beta", "utf8");
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editFile({ workspace: WORKSPACE, path: filePath, edits: [{ find: "gamma", replace: "delta" }] }),
+      tools.editFile.execute({ path: filePath, edits: [{ find: "gamma", replace: "delta" }] }, "call_edit_recovery"),
     ).rejects.toMatchObject({
       code: TOOL_ERROR_CODES.editFileFindNotFound,
     });
   });
 
   test("allows a tiny whole-file snippet when it is only a few lines", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-small-snippet-${crypto.randomUUID()}.md`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-snippet-");
+    const filePath = join(workspace, `test-small-snippet-${crypto.randomUUID()}.md`);
     await writeFile(filePath, "# Demo\n\n## Documentation\n- [Contributing](CONTRIBUTING.md)\n", "utf8");
-
-    const result = await editFile({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [
-        {
-          find: "# Demo\n\n## Documentation\n- [Contributing](CONTRIBUTING.md)\n",
-          replace: "# Demo\n\n## Documentation\n- [Contributing](docs/contributing.md)\n",
-        },
-      ],
-    });
-
-    expect(result).toContain("edits=1");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editFile.execute(
+      {
+        path: filePath,
+        edits: [
+          {
+            find: "# Demo\n\n## Documentation\n- [Contributing](CONTRIBUTING.md)\n",
+            replace: "# Demo\n\n## Documentation\n- [Contributing](docs/contributing.md)\n",
+          },
+        ],
+      },
+      "call_edit_snippet",
+    );
+    expect(result.result.output).toContain("edits=1");
     await expect(readFile(filePath, "utf8")).resolves.toContain("docs/contributing.md");
   });
 
   test("rejects long find snippets even when they are unique", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-long-snippet-${crypto.randomUUID()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-longsnip-");
+    const filePath = join(workspace, `test-long-snippet-${crypto.randomUUID()}.txt`);
     const content = Array.from({ length: 10 }, (_, index) => `line-${index + 1}`).join("\n");
     await writeFile(filePath, `${content}\n`, "utf8");
-
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editFile({
-        workspace: WORKSPACE,
-        path: filePath,
-        edits: [{ find: `${content}\n`, replace: "short\n" }],
-      }),
+      tools.editFile.execute(
+        { path: filePath, edits: [{ find: `${content}\n`, replace: "short\n" }] },
+        "call_edit_longsnip",
+      ),
     ).rejects.toMatchObject({
       code: TOOL_ERROR_CODES.editFileFindTooLarge,
     });
   });
 
   test("rejects oversized replace blocks for find-based edits", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-large-replace-${crypto.randomUUID()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-largerepl-");
+    const filePath = join(workspace, `test-large-replace-${crypto.randomUUID()}.ts`);
     const content = Array.from({ length: 40 }, (_, index) => `line-${index + 1}`).join("\n");
     await writeFile(filePath, `${content}\n`, "utf8");
-
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editFile({
-        workspace: WORKSPACE,
-        path: filePath,
-        edits: [
-          {
-            find: "line-2\nline-3\nline-4",
-            replace: `${content}\n`,
-          },
-        ],
-      }),
+      tools.editFile.execute(
+        {
+          path: filePath,
+          edits: [
+            {
+              find: "line-2\nline-3\nline-4",
+              replace: `${content}\n`,
+            },
+          ],
+        },
+        "call_edit_largerepl",
+      ),
     ).rejects.toMatchObject({ code: TOOL_ERROR_CODES.editFileReplaceTooLarge });
   });
 
   test("rejects batched find edits that rewrite too much of the file", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-batch-rewrite-${crypto.randomUUID()}.ts`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-batchrw-");
+    const filePath = join(workspace, `test-batch-rewrite-${crypto.randomUUID()}.ts`);
     const content = Array.from({ length: 40 }, (_, index) => `line-${index + 1}`).join("\n");
     await writeFile(filePath, `${content}\n`, "utf8");
-
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editFile({
-        workspace: WORKSPACE,
-        path: filePath,
-        edits: Array.from({ length: 33 }, (_, index) => ({
-          find: `line-${index + 1}\n`,
-          replace: `updated-${index + 1}\n`,
-        })),
-      }),
+      tools.editFile.execute(
+        {
+          path: filePath,
+          edits: Array.from({ length: 33 }, (_, index) => ({
+            find: `line-${index + 1}\n`,
+            replace: `updated-${index + 1}\n`,
+          })),
+        },
+        "call_edit_batchrw",
+      ),
     ).rejects.toMatchObject({ code: TOOL_ERROR_CODES.editFileBatchTooLarge });
   });
 
   test("rejects replace text that duplicates content after edit point", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-dup-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-dup-");
+    const filePath = join(workspace, `test-dup-${testUuid()}.txt`);
     await writeFile(filePath, "line1\nline2\nline3\nline4\nline5\nline6", "utf8");
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editFile({
-        workspace: WORKSPACE,
-        path: filePath,
-        edits: [{ find: "line1\nline2", replace: "line1_new\nline2_new\nline3\nline4\nline5" }],
-      }),
+      tools.editFile.execute(
+        { path: filePath, edits: [{ find: "line1\nline2", replace: "line1_new\nline2_new\nline3\nline4\nline5" }] },
+        "call_edit_dup",
+      ),
     ).rejects.toThrow("duplicate content");
   });
 
   test("line-range basic replacement", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-lr-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-lr-");
+    const filePath = join(workspace, `test-lr-${testUuid()}.txt`);
     await writeFile(filePath, "line1\nline2\nline3\nline4\nline5\n", "utf8");
-    const result = await editFile({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [{ startLine: 2, endLine: 3, replace: "replaced2\nreplaced3\n" }],
-    });
-    expect(result).toContain("edits=1");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editFile.execute(
+      { path: filePath, edits: [{ startLine: 2, endLine: 3, replace: "replaced2\nreplaced3\n" }] },
+      "call_edit_lr",
+    );
+    expect(result.result.output).toContain("edits=1");
     const content = await readFile(filePath, "utf8");
     expect(content).toBe("line1\nreplaced2\nreplaced3\nline4\nline5\n");
   });
 
   test("line-range rejects startLine > endLine", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-lr2-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-lr2-");
+    const filePath = join(workspace, `test-lr2-${testUuid()}.txt`);
     await writeFile(filePath, "a\nb\nc\n", "utf8");
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editFile({ workspace: WORKSPACE, path: filePath, edits: [{ startLine: 5, endLine: 3, replace: "x" }] }),
+      tools.editFile.execute(
+        { path: filePath, edits: [{ startLine: 5, endLine: 3, replace: "x" }] },
+        "call_edit_lr2",
+      ),
     ).rejects.toThrow("startLine (5) must be <= endLine (3)");
   });
 
   test("line-range clamps endLine beyond file", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-lr3-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-lr3-");
+    const filePath = join(workspace, `test-lr3-${testUuid()}.txt`);
     await writeFile(filePath, "a\nb\nc\n", "utf8");
-    await editFile({ workspace: WORKSPACE, path: filePath, edits: [{ startLine: 1, endLine: 10, replace: "x" }] });
+    const { tools } = toolsForAgent({ workspace });
+    await tools.editFile.execute(
+      { path: filePath, edits: [{ startLine: 1, endLine: 10, replace: "x" }] },
+      "call_edit_lr3",
+    );
     const result = await readFile(filePath, "utf8");
     expect(result).toBe("x");
   });
 
   test("line-range rejects line numbers < 1", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-lr4-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-lr4-");
+    const filePath = join(workspace, `test-lr4-${testUuid()}.txt`);
     await writeFile(filePath, "a\nb\n", "utf8");
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editFile({ workspace: WORKSPACE, path: filePath, edits: [{ startLine: 0, endLine: 1, replace: "x" }] }),
+      tools.editFile.execute(
+        { path: filePath, edits: [{ startLine: 0, endLine: 1, replace: "x" }] },
+        "call_edit_lr4",
+      ),
     ).rejects.toThrow("Line numbers must be >= 1");
   });
 
   test("mixed find/replace and line-range", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-lr5-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-lr5-");
+    const filePath = join(workspace, `test-lr5-${testUuid()}.txt`);
     await writeFile(filePath, "aaa\nbbb\nccc\nddd\neee\n", "utf8");
-    const result = await editFile({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [
-        { find: "aaa", replace: "AAA" },
-        { startLine: 4, endLine: 5, replace: "DDD\nEEE\n" },
-      ],
-    });
-    expect(result).toContain("edits=2");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editFile.execute(
+      {
+        path: filePath,
+        edits: [
+          { find: "aaa", replace: "AAA" },
+          { startLine: 4, endLine: 5, replace: "DDD\nEEE\n" },
+        ],
+      },
+      "call_edit_lr5",
+    );
+    expect(result.result.output).toContain("edits=2");
     const content = await readFile(filePath, "utf8");
     expect(content).toBe("AAA\nbbb\nccc\nDDD\nEEE\n");
   });
 
   test("line-range overlapping ranges rejected", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-lr6-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-lr6-");
+    const filePath = join(workspace, `test-lr6-${testUuid()}.txt`);
     await writeFile(filePath, "a\nb\nc\nd\ne\n", "utf8");
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editFile({
-        workspace: WORKSPACE,
-        path: filePath,
-        edits: [
-          { startLine: 1, endLine: 3, replace: "x\n" },
-          { startLine: 2, endLine: 4, replace: "y\n" },
-        ],
-      }),
+      tools.editFile.execute(
+        {
+          path: filePath,
+          edits: [
+            { startLine: 1, endLine: 3, replace: "x\n" },
+            { startLine: 2, endLine: 4, replace: "y\n" },
+          ],
+        },
+        "call_edit_lr6",
+      ),
     ).rejects.toThrow("overlap");
   });
 
   test("line-range full-file replacement", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-lr7-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-lr7-");
+    const filePath = join(workspace, `test-lr7-${testUuid()}.txt`);
     await writeFile(filePath, "line1\nline2\nline3\nline4\nline5\n", "utf8");
-    const result = await editFile({
-      workspace: WORKSPACE,
-      path: filePath,
-      edits: [{ startLine: 1, endLine: 5, replace: "entirely\nnew\ncontent\n" }],
-    });
-    expect(result).toContain("edits=1");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.editFile.execute(
+      { path: filePath, edits: [{ startLine: 1, endLine: 5, replace: "entirely\nnew\ncontent\n" }] },
+      "call_edit_lr7",
+    );
+    expect(result.result.output).toContain("edits=1");
     const content = await readFile(filePath, "utf8");
     expect(content).toBe("entirely\nnew\ncontent\n");
   });
 
   test("line-range rejects whole-file clear edits", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-lr8-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-edit-lr8-");
+    const filePath = join(workspace, `test-lr8-${testUuid()}.txt`);
     await writeFile(filePath, "line1\nline2\nline3\n", "utf8");
+    const { tools } = toolsForAgent({ workspace });
     await expect(
-      editFile({
-        workspace: WORKSPACE,
-        path: filePath,
-        edits: [{ startLine: 1, endLine: 99, replace: "" }],
-      }),
+      tools.editFile.execute(
+        { path: filePath, edits: [{ startLine: 1, endLine: 99, replace: "" }] },
+        "call_edit_lr8",
+      ),
     ).rejects.toMatchObject({ code: TOOL_ERROR_CODES.editFileLineRangeTooLarge });
   });
 });
 
 describe("searchFiles", () => {
   test("rejects when a scoped file has no matches", async () => {
-    const filePath = join(WORKSPACE, `tmp-search-no-match-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-search-nomatch-");
+    const filePath = join(workspace, `tmp-search-no-match-${testUuid()}.txt`);
     await writeFile(filePath, "alpha beta\n", "utf8");
-    await expect(searchFiles(WORKSPACE, ["gamma"], 20, [filePath])).rejects.toMatchObject({
+    const { tools } = toolsForAgent({ workspace });
+    await expect(
+      tools.searchFiles.execute({ patterns: ["gamma"], maxResults: 20, paths: [filePath] }, "call_search_nomatch"),
+    ).rejects.toMatchObject({
       code: TOOL_ERROR_CODES.searchFilesNoMatch,
     });
   });
 
   test("scopes matches to a single file path", async () => {
-    const dir = join(WORKSPACE, `acolyte-test-search-${testUuid()}`);
-    tempDirs.push(dir);
+    const workspace = dirs.createDir("acolyte-search-scope-");
+    const dir = join(workspace, "sub");
     await mkdir(dir, { recursive: true });
     const first = join(dir, "first.ts");
     const second = join(dir, "second.ts");
     await writeFile(first, 'export const first = "needle";\n', "utf8");
     await writeFile(second, 'export const second = "needle";\n', "utf8");
-    const result = await searchFiles(WORKSPACE, ["needle"], 20, [first]);
-    expect(result).toContain("first.ts:1:");
-    expect(result).not.toContain("second.ts");
+    const { tools, session } = toolsForAgent({ workspace });
+    const result = await tools.searchFiles.execute(
+      { patterns: ["needle"], maxResults: 20, paths: [first] },
+      "call_search_scope",
+    );
+    expect(result.result.output).toContain("first.ts:1:");
+    expect(result.result.output).not.toContain("second.ts");
+    expect(session.callLog[0]?.toolName).toBe("file-search");
   });
 
   test("scopes matches to a directory path", async () => {
-    const dir = join(WORKSPACE, `acolyte-test-search-dir-${testUuid()}`);
-    tempDirs.push(dir);
-    await mkdir(join(dir, "sub"), { recursive: true });
-    await writeFile(join(dir, "sub", "inside.ts"), 'export const inside = "needle";\n', "utf8");
-    const outside = join(WORKSPACE, `acolyte-test-search-outside-${testUuid()}.ts`);
-    tempFiles.push(outside);
-    await writeFile(outside, 'export const outside = "needle";\n', "utf8");
-    const result = await searchFiles(WORKSPACE, ["needle"], 20, [dir]);
-    expect(result).toContain("inside.ts:1:");
-    expect(result).not.toContain(outside.split("/").at(-1) ?? "");
+    const workspace = dirs.createDir("acolyte-search-dir-");
+    await mkdir(join(workspace, "sub"), { recursive: true });
+    await writeFile(join(workspace, "sub", "inside.ts"), 'export const inside = "needle";\n', "utf8");
+    const outsideFile = join(workspace, `outside-${testUuid()}.ts`);
+    await writeFile(outsideFile, 'export const outside = "needle";\n', "utf8");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.searchFiles.execute(
+      { patterns: ["needle"], maxResults: 20, paths: [join(workspace, "sub")] },
+      "call_search_dir",
+    );
+    expect(result.result.output).toContain("inside.ts:1:");
+    expect(result.result.output).not.toContain("outside");
   });
 
   test("accepts canonical absolute paths inside a symlinked workspace root", async () => {
@@ -341,28 +371,38 @@ describe("searchFiles", () => {
     await mkdir(realWorkspace, { recursive: true });
     await writeFile(filePath, 'export const inside = "needle";\n', "utf8");
     await symlink(realWorkspace, linkWorkspace);
-
-    const result = await searchFiles(linkWorkspace, ["needle"], 20, [filePath]);
-    expect(result).toContain("inside.ts:1:");
+    const { tools } = toolsForAgent({ workspace: linkWorkspace });
+    const result = await tools.searchFiles.execute(
+      { patterns: ["needle"], maxResults: 20, paths: [filePath] },
+      "call_search_symlink",
+    );
+    expect(result.result.output).toContain("inside.ts:1:");
   });
 });
 
-describe("writeTextFile", () => {
+describe("createFile", () => {
   test("creates workspace files", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-write-${testUuid()}.txt`);
-    tempFiles.push(filePath);
-    const result = await writeTextFile({ workspace: WORKSPACE, path: filePath, content: "hello" });
-    expect(result).toContain("bytes=5");
+    const workspace = dirs.createDir("acolyte-create-ws-");
+    const filePath = join(workspace, `test-write-${testUuid()}.txt`);
+    const { tools, session } = toolsForAgent({ workspace });
+    const result = await tools.createFile.execute({ path: filePath, content: "hello" }, "call_create_ws");
+    expect(result.result.output).toContain("bytes=5");
+    expect(session.callLog[0]?.toolName).toBe("file-create");
   });
 });
 
-describe("deleteTextFile", () => {
+describe("deleteFile", () => {
   test("deletes workspace files", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-delete-${testUuid()}.txt`);
-    tempFiles.push(filePath);
+    const workspace = dirs.createDir("acolyte-delete-ws-");
+    const filePath = join(workspace, `test-delete-${testUuid()}.txt`);
     await writeFile(filePath, "alpha\nbeta\n", "utf8");
-    const result = await deleteTextFile({ workspace: WORKSPACE, path: filePath });
-    expect(result).toContain("bytes=");
-    await expect(readFileContent(WORKSPACE, filePath)).rejects.toThrow();
+    const { tools, session } = toolsForAgent({ workspace });
+    const result = await tools.deleteFile.execute({ paths: [filePath] }, "call_delete_ws");
+    expect(result.result.output).toContain("bytes=");
+    expect(session.callLog[0]?.toolName).toBe("file-delete");
+    const { tools: tools2 } = toolsForAgent({ workspace });
+    await expect(
+      tools2.readFile.execute({ paths: [{ path: filePath }] }, "call_delete_verify"),
+    ).rejects.toThrow();
   });
 });

--- a/src/lifecycle-effects.int.test.ts
+++ b/src/lifecycle-effects.int.test.ts
@@ -1,33 +1,83 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
-import { installEffect } from "./lifecycle-effects";
+import { attachLifecycleEffectHandlers } from "./lifecycle-effects";
 import { createRunContext, tempDir } from "./test-utils";
+import { toolsForAgent } from "./tool-registry";
 
 const { createDir, cleanupDirs } = tempDir();
 afterEach(() => cleanupDirs());
 
-function ctxWith(overrides: Parameters<typeof createRunContext>[0] = {}) {
-  return createRunContext({
-    workspace: "/ws",
-    policy: {
-      ...createRunContext().policy,
-      formatCommand: { bin: "fmt", args: ["--write"] },
-      lintCommand: { bin: "lint", args: ["--fix"] },
-    },
-    ...overrides,
-  });
-}
+describe("lifecycle effects through tool dispatch", () => {
+  test("format effect fires after write tool succeeds", async () => {
+    const workspace = createDir("acolyte-effect-format-");
+    await writeFile(join(workspace, "demo.ts"), "const   x=1\n", "utf8");
 
-describe("installEffect", () => {
-  test("skips install when depsDir exists", () => {
-    const ws = createDir("acolyte-install-");
-    mkdirSync(join(ws, "node_modules"), { recursive: true });
-    const ctx = ctxWith({
-      workspace: ws,
-      policy: { ...createRunContext().policy, installCommand: { bin: "npm", args: ["install"] } },
+    const { tools, session } = toolsForAgent({ workspace });
+    const debugEvents: Array<{ event: string; data: Record<string, unknown> }> = [];
+    const ctx = createRunContext({
+      workspace,
+      session,
+      debug: (event, data) => debugEvents.push({ event, data }),
+      policy: {
+        ...createRunContext().policy,
+        formatCommand: { bin: "bunx", args: ["biome", "check", "--write", "$FILES"] },
+      },
     });
-    ctx.session.workspaceProfile = { depsDir: "node_modules" };
-    expect(installEffect.run(ctx, [])).toEqual({ type: "done" });
+    attachLifecycleEffectHandlers(ctx, session);
+
+    await tools.editFile.execute(
+      { path: join(workspace, "demo.ts"), edits: [{ find: "x=1", replace: "x = 1" }] },
+      "call_1",
+    );
+
+    expect(debugEvents.some((e) => e.event === "lifecycle.effect.format")).toBe(true);
+  });
+
+  test("effects do not fire for read tools", async () => {
+    const workspace = createDir("acolyte-effect-read-");
+    await writeFile(join(workspace, "a.txt"), "ok", "utf8");
+
+    const { tools, session } = toolsForAgent({ workspace });
+    const debugEvents: Array<{ event: string }> = [];
+    const ctx = createRunContext({
+      workspace,
+      session,
+      debug: (event) => debugEvents.push({ event }),
+      policy: {
+        ...createRunContext().policy,
+        formatCommand: { bin: "bunx", args: ["biome", "check", "--write", "$FILES"] },
+      },
+    });
+    attachLifecycleEffectHandlers(ctx, session);
+
+    await tools.readFile.execute({ paths: [{ path: join(workspace, "a.txt") }] }, "call_2");
+
+    expect(debugEvents.some((e) => e.event === "lifecycle.effect.format")).toBe(false);
+  });
+
+  test("install effect skips when depsDir exists", async () => {
+    const workspace = createDir("acolyte-effect-install-");
+    mkdirSync(join(workspace, "node_modules"), { recursive: true });
+    await writeFile(join(workspace, "src.ts"), "const x = 1;\n", "utf8");
+
+    const { tools, session } = toolsForAgent({ workspace });
+    const debugEvents: Array<{ event: string }> = [];
+    const ctx = createRunContext({
+      workspace,
+      session,
+      debug: (event) => debugEvents.push({ event }),
+      policy: {
+        ...createRunContext().policy,
+        installCommand: { bin: "npm", args: ["install"] },
+      },
+    });
+    session.workspaceProfile = { depsDir: "node_modules" };
+    attachLifecycleEffectHandlers(ctx, session);
+
+    await tools.readFile.execute({ paths: [{ path: join(workspace, "src.ts") }] }, "call_3");
+
+    expect(debugEvents.some((e) => e.event === "lifecycle.effect.install")).toBe(false);
   });
 });

--- a/src/lifecycle-effects.int.test.ts
+++ b/src/lifecycle-effects.int.test.ts
@@ -15,11 +15,11 @@ describe("lifecycle effects through tool dispatch", () => {
     await writeFile(join(workspace, "demo.ts"), "const   x=1\n", "utf8");
 
     const { tools, session } = toolsForAgent({ workspace });
-    const debugEvents: Array<{ event: string; data: Record<string, unknown> }> = [];
+    const debugEvents: Array<{ event: string }> = [];
     const ctx = createRunContext({
       workspace,
       session,
-      debug: (event, data) => debugEvents.push({ event, data }),
+      debug: (event) => debugEvents.push({ event }),
       policy: {
         ...createRunContext().policy,
         formatCommand: { bin: "bunx", args: ["biome", "check", "--write", "$FILES"] },

--- a/src/shell-ops.int.test.ts
+++ b/src/shell-ops.int.test.ts
@@ -1,73 +1,80 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
-import { basename, join, resolve } from "node:path";
+import { basename, join } from "node:path";
 import { TOOL_ERROR_CODES } from "./error-contract";
-import { runShellCommand } from "./shell-ops";
 import { tempDir, testUuid } from "./test-utils";
+import { toolsForAgent } from "./tool-registry";
 
-const WORKSPACE = resolve(process.cwd());
 const dirs = tempDir();
-
 afterEach(dirs.cleanupDirs);
 
-describe("runShellCommand", () => {
+describe("shell-run through registry dispatch", () => {
   test("runs in-workspace commands", async () => {
-    const output = await runShellCommand(WORKSPACE, { cmd: "printf", args: ["ok"] });
-    expect(output).toContain("exit_code=0");
-    expect(output).toContain("ok");
+    const workspace = dirs.createDir("acolyte-shell-run-");
+    const { tools, session } = toolsForAgent({ workspace });
+    const result = await tools.runCommand.execute({ cmd: "printf", args: ["ok"] }, "call_1");
+    expect(result.result.output).toContain("ok");
+    expect(result.result.exitCode).toBe(0);
+    expect(session.callLog[0]?.toolName).toBe("shell-run");
   });
 
   test("allows workspace paths", async () => {
-    const filePath = join(WORKSPACE, `acolyte-test-run-${testUuid()}.txt`);
+    const workspace = dirs.createDir("acolyte-shell-ws-");
+    const filePath = join(workspace, `test-${testUuid()}.txt`);
     try {
       await writeFile(filePath, "ok\n", "utf8");
-      const output = await runShellCommand(WORKSPACE, { cmd: "cat", args: [filePath] });
-      expect(output).toContain("exit_code=0");
-      expect(output).toContain("ok");
+      const { tools } = toolsForAgent({ workspace });
+      const result = await tools.runCommand.execute({ cmd: "cat", args: [filePath] }, "call_2");
+      expect(result.result.output).toContain("ok");
     } finally {
       await rm(filePath, { force: true });
     }
   });
 
-  test("includes timeout indicator when command exceeds timeout", async () => {
-    const output = await runShellCommand(WORKSPACE, { cmd: "sleep", args: ["5"] }, 500);
-    expect(output).toContain("TIMED OUT after 500ms");
+  test("rejects with timeout error when command exceeds limit", async () => {
+    const workspace = dirs.createDir("acolyte-shell-timeout-");
+    const { tools } = toolsForAgent({ workspace });
+    await expect(
+      tools.runCommand.execute({ cmd: "sleep", args: ["5"], timeoutMs: 500 }, "call_3"),
+    ).rejects.toThrow(/timed out/i);
   });
 
   test("allows flag arguments containing slashes", async () => {
-    const output = await runShellCommand(WORKSPACE, { cmd: "echo", args: ["--format=json/pretty"] });
-    expect(output).toContain("exit_code=0");
-    expect(output).toContain("--format=json/pretty");
+    const workspace = dirs.createDir("acolyte-shell-flags-");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.runCommand.execute({ cmd: "echo", args: ["--format=json/pretty"] }, "call_4");
+    expect(result.result.output).toContain("--format=json/pretty");
   });
 
   test("does not evaluate shell operators", async () => {
-    const output = await runShellCommand(WORKSPACE, { cmd: "echo", args: ["hello", "&&", "echo", "nope"] });
-    expect(output).toContain("exit_code=0");
-    expect(output).toContain("hello && echo nope");
+    const workspace = dirs.createDir("acolyte-shell-ops-");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.runCommand.execute({ cmd: "echo", args: ["hello", "&&", "echo", "nope"] }, "call_5");
+    expect(result.result.output).toContain("hello && echo nope");
   });
 
   test("blocks bare relative symlink escapes", async () => {
-    const linkPath = join(WORKSPACE, `acolyte-test-link-${testUuid()}`);
+    const workspace = dirs.createDir("acolyte-shell-symlink-");
+    const linkPath = join(workspace, `test-link-${testUuid()}`);
     try {
       await symlink("/etc/hosts", linkPath);
-      await expect(runShellCommand(WORKSPACE, { cmd: "cat", args: [basename(linkPath)] })).rejects.toMatchObject({
-        code: TOOL_ERROR_CODES.sandboxViolation,
-      });
+      const { tools } = toolsForAgent({ workspace });
+      await expect(
+        tools.runCommand.execute({ cmd: "cat", args: [basename(linkPath)] }, "call_6"),
+      ).rejects.toMatchObject({ code: TOOL_ERROR_CODES.sandboxViolation });
     } finally {
       await rm(linkPath, { force: true });
     }
   });
 
   test("allows nested relative paths within workspace", async () => {
-    const dir = dirs.createDir("acolyte-shell-sandbox-");
-    const workspaceDir = join(dir, "workspace");
-    const nestedDir = join(workspaceDir, "nested");
-    const nestedFile = join(nestedDir, "note.txt");
+    const workspace = dirs.createDir("acolyte-shell-nested-");
+    const nestedDir = join(workspace, "nested");
     await mkdir(nestedDir, { recursive: true });
-    await writeFile(nestedFile, "nested-ok\n", "utf8");
+    await writeFile(join(nestedDir, "note.txt"), "nested-ok\n", "utf8");
 
-    const output = await runShellCommand(workspaceDir, { cmd: "cat", args: ["nested/note.txt"] });
-    expect(output).toContain("exit_code=0");
-    expect(output).toContain("nested-ok");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.runCommand.execute({ cmd: "cat", args: ["nested/note.txt"] }, "call_7");
+    expect(result.result.output).toContain("nested-ok");
   });
 });

--- a/src/shell-ops.int.test.ts
+++ b/src/shell-ops.int.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
-import { basename, join } from "node:path";
+import { mkdir, symlink, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import { TOOL_ERROR_CODES } from "./error-contract";
-import { tempDir, testUuid } from "./test-utils";
+import { tempDir } from "./test-utils";
 import { toolsForAgent } from "./tool-registry";
 
 const dirs = tempDir();
@@ -20,15 +20,11 @@ describe("shell-run through registry dispatch", () => {
 
   test("allows workspace paths", async () => {
     const workspace = dirs.createDir("acolyte-shell-ws-");
-    const filePath = join(workspace, `test-${testUuid()}.txt`);
-    try {
-      await writeFile(filePath, "ok\n", "utf8");
-      const { tools } = toolsForAgent({ workspace });
-      const result = await tools.runCommand.execute({ cmd: "cat", args: [filePath] }, "call_2");
-      expect((result.result as Record<string, unknown>).output).toContain("ok");
-    } finally {
-      await rm(filePath, { force: true });
-    }
+    const filePath = join(workspace, "test.txt");
+    await writeFile(filePath, "ok\n", "utf8");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.runCommand.execute({ cmd: "cat", args: [filePath] }, "call_2");
+    expect((result.result as Record<string, unknown>).output).toContain("ok");
   });
 
   test("rejects with timeout error when command exceeds limit", async () => {
@@ -55,16 +51,12 @@ describe("shell-run through registry dispatch", () => {
 
   test("blocks bare relative symlink escapes", async () => {
     const workspace = dirs.createDir("acolyte-shell-symlink-");
-    const linkPath = join(workspace, `test-link-${testUuid()}`);
-    try {
-      await symlink("/etc/hosts", linkPath);
-      const { tools } = toolsForAgent({ workspace });
-      await expect(
-        tools.runCommand.execute({ cmd: "cat", args: [basename(linkPath)] }, "call_6"),
-      ).rejects.toMatchObject({ code: TOOL_ERROR_CODES.sandboxViolation });
-    } finally {
-      await rm(linkPath, { force: true });
-    }
+    const linkPath = join(workspace, "escape-link");
+    await symlink("/etc/hosts", linkPath);
+    const { tools } = toolsForAgent({ workspace });
+    await expect(tools.runCommand.execute({ cmd: "cat", args: ["escape-link"] }, "call_6")).rejects.toMatchObject({
+      code: TOOL_ERROR_CODES.sandboxViolation,
+    });
   });
 
   test("allows nested relative paths within workspace", async () => {

--- a/src/shell-ops.int.test.ts
+++ b/src/shell-ops.int.test.ts
@@ -13,8 +13,8 @@ describe("shell-run through registry dispatch", () => {
     const workspace = dirs.createDir("acolyte-shell-run-");
     const { tools, session } = toolsForAgent({ workspace });
     const result = await tools.runCommand.execute({ cmd: "printf", args: ["ok"] }, "call_1");
-    expect(result.result.output).toContain("ok");
-    expect(result.result.exitCode).toBe(0);
+    expect((result.result as Record<string, unknown>).output).toContain("ok");
+    expect((result.result as Record<string, unknown>).exitCode).toBe(0);
     expect(session.callLog[0]?.toolName).toBe("shell-run");
   });
 
@@ -25,7 +25,7 @@ describe("shell-run through registry dispatch", () => {
       await writeFile(filePath, "ok\n", "utf8");
       const { tools } = toolsForAgent({ workspace });
       const result = await tools.runCommand.execute({ cmd: "cat", args: [filePath] }, "call_2");
-      expect(result.result.output).toContain("ok");
+      expect((result.result as Record<string, unknown>).output).toContain("ok");
     } finally {
       await rm(filePath, { force: true });
     }
@@ -34,23 +34,23 @@ describe("shell-run through registry dispatch", () => {
   test("rejects with timeout error when command exceeds limit", async () => {
     const workspace = dirs.createDir("acolyte-shell-timeout-");
     const { tools } = toolsForAgent({ workspace });
-    await expect(
-      tools.runCommand.execute({ cmd: "sleep", args: ["5"], timeoutMs: 500 }, "call_3"),
-    ).rejects.toThrow(/timed out/i);
+    await expect(tools.runCommand.execute({ cmd: "sleep", args: ["5"], timeoutMs: 500 }, "call_3")).rejects.toThrow(
+      /timed out/i,
+    );
   });
 
   test("allows flag arguments containing slashes", async () => {
     const workspace = dirs.createDir("acolyte-shell-flags-");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.runCommand.execute({ cmd: "echo", args: ["--format=json/pretty"] }, "call_4");
-    expect(result.result.output).toContain("--format=json/pretty");
+    expect((result.result as Record<string, unknown>).output).toContain("--format=json/pretty");
   });
 
   test("does not evaluate shell operators", async () => {
     const workspace = dirs.createDir("acolyte-shell-ops-");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.runCommand.execute({ cmd: "echo", args: ["hello", "&&", "echo", "nope"] }, "call_5");
-    expect(result.result.output).toContain("hello && echo nope");
+    expect((result.result as Record<string, unknown>).output).toContain("hello && echo nope");
   });
 
   test("blocks bare relative symlink escapes", async () => {
@@ -75,6 +75,6 @@ describe("shell-run through registry dispatch", () => {
 
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.runCommand.execute({ cmd: "cat", args: ["nested/note.txt"] }, "call_7");
-    expect(result.result.output).toContain("nested-ok");
+    expect((result.result as Record<string, unknown>).output).toContain("nested-ok");
   });
 });


### PR DESCRIPTION
## Motivation

Integration tests for file-ops, shell-ops, code-ops, and lifecycle-effects called underlying functions directly, bypassing the tool dispatch pipeline (budget checks, hooks, caching, call logging). Per spike #187, `toolsForAgent({ workspace })` + `tools.<name>.execute()` exercises the same path production uses.

## Summary

- add integration test boundary rules to `docs/testing.md`
- rewrite `shell-ops.int.test.ts` to dispatch through `tools.runCommand.execute()`
- rewrite `lifecycle-effects.int.test.ts` to verify effects via `attachLifecycleEffectHandlers` + debug events
- rewrite `file-ops.int.test.ts` to dispatch through `tools.editFile`, `tools.createFile`, `tools.readFile`, etc.
- rewrite `code-ops.int.test.ts` to dispatch through `tools.editCode` and `tools.scanCode`
- use `Record<string, unknown>` for dispatch result types until #189 threads generics through `runTool`

Fixes #188