### PR TITLE
feat(skills): suggest skill activation

### DIFF
--- a/src/agent-input.ts
+++ b/src/agent-input.ts
@@ -216,7 +216,9 @@ export function createAgentInput(
 
   for (const suggestion of req.suggestions ?? []) {
     const suggestionTokens = estimateTokens(suggestion);
-    if (suggestionTokens <= tokenBudget.remaining()) {
+    if (suggestionTokens > tokenBudget.remaining()) {
+      log.warn("suggestion dropped", { tokens: suggestionTokens, remaining: tokenBudget.remaining() });
+    } else {
       lines.push(suggestion);
       tokenBudget.consume(suggestionTokens);
     }

--- a/src/agent-input.ts
+++ b/src/agent-input.ts
@@ -214,6 +214,14 @@ export function createAgentInput(
     }
   }
 
+  for (const suggestion of req.suggestions ?? []) {
+    const suggestionTokens = estimateTokens(suggestion);
+    if (suggestionTokens <= tokenBudget.remaining()) {
+      lines.push(suggestion);
+      tokenBudget.consume(suggestionTokens);
+    }
+  }
+
   const relevantFiles = req.history.filter(
     (message) => message.role === "system" && isRelevantFileContext(message.content),
   );

--- a/src/api.ts
+++ b/src/api.ts
@@ -18,6 +18,7 @@ export interface ChatRequest {
   readonly sessionId?: SessionId;
   readonly resourceId?: ResourceId;
   readonly activeSkills?: ActiveSkill[];
+  readonly suggestions?: string[];
   /** When true, stored memories and distill observations are included in context. */
   readonly useMemory?: boolean;
   /** Client working directory. Falls back to server CWD when omitted. */

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -19,6 +19,7 @@ import { log } from "./log";
 import { addMemory } from "./memory-ops";
 import { palette } from "./palette";
 import type { Session, SessionState, SessionTokenUsageEntry } from "./session-contract";
+import { createSkillSuggestion } from "./skill-triggers";
 
 type CreateMessageHandlerInput = {
   client: Client;
@@ -111,6 +112,10 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
     let keepPendingForRemoteTask = false;
 
     try {
+      const suggestions: string[] = [];
+      const skillSuggestion = createSkillSuggestion(userText, input.currentSession.activeSkills);
+      if (skillSuggestion) suggestions.push(skillSuggestion);
+
       const turn = await runAssistantTurn({
         client: input.client,
         userText,
@@ -118,6 +123,7 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
         model: input.currentSession.model,
         sessionId: input.currentSession.id,
         activeSkills: input.currentSession.activeSkills,
+        suggestions,
         workspace: input.currentSession.workspace,
         useMemory: input.useMemory,
         signal: controller.signal,

--- a/src/chat-turn.ts
+++ b/src/chat-turn.ts
@@ -89,6 +89,7 @@ type RunAssistantTurnParams = {
   model: string;
   sessionId: string;
   activeSkills?: ActiveSkill[];
+  suggestions?: string[];
   workspace?: string;
   useMemory?: boolean;
   signal?: AbortSignal;
@@ -109,6 +110,7 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
       model: params.model,
       sessionId: params.sessionId,
       activeSkills: params.activeSkills,
+      suggestions: params.suggestions,
       useMemory: params.useMemory,
       ...createWorkspaceSpecifier(params.workspace ?? process.cwd()),
     },

--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -10,6 +10,7 @@ import { formatPromptError } from "./error-messages";
 import { t } from "./i18n";
 import type { ResourceId } from "./resource-id";
 import type { Session } from "./session-contract";
+import { createSkillSuggestion } from "./skill-triggers";
 import { createToolOutputState, formatToolOutput } from "./tool-output-content";
 import { printDim, printError, printOutput, streamText } from "./ui";
 
@@ -96,6 +97,10 @@ export async function handlePrompt(
     const snapshotByCallId = new Map<string, string>();
     let hasPrintedToolProgress = false;
 
+    const suggestions: string[] = [];
+    const skillSuggestion = createSkillSuggestion(prompt, session.activeSkills);
+    if (skillSuggestion) suggestions.push(skillSuggestion);
+
     const reply = await client.replyStream({
       request: {
         message: prompt,
@@ -103,6 +108,7 @@ export async function handlePrompt(
         model: session.model,
         sessionId: session.id,
         activeSkills: session.activeSkills,
+        suggestions,
         resourceId: options?.resourceId,
         ...createWorkspaceSpecifier(options?.workspace),
       },

--- a/src/lifecycle-prepare.ts
+++ b/src/lifecycle-prepare.ts
@@ -1,6 +1,5 @@
 import { createAgentInput, estimateTokens } from "./agent-input";
 import type { PhasePrepareInput, PhasePrepareResult } from "./lifecycle-contract";
-import { createSkillSuggestion } from "./skill-triggers";
 import { toolsForAgent } from "./tool-registry";
 
 /** Approximate overhead for BASE_INSTRUCTIONS + runtime instructions. */
@@ -39,7 +38,7 @@ export function phasePrepare(input: PhasePrepareInput): PhasePrepareResult {
       maxSkillContextTokens: policy.maxSkillContextTokens,
     },
   });
-  let baseAgentInput = requestInput.input;
+  const baseAgentInput = requestInput.input;
 
   session.toolTimeoutMs = input.policy.toolTimeoutMs;
 
@@ -53,12 +52,6 @@ export function phasePrepare(input: PhasePrepareInput): PhasePrepareResult {
     input.debug("lifecycle.skill.context", {
       skill_names: input.request.activeSkills.map((s) => s.name),
     });
-  }
-
-  const skillSuggestion = createSkillSuggestion(input.request.message, input.request.activeSkills);
-  if (skillSuggestion) {
-    baseAgentInput = `${skillSuggestion}\n\n${baseAgentInput}`;
-    input.debug("lifecycle.skill.suggestion", { suggestion: skillSuggestion });
   }
 
   return { session, tools, baseAgentInput, promptUsage: requestInput.usage };

--- a/src/lifecycle-prepare.ts
+++ b/src/lifecycle-prepare.ts
@@ -1,6 +1,6 @@
 import { createAgentInput, estimateTokens } from "./agent-input";
 import type { PhasePrepareInput, PhasePrepareResult } from "./lifecycle-contract";
-import { createSkillSuggestions } from "./skill-triggers";
+import { createSkillSuggestion } from "./skill-triggers";
 import { toolsForAgent } from "./tool-registry";
 
 /** Approximate overhead for BASE_INSTRUCTIONS + runtime instructions. */
@@ -55,10 +55,10 @@ export function phasePrepare(input: PhasePrepareInput): PhasePrepareResult {
     });
   }
 
-  const suggestions = createSkillSuggestions(input.request.message, input.request.activeSkills);
-  if (suggestions.length > 0) {
-    baseAgentInput = `${suggestions.join("\n")}\n\n${baseAgentInput}`;
-    input.debug("lifecycle.skill.suggestion", { count: suggestions.length });
+  const skillSuggestion = createSkillSuggestion(input.request.message, input.request.activeSkills);
+  if (skillSuggestion) {
+    baseAgentInput = `${skillSuggestion}\n\n${baseAgentInput}`;
+    input.debug("lifecycle.skill.suggestion", { suggestion: skillSuggestion });
   }
 
   return { session, tools, baseAgentInput, promptUsage: requestInput.usage };

--- a/src/lifecycle-prepare.ts
+++ b/src/lifecycle-prepare.ts
@@ -1,5 +1,6 @@
 import { createAgentInput, estimateTokens } from "./agent-input";
 import type { PhasePrepareInput, PhasePrepareResult } from "./lifecycle-contract";
+import { createSkillSuggestions } from "./skill-triggers";
 import { toolsForAgent } from "./tool-registry";
 
 /** Approximate overhead for BASE_INSTRUCTIONS + runtime instructions. */
@@ -38,7 +39,7 @@ export function phasePrepare(input: PhasePrepareInput): PhasePrepareResult {
       maxSkillContextTokens: policy.maxSkillContextTokens,
     },
   });
-  const baseAgentInput = requestInput.input;
+  let baseAgentInput = requestInput.input;
 
   session.toolTimeoutMs = input.policy.toolTimeoutMs;
 
@@ -52,6 +53,12 @@ export function phasePrepare(input: PhasePrepareInput): PhasePrepareResult {
     input.debug("lifecycle.skill.context", {
       skill_names: input.request.activeSkills.map((s) => s.name),
     });
+  }
+
+  const suggestions = createSkillSuggestions(input.request.message, input.request.activeSkills);
+  if (suggestions.length > 0) {
+    baseAgentInput = `${suggestions.join("\n")}\n\n${baseAgentInput}`;
+    input.debug("lifecycle.skill.suggestion", { count: suggestions.length });
   }
 
   return { session, tools, baseAgentInput, promptUsage: requestInput.usage };

--- a/src/rpc-protocol.ts
+++ b/src/rpc-protocol.ts
@@ -23,6 +23,7 @@ const chatRequestSchema = z
     sessionId: sessionIdSchema.optional(),
     resourceId: resourceIdSchema.optional(),
     activeSkills: z.array(activeSkillSchema).optional(),
+    suggestions: z.array(z.string().max(1_000)).max(10).optional(),
     useMemory: z.boolean().optional(),
     workspace: z.string().max(4096).optional(),
   })

--- a/src/server-chat-runtime.ts
+++ b/src/server-chat-runtime.ts
@@ -123,6 +123,7 @@ export function isChatRequest(value: unknown): value is ChatRequest {
     (req.sessionId === undefined || typeof req.sessionId === "string") &&
     (req.resourceId === undefined || typeof req.resourceId === "string") &&
     (req.activeSkills === undefined || isActiveSkillsPayload(req.activeSkills)) &&
+    (req.suggestions === undefined || Array.isArray(req.suggestions)) &&
     (req.useMemory === undefined || typeof req.useMemory === "boolean") &&
     (req.workspace === undefined || typeof req.workspace === "string")
   );

--- a/src/skill-toolkit.int.test.ts
+++ b/src/skill-toolkit.int.test.ts
@@ -8,7 +8,7 @@ import type { ToolkitInput } from "./tool-contract";
 import { createSessionContext } from "./tool-session";
 
 type SkillListResult = { kind: string; skills: { name: string; description: string; source: string }[] };
-type SkillActivateResult = { kind: string; name: string; source: string; instructions: string };
+type SkillActivateResult = { kind: string; activated: { name: string; source: string; instructions: string }[] };
 
 const { createDir, cleanupDirs } = tempDir();
 
@@ -69,32 +69,33 @@ describe("skill-list", () => {
 });
 
 describe("skill-activate", () => {
-  test("returns instructions for bundled skill and sets session activeSkill", async () => {
+  test("activates bundled skill and sets session activeSkills", async () => {
     const dir = createDir("acolyte-skill-activate-");
     await loadSkills(dir);
     const input = createToolkitInput(dir);
     const toolkit = createSkillToolkit(input);
-    const { result } = (await toolkit.activateSkill.execute({ name: "build" }, "call-4")) as {
+    const { result } = (await toolkit.activateSkill.execute({ names: ["build"] }, "call-4")) as {
       result: SkillActivateResult;
     };
     expect(result.kind).toBe("skill-activate");
-    expect(result.name).toBe("build");
-    expect(result.source).toBe("bundled");
-    expect(result.instructions.length).toBeGreaterThan(0);
-    expect(input.session.activeSkills).toEqual([{ name: "build", instructions: result.instructions }]);
+    expect(result.activated).toHaveLength(1);
+    expect(result.activated[0]?.name).toBe("build");
+    expect(result.activated[0]?.source).toBe("bundled");
+    expect(result.activated[0]?.instructions.length).toBeGreaterThan(0);
+    expect(input.session.activeSkills).toEqual([{ name: "build", instructions: result.activated[0]?.instructions }]);
   });
 
-  test("returns instructions for project skill", async () => {
+  test("activates project skill", async () => {
     const dir = createDir("acolyte-skill-activate-proj-");
     writeProjectSkill(dir, "deploy", "Deploy to prod", "# Deploy\nRun the deploy script.");
     await loadSkills(dir);
     const toolkit = createSkillToolkit(createToolkitInput(dir));
-    const { result } = (await toolkit.activateSkill.execute({ name: "deploy" }, "call-5")) as {
+    const { result } = (await toolkit.activateSkill.execute({ names: ["deploy"] }, "call-5")) as {
       result: SkillActivateResult;
     };
-    expect(result.name).toBe("deploy");
-    expect(result.source).toBe("project");
-    expect(result.instructions).toContain("deploy script");
+    expect(result.activated[0]?.name).toBe("deploy");
+    expect(result.activated[0]?.source).toBe("project");
+    expect(result.activated[0]?.instructions).toContain("deploy script");
   });
 
   test("project skill overrides bundled skill with same name", async () => {
@@ -102,31 +103,46 @@ describe("skill-activate", () => {
     writeProjectSkill(dir, "build", "Custom build", "# Custom Build\nProject-specific build.");
     await loadSkills(dir);
     const toolkit = createSkillToolkit(createToolkitInput(dir));
-    const { result } = (await toolkit.activateSkill.execute({ name: "build" }, "call-6")) as {
+    const { result } = (await toolkit.activateSkill.execute({ names: ["build"] }, "call-6")) as {
       result: SkillActivateResult;
     };
-    expect(result.source).toBe("project");
-    expect(result.instructions).toContain("Project-specific build");
+    expect(result.activated[0]?.source).toBe("project");
+    expect(result.activated[0]?.instructions).toContain("Project-specific build");
   });
 
   test("throws for unknown skill", async () => {
     const dir = createDir("acolyte-skill-unknown-");
     await loadSkills(dir);
     const toolkit = createSkillToolkit(createToolkitInput(dir));
-    await expect(toolkit.activateSkill.execute({ name: "nonexistent" }, "call-7")).rejects.toThrow("skill not found");
+    await expect(toolkit.activateSkill.execute({ names: ["nonexistent"] }, "call-7")).rejects.toThrow(
+      "skill not found",
+    );
   });
 
-  test("emits tool-header output on activation", async () => {
+  test("activates multiple skills in one call", async () => {
+    const dir = createDir("acolyte-skill-activate-multi-");
+    await loadSkills(dir);
+    const input = createToolkitInput(dir);
+    const toolkit = createSkillToolkit(input);
+    const { result } = (await toolkit.activateSkill.execute({ names: ["build", "git"] }, "call-multi")) as {
+      result: SkillActivateResult;
+    };
+    expect(result.activated).toHaveLength(2);
+    expect(result.activated.map((s) => s.name)).toEqual(["build", "git"]);
+    expect(input.session.activeSkills?.map((s) => s.name)).toEqual(["build", "git"]);
+  });
+
+  test("emits tool-header output per activated skill", async () => {
     const dir = createDir("acolyte-skill-activate-output-");
     await loadSkills(dir);
     const outputs: OutputEvent[] = [];
     const input = createToolkitInput(dir, outputs);
     const toolkit = createSkillToolkit(input);
-    await toolkit.activateSkill.execute({ name: "build" }, "call-output");
-    const header = outputs.find((o) => (o.content as { kind: string }).kind === "tool-header");
-    expect(header).toBeDefined();
-    expect(header?.toolName).toBe("skill-activate");
-    expect((header?.content as { detail: string }).detail).toBe("build");
+    await toolkit.activateSkill.execute({ names: ["build", "git"] }, "call-output");
+    const headers = outputs.filter((o) => (o.content as { kind: string }).kind === "tool-header");
+    expect(headers).toHaveLength(2);
+    expect((headers[0]?.content as { detail: string }).detail).toBe("build");
+    expect((headers[1]?.content as { detail: string }).detail).toBe("git");
   });
 
   test("substitutes arguments in instructions", async () => {
@@ -134,9 +150,9 @@ describe("skill-activate", () => {
     writeProjectSkill(dir, "greet", "Greet someone", "# Greet\nHello $ARGUMENTS!");
     await loadSkills(dir);
     const toolkit = createSkillToolkit(createToolkitInput(dir));
-    const { result } = (await toolkit.activateSkill.execute({ name: "greet", args: "world" }, "call-8")) as {
+    const { result } = (await toolkit.activateSkill.execute({ names: ["greet"], args: "world" }, "call-8")) as {
       result: SkillActivateResult;
     };
-    expect(result.instructions).toContain("Hello world!");
+    expect(result.activated[0]?.instructions).toContain("Hello world!");
   });
 });

--- a/src/skill-toolkit.ts
+++ b/src/skill-toolkit.ts
@@ -47,7 +47,7 @@ function createActivateSkillTool(input: ToolkitInput) {
     category: "meta",
     description: "Activate one or more skills by name to load structured guidance into context.",
     instruction:
-      "Use `skill-activate` when you recognize that a skill's structured guidance would help with the current task. Use `skill-list` first to discover available skills.",
+      "Use `skill-activate` with one or more skill names to load structured guidance. Use `skill-list` to discover project-specific skills.",
     inputSchema: z.object({
       names: z.array(z.string().min(1)).min(1),
       args: z.string().optional(),

--- a/src/skill-toolkit.ts
+++ b/src/skill-toolkit.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { addActiveSkill } from "./chat-skill-activator";
 import { compactText } from "./compact-text";
-import { skillSourceSchema } from "./skill-contract";
+import { type SkillSource, skillSourceSchema } from "./skill-contract";
 import { findSkillByName, getLoadedSkills, readSkillInstructions, SKILL_BUDGET } from "./skill-ops";
 import type { ToolkitInput } from "./tool-contract";
 import { createTool } from "./tool-contract";
@@ -45,38 +45,41 @@ function createActivateSkillTool(input: ToolkitInput) {
     id: "skill-activate",
     toolkit: "skill",
     category: "meta",
-    description: "Activate a skill by name to load its structured guidance into context.",
+    description: "Activate one or more skills by name to load structured guidance into context.",
     instruction:
       "Use `skill-activate` when you recognize that a skill's structured guidance would help with the current task. Use `skill-list` first to discover available skills.",
     inputSchema: z.object({
-      name: z.string().min(1),
+      names: z.array(z.string().min(1)).min(1),
       args: z.string().optional(),
     }),
     outputSchema: z.object({
       kind: z.literal("skill-activate"),
-      name: z.string(),
-      source: skillSourceSchema,
-      instructions: z.string(),
+      activated: z.array(
+        z.object({
+          name: z.string(),
+          source: skillSourceSchema,
+          instructions: z.string(),
+        }),
+      ),
     }),
-    outputBudget: { maxChars: 4_000, maxLines: 120 },
+    outputBudget: { maxChars: 8_000, maxLines: 240 },
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "skill-activate", toolCallId, toolInput, async (callId) => {
-        const skill = findSkillByName(toolInput.name);
-        if (!skill) throw new Error(`skill not found: "${toolInput.name}"`);
-        input.onOutput({
-          toolName: "skill-activate",
-          content: { kind: "tool-header", labelKey: toolLabelKey("skill-activate"), detail: skill.name },
-          toolCallId: callId,
-        });
-        const raw = await readSkillInstructions(skill.path, toolInput.args);
-        const instructions = compactText(raw, SKILL_BUDGET);
-        addActiveSkill(input.session, { name: skill.name, instructions });
-        return {
-          kind: "skill-activate" as const,
-          name: skill.name,
-          source: skill.source,
-          instructions,
-        };
+        const activated: { name: string; source: SkillSource; instructions: string }[] = [];
+        for (const skillName of toolInput.names) {
+          const skill = findSkillByName(skillName);
+          if (!skill) throw new Error(`skill not found: "${skillName}"`);
+          input.onOutput({
+            toolName: "skill-activate",
+            content: { kind: "tool-header", labelKey: toolLabelKey("skill-activate"), detail: skill.name },
+            toolCallId: callId,
+          });
+          const raw = await readSkillInstructions(skill.path, toolInput.args);
+          const instructions = compactText(raw, SKILL_BUDGET);
+          addActiveSkill(input.session, { name: skill.name, instructions });
+          activated.push({ name: skill.name, source: skill.source, instructions });
+        }
+        return { kind: "skill-activate" as const, activated };
       });
     },
   });

--- a/src/skill-triggers.test.ts
+++ b/src/skill-triggers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { matchSkillTriggers } from "./skill-triggers";
+import { createSkillSuggestion, matchSkillTriggers } from "./skill-triggers";
 
 describe("matchSkillTriggers", () => {
   test("matches build skill from keyword", () => {
@@ -37,5 +37,28 @@ describe("matchSkillTriggers", () => {
     const matches = matchSkillTriggers("implement the feature and commit", [{ name: "build", instructions: "..." }]);
     expect(matches).not.toContain("build");
     expect(matches).toContain("git");
+  });
+
+  test("does not match common words used in non-skill context", () => {
+    expect(matchSkillTriggers("add error handling to the endpoint")).not.toContain("debug");
+    expect(matchSkillTriggers("remove this line from the file")).not.toContain("deprecation");
+  });
+});
+
+describe("createSkillSuggestion", () => {
+  test("returns null when no triggers match", () => {
+    expect(createSkillSuggestion("hello world")).toBeNull();
+  });
+
+  test("returns directive suggestion for single match", () => {
+    const result = createSkillSuggestion("implement the login feature");
+    expect(result).toBe("Use `skill-activate` to load `build` before starting.");
+  });
+
+  test("returns batched suggestion for multiple matches", () => {
+    const result = createSkillSuggestion("review the pull request and fix bug");
+    expect(result).toContain("`debug`");
+    expect(result).toContain("`review`");
+    expect(result).toMatch(/^Use `skill-activate` to load .+ before starting\.$/);
   });
 });

--- a/src/skill-triggers.test.ts
+++ b/src/skill-triggers.test.ts
@@ -29,16 +29,12 @@ describe("matchSkillTriggers", () => {
   });
 
   test("skips already active skills", () => {
-    const matches = matchSkillTriggers("implement the feature", [
-      { name: "build", instructions: "..." },
-    ]);
+    const matches = matchSkillTriggers("implement the feature", [{ name: "build", instructions: "..." }]);
     expect(matches).not.toContain("build");
   });
 
   test("suggests non-active skills even when some are active", () => {
-    const matches = matchSkillTriggers("implement the feature and commit", [
-      { name: "build", instructions: "..." },
-    ]);
+    const matches = matchSkillTriggers("implement the feature and commit", [{ name: "build", instructions: "..." }]);
     expect(matches).not.toContain("build");
     expect(matches).toContain("git");
   });

--- a/src/skill-triggers.test.ts
+++ b/src/skill-triggers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { matchSkillTriggers } from "./skill-triggers";
+
+describe("matchSkillTriggers", () => {
+  test("matches build skill from keyword", () => {
+    expect(matchSkillTriggers("implement the login feature")).toContain("build");
+  });
+
+  test("matches debug skill from keyword", () => {
+    expect(matchSkillTriggers("fix bug in the parser")).toContain("debug");
+  });
+
+  test("matches git skill from keyword", () => {
+    expect(matchSkillTriggers("commit these changes")).toContain("git");
+  });
+
+  test("matches multiple skills from message", () => {
+    const matches = matchSkillTriggers("review the pull request and fix bug");
+    expect(matches).toContain("review");
+    expect(matches).toContain("debug");
+  });
+
+  test("is case insensitive", () => {
+    expect(matchSkillTriggers("DEBUG this issue")).toContain("debug");
+  });
+
+  test("returns empty array for unrelated message", () => {
+    expect(matchSkillTriggers("hello world")).toEqual([]);
+  });
+
+  test("skips already active skills", () => {
+    const matches = matchSkillTriggers("implement the feature", [
+      { name: "build", instructions: "..." },
+    ]);
+    expect(matches).not.toContain("build");
+  });
+
+  test("suggests non-active skills even when some are active", () => {
+    const matches = matchSkillTriggers("implement the feature and commit", [
+      { name: "build", instructions: "..." },
+    ]);
+    expect(matches).not.toContain("build");
+    expect(matches).toContain("git");
+  });
+});

--- a/src/skill-triggers.ts
+++ b/src/skill-triggers.ts
@@ -1,0 +1,36 @@
+import type { ActiveSkill } from "./session-contract";
+
+const SKILL_TRIGGERS: Record<string, string[]> = {
+  build: ["implement", "add feature", "build", "create feature", "new feature", "add functionality"],
+  debug: ["debug", "fix bug", "broken", "failing test", "error", "not working", "investigate"],
+  tdd: ["test first", "red green", "tdd", "test driven"],
+  git: ["commit", "branch", "rebase", "merge", "cherry pick", "squash", "git"],
+  review: ["review", "pull request", "pr review", "code review"],
+  plan: ["plan", "design", "scope", "break down", "decompose"],
+  explore: ["explore", "understand", "how does", "what does", "walk me through"],
+  simplify: ["simplify", "reduce complexity", "clean up", "refactor"],
+  security: ["security", "vulnerability", "auth", "injection", "xss", "csrf"],
+  tests: ["test coverage", "missing tests", "add tests", "test quality"],
+  style: ["naming", "code style", "consistency", "conventions"],
+  docs: ["documentation", "update docs", "readme", "changelog"],
+  architecture: ["architecture", "module boundary", "dependency", "coupling"],
+  deprecation: ["deprecate", "remove", "replace", "migrate away"],
+  design: ["interface", "api design", "contract", "public api"],
+};
+
+function buildTriggerPatterns(): { name: string; pattern: RegExp }[] {
+  return Object.entries(SKILL_TRIGGERS).map(([name, keywords]) => {
+    const escaped = keywords.map((kw) => kw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+    const pattern = new RegExp(`\\b(?:${escaped.join("|")})\\b`, "i");
+    return { name, pattern };
+  });
+}
+
+const triggerPatterns = buildTriggerPatterns();
+
+export function matchSkillTriggers(message: string, activeSkills?: ActiveSkill[]): string[] {
+  const activeNames = new Set(activeSkills?.map((s) => s.name) ?? []);
+  return triggerPatterns
+    .filter(({ name, pattern }) => !activeNames.has(name) && pattern.test(message))
+    .map(({ name }) => name);
+}

--- a/src/skill-triggers.ts
+++ b/src/skill-triggers.ts
@@ -1,4 +1,4 @@
-import type { ActiveSkill } from "./session-contract";
+import type { ActiveSkill } from "./skill-contract";
 
 const SKILL_TRIGGERS: Record<string, string[]> = {
   build: ["implement", "add feature", "build", "create feature", "new feature", "add functionality"],
@@ -33,4 +33,10 @@ export function matchSkillTriggers(message: string, activeSkills?: ActiveSkill[]
   return triggerPatterns
     .filter(({ name, pattern }) => !activeNames.has(name) && pattern.test(message))
     .map(({ name }) => name);
+}
+
+export function createSkillSuggestions(message: string, activeSkills?: ActiveSkill[]): string[] {
+  return matchSkillTriggers(message, activeSkills).map(
+    (name) => `Use \`skill-activate\` to load \`${name}\` before starting.`,
+  );
 }

--- a/src/skill-triggers.ts
+++ b/src/skill-triggers.ts
@@ -1,21 +1,21 @@
 import type { ActiveSkill } from "./skill-contract";
 
 const SKILL_TRIGGERS: Record<string, string[]> = {
-  build: ["implement", "add feature", "build", "create feature", "new feature", "add functionality"],
-  debug: ["debug", "fix bug", "broken", "failing test", "error", "not working", "investigate"],
+  build: ["implement", "add feature", "create feature", "new feature", "add functionality"],
+  debug: ["debug", "fix bug", "broken", "failing test", "not working", "investigate"],
   tdd: ["test first", "red green", "tdd", "test driven"],
-  git: ["commit", "branch", "rebase", "merge", "cherry pick", "squash", "git"],
+  git: ["commit", "rebase", "cherry pick", "squash", "git log", "git diff"],
   review: ["review", "pull request", "pr review", "code review"],
-  plan: ["plan", "design", "scope", "break down", "decompose"],
-  explore: ["explore", "understand", "how does", "what does", "walk me through"],
-  simplify: ["simplify", "reduce complexity", "clean up", "refactor"],
-  security: ["security", "vulnerability", "auth", "injection", "xss", "csrf"],
+  plan: ["plan this", "scope", "break down", "decompose"],
+  explore: ["explore", "how does", "what does", "walk me through"],
+  simplify: ["simplify", "reduce complexity", "clean up"],
+  security: ["security review", "vulnerability", "injection", "xss", "csrf"],
   tests: ["test coverage", "missing tests", "add tests", "test quality"],
-  style: ["naming", "code style", "consistency", "conventions"],
-  docs: ["documentation", "update docs", "readme", "changelog"],
-  architecture: ["architecture", "module boundary", "dependency", "coupling"],
-  deprecation: ["deprecate", "remove", "replace", "migrate away"],
-  design: ["interface", "api design", "contract", "public api"],
+  style: ["code style", "style review", "naming conventions"],
+  docs: ["documentation", "update docs"],
+  architecture: ["architecture", "module boundary"],
+  deprecation: ["deprecate", "migrate away", "phase out"],
+  design: ["api design", "design interface", "public api"],
 };
 
 function buildTriggerPatterns(): { name: string; pattern: RegExp }[] {

--- a/src/skill-triggers.ts
+++ b/src/skill-triggers.ts
@@ -35,8 +35,9 @@ export function matchSkillTriggers(message: string, activeSkills?: ActiveSkill[]
     .map(({ name }) => name);
 }
 
-export function createSkillSuggestions(message: string, activeSkills?: ActiveSkill[]): string[] {
-  return matchSkillTriggers(message, activeSkills).map(
-    (name) => `Use \`skill-activate\` to load \`${name}\` before starting.`,
-  );
+export function createSkillSuggestion(message: string, activeSkills?: ActiveSkill[]): string | null {
+  const matches = matchSkillTriggers(message, activeSkills);
+  if (matches.length === 0) return null;
+  const names = matches.map((n) => `\`${n}\``).join(", ");
+  return `Use \`skill-activate\` to load ${names} before starting.`;
 }


### PR DESCRIPTION
## Motivation

The agent relies on its own judgment to decide when to activate a skill. A system-level hint based on the user's message improves activation rates without adding tool call overhead.

## Summary

- add trigger keyword map for bundled skills in `skill-triggers.ts`
- in `phasePrepare`, scan user message for trigger matches and prepend a directive suggestion to the agent input
- skip suggestions for already active skills
- batch `skill-activate` tool to accept multiple names in one call
- update tool instruction and output schema for batched activation

Fixes #194