### PR TITLE
refactor(memory): unify usage accounting

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -30,9 +30,8 @@ Memory kinds in storage: `stored` (explicit user/tool-created), `observation` (d
 
 ## Controls
 
-- Request-level off switch: `useMemory=false`
-  - Skips memory commit for that request
-  - Memory toolkit tools remain available (on-demand access is not gated)
+- Memory behavior is runtime policy-driven, not request-scoped
+- Distill and recall costs are reported under the single `memory` usage metric
 
 ## Inspiration
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -19,8 +19,6 @@ export interface ChatRequest {
   readonly resourceId?: ResourceId;
   readonly activeSkills?: ActiveSkill[];
   readonly suggestions?: string[];
-  /** When true, stored memories and distill observations are included in context. */
-  readonly useMemory?: boolean;
   /** Client working directory. Falls back to server CWD when omitted. */
   readonly workspace?: string;
 }

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -49,7 +49,6 @@ type CreateMessageHandlerInput = {
   createMessage: (role: ChatMessage["role"], content: string) => ChatMessage;
   nowIso: () => string;
   setInterrupt: (handler: (() => void) | null) => void;
-  useMemory?: boolean;
   promote?: () => void;
   clearTranscript: (sessionId?: string) => void;
 };
@@ -120,7 +119,6 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
         activeSkills: input.currentSession.activeSkills,
         suggestions,
         workspace: input.currentSession.workspace,
-        useMemory: input.useMemory,
         signal: controller.signal,
         onEvent: (event) => {
           switch (event.type) {

--- a/src/chat-state.ts
+++ b/src/chat-state.ts
@@ -32,7 +32,6 @@ export interface ChatAppProps {
   persist: () => Promise<void>;
   onSessionChange?: (next: Session) => void;
   version: string;
-  useMemory?: boolean;
 }
 
 export interface ChatStateResult {
@@ -63,7 +62,7 @@ export interface ChatStateResult {
 }
 
 export function useChatState(props: ChatAppProps, exit: () => void): ChatStateResult {
-  const { client, session, sessionState, persist, useMemory } = props;
+  const { client, session, sessionState, persist } = props;
 
   const [currentSession, setCurrentSession] = useState<Session>(session);
   const updateSession = useCallback(
@@ -218,7 +217,6 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
     setInterrupt: (handler) => {
       interruptRef.current = handler;
     },
-    useMemory,
     promote,
     clearTranscript,
   });

--- a/src/chat-turn.ts
+++ b/src/chat-turn.ts
@@ -105,7 +105,6 @@ type RunAssistantTurnParams = {
   activeSkills?: ActiveSkill[];
   suggestions?: string[];
   workspace?: string;
-  useMemory?: boolean;
   signal?: AbortSignal;
   onEvent?: (event: StreamEvent) => void;
   pendingStartedAt: number;
@@ -125,7 +124,6 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
       sessionId: params.sessionId,
       activeSkills: params.activeSkills,
       suggestions: params.suggestions,
-      useMemory: params.useMemory,
       ...createWorkspaceSpecifier(params.workspace ?? process.cwd()),
     },
     signal: params.signal,

--- a/src/cli-chat.ts
+++ b/src/cli-chat.ts
@@ -116,7 +116,6 @@ export async function chatModeWithOptions(options: { resumeLatest: boolean; resu
       persist,
       onSessionChange,
       version: CLI_VERSION,
-      useMemory: isResumed,
     });
     if (output.isTTY) clearScreen();
     const resumeId = state.activeSessionId ?? session.id;

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -65,27 +65,11 @@ export type PromptUsage = {
   includedHistoryMessages: number;
   totalHistoryMessages: number;
 };
-export type PromptBreakdownTotals = {
-  systemTokens: number;
-  toolTokens: number;
-  skillTokens: number;
-  memoryTokens: number;
-  messageTokens: number;
-};
 
-export function createEmptyPromptBreakdownTotals(): PromptBreakdownTotals {
-  return {
-    systemTokens: 0,
-    toolTokens: 0,
-    skillTokens: 0,
-    memoryTokens: 0,
-    messageTokens: 0,
-  };
+export function promptUsageTotalTokens(usage: PromptUsage): number {
+  return usage.systemPromptTokens + usage.toolTokens + usage.skillTokens + usage.memoryTokens + usage.messageTokens;
 }
 
-export function totalPromptBreakdownTokens(totals: PromptBreakdownTotals): number {
-  return totals.systemTokens + totals.toolTokens + totals.skillTokens + totals.memoryTokens + totals.messageTokens;
-}
 export type TextDeltaPayload = { text?: string };
 export type ToolCallPayload = { toolCallId?: string; toolName?: string; args?: Record<string, unknown> };
 export type ToolResultPayload = { toolCallId?: string; toolName?: string; result?: unknown };
@@ -181,7 +165,6 @@ export type RunContext = {
   modelCallCount: number;
   inputTokensAccum: number;
   outputTokensAccum: number;
-  promptBreakdownTotals: PromptBreakdownTotals;
   streamingChars: number;
   lastUsageEmitChars: number;
   currentError?: LifecycleError;

--- a/src/lifecycle-finalize.test.ts
+++ b/src/lifecycle-finalize.test.ts
@@ -34,7 +34,7 @@ describe("ChatResponse error field", () => {
 });
 
 describe("phaseFinalize", () => {
-  test("uses prompt breakdown totals for token accounting", () => {
+  test("derives prompt breakdown from promptUsage for token accounting", () => {
     const ctx = createRunContext({
       promptUsage: {
         inputTokens: 12,
@@ -47,7 +47,6 @@ describe("phaseFinalize", () => {
         includedHistoryMessages: 3,
         totalHistoryMessages: 6,
       },
-      promptBreakdownTotals: { systemTokens: 48, toolTokens: 20, skillTokens: 0, memoryTokens: 0, messageTokens: 12 },
       inputTokensAccum: 0,
       outputTokensAccum: 0,
       result: { text: "done", toolCalls: [] },
@@ -58,6 +57,15 @@ describe("phaseFinalize", () => {
     expect(response.usage?.inputTokens).toBe(80);
     expect(response.usage?.totalTokens).toBe(81);
     expect(response.promptBreakdown?.usedTokens).toBe(80);
+    expect(response.promptBreakdown).toEqual({
+      budgetTokens: 100,
+      usedTokens: 80,
+      systemTokens: 48,
+      toolTokens: 20,
+      skillTokens: 0,
+      memoryTokens: 0,
+      messageTokens: 12,
+    });
   });
 
   test("includes promptBreakdown when currentError is set", () => {
@@ -73,7 +81,6 @@ describe("phaseFinalize", () => {
         includedHistoryMessages: 3,
         totalHistoryMessages: 6,
       },
-      promptBreakdownTotals: { systemTokens: 48, toolTokens: 20, skillTokens: 0, memoryTokens: 0, messageTokens: 12 },
       inputTokensAccum: 0,
       outputTokensAccum: 0,
       currentError: { message: "tool failed", category: "other" },
@@ -85,45 +92,6 @@ describe("phaseFinalize", () => {
     expect(response.error).toBe("tool failed");
     expect(response.promptBreakdown).toBeDefined();
     expect(response.promptBreakdown?.usedTokens).toBe(80);
-  });
-
-  test("uses accumulated prompt breakdown totals across multiple model calls", () => {
-    const ctx = createRunContext({
-      baseAgentInput: "USER: first prompt",
-      promptUsage: {
-        inputTokens: 12,
-        systemPromptTokens: 48,
-        toolTokens: 20,
-        skillTokens: 0,
-        memoryTokens: 0,
-        messageTokens: 12,
-        inputBudgetTokens: 100,
-        includedHistoryMessages: 3,
-        totalHistoryMessages: 6,
-      },
-      inputTokensAccum: 120,
-      promptBreakdownTotals: {
-        systemTokens: 80,
-        toolTokens: 40,
-        skillTokens: 0,
-        memoryTokens: 0,
-        messageTokens: 34,
-      },
-      result: { text: "done", toolCalls: [] },
-    });
-
-    const response = phaseFinalize(ctx);
-
-    expect(response.usage?.inputTokens).toBe(154);
-    expect(response.promptBreakdown).toEqual({
-      budgetTokens: 100,
-      usedTokens: 154,
-      systemTokens: 80,
-      toolTokens: 40,
-      skillTokens: 0,
-      memoryTokens: 0,
-      messageTokens: 34,
-    });
   });
 
   test("sets state to awaiting-input when signal is blocked", () => {

--- a/src/lifecycle-finalize.ts
+++ b/src/lifecycle-finalize.ts
@@ -1,7 +1,7 @@
 import { estimateTokens } from "./agent-input";
 import type { ChatResponse } from "./api";
 import { t } from "./i18n";
-import { type RunContext, totalPromptBreakdownTokens } from "./lifecycle-contract";
+import { promptUsageTotalTokens, type RunContext } from "./lifecycle-contract";
 import { stripSignalLine } from "./lifecycle-signal";
 import { DISCOVERY_TOOL_SET, READ_TOOL_SET, SEARCH_TOOL_SET, WRITE_TOOL_SET } from "./tool-registry";
 import { scopedCallLog } from "./tool-session";
@@ -15,7 +15,8 @@ export function phaseFinalize(ctx: RunContext): ChatResponse {
         ? t("agent.output.no_response_after_tools")
         : t("agent.output.no_output");
 
-  const promptInputTokens = totalPromptBreakdownTokens(ctx.promptBreakdownTotals);
+  const { promptUsage } = ctx;
+  const promptInputTokens = promptUsageTotalTokens(promptUsage);
   const inputTokens = Math.max(ctx.inputTokensAccum, promptInputTokens);
   const outputTokens = ctx.outputTokensAccum || estimateTokens(output);
 
@@ -69,13 +70,13 @@ export function phaseFinalize(ctx: RunContext): ChatResponse {
       inputBudgetTokens: ctx.promptUsage.inputBudgetTokens,
     },
     promptBreakdown: {
-      budgetTokens: ctx.promptUsage.inputBudgetTokens,
+      budgetTokens: promptUsage.inputBudgetTokens,
       usedTokens: inputTokens,
-      systemTokens: ctx.promptBreakdownTotals.systemTokens,
-      toolTokens: ctx.promptBreakdownTotals.toolTokens,
-      skillTokens: ctx.promptBreakdownTotals.skillTokens,
-      memoryTokens: ctx.promptBreakdownTotals.memoryTokens,
-      messageTokens: ctx.promptBreakdownTotals.messageTokens,
+      systemTokens: promptUsage.systemPromptTokens,
+      toolTokens: promptUsage.toolTokens,
+      skillTokens: promptUsage.skillTokens,
+      memoryTokens: promptUsage.memoryTokens,
+      messageTokens: promptUsage.messageTokens,
     },
   };
 }

--- a/src/lifecycle-generate.test.ts
+++ b/src/lifecycle-generate.test.ts
@@ -217,4 +217,52 @@ describe("phaseGenerate", () => {
     expect(ctx.currentError?.message).toBe("invalid_api_key");
     expect(ctx.currentError?.source).toBe("generate");
   });
+
+  test("accounts memory recall tokens from memory-search results", async () => {
+    const ctx = createRunContext({
+      request: { model: "gpt-5-mini", message: "test", history: [] },
+      agent: {
+        id: "test-agent",
+        name: "test-agent",
+        instructions: "",
+        model: {} as RunContext["agent"]["model"],
+        tools: {},
+        async stream() {
+          const chunks = [
+            {
+              type: "tool-call" as const,
+              payload: { toolCallId: "call_1", toolName: "memory-search", args: { query: "auth" } },
+            },
+            {
+              type: "tool-result" as const,
+              payload: {
+                toolCallId: "call_1",
+                toolName: "memory-search",
+                result: {
+                  kind: "memory-search",
+                  results: [{ id: "mem_1", content: "Use OAuth", scope: "project" }],
+                },
+              },
+            },
+          ];
+          return {
+            fullStream: new ReadableStream({
+              start(controller) {
+                for (const chunk of chunks) controller.enqueue(chunk);
+                controller.close();
+              },
+            }),
+            async getFullOutput() {
+              return { text: "Done.", toolCalls: [], signal: "done" as const };
+            },
+          };
+        },
+      },
+    });
+
+    await phaseGenerate(ctx, { timeoutMs: 1000 });
+
+    expect(ctx.promptBreakdownTotals.memoryTokens).toBeGreaterThan(0);
+    expect(ctx.promptUsage.memoryTokens).toBeGreaterThan(0);
+  });
 });

--- a/src/lifecycle-generate.test.ts
+++ b/src/lifecycle-generate.test.ts
@@ -265,4 +265,49 @@ describe("phaseGenerate", () => {
     expect(ctx.promptBreakdownTotals.memoryTokens).toBeGreaterThan(0);
     expect(ctx.promptUsage.memoryTokens).toBeGreaterThan(0);
   });
+
+  test("does not account memory recall tokens for failed memory-search", async () => {
+    const ctx = createRunContext({
+      request: { model: "gpt-5-mini", message: "test", history: [] },
+      agent: {
+        id: "test-agent",
+        name: "test-agent",
+        instructions: "",
+        model: {} as RunContext["agent"]["model"],
+        tools: {},
+        async stream() {
+          const chunks = [
+            {
+              type: "tool-call" as const,
+              payload: { toolCallId: "call_1", toolName: "memory-search", args: { query: "auth" } },
+            },
+            {
+              type: "tool-result" as const,
+              payload: {
+                toolCallId: "call_1",
+                toolName: "memory-search",
+                result: { error: "backend unavailable" },
+              },
+            },
+          ];
+          return {
+            fullStream: new ReadableStream({
+              start(controller) {
+                for (const chunk of chunks) controller.enqueue(chunk);
+                controller.close();
+              },
+            }),
+            async getFullOutput() {
+              return { text: "Done.", toolCalls: [], signal: "done" as const };
+            },
+          };
+        },
+      },
+    });
+
+    await phaseGenerate(ctx, { timeoutMs: 1000 });
+
+    expect(ctx.promptBreakdownTotals.memoryTokens).toBe(0);
+    expect(ctx.promptUsage.memoryTokens).toBe(0);
+  });
 });

--- a/src/lifecycle-generate.test.ts
+++ b/src/lifecycle-generate.test.ts
@@ -262,7 +262,6 @@ describe("phaseGenerate", () => {
 
     await phaseGenerate(ctx, { timeoutMs: 1000 });
 
-    expect(ctx.promptBreakdownTotals.memoryTokens).toBeGreaterThan(0);
     expect(ctx.promptUsage.memoryTokens).toBeGreaterThan(0);
   });
 
@@ -307,7 +306,6 @@ describe("phaseGenerate", () => {
 
     await phaseGenerate(ctx, { timeoutMs: 1000 });
 
-    expect(ctx.promptBreakdownTotals.memoryTokens).toBe(0);
     expect(ctx.promptUsage.memoryTokens).toBe(0);
   });
 });

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -248,6 +248,16 @@ function emitStreamingUsage(ctx: RunContext, chars: number): void {
   }
 }
 
+function accountMemoryRecallTokens(ctx: RunContext, toolName: string, result: unknown): void {
+  if (toolName !== "memory-search") return;
+  if (result === undefined) return;
+  const serialized = JSON.stringify(result);
+  if (!serialized) return;
+  const tokens = estimateTokens(serialized);
+  ctx.promptUsage.memoryTokens += tokens;
+  ctx.promptBreakdownTotals.memoryTokens += tokens;
+}
+
 function clearResolvedToolError(ctx: RunContext, started: { toolName: string }): void {
   if (!ctx.currentError) return;
   if (ctx.currentError.source !== "tool-error" && ctx.currentError.source !== "tool-result") return;
@@ -322,6 +332,7 @@ const CHUNK_HANDLERS: Record<StreamChunk["type"], ChunkHandler> = {
     } else {
       clearResolvedToolError(ctx, started ?? { toolName });
     }
+    accountMemoryRecallTokens(ctx, toolName, p.result);
     completeToolCall(ctx, p.toolCallId, toolName);
     emitToolResult(ctx, p.toolCallId, toolName, isError);
   },

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -16,9 +16,9 @@ import {
 import {
   type GenerateOptions,
   type GenerateResult,
+  promptUsageTotalTokens,
   type RunContext,
   type StreamChunk,
-  totalPromptBreakdownTokens,
 } from "./lifecycle-contract";
 import { providerFromModel, reasoningProviderOptions } from "./provider-config";
 import type { StreamError } from "./stream-error";
@@ -51,7 +51,7 @@ function formatToolArgs(args: Record<string, unknown>): Record<string, string | 
 }
 
 function emitInputTokens(ctx: RunContext): number {
-  return Math.max(ctx.inputTokensAccum, totalPromptBreakdownTokens(ctx.promptBreakdownTotals));
+  return Math.max(ctx.inputTokensAccum, promptUsageTotalTokens(ctx.promptUsage));
 }
 
 function captureError(ctx: RunContext, message: string, meta?: CaptureErrorMeta): void {
@@ -255,7 +255,6 @@ function accountMemoryRecallTokens(ctx: RunContext, toolName: string, result: un
   if (!serialized) return;
   const tokens = estimateTokens(serialized);
   ctx.promptUsage.memoryTokens += tokens;
-  ctx.promptBreakdownTotals.memoryTokens += tokens;
 }
 
 function clearResolvedToolError(ctx: RunContext, started: { toolName: string }): void {

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -332,7 +332,7 @@ const CHUNK_HANDLERS: Record<StreamChunk["type"], ChunkHandler> = {
     } else {
       clearResolvedToolError(ctx, started ?? { toolName });
     }
-    accountMemoryRecallTokens(ctx, toolName, p.result);
+    if (!isError) accountMemoryRecallTokens(ctx, toolName, p.result);
     completeToolCall(ctx, p.toolCallId, toolName);
     emitToolResult(ctx, p.toolCallId, toolName, isError);
   },

--- a/src/lifecycle.int.test.ts
+++ b/src/lifecycle.int.test.ts
@@ -12,7 +12,7 @@ import {
 import { appConfig } from "./app-config";
 import { runLifecycle } from "./lifecycle";
 import { createRunControl } from "./lifecycle-contract";
-import { createLifecycleDeps, tempDir } from "./test-utils";
+import { createLifecycleDeps, createLifecycleInput, tempDir } from "./test-utils";
 import { runTool } from "./tool-execution";
 import type { SessionContext } from "./tool-session";
 import { listUndoCheckpoints } from "./undo-checkpoints";
@@ -49,11 +49,7 @@ function setupFakeProvider(handler: (ctx: FakeProviderRequestContext) => Record<
 }
 
 function run(message: string) {
-  return runLifecycle({
-    request: { model: "gpt-5-mini", message, history: [] },
-    soulPrompt: "",
-    workspace,
-  });
+  return runLifecycle(createLifecycleInput({ request: { model: "gpt-5-mini", message, history: [] }, workspace }));
 }
 
 async function writeExecutableScript(name: string, body: string): Promise<string> {
@@ -158,14 +154,13 @@ printf '%s\n' "$@" > "${formatLog}"
       return createMessagePayload(ctx.model, ctx.responseCounter, "Updated x to 6.\n\n@signal done");
     });
 
-    await runLifecycle({
-      request: { model: "gpt-5-mini", message: "update x to 6", history: [] },
-      soulPrompt: "",
-      workspace,
-      lifecyclePolicy: {
-        formatCommand: { bin: "/bin/sh", args: [formatScript, "$FILES"] },
-      },
-    });
+    await runLifecycle(
+      createLifecycleInput({
+        request: { model: "gpt-5-mini", message: "update x to 6", history: [] },
+        workspace,
+        lifecyclePolicy: { formatCommand: { bin: "/bin/sh", args: [formatScript, "$FILES"] } },
+      }),
+    );
 
     expect(turnCount).toBe(2);
     expect(await readFile(formatLog, "utf8")).toContain(join(workspace, "a.ts"));
@@ -201,14 +196,13 @@ exit 1
       return createMessagePayload(ctx.model, ctx.responseCounter, "Updated x to 7.\n\n@signal done");
     });
 
-    const reply = await runLifecycle({
-      request: { model: "gpt-5-mini", message: "update x to 7", history: [] },
-      soulPrompt: "",
-      workspace,
-      lifecyclePolicy: {
-        lintCommand: { bin: "/bin/sh", args: [lintScript, "$FILES"] },
-      },
-    });
+    const reply = await runLifecycle(
+      createLifecycleInput({
+        request: { model: "gpt-5-mini", message: "update x to 7", history: [] },
+        workspace,
+        lifecyclePolicy: { lintCommand: { bin: "/bin/sh", args: [lintScript, "$FILES"] } },
+      }),
+    );
 
     expect(turnCount).toBe(2);
     expect(reply.output).toContain("Updated x to 7.");
@@ -220,13 +214,14 @@ exit 1
     });
 
     const debugEvents: string[] = [];
-    const reply = await runLifecycle({
-      request: { model: "gpt-5-mini", message: "hi", history: [] },
-      soulPrompt: "",
-      workspace,
-      runControl: createRunControl({ shouldYield: () => true }),
-      onDebug: (entry) => debugEvents.push(entry.event),
-    });
+    const reply = await runLifecycle(
+      createLifecycleInput({
+        request: { model: "gpt-5-mini", message: "hi", history: [] },
+        workspace,
+        runControl: createRunControl({ shouldYield: () => true }),
+        onDebug: (entry) => debugEvents.push(entry.event),
+      }),
+    );
 
     expect(reply.output).toContain("Hello there.");
     expect(debugEvents).toContain("lifecycle.yield");
@@ -237,12 +232,13 @@ exit 1
       return createMessagePayload(ctx.model, ctx.responseCounter, "  ");
     });
 
-    const reply = await runLifecycle({
-      request: { model: "gpt-5-mini", message: "hi", history: [] },
-      soulPrompt: "",
-      workspace,
-      runControl: createRunControl({ shouldYield: () => true }),
-    });
+    const reply = await runLifecycle(
+      createLifecycleInput({
+        request: { model: "gpt-5-mini", message: "hi", history: [] },
+        workspace,
+        runControl: createRunControl({ shouldYield: () => true }),
+      }),
+    );
 
     expect(reply.output).toBe("Yielding to a newer pending message.");
   });
@@ -264,22 +260,12 @@ exit 1
     });
 
     await runLifecycle(
-      {
-        request: {
-          model: "gpt-5-mini",
-          message: "test",
-          history: [],
-          sessionId: "sess_undo",
-        },
+      createLifecycleInput({
+        request: { model: "gpt-5-mini", message: "test", history: [], sessionId: "sess_undo" },
         soulPrompt: "SOUL",
         workspace: undoWorkspace,
-        features: {
-          syncAgents: false,
-          undoCheckpoints: true,
-          parallelWorkspaces: false,
-          cloudSync: false,
-        },
-      },
+        features: { syncAgents: false, undoCheckpoints: true, parallelWorkspaces: false, cloudSync: false, mcp: false },
+      }),
       deps,
     );
 

--- a/src/lifecycle.int.test.ts
+++ b/src/lifecycle.int.test.ts
@@ -12,7 +12,7 @@ import {
 import { appConfig } from "./app-config";
 import { runLifecycle } from "./lifecycle";
 import { createRunControl } from "./lifecycle-contract";
-import { createLifecycleDeps, createLifecycleInput, tempDir } from "./test-utils";
+import { createLifecycleDeps, tempDir } from "./test-utils";
 import { runTool } from "./tool-execution";
 import type { SessionContext } from "./tool-session";
 import { listUndoCheckpoints } from "./undo-checkpoints";
@@ -49,9 +49,11 @@ function setupFakeProvider(handler: (ctx: FakeProviderRequestContext) => Record<
 }
 
 function run(message: string) {
-  return runLifecycle(
-    createLifecycleInput({ request: { model: "gpt-5-mini", message, history: [], useMemory: false }, workspace }),
-  );
+  return runLifecycle({
+    request: { model: "gpt-5-mini", message, history: [] },
+    soulPrompt: "",
+    workspace,
+  });
 }
 
 async function writeExecutableScript(name: string, body: string): Promise<string> {
@@ -156,13 +158,14 @@ printf '%s\n' "$@" > "${formatLog}"
       return createMessagePayload(ctx.model, ctx.responseCounter, "Updated x to 6.\n\n@signal done");
     });
 
-    await runLifecycle(
-      createLifecycleInput({
-        request: { model: "gpt-5-mini", message: "update x to 6", history: [], useMemory: false },
-        workspace,
-        lifecyclePolicy: { formatCommand: { bin: "/bin/sh", args: [formatScript, "$FILES"] } },
-      }),
-    );
+    await runLifecycle({
+      request: { model: "gpt-5-mini", message: "update x to 6", history: [] },
+      soulPrompt: "",
+      workspace,
+      lifecyclePolicy: {
+        formatCommand: { bin: "/bin/sh", args: [formatScript, "$FILES"] },
+      },
+    });
 
     expect(turnCount).toBe(2);
     expect(await readFile(formatLog, "utf8")).toContain(join(workspace, "a.ts"));
@@ -198,13 +201,14 @@ exit 1
       return createMessagePayload(ctx.model, ctx.responseCounter, "Updated x to 7.\n\n@signal done");
     });
 
-    const reply = await runLifecycle(
-      createLifecycleInput({
-        request: { model: "gpt-5-mini", message: "update x to 7", history: [], useMemory: false },
-        workspace,
-        lifecyclePolicy: { lintCommand: { bin: "/bin/sh", args: [lintScript, "$FILES"] } },
-      }),
-    );
+    const reply = await runLifecycle({
+      request: { model: "gpt-5-mini", message: "update x to 7", history: [] },
+      soulPrompt: "",
+      workspace,
+      lifecyclePolicy: {
+        lintCommand: { bin: "/bin/sh", args: [lintScript, "$FILES"] },
+      },
+    });
 
     expect(turnCount).toBe(2);
     expect(reply.output).toContain("Updated x to 7.");
@@ -216,14 +220,13 @@ exit 1
     });
 
     const debugEvents: string[] = [];
-    const reply = await runLifecycle(
-      createLifecycleInput({
-        request: { model: "gpt-5-mini", message: "hi", history: [], useMemory: false },
-        workspace,
-        runControl: createRunControl({ shouldYield: () => true }),
-        onDebug: (entry) => debugEvents.push(entry.event),
-      }),
-    );
+    const reply = await runLifecycle({
+      request: { model: "gpt-5-mini", message: "hi", history: [] },
+      soulPrompt: "",
+      workspace,
+      runControl: createRunControl({ shouldYield: () => true }),
+      onDebug: (entry) => debugEvents.push(entry.event),
+    });
 
     expect(reply.output).toContain("Hello there.");
     expect(debugEvents).toContain("lifecycle.yield");
@@ -234,13 +237,12 @@ exit 1
       return createMessagePayload(ctx.model, ctx.responseCounter, "  ");
     });
 
-    const reply = await runLifecycle(
-      createLifecycleInput({
-        request: { model: "gpt-5-mini", message: "hi", history: [], useMemory: false },
-        workspace,
-        runControl: createRunControl({ shouldYield: () => true }),
-      }),
-    );
+    const reply = await runLifecycle({
+      request: { model: "gpt-5-mini", message: "hi", history: [] },
+      soulPrompt: "",
+      workspace,
+      runControl: createRunControl({ shouldYield: () => true }),
+    });
 
     expect(reply.output).toBe("Yielding to a newer pending message.");
   });
@@ -262,12 +264,22 @@ exit 1
     });
 
     await runLifecycle(
-      createLifecycleInput({
-        request: { model: "gpt-5-mini", message: "test", history: [], useMemory: false, sessionId: "sess_undo" },
+      {
+        request: {
+          model: "gpt-5-mini",
+          message: "test",
+          history: [],
+          sessionId: "sess_undo",
+        },
         soulPrompt: "SOUL",
         workspace: undoWorkspace,
-        features: { syncAgents: false, undoCheckpoints: true, parallelWorkspaces: false, cloudSync: false, mcp: false },
-      }),
+        features: {
+          syncAgents: false,
+          undoCheckpoints: true,
+          parallelWorkspaces: false,
+          cloudSync: false,
+        },
+      },
       deps,
     );
 

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -2,19 +2,14 @@ import { describe, expect, mock, test } from "bun:test";
 import type { ChatResponse } from "./api";
 import { runLifecycle, scheduleMemoryCommit } from "./lifecycle";
 import { createRunControl } from "./lifecycle-contract";
-import { createLifecycleDeps } from "./test-utils";
+import { createLifecycleDeps, createLifecycleInput } from "./test-utils";
 
 describe("runLifecycle", () => {
   test("orchestrates phases", async () => {
     const deps = createLifecycleDeps();
 
     const response = await runLifecycle(
-      {
-        request: { model: "gpt-5-mini", message: "test", history: [] },
-        soulPrompt: "SOUL",
-        workspace: process.cwd(),
-        taskId: "task_test",
-      },
+      createLifecycleInput({ soulPrompt: "SOUL", workspace: process.cwd(), taskId: "task_test" }),
       deps,
     );
 
@@ -37,11 +32,11 @@ describe("runLifecycle", () => {
     });
 
     const response = await runLifecycle(
-      {
+      createLifecycleInput({
         request: { model: "gpt-5-mini", message: "test", history: [] },
         soulPrompt: "SOUL",
         workspace: process.cwd(),
-      },
+      }),
       deps,
     );
 
@@ -71,11 +66,11 @@ describe("runLifecycle", () => {
     });
 
     const response = await runLifecycle(
-      {
+      createLifecycleInput({
         request: { model: "gpt-5-mini", message: "test", history: [] },
         soulPrompt: "SOUL",
         workspace: process.cwd(),
-      },
+      }),
       deps,
     );
 
@@ -205,12 +200,7 @@ describe("scheduleMemoryCommit", () => {
 });
 
 describe("runLifecycle yield", () => {
-  const baseInput = {
-    request: { model: "gpt-5-mini" as const, message: "test", history: [] as never[] },
-    soulPrompt: "SOUL",
-    workspace: process.cwd(),
-    taskId: "task_test",
-  };
+  const baseInput = createLifecycleInput({ soulPrompt: "SOUL", workspace: process.cwd(), taskId: "task_test" });
 
   test("skips acceptResult when runControl yields", async () => {
     const deps = createLifecycleDeps();

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -1,15 +1,20 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { ChatResponse } from "./api";
-import { runLifecycle, scheduleMemoryCommit, shouldCommitMemory } from "./lifecycle";
+import { runLifecycle, scheduleMemoryCommit } from "./lifecycle";
 import { createRunControl } from "./lifecycle-contract";
-import { createLifecycleDeps, createLifecycleInput } from "./test-utils";
+import { createLifecycleDeps } from "./test-utils";
 
 describe("runLifecycle", () => {
   test("orchestrates phases", async () => {
     const deps = createLifecycleDeps();
 
     const response = await runLifecycle(
-      createLifecycleInput({ soulPrompt: "SOUL", workspace: process.cwd(), taskId: "task_test" }),
+      {
+        request: { model: "gpt-5-mini", message: "test", history: [] },
+        soulPrompt: "SOUL",
+        workspace: process.cwd(),
+        taskId: "task_test",
+      },
       deps,
     );
 
@@ -19,17 +24,62 @@ describe("runLifecycle", () => {
     expect(deps.phaseFinalize).toHaveBeenCalledTimes(1);
     expect(response).toEqual({ state: "done", model: "gpt-5-mini", output: "Generated output" });
   });
-});
 
-describe("shouldCommitMemory", () => {
-  test("returns false when request disables memory", () => {
-    expect(shouldCommitMemory(createLifecycleInput())).toBe(false);
+  test("accounts memory tokens when distilling", async () => {
+    const deps = createLifecycleDeps({
+      phaseFinalize: mock(
+        (ctx: { promptBreakdownTotals: { memoryTokens: number } }): ChatResponse => ({
+          state: "done",
+          model: "gpt-5-mini",
+          output: String(ctx.promptBreakdownTotals.memoryTokens),
+        }),
+      ),
+    });
+
+    const response = await runLifecycle(
+      {
+        request: { model: "gpt-5-mini", message: "test", history: [] },
+        soulPrompt: "SOUL",
+        workspace: process.cwd(),
+      },
+      deps,
+    );
+
+    expect(Number(response.output)).toBeGreaterThan(0);
   });
 
-  test("returns true when request does not disable memory", () => {
-    expect(
-      shouldCommitMemory(createLifecycleInput({ request: { model: "gpt-5-mini", message: "test", history: [] } })),
-    ).toBe(true);
+  test("adds distill tokens on top of existing memory tokens", async () => {
+    const deps = createLifecycleDeps({
+      phaseGenerate: mock(
+        async (ctx: {
+          promptBreakdownTotals: { memoryTokens: number };
+          promptUsage: { memoryTokens: number };
+          result?: unknown;
+        }) => {
+          ctx.promptBreakdownTotals.memoryTokens = 5;
+          ctx.promptUsage.memoryTokens = 5;
+          ctx.result = { text: "Generated output", toolCalls: [], signal: "done" };
+        },
+      ),
+      phaseFinalize: mock(
+        (ctx: { promptBreakdownTotals: { memoryTokens: number } }): ChatResponse => ({
+          state: "done",
+          model: "gpt-5-mini",
+          output: String(ctx.promptBreakdownTotals.memoryTokens),
+        }),
+      ),
+    });
+
+    const response = await runLifecycle(
+      {
+        request: { model: "gpt-5-mini", message: "test", history: [] },
+        soulPrompt: "SOUL",
+        workspace: process.cwd(),
+      },
+      deps,
+    );
+
+    expect(Number(response.output)).toBeGreaterThan(5);
   });
 });
 
@@ -155,7 +205,12 @@ describe("scheduleMemoryCommit", () => {
 });
 
 describe("runLifecycle yield", () => {
-  const baseInput = createLifecycleInput({ soulPrompt: "SOUL", workspace: process.cwd(), taskId: "task_test" });
+  const baseInput = {
+    request: { model: "gpt-5-mini" as const, message: "test", history: [] as never[] },
+    soulPrompt: "SOUL",
+    workspace: process.cwd(),
+    taskId: "task_test",
+  };
 
   test("skips acceptResult when runControl yields", async () => {
     const deps = createLifecycleDeps();

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -23,10 +23,10 @@ describe("runLifecycle", () => {
   test("accounts memory tokens when distilling", async () => {
     const deps = createLifecycleDeps({
       phaseFinalize: mock(
-        (ctx: { promptBreakdownTotals: { memoryTokens: number } }): ChatResponse => ({
+        (ctx: { promptUsage: { memoryTokens: number } }): ChatResponse => ({
           state: "done",
           model: "gpt-5-mini",
-          output: String(ctx.promptBreakdownTotals.memoryTokens),
+          output: String(ctx.promptUsage.memoryTokens),
         }),
       ),
     });
@@ -45,22 +45,15 @@ describe("runLifecycle", () => {
 
   test("adds distill tokens on top of existing memory tokens", async () => {
     const deps = createLifecycleDeps({
-      phaseGenerate: mock(
-        async (ctx: {
-          promptBreakdownTotals: { memoryTokens: number };
-          promptUsage: { memoryTokens: number };
-          result?: unknown;
-        }) => {
-          ctx.promptBreakdownTotals.memoryTokens = 5;
-          ctx.promptUsage.memoryTokens = 5;
-          ctx.result = { text: "Generated output", toolCalls: [], signal: "done" };
-        },
-      ),
+      phaseGenerate: mock(async (ctx: { promptUsage: { memoryTokens: number }; result?: unknown }) => {
+        ctx.promptUsage.memoryTokens = 5;
+        ctx.result = { text: "Generated output", toolCalls: [], signal: "done" };
+      }),
       phaseFinalize: mock(
-        (ctx: { promptBreakdownTotals: { memoryTokens: number } }): ChatResponse => ({
+        (ctx: { promptUsage: { memoryTokens: number } }): ChatResponse => ({
           state: "done",
           model: "gpt-5-mini",
-          output: String(ctx.promptBreakdownTotals.memoryTokens),
+          output: String(ctx.promptUsage.memoryTokens),
         }),
       ),
     });

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -121,13 +121,6 @@ function createRunContext(
     modelCallCount: 0,
     inputTokensAccum: 0,
     outputTokensAccum: 0,
-    promptBreakdownTotals: {
-      systemTokens: params.prepared.promptUsage.systemPromptTokens,
-      toolTokens: params.prepared.promptUsage.toolTokens,
-      skillTokens: params.prepared.promptUsage.skillTokens,
-      memoryTokens: params.prepared.promptUsage.memoryTokens,
-      messageTokens: params.prepared.promptUsage.messageTokens,
-    },
     streamingChars: 0,
     lastUsageEmitChars: 0,
     errorStats: createErrorStats(),
@@ -171,7 +164,6 @@ function commitMemory(ctx: RunContext, input: LifecycleInput): void {
   ];
   const distillTokens = estimateDistillPromptTokens(messages, output);
   ctx.promptUsage.memoryTokens += distillTokens;
-  ctx.promptBreakdownTotals.memoryTokens += distillTokens;
   scheduleMemoryCommit(
     {
       sessionId: ctx.request.sessionId,

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -46,10 +46,6 @@ const defaultLifecycleDeps: LifecycleDeps = {
   phaseFinalize,
 };
 
-export function shouldCommitMemory(input: LifecycleInput): boolean {
-  return input.request.useMemory !== false;
-}
-
 export function scheduleMemoryCommit(
   commitCtx: MemoryCommitContext,
   debug: RunContext["debug"],
@@ -173,9 +169,9 @@ function commitMemory(ctx: RunContext, input: LifecycleInput): void {
     ...ctx.request.history.map((m) => ({ role: m.role, content: m.content })),
     { role: "user", content: ctx.request.message },
   ];
-  const memoryTokens = estimateDistillPromptTokens(messages, output);
-  ctx.promptUsage.memoryTokens = memoryTokens;
-  ctx.promptBreakdownTotals.memoryTokens = memoryTokens;
+  const distillTokens = estimateDistillPromptTokens(messages, output);
+  ctx.promptUsage.memoryTokens += distillTokens;
+  ctx.promptBreakdownTotals.memoryTokens += distillTokens;
   scheduleMemoryCommit(
     {
       sessionId: ctx.request.sessionId,
@@ -330,9 +326,7 @@ export async function runLifecycle(input: LifecycleInput, deps: LifecycleDeps = 
 
   acceptResult(ctx);
 
-  if (shouldCommitMemory(input)) {
-    commitMemory(ctx, input);
-  }
+  commitMemory(ctx, input);
 
   return deps.phaseFinalize(ctx);
 }

--- a/src/rpc-protocol.ts
+++ b/src/rpc-protocol.ts
@@ -24,7 +24,6 @@ const chatRequestSchema = z
     resourceId: resourceIdSchema.optional(),
     activeSkills: z.array(activeSkillSchema).optional(),
     suggestions: z.array(z.string().max(1_000)).max(10).optional(),
-    useMemory: z.boolean().optional(),
     workspace: z.string().max(4096).optional(),
   })
   .strict();

--- a/src/server-chat-runtime.ts
+++ b/src/server-chat-runtime.ts
@@ -124,7 +124,6 @@ export function isChatRequest(value: unknown): value is ChatRequest {
     (req.resourceId === undefined || typeof req.resourceId === "string") &&
     (req.activeSkills === undefined || isActiveSkillsPayload(req.activeSkills)) &&
     (req.suggestions === undefined || Array.isArray(req.suggestions)) &&
-    (req.useMemory === undefined || typeof req.useMemory === "boolean") &&
     (req.workspace === undefined || typeof req.workspace === "string")
   );
 }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -12,7 +12,7 @@ import type { Client, PendingState, StreamEvent } from "./client-contract";
 import { createErrorStats } from "./error-handling";
 import { DEFAULT_FEATURE_FLAGS } from "./feature-flags-contract";
 import type { LifecycleDeps } from "./lifecycle";
-import { createEmptyPromptBreakdownTotals, type LifecycleInput, type RunContext } from "./lifecycle-contract";
+import type { LifecycleInput, RunContext } from "./lifecycle-contract";
 import { defaultLifecyclePolicy } from "./lifecycle-policy";
 import type { Session, SessionState, SessionTokenUsageEntry } from "./session-contract";
 import type { Toolset } from "./tool-registry";
@@ -526,7 +526,6 @@ export function createRunContext(overrides: Partial<RunContext> = {}): RunContex
     modelCallCount: 1,
     inputTokensAccum: 0,
     outputTokensAccum: 0,
-    promptBreakdownTotals: createEmptyPromptBreakdownTotals(),
     streamingChars: 0,
     lastUsageEmitChars: 0,
     errorStats: createErrorStats(),

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -489,7 +489,7 @@ export function createLifecycleDeps(overrides?: Partial<LifecycleDeps>): Lifecyc
 
 export function createLifecycleInput(overrides: Partial<LifecycleInput> = {}): LifecycleInput {
   return {
-    request: { model: "gpt-5-mini", message: "test", history: [], useMemory: false },
+    request: { model: "gpt-5-mini", message: "test", history: [] },
     soulPrompt: "",
     features: DEFAULT_FEATURE_FLAGS,
     ...overrides,


### PR DESCRIPTION
## Motivation

Request-level memory gating was legacy from prompt injection and caused confusing usage behavior, especially for new sessions and recall paths.

## Summary

- remove `useMemory` from chat request contracts and client/server plumbing
- make memory commit policy-driven in lifecycle instead of request-scoped
- count successful `memory-search` recall payloads into the single memory usage metric
- accumulate distill token estimates with existing memory usage instead of overwriting
- remove `promptBreakdownTotals` duplication — derive prompt breakdown from `promptUsage` at finalize
- extract `promptUsageTotalTokens` helper to replace inline sums
- add tests for distill accounting, recall accounting, and failed recall non-accounting

Fixes #202