### PR TITLE
refactor(chat): remove auto file and dir attachment

### DIFF
--- a/src/agent-input.test.ts
+++ b/src/agent-input.test.ts
@@ -34,15 +34,7 @@ function createRequest(content: string): ChatRequest {
 }
 
 describe("createAgentInput", () => {
-  test("keeps large attached-file system context", () => {
-    const attachment = `Attached file: AGENTS.md\n${"A".repeat(6000)}`;
-    const { input } = createAgentInput(createRequest(attachment), defaultOptions);
-    expect(input).toContain("Attached file: AGENTS.md");
-    expect(input).toContain("A".repeat(5000));
-    expect(input.endsWith("…")).toBe(false);
-  });
-
-  test("still truncates non-attachment long messages", () => {
+  test("truncates long system messages", () => {
     const longSystem = `General note: ${"B".repeat(4000)}`;
     const { input } = createAgentInput(createRequest(longSystem), defaultOptions);
     expect(input).toContain("General note:");

--- a/src/agent-input.test.ts
+++ b/src/agent-input.test.ts
@@ -8,7 +8,6 @@ const defaultOptions = {
   budget: {
     maxHistoryMessages: defaultLifecyclePolicy.maxHistoryMessages,
     maxMessageTokens: defaultLifecyclePolicy.maxMessageTokens,
-    maxAttachmentMessageTokens: defaultLifecyclePolicy.maxAttachmentMessageTokens,
     maxSkillContextTokens: defaultLifecyclePolicy.maxSkillContextTokens,
   } satisfies InputBudget,
 };

--- a/src/agent-input.ts
+++ b/src/agent-input.ts
@@ -82,10 +82,6 @@ function truncateByTokens(input: string, maxTokens: number): string {
   return `${input.slice(0, lo)}…`;
 }
 
-function isRelevantFileContext(content: string): boolean {
-  return content.startsWith("Attached file:") || content.startsWith("Attached directory:");
-}
-
 function isToolPayloadMessage(message: ChatRequest["history"][number]): boolean {
   return message.kind === "tool_payload";
 }
@@ -164,7 +160,6 @@ function resolveMessageTokenCap(
 export type InputBudget = {
   maxHistoryMessages: number;
   maxMessageTokens: number;
-  maxAttachmentMessageTokens: number;
   maxSkillContextTokens: number;
 };
 
@@ -223,18 +218,6 @@ export function createAgentInput(
       tokenBudget.consume(suggestionTokens);
     }
   }
-
-  const relevantFiles = req.history.filter(
-    (message) => message.role === "system" && isRelevantFileContext(message.content),
-  );
-  const filesResult = collectLinesWithinBudget(
-    relevantFiles,
-    usedIds,
-    tokenBudget.remaining(),
-    budget.maxAttachmentMessageTokens,
-    budget.maxHistoryMessages,
-  );
-  lines.push(...filesResult.lines);
 
   const recentResult = collectLinesWithinBudget(
     req.history,

--- a/src/chat-message-handler.int.test.ts
+++ b/src/chat-message-handler.int.test.ts
@@ -422,72 +422,35 @@ describe("chat message handler", () => {
     ]);
   });
 
-  test("stops before server call when all @references are unresolved", async () => {
-    const rows: ChatRow[] = [];
+  test("shows warning for unresolved @references but continues turn", async () => {
     let replyCalls = 0;
-
-    const session = createSession({ id: "sess_test" });
-    const sessionState = createSessionState({ activeSessionId: session.id, sessions: [session] });
-
-    const { handleSubmit } = createMessageHandler({
+    const { handleMessage, rows } = createMessageHandlerHarness({
       client: createClient({
-        replyStream: async () => {
+        replyStream: async (input) => {
           replyCalls += 1;
+          input.onEvent({ type: "text-delta", text: "ok" });
           return { state: "done" as const, model: "gpt-5-mini", output: "ok" };
         },
         status: async () => ({}),
       }),
-      sessionState,
-      currentSession: session,
-      setCurrentSession: () => {},
-      toRows: () => [],
-      setRows: (updater) => {
-        rows.splice(0, rows.length, ...updater(rows));
-      },
-      setShowHelp: () => {},
-      setValue: () => {},
-      persist: async () => {},
-      exit: () => {},
-      openSkillsPanel: async () => {},
-      activateSkill: async () => true,
-      openResumePanel: () => {},
-      openModelPanel: () => {},
-      tokenUsage: [],
-      isPending: false,
-      setInputHistory: () => {},
-      setInputHistoryIndex: () => {},
-      setInputHistoryDraft: () => {},
-      onStartPending: () => {},
-      onStopPending: () => {},
-      setPendingState: () => {},
-      setRunningUsage: () => {},
-      setTokenUsage: () => {},
-      createMessage,
-      nowIso: () => "2026-02-20T00:00:00.000Z",
-      setInterrupt: () => {},
-      clearTranscript: () => {},
     });
 
-    await handleSubmit("review @definitely-not-a-real-file-xyz");
+    await handleMessage("review @definitely-not-a-real-file-xyz");
 
-    expect(replyCalls).toBe(0);
+    expect(replyCalls).toBe(1);
     expect(rows.some((row) => typeof row.content === "string" && row.content.includes("No file or folder found"))).toBe(
       true,
     );
   });
 
-  test("continues with resolved @references even when some are unresolved", async () => {
-    const rows: ChatRow[] = [];
+  test("shows warning for unresolved @references alongside resolved ones", async () => {
     let replyCalls = 0;
     const fixture = `tmp-chat-handleMessage-${testUuid()}.txt`;
     const fixturePath = join(process.cwd(), fixture);
     await writeFile(fixturePath, "fixture");
 
     try {
-      const session = createSession({ id: "sess_test" });
-      const sessionState = createSessionState({ activeSessionId: session.id, sessions: [session] });
-
-      const { handleSubmit } = createMessageHandler({
+      const { handleMessage, rows } = createMessageHandlerHarness({
         client: createClient({
           replyStream: async (input) => {
             replyCalls += 1;
@@ -496,38 +459,9 @@ describe("chat message handler", () => {
           },
           status: async () => ({}),
         }),
-        sessionState,
-        currentSession: session,
-        setCurrentSession: () => {},
-        toRows: () => [],
-        setRows: (updater) => {
-          rows.splice(0, rows.length, ...updater(rows));
-        },
-        setShowHelp: () => {},
-        setValue: () => {},
-        persist: async () => {},
-        exit: () => {},
-        openSkillsPanel: async () => {},
-        activateSkill: async () => true,
-        openResumePanel: () => {},
-        openModelPanel: () => {},
-        tokenUsage: [],
-        isPending: false,
-        setInputHistory: () => {},
-        setInputHistoryIndex: () => {},
-        setInputHistoryDraft: () => {},
-        onStartPending: () => {},
-        onStopPending: () => {},
-        setPendingState: () => {},
-        setRunningUsage: () => {},
-        setTokenUsage: () => {},
-        createMessage,
-        nowIso: () => "2026-02-20T00:00:00.000Z",
-        setInterrupt: () => {},
-        clearTranscript: () => {},
       });
 
-      await handleSubmit(`review @${fixture} and @definitely-not-a-real-file-xyz`);
+      await handleMessage(`review @${fixture} and @definitely-not-a-real-file-xyz`);
 
       expect(replyCalls).toBe(1);
       expect(

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -9,7 +9,7 @@ import { isKnownSlashToken, suggestSlashCommands } from "./chat-slash";
 import {
   appendInputHistory,
   applyUserTurn,
-  resolveReferencedFileContext,
+  resolveAtReferenceDirective,
   runAssistantTurn,
   unresolvedPathRows,
 } from "./chat-turn";
@@ -89,16 +89,11 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
     const userMessage = input.createMessage("user", userText);
     input.currentSession.messages.push(userMessage);
     input.currentSession.updatedAt = input.nowIso();
-    const { contexts, unresolvedPaths } = await resolveReferencedFileContext(userText, {
+    const { directive, unresolvedPaths } = await resolveAtReferenceDirective(userText, {
       workspace: input.currentSession.workspace,
     });
-    const fileContextMessages: ChatMessage[] = contexts.map((context) => input.createMessage("system", context));
+    const directiveMessages: ChatMessage[] = directive ? [input.createMessage("system", directive)] : [];
     if (unresolvedPaths.length > 0) input.setRows((current) => [...current, ...unresolvedPathRows(unresolvedPaths)]);
-    if (unresolvedPaths.length > 0 && contexts.length === 0) {
-      stopPending();
-      await input.persist();
-      return;
-    }
     input.setPendingState({ kind: "running" });
     const controller = new AbortController();
     input.setInterrupt(() => controller.abort());
@@ -119,7 +114,7 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
       const turn = await runAssistantTurn({
         client: input.client,
         userText,
-        history: [...fileContextMessages, ...input.currentSession.messages],
+        history: [...directiveMessages, ...input.currentSession.messages],
         model: input.currentSession.model,
         sessionId: input.currentSession.id,
         activeSkills: input.currentSession.activeSkills,

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -9,7 +9,7 @@ import { isKnownSlashToken, suggestSlashCommands } from "./chat-slash";
 import {
   appendInputHistory,
   applyUserTurn,
-  resolveAtReferenceDirective,
+  createAtReferenceSuggestion,
   runAssistantTurn,
   unresolvedPathRows,
 } from "./chat-turn";
@@ -89,10 +89,9 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
     const userMessage = input.createMessage("user", userText);
     input.currentSession.messages.push(userMessage);
     input.currentSession.updatedAt = input.nowIso();
-    const { directive, unresolvedPaths } = await resolveAtReferenceDirective(userText, {
+    const { suggestion: fileSuggestion, unresolvedPaths } = await createAtReferenceSuggestion(userText, {
       workspace: input.currentSession.workspace,
     });
-    const directiveMessages: ChatMessage[] = directive ? [input.createMessage("system", directive)] : [];
     if (unresolvedPaths.length > 0) input.setRows((current) => [...current, ...unresolvedPathRows(unresolvedPaths)]);
     input.setPendingState({ kind: "running" });
     const controller = new AbortController();
@@ -110,11 +109,12 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
       const suggestions: string[] = [];
       const skillSuggestion = createSkillSuggestion(userText, input.currentSession.activeSkills);
       if (skillSuggestion) suggestions.push(skillSuggestion);
+      if (fileSuggestion) suggestions.push(fileSuggestion);
 
       const turn = await runAssistantTurn({
         client: input.client,
         userText,
-        history: [...directiveMessages, ...input.currentSession.messages],
+        history: input.currentSession.messages,
         model: input.currentSession.model,
         sessionId: input.currentSession.id,
         activeSkills: input.currentSession.activeSkills,

--- a/src/chat-turn.test.ts
+++ b/src/chat-turn.test.ts
@@ -52,20 +52,53 @@ describe("chat turn helpers", () => {
   describe("createAtReferenceSuggestion", () => {
     const { createDir, cleanupDirs } = tempDir();
 
-    test("returns suggestion with file-read for files and file-find for directories", async () => {
-      const root = createDir("acolyte-at-ref-");
-      const file = join(root, "demo.ts");
-      writeFileSync(file, "const x = 1;\n", "utf8");
+    test("suggests code-scan for parseable code files", async () => {
+      const root = createDir("acolyte-at-ref-code-");
+      writeFileSync(join(root, "demo.ts"), "const x = 1;\n", "utf8");
+
+      const result = await createAtReferenceSuggestion("review @demo.ts", { workspace: root });
+
+      expect(result.suggestion).toContain("Use `code-scan` on demo.ts");
+      expect(result.unresolvedPaths).toEqual([]);
+      cleanupDirs();
+    });
+
+    test("suggests file-read for non-code files", async () => {
+      const root = createDir("acolyte-at-ref-text-");
+      writeFileSync(join(root, "config.json"), "{}\n", "utf8");
+
+      const result = await createAtReferenceSuggestion("review @config.json", { workspace: root });
+
+      expect(result.suggestion).toContain("Use `file-read` on config.json");
+      expect(result.unresolvedPaths).toEqual([]);
+      cleanupDirs();
+    });
+
+    test("suggests file-find for directories", async () => {
+      const root = createDir("acolyte-at-ref-dir-");
       mkdirSync(join(root, "src"), { recursive: true });
 
-      const result = await createAtReferenceSuggestion(`review @demo.ts and @src/`, {
+      const result = await createAtReferenceSuggestion("review @src/", { workspace: root });
+
+      expect(result.suggestion).toContain("Use `file-find` on src/");
+      expect(result.unresolvedPaths).toEqual([]);
+      cleanupDirs();
+    });
+
+    test("combines code-scan, file-read, and file-find in one suggestion", async () => {
+      const root = createDir("acolyte-at-ref-mixed-");
+      writeFileSync(join(root, "app.ts"), "export {}", "utf8");
+      writeFileSync(join(root, "config.json"), "{}", "utf8");
+      mkdirSync(join(root, "lib"), { recursive: true });
+
+      const result = await createAtReferenceSuggestion("review @app.ts @config.json @lib/", {
         workspace: root,
       });
 
-      expect(result.suggestion).toContain("Use `file-read` on demo.ts");
-      expect(result.suggestion).toContain("Use `file-find` on src/");
+      expect(result.suggestion).toContain("Use `code-scan` on app.ts");
+      expect(result.suggestion).toContain("Use `file-read` on config.json");
+      expect(result.suggestion).toContain("Use `file-find` on lib/");
       expect(result.suggestion).toContain("before responding.");
-      expect(result.unresolvedPaths).toEqual([]);
       cleanupDirs();
     });
 

--- a/src/chat-turn.test.ts
+++ b/src/chat-turn.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from "bun:test";
-import { appendInputHistory, applyUserTurn, createInputHistory, runAssistantTurn } from "./chat-turn";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+  appendInputHistory,
+  applyUserTurn,
+  createInputHistory,
+  resolveAtReferenceDirective,
+  runAssistantTurn,
+} from "./chat-turn";
 import type { Session } from "./session-contract";
+import { tempDir } from "./test-utils";
 
 describe("chat turn helpers", () => {
   test("appendInputHistory avoids duplicate consecutive entries", () => {
@@ -38,6 +47,44 @@ describe("chat turn helpers", () => {
     expect(session.title).toBe("hello there");
     expect(result.row.kind).toBe("user");
     expect(result.row.content).toBe("hello there");
+  });
+
+  describe("resolveAtReferenceDirective", () => {
+    const { createDir, cleanupDirs } = tempDir();
+
+    test("returns directive with file-read for files and file-find for directories", async () => {
+      const root = createDir("acolyte-at-ref-");
+      const file = join(root, "demo.ts");
+      writeFileSync(file, "const x = 1;\n", "utf8");
+      mkdirSync(join(root, "src"), { recursive: true });
+
+      const result = await resolveAtReferenceDirective(`review @demo.ts and @src/`, {
+        workspace: root,
+      });
+
+      expect(result.directive).toContain("file-read");
+      expect(result.directive).toContain("demo.ts");
+      expect(result.directive).toContain("file-find");
+      expect(result.directive).toContain("src/");
+      expect(result.unresolvedPaths).toEqual([]);
+      cleanupDirs();
+    });
+
+    test("returns null directive when no @ references", async () => {
+      const result = await resolveAtReferenceDirective("just a normal message");
+      expect(result.directive).toBeNull();
+      expect(result.unresolvedPaths).toEqual([]);
+    });
+
+    test("reports unresolved paths for missing files", async () => {
+      const root = createDir("acolyte-at-ref-missing-");
+      const result = await resolveAtReferenceDirective("review @nonexistent.ts", {
+        workspace: root,
+      });
+      expect(result.directive).toBeNull();
+      expect(result.unresolvedPaths).toEqual(["nonexistent.ts"]);
+      cleanupDirs();
+    });
   });
 
   test("runAssistantTurn ignores reply progress payload rows", async () => {

--- a/src/chat-turn.test.ts
+++ b/src/chat-turn.test.ts
@@ -62,10 +62,9 @@ describe("chat turn helpers", () => {
         workspace: root,
       });
 
-      expect(result.directive).toContain("file-read");
-      expect(result.directive).toContain("demo.ts");
-      expect(result.directive).toContain("file-find");
-      expect(result.directive).toContain("src/");
+      expect(result.directive).toContain("Use `file-read` on demo.ts");
+      expect(result.directive).toContain("Use `file-find` on src/");
+      expect(result.directive).toContain("before responding.");
       expect(result.unresolvedPaths).toEqual([]);
       cleanupDirs();
     });

--- a/src/chat-turn.test.ts
+++ b/src/chat-turn.test.ts
@@ -4,8 +4,8 @@ import { join } from "node:path";
 import {
   appendInputHistory,
   applyUserTurn,
+  createAtReferenceSuggestion,
   createInputHistory,
-  resolveAtReferenceDirective,
   runAssistantTurn,
 } from "./chat-turn";
 import type { Session } from "./session-contract";
@@ -49,38 +49,38 @@ describe("chat turn helpers", () => {
     expect(result.row.content).toBe("hello there");
   });
 
-  describe("resolveAtReferenceDirective", () => {
+  describe("createAtReferenceSuggestion", () => {
     const { createDir, cleanupDirs } = tempDir();
 
-    test("returns directive with file-read for files and file-find for directories", async () => {
+    test("returns suggestion with file-read for files and file-find for directories", async () => {
       const root = createDir("acolyte-at-ref-");
       const file = join(root, "demo.ts");
       writeFileSync(file, "const x = 1;\n", "utf8");
       mkdirSync(join(root, "src"), { recursive: true });
 
-      const result = await resolveAtReferenceDirective(`review @demo.ts and @src/`, {
+      const result = await createAtReferenceSuggestion(`review @demo.ts and @src/`, {
         workspace: root,
       });
 
-      expect(result.directive).toContain("Use `file-read` on demo.ts");
-      expect(result.directive).toContain("Use `file-find` on src/");
-      expect(result.directive).toContain("before responding.");
+      expect(result.suggestion).toContain("Use `file-read` on demo.ts");
+      expect(result.suggestion).toContain("Use `file-find` on src/");
+      expect(result.suggestion).toContain("before responding.");
       expect(result.unresolvedPaths).toEqual([]);
       cleanupDirs();
     });
 
-    test("returns null directive when no @ references", async () => {
-      const result = await resolveAtReferenceDirective("just a normal message");
-      expect(result.directive).toBeNull();
+    test("returns null suggestion when no @ references", async () => {
+      const result = await createAtReferenceSuggestion("just a normal message");
+      expect(result.suggestion).toBeNull();
       expect(result.unresolvedPaths).toEqual([]);
     });
 
     test("reports unresolved paths for missing files", async () => {
       const root = createDir("acolyte-at-ref-missing-");
-      const result = await resolveAtReferenceDirective("review @nonexistent.ts", {
+      const result = await createAtReferenceSuggestion("review @nonexistent.ts", {
         workspace: root,
       });
-      expect(result.directive).toBeNull();
+      expect(result.suggestion).toBeNull();
       expect(result.unresolvedPaths).toEqual(["nonexistent.ts"]);
       cleanupDirs();
     });

--- a/src/chat-turn.ts
+++ b/src/chat-turn.ts
@@ -6,6 +6,7 @@ import { type ChatRow, createRow } from "./chat-contract";
 import { extractAtReferencePaths } from "./chat-file-ref";
 import { formatTokenCount } from "./chat-format";
 import type { Client, StreamEvent } from "./client-contract";
+import { isParseable } from "./code-ops";
 import { formatDuration } from "./datetime";
 import { t } from "./i18n";
 import { palette } from "./palette";
@@ -35,6 +36,7 @@ export async function createAtReferenceSuggestion(
 }> {
   const referencedPaths = extractAtReferencePaths(userText);
   if (referencedPaths.length === 0) return { suggestion: null, unresolvedPaths: [] };
+  const codeRefs: string[] = [];
   const fileRefs: string[] = [];
   const dirRefs: string[] = [];
   const unresolvedPaths: string[] = [];
@@ -42,15 +44,19 @@ export async function createAtReferenceSuggestion(
   for (const pathInput of referencedPaths) {
     try {
       ensurePathWithinSandbox(pathInput, workspace);
-      const info = await stat(resolve(workspace, pathInput));
+      const absPath = resolve(workspace, pathInput);
+      const info = await stat(absPath);
       if (info.isDirectory()) dirRefs.push(pathInput);
+      else if (isParseable(absPath)) codeRefs.push(pathInput);
       else fileRefs.push(pathInput);
     } catch {
       unresolvedPaths.push(pathInput);
     }
   }
-  if (fileRefs.length === 0 && dirRefs.length === 0) return { suggestion: null, unresolvedPaths };
+  if (codeRefs.length === 0 && fileRefs.length === 0 && dirRefs.length === 0)
+    return { suggestion: null, unresolvedPaths };
   const parts: string[] = [];
+  if (codeRefs.length > 0) parts.push(`Use \`code-scan\` on ${codeRefs.join(", ")}`);
   if (fileRefs.length > 0) parts.push(`Use \`file-read\` on ${fileRefs.join(", ")}`);
   if (dirRefs.length > 0) parts.push(`Use \`file-find\` on ${dirRefs.join(", ")}`);
   return { suggestion: `${parts.join(". ")} before responding.`, unresolvedPaths };

--- a/src/chat-turn.ts
+++ b/src/chat-turn.ts
@@ -50,10 +50,10 @@ export async function resolveAtReferenceDirective(
     }
   }
   if (fileRefs.length === 0 && dirRefs.length === 0) return { directive: null, unresolvedPaths };
-  const lines = ["Read the following before responding:"];
-  for (const ref of fileRefs) lines.push(`- ${ref} (file-read)`);
-  for (const ref of dirRefs) lines.push(`- ${ref} (file-find)`);
-  return { directive: lines.join("\n"), unresolvedPaths };
+  const parts: string[] = [];
+  if (fileRefs.length > 0) parts.push(`Use \`file-read\` on ${fileRefs.join(", ")}`);
+  if (dirRefs.length > 0) parts.push(`Use \`file-find\` on ${dirRefs.join(", ")}`);
+  return { directive: `${parts.join(". ")} before responding.`, unresolvedPaths };
 }
 
 export function unresolvedPathRows(unresolvedPaths: string[]): ChatRow[] {

--- a/src/chat-turn.ts
+++ b/src/chat-turn.ts
@@ -26,15 +26,15 @@ export function estimateTokenUsageFallback(prompt: string, output: string): Toke
   };
 }
 
-export async function resolveAtReferenceDirective(
+export async function createAtReferenceSuggestion(
   userText: string,
   options?: { workspace?: string },
 ): Promise<{
-  directive: string | null;
+  suggestion: string | null;
   unresolvedPaths: string[];
 }> {
   const referencedPaths = extractAtReferencePaths(userText);
-  if (referencedPaths.length === 0) return { directive: null, unresolvedPaths: [] };
+  if (referencedPaths.length === 0) return { suggestion: null, unresolvedPaths: [] };
   const fileRefs: string[] = [];
   const dirRefs: string[] = [];
   const unresolvedPaths: string[] = [];
@@ -49,11 +49,11 @@ export async function resolveAtReferenceDirective(
       unresolvedPaths.push(pathInput);
     }
   }
-  if (fileRefs.length === 0 && dirRefs.length === 0) return { directive: null, unresolvedPaths };
+  if (fileRefs.length === 0 && dirRefs.length === 0) return { suggestion: null, unresolvedPaths };
   const parts: string[] = [];
   if (fileRefs.length > 0) parts.push(`Use \`file-read\` on ${fileRefs.join(", ")}`);
   if (dirRefs.length > 0) parts.push(`Use \`file-find\` on ${dirRefs.join(", ")}`);
-  return { directive: `${parts.join(". ")} before responding.`, unresolvedPaths };
+  return { suggestion: `${parts.join(". ")} before responding.`, unresolvedPaths };
 }
 
 export function unresolvedPathRows(unresolvedPaths: string[]): ChatRow[] {

--- a/src/chat-turn.ts
+++ b/src/chat-turn.ts
@@ -1,3 +1,5 @@
+import { stat } from "node:fs/promises";
+import { resolve } from "node:path";
 import { createWorkspaceSpecifier, type TokenUsage } from "./api";
 import type { ChatMessage } from "./chat-contract";
 import { type ChatRow, createRow } from "./chat-contract";
@@ -5,7 +7,6 @@ import { extractAtReferencePaths } from "./chat-file-ref";
 import { formatTokenCount } from "./chat-format";
 import type { Client, StreamEvent } from "./client-contract";
 import { formatDuration } from "./datetime";
-import { formatFileContext } from "./file-context";
 import { t } from "./i18n";
 import { palette } from "./palette";
 import type { Session, SessionTokenUsageEntry } from "./session-contract";
@@ -25,27 +26,34 @@ export function estimateTokenUsageFallback(prompt: string, output: string): Toke
   };
 }
 
-export async function resolveReferencedFileContext(
+export async function resolveAtReferenceDirective(
   userText: string,
   options?: { workspace?: string },
 ): Promise<{
-  contexts: string[];
+  directive: string | null;
   unresolvedPaths: string[];
 }> {
   const referencedPaths = extractAtReferencePaths(userText);
-  const contexts: string[] = [];
+  if (referencedPaths.length === 0) return { directive: null, unresolvedPaths: [] };
+  const fileRefs: string[] = [];
+  const dirRefs: string[] = [];
   const unresolvedPaths: string[] = [];
   const workspace = options?.workspace ?? process.cwd();
   for (const pathInput of referencedPaths) {
     try {
       ensurePathWithinSandbox(pathInput, workspace);
-      const context = await formatFileContext(pathInput, workspace);
-      contexts.push(context);
+      const info = await stat(resolve(workspace, pathInput));
+      if (info.isDirectory()) dirRefs.push(pathInput);
+      else fileRefs.push(pathInput);
     } catch {
       unresolvedPaths.push(pathInput);
     }
   }
-  return { contexts, unresolvedPaths };
+  if (fileRefs.length === 0 && dirRefs.length === 0) return { directive: null, unresolvedPaths };
+  const lines = ["Read the following before responding:"];
+  for (const ref of fileRefs) lines.push(`- ${ref} (file-read)`);
+  for (const ref of dirRefs) lines.push(`- ${ref} (file-find)`);
+  return { directive: lines.join("\n"), unresolvedPaths };
 }
 
 export function unresolvedPathRows(unresolvedPaths: string[]): ChatRow[] {

--- a/src/code-ops.ts
+++ b/src/code-ops.ts
@@ -65,7 +65,7 @@ function languageFromPath(filePath: string): string | undefined {
   return LANGUAGE_MAP[filePath.slice(dot).toLowerCase()];
 }
 
-function isParseable(filePath: string): boolean {
+export function isParseable(filePath: string): boolean {
   const dot = filePath.lastIndexOf(".");
   return dot >= 0 && filePath.slice(dot).toLowerCase() in LANGUAGE_MAP;
 }

--- a/src/lifecycle-constants.ts
+++ b/src/lifecycle-constants.ts
@@ -7,5 +7,4 @@ export const TOOL_TIMEOUT_MS = 10_000;
 export const CONTEXT_MAX_TOKENS = 100_000;
 export const MAX_HISTORY_MESSAGES = 40;
 export const MAX_MESSAGE_TOKENS = 600;
-export const MAX_ATTACHMENT_MESSAGE_TOKENS = 3_000;
 export const MAX_SKILL_CONTEXT_TOKENS = 2_400;

--- a/src/lifecycle-policy.ts
+++ b/src/lifecycle-policy.ts
@@ -1,7 +1,6 @@
 import {
   CONTEXT_MAX_TOKENS,
   INITIAL_MAX_STEPS,
-  MAX_ATTACHMENT_MESSAGE_TOKENS,
   MAX_HISTORY_MESSAGES,
   MAX_MESSAGE_TOKENS,
   MAX_NUDGES_PER_GENERATION,
@@ -26,7 +25,6 @@ export type LifecyclePolicy = {
   contextMaxTokens: number;
   maxHistoryMessages: number;
   maxMessageTokens: number;
-  maxAttachmentMessageTokens: number;
   maxSkillContextTokens: number;
   // Workspace commands
   installCommand?: WorkspaceCommand;
@@ -44,7 +42,6 @@ export const defaultLifecyclePolicy: LifecyclePolicy = {
   contextMaxTokens: CONTEXT_MAX_TOKENS,
   maxHistoryMessages: MAX_HISTORY_MESSAGES,
   maxMessageTokens: MAX_MESSAGE_TOKENS,
-  maxAttachmentMessageTokens: MAX_ATTACHMENT_MESSAGE_TOKENS,
   maxSkillContextTokens: MAX_SKILL_CONTEXT_TOKENS,
 };
 

--- a/src/lifecycle-prepare.ts
+++ b/src/lifecycle-prepare.ts
@@ -34,7 +34,6 @@ export function phasePrepare(input: PhasePrepareInput): PhasePrepareResult {
     budget: {
       maxHistoryMessages: policy.maxHistoryMessages,
       maxMessageTokens: policy.maxMessageTokens,
-      maxAttachmentMessageTokens: policy.maxAttachmentMessageTokens,
       maxSkillContextTokens: policy.maxSkillContextTokens,
     },
   });


### PR DESCRIPTION
## Motivation

Auto-inlining `@` file and directory contents burned context tokens before the model decided what was relevant. Letting the model pull what it needs through existing tools aligns with the on-demand retrieval pattern already used by memory.

## Summary

- replace file content injection with suggestions via `req.suggestions`
- suggest `code-scan` for parseable code files, `file-read` for other files, `file-find` for directories
- remove `isRelevantFileContext` and attachment message token budget from agent input
- remove `maxAttachmentMessageTokens` from lifecycle policy and constants
- unresolved `@` refs now warn but no longer block the turn
- export `isParseable` from `code-ops` for reuse

Fixes #196