### PR TITLE
fix(signal): detect inline signal tokens

### DIFF
--- a/src/agent-contract.ts
+++ b/src/agent-contract.ts
@@ -15,8 +15,6 @@ export type StreamOptions = {
   toolChoice?: "auto" | "none" | "required";
   temperature?: number;
   providerOptions?: SharedV3ProviderOptions;
-  /** Max nudge re-prompts when the model stops prematurely. 0 disables. */
-  maxNudges?: number;
 };
 
 export type StreamOutput = {

--- a/src/agent-instructions.ts
+++ b/src/agent-instructions.ts
@@ -14,7 +14,7 @@ const CORE_INSTRUCTIONS = [
   "After changing behavior, run related validation first. If validation is blocked or unavailable, say what was skipped and why.",
   "Keep responses concise and outcome-first. Format as plain text. Use `backticks` for code identifiers and **bold** for emphasis. No headings, links, or code blocks. Only use lists when absolutely necessary.",
   "Make reasonable assumptions to keep momentum; ask only when ambiguity or risk truly blocks progress.",
-  "End every final response with exactly one signal line: `@signal done`, `@signal no_op`, or `@signal blocked`. If blocked, add one concise next line with what is missing and what you will do once it is provided.",
+  "End every final response with exactly one signal on its own line: `@signal done`, `@signal no_op`, or `@signal blocked`. Place the signal on a separate line — do not inline it with other text. If blocked, add one concise next line with what is missing and what you will do once it is provided.",
 ];
 
 const TOOL_IDS = toolIds();

--- a/src/agent-stream.test.ts
+++ b/src/agent-stream.test.ts
@@ -16,6 +16,10 @@ describe("stripSignalLine", () => {
     expect(stripSignalLine("@signal no_op")).toBe("");
   });
 
+  test("returns text before an inline signal", () => {
+    expect(stripSignalLine("Build skill activated. @signal done")).toBe("Build skill activated.");
+  });
+
   test("returns full text when no signal is present", () => {
     expect(stripSignalLine("No signal here.")).toBe("No signal here.");
   });
@@ -40,6 +44,17 @@ describe("extractLifecycleSignal", () => {
   test("strips a leading signal and returns empty string", () => {
     expect(extractLifecycleSignal("@signal no_op")).toEqual({ signal: "no_op", text: "" });
     expect(extractLifecycleSignal("@signal done\n")).toEqual({ signal: "done", text: "" });
+  });
+
+  test("detects an inline signal preceded by a space", () => {
+    expect(extractLifecycleSignal("Build skill activated. @signal done")).toEqual({
+      signal: "done",
+      text: "Build skill activated.",
+    });
+    expect(extractLifecycleSignal("All good. @signal no_op\n")).toEqual({
+      signal: "no_op",
+      text: "All good.",
+    });
   });
 
   test("leaves plain text unchanged when no signal is present", () => {
@@ -89,6 +104,33 @@ describe("lifecycle text streaming", () => {
     expect(appendLifecycleTextDelta(state, "\n")).toBe("");
     expect(appendLifecycleTextDelta(state, "After.")).toBe("");
     expect(finalizeLifecycleText(state)).toEqual({ signal: "done", text: "" });
+  });
+
+  test("detects and strips an inline signal during streaming", () => {
+    const state = createLifecycleTextStreamState();
+    expect(appendLifecycleTextDelta(state, "Build skill activated. @signal done")).toBe("Build skill activated.");
+    expect(finalizeLifecycleText(state)).toEqual({ signal: "done", text: "" });
+  });
+
+  test("strips inline signal regardless of delta boundary", () => {
+    const signal = " @signal done";
+    for (let split = 1; split < signal.length; split++) {
+      const state = createLifecycleTextStreamState();
+      const left = `Text.${signal.slice(0, split)}`;
+      const right = signal.slice(split);
+      let visible = appendLifecycleTextDelta(state, left);
+      visible += appendLifecycleTextDelta(state, right);
+      const fin = finalizeLifecycleText(state);
+      expect(fin.signal).toBe("done");
+      expect((visible + fin.text).trim()).toBe("Text.");
+    }
+  });
+
+  test("last well-formed signal wins when multiple appear inline", () => {
+    const state = createLifecycleTextStreamState();
+    // Only the final signal satisfies the end-of-line/string anchor
+    expect(appendLifecycleTextDelta(state, "Done. @signal done Also. @signal blocked")).toBe("Done. Also.");
+    expect(finalizeLifecycleText(state)).toEqual({ signal: "blocked", text: "" });
   });
 
   test("treats invalid signal-looking text as normal output", () => {

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -58,8 +58,6 @@ export function createAgentStream(
     let fullText = "";
     const allToolCalls: ToolCallEntry[] = [];
     let loopIteration = 0;
-    let nudgeCount = 0;
-    const maxNudges = options.maxNudges ?? 0;
     let streamController!: ReadableStreamDefaultController<StreamChunk>;
     const fullStream = new ReadableStream<StreamChunk>({
       start(controller) {
@@ -69,6 +67,7 @@ export function createAgentStream(
 
     const resultPromise = (async (): Promise<GenerateResult> => {
       let lifecycleSignal: LifecycleSignal | undefined;
+      let finishReason: LanguageModelV3FinishReason | undefined;
       while (true) {
         loopIteration++;
         if (loopIteration > 1) streamController.enqueue({ type: "step-start" });
@@ -103,7 +102,7 @@ export function createAgentStream(
           toolName: string;
           input: string;
         }> = [];
-        let finishReason: LanguageModelV3FinishReason | undefined;
+        finishReason = undefined;
         const stepTextParts: string[] = [];
         const lifecycleTextState = createLifecycleTextStreamState();
 
@@ -134,41 +133,7 @@ export function createAgentStream(
         const stepText = stepTextParts.join("");
         if (stepText.length > 0) fullText += stepText;
 
-        if (pendingToolCalls.length === 0) {
-          if (nudgeCount < maxNudges && allToolCalls.length > 0 && !lifecycleSignal && stepText.trim().length > 0) {
-            nudgeCount++;
-            log.debug("agent-stream.nudge", {
-              reason: "no_tool_calls",
-              nudge_count: nudgeCount,
-              max_nudges: maxNudges,
-              iteration: loopIteration,
-              finish_reason: finishReason?.unified ?? "undefined",
-              text_length: stepText.length,
-              total_tool_calls: allToolCalls.length,
-            });
-            messages.push({ role: "assistant", content: [{ type: "text", text: stepText }] });
-            messages.push({
-              role: "user",
-              content: [
-                {
-                  type: "text",
-                  text: "[system] You stopped before completing the task. If you are done, use @signal done or @signal no_op. If blocked, use @signal blocked. Otherwise, continue working with the available tools.",
-                },
-              ],
-            });
-            continue;
-          }
-          log.debug("agent-stream.loop.exit", {
-            reason: "no_tool_calls",
-            iteration: loopIteration,
-            finish_reason: finishReason?.unified ?? "undefined",
-            finish_reason_raw: JSON.stringify(finishReason ?? null),
-            text_length: stepText.length,
-            total_tool_calls: allToolCalls.length,
-            signal: lifecycleSignal ?? null,
-          });
-          break;
-        }
+        if (pendingToolCalls.length === 0) break;
 
         const assistantContent: LanguageModelV3ToolCallPart[] = pendingToolCalls.map((tc) => ({
           type: "tool-call" as const,
@@ -178,12 +143,10 @@ export function createAgentStream(
         }));
 
         const toolResultParts: LanguageModelV3ToolResultPart[] = [];
-        let batchHadError = false;
         for (const tc of pendingToolCalls) {
           allToolCalls.push({ toolCallId: tc.toolCallId, toolName: tc.toolName, args: tc.input });
           const tool = toolsByName.get(tc.toolName);
           if (!tool) {
-            batchHadError = true;
             const error = `Unknown tool: ${tc.toolName}`;
             streamController.enqueue({
               type: "tool-error",
@@ -213,7 +176,6 @@ export function createAgentStream(
               output: { type: "text", value: outputValue },
             });
           } catch (error) {
-            batchHadError = true;
             const serializedError = serializeToolError(error);
             const message = serializedError.error.message;
             const code = serializedError.error.code;
@@ -241,44 +203,15 @@ export function createAgentStream(
         messages.push({ role: "assistant", content: assistantContent });
         messages.push({ role: "tool", content: toolResultParts });
 
-        if (finishReason?.unified !== "tool-calls" && finishReason !== undefined) {
-          if (nudgeCount < maxNudges && batchHadError) {
-            nudgeCount++;
-            log.debug("agent-stream.nudge", {
-              reason: "tool_error_early_stop",
-              nudge_count: nudgeCount,
-              max_nudges: maxNudges,
-              iteration: loopIteration,
-              finish_reason: finishReason.unified,
-              total_tool_calls: allToolCalls.length,
-            });
-            messages.push({
-              role: "user",
-              content: [
-                {
-                  type: "text",
-                  text: "[system] One or more tool calls failed. Review the errors above and retry or take a different approach. Do not give up.",
-                },
-              ],
-            });
-            continue;
-          }
-          log.debug("agent-stream.loop.exit", {
-            reason: "finish_reason_not_tool_calls",
-            iteration: loopIteration,
-            finish_reason: finishReason.unified,
-            finish_reason_raw: JSON.stringify(finishReason),
-            pending_tool_calls: pendingToolCalls.length,
-            total_tool_calls: allToolCalls.length,
-          });
-          break;
-        }
+        if (finishReason?.unified !== "tool-calls" && finishReason !== undefined) break;
       }
 
       log.debug("agent-stream.complete", {
         iterations: loopIteration,
         total_tool_calls: allToolCalls.length,
         text_length: fullText.length,
+        finish_reason: finishReason?.unified ?? "unknown",
+        signal: lifecycleSignal ?? null,
       });
       streamController.close();
       return { text: fullText, toolCalls: allToolCalls, ...(lifecycleSignal ? { signal: lifecycleSignal } : {}) };

--- a/src/lifecycle-constants.ts
+++ b/src/lifecycle-constants.ts
@@ -2,7 +2,6 @@ export const TOTAL_MAX_STEPS = 200;
 export const INITIAL_MAX_STEPS = 80;
 export const STEP_TIMEOUT_MS = 120_000;
 export const MAX_UNKNOWN_ERRORS_PER_REQUEST = 2;
-export const MAX_NUDGES_PER_GENERATION = 2;
 export const TOOL_TIMEOUT_MS = 10_000;
 export const CONTEXT_MAX_TOKENS = 100_000;
 export const MAX_HISTORY_MESSAGES = 40;

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -164,7 +164,6 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
       toolChoice: "auto",
       ...(typeof temperature === "number" ? { temperature } : {}),
       ...(providerOptions ? { providerOptions } : {}),
-      maxNudges: ctx.policy.maxNudgesPerGeneration,
     });
     const fullOutput = streamOutput.getFullOutput();
     // If the AI SDK rejects an internal promise outside the reader chain, pipe it into the

--- a/src/lifecycle-policy.ts
+++ b/src/lifecycle-policy.ts
@@ -3,7 +3,6 @@ import {
   INITIAL_MAX_STEPS,
   MAX_HISTORY_MESSAGES,
   MAX_MESSAGE_TOKENS,
-  MAX_NUDGES_PER_GENERATION,
   MAX_SKILL_CONTEXT_TOKENS,
   MAX_UNKNOWN_ERRORS_PER_REQUEST,
   STEP_TIMEOUT_MS,
@@ -16,7 +15,6 @@ export type LifecyclePolicy = {
   // Step limits
   totalMaxSteps: number;
   initialMaxSteps: number;
-  maxNudgesPerGeneration: number;
   maxUnknownErrorsPerRequest: number;
   // Timeouts
   stepTimeoutMs: number;
@@ -37,7 +35,6 @@ export const defaultLifecyclePolicy: LifecyclePolicy = {
   initialMaxSteps: INITIAL_MAX_STEPS,
   stepTimeoutMs: STEP_TIMEOUT_MS,
   maxUnknownErrorsPerRequest: MAX_UNKNOWN_ERRORS_PER_REQUEST,
-  maxNudgesPerGeneration: MAX_NUDGES_PER_GENERATION,
   toolTimeoutMs: TOOL_TIMEOUT_MS,
   contextMaxTokens: CONTEXT_MAX_TOKENS,
   maxHistoryMessages: MAX_HISTORY_MESSAGES,

--- a/src/lifecycle-signal.ts
+++ b/src/lifecycle-signal.ts
@@ -1,19 +1,25 @@
 import type { LifecycleSignal } from "./lifecycle-contract";
 
-const SIGNAL_RE = /(?:^|\n)@signal\s+(done|no_op|blocked)\s*(?:\n|$)/;
+const SIGNAL_RE = /(?:^|\n| )@signal\s+(done|no_op|blocked)\s*(?:\n|$)/;
+const SIGNAL_SANITIZE_RE = /\s*@signal\s+(?:done|no_op|blocked)\b/g;
 const SIGNAL_PREFIXES = ["@signal done", "@signal no_op", "@signal blocked"] as const;
 
 export function stripSignalLine(text: string): string {
   return extractLifecycleSignal(text).text;
 }
 
+function sanitizeSignalTokens(text: string): string {
+  return text.replace(SIGNAL_SANITIZE_RE, "");
+}
+
 export function extractLifecycleSignal(text: string): { signal?: LifecycleSignal; text: string } {
   const match = text.match(SIGNAL_RE);
-  if (!match) return { text };
+  if (!match) return { text: sanitizeSignalTokens(text) };
   const signal = match[1] as LifecycleSignal;
   const before = text.slice(0, match.index ?? 0).trimEnd();
   const after = text.slice((match.index ?? 0) + match[0].length).trimStart();
-  return { signal, text: [before, after].filter(Boolean).join("\n") };
+  const joined = [before, after].filter(Boolean).join("\n");
+  return { signal, text: sanitizeSignalTokens(joined) };
 }
 
 export type LifecycleTextStreamState = {
@@ -27,11 +33,11 @@ export function createLifecycleTextStreamState(): LifecycleTextStreamState {
 
 // Returns the index within `text` from which to start buffering a potential @signal,
 // or -1 if no buffering is needed.
-// Includes the preceding newline so it is not emitted prematurely.
+// Includes the preceding delimiter (newline or space) so it is not emitted prematurely.
 function findSignalBufferPoint(text: string): number {
   for (let i = text.length - 1; i >= 0; i--) {
     if (text[i] !== "@") continue;
-    if (i !== 0 && text[i - 1] !== "\n") continue;
+    if (i !== 0 && text[i - 1] !== "\n" && text[i - 1] !== " ") continue;
     const partial = text.slice(i);
     if (partial.includes("\n")) break; // newline already confirms or denies the signal
     if (SIGNAL_PREFIXES.some((p) => p.startsWith(partial))) {
@@ -55,7 +61,7 @@ export function appendLifecycleTextDelta(state: LifecycleTextStreamState, delta:
     const after = state.pending.slice((match.index ?? 0) + match[0].length).trimStart();
     state.signal = match[1] as LifecycleSignal;
     state.pending = "";
-    return [before, after].filter(Boolean).join("\n");
+    return sanitizeSignalTokens([before, after].filter(Boolean).join("\n"));
   }
 
   // Check whether the end of pending could be the start of an @signal line.
@@ -63,13 +69,13 @@ export function appendLifecycleTextDelta(state: LifecycleTextStreamState, delta:
   if (bufferPoint !== -1) {
     const visible = state.pending.slice(0, bufferPoint);
     state.pending = state.pending.slice(bufferPoint);
-    return visible;
+    return sanitizeSignalTokens(visible);
   }
 
   // No signal or partial signal — emit everything.
   const visible = state.pending;
   state.pending = "";
-  return visible;
+  return sanitizeSignalTokens(visible);
 }
 
 export function finalizeLifecycleText(state: LifecycleTextStreamState): { signal?: LifecycleSignal; text: string } {

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -445,7 +445,6 @@ export function createLifecycleDeps(overrides?: Partial<LifecycleDeps>): Lifecyc
       initialMaxSteps: 3,
       stepTimeoutMs: 1000,
       totalMaxSteps: 12,
-      maxNudgesPerGeneration: 1,
     }),
     phasePrepare: mock(() => ({
       session: createSessionContext(),


### PR DESCRIPTION
## Motivation

When the model writes `@signal done` inline (e.g. `"Build skill activated. @signal done"`), the signal regex fails to match because it requires a newline or start-of-string before `@signal`. This causes the nudge system to re-prompt, the model repeats itself, and `@signal done` leaks into the TUI output.

## Summary

- widen `SIGNAL_RE` to also match `@signal` preceded by a space
- widen `findSignalBufferPoint` to buffer inline signals during streaming
- add `sanitizeSignalTokens` as defense-in-depth to strip stray signal tokens from all output paths
- update agent instruction to explicitly say "on its own line" and "do not inline"
- remove the nudge system entirely — trust the model's signal intent
- clean up `batchHadError`, `maxNudges` contract, policy constant, and related plumbing
- unify loop exit points into a single `agent-stream.complete` log with `finish_reason` and `signal`
- add tests for inline signal detection, delta-boundary splitting, and multi-signal behavior

Fixes #206