### PR TITLE
fix(skills): persist tool-activated skills across turns

### DIFF
--- a/docs/skills/architecture.md
+++ b/docs/skills/architecture.md
@@ -1,6 +1,6 @@
 ---
 name: architecture
-description: Review architecture, boundaries, and design consistency. Use when reviewing module boundaries, extension seams, or contract drift.
+description: Review architecture, boundaries, and design consistency.
 ---
 
 # Architecture

--- a/docs/skills/build.md
+++ b/docs/skills/build.md
@@ -1,6 +1,6 @@
 ---
 name: build
-description: Implement features incrementally through vertical slices. Use when building features, adding functionality, or implementing tasks that touch multiple files.
+description: Implement features incrementally through vertical slices.
 ---
 
 # Build

--- a/docs/skills/debug.md
+++ b/docs/skills/debug.md
@@ -1,6 +1,6 @@
 ---
 name: debug
-description: Debug systematically with structured triage. Use when tests fail, builds break, or runtime behavior doesn't match expectations.
+description: Debug systematically with structured triage.
 ---
 
 # Debug

--- a/docs/skills/deprecation.md
+++ b/docs/skills/deprecation.md
@@ -1,6 +1,6 @@
 ---
 name: deprecation
-description: Deprecate and remove code safely. Use when replacing systems, removing unused features, or consolidating duplicate implementations.
+description: Deprecate and remove code safely.
 ---
 
 # Deprecation

--- a/docs/skills/design.md
+++ b/docs/skills/design.md
@@ -1,6 +1,6 @@
 ---
 name: design
-description: Design stable interfaces that are hard to misuse. Use when defining contracts, module boundaries, or public APIs.
+description: Design stable interfaces that are hard to misuse.
 ---
 
 # Design

--- a/docs/skills/docs.md
+++ b/docs/skills/docs.md
@@ -1,6 +1,6 @@
 ---
 name: docs
-description: Review docs for drift, missing updates, and terminology changes. Use when code changes should be reflected in documentation.
+description: Review docs for drift, missing updates, and terminology changes.
 ---
 
 # Documentation

--- a/docs/skills/explore.md
+++ b/docs/skills/explore.md
@@ -1,6 +1,6 @@
 ---
 name: explore
-description: Explore a task or design through systematic questions until reaching shared understanding. Use before implementing complex or ambiguous work.
+description: Explore a task or design through systematic questions until reaching shared understanding.
 ---
 
 # Explore

--- a/docs/skills/git.md
+++ b/docs/skills/git.md
@@ -1,6 +1,6 @@
 ---
 name: git
-description: Manage commits, branches, and change history. Use when committing, branching, or managing version control.
+description: Manage commits, branches, and change history.
 ---
 
 # Git

--- a/docs/skills/plan.md
+++ b/docs/skills/plan.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: Design a feature or behavior change through dialogue. Use when asked to plan, scope, design, or break down work before coding.
+description: Design a feature or behavior change through dialogue.
 ---
 
 # Plan

--- a/docs/skills/review.md
+++ b/docs/skills/review.md
@@ -1,6 +1,6 @@
 ---
 name: review
-description: Run all review skills against the current branch diff. Use when reviewing a feature branch before merge.
+description: Run all review skills against the current branch diff.
 ---
 
 # Review

--- a/docs/skills/security.md
+++ b/docs/skills/security.md
@@ -1,6 +1,6 @@
 ---
 name: security
-description: Review security risks, trust boundaries, and unsafe defaults. Use when reviewing security posture or assessing risk before release.
+description: Review security risks, trust boundaries, and unsafe defaults.
 ---
 
 # Security

--- a/docs/skills/simplify.md
+++ b/docs/skills/simplify.md
@@ -1,6 +1,6 @@
 ---
 name: simplify
-description: Simplify code by reducing complexity while preserving exact behavior. Use after a feature is working, during review when complexity is flagged, or when encountering unclear code.
+description: Simplify code by reducing complexity while preserving exact behavior.
 ---
 
 # Simplify

--- a/docs/skills/style.md
+++ b/docs/skills/style.md
@@ -1,6 +1,6 @@
 ---
 name: style
-description: Review code style, naming, patterns, and consistency. Use when reviewing code quality or style drift.
+description: Review code style, naming, patterns, and consistency.
 ---
 
 # Style

--- a/docs/skills/tdd.md
+++ b/docs/skills/tdd.md
@@ -1,6 +1,6 @@
 ---
 name: tdd
-description: Drive implementation with red-green-refactor. Use when building features or fixing bugs test-first.
+description: Drive implementation with red-green-refactor.
 ---
 
 # TDD

--- a/docs/skills/tests.md
+++ b/docs/skills/tests.md
@@ -1,6 +1,6 @@
 ---
 name: tests
-description: Review test coverage, quality, and missing edge cases. Use when reviewing whether changed code has adequate tests.
+description: Review test coverage, quality, and missing edge cases.
 ---
 
 # Tests

--- a/src/api.ts
+++ b/src/api.ts
@@ -36,6 +36,7 @@ export interface ChatResponse {
   toolCalls?: string[];
   modelCalls?: number;
   error?: string;
+  activeSkills?: ActiveSkill[];
 }
 
 export type WorkspaceSpecifier = Pick<ChatRequest, "workspace">;

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -164,6 +164,9 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
       const assistantMessage = turn.assistantMessage;
       streamState.finalize();
 
+      if (turn.activeSkills?.length) {
+        input.currentSession.activeSkills = turn.activeSkills;
+      }
       input.currentSession.messages.push(assistantMessage);
       for (const row of turn.rows) {
         if (row.kind === "status" && typeof row.content === "string") {

--- a/src/chat-turn.test.ts
+++ b/src/chat-turn.test.ts
@@ -149,6 +149,35 @@ describe("chat turn helpers", () => {
     expect(turn.assistantMessage.content).toBe("done");
   });
 
+  test("runAssistantTurn propagates activeSkills from response", async () => {
+    const skills = [{ name: "build", instructions: "Build instructions" }];
+    const turn = await runAssistantTurn({
+      client: {
+        replyStream: async () => ({
+          state: "done" as const,
+          model: "gpt-5-mini",
+          output: "done",
+          activeSkills: skills,
+        }),
+        status: async () => ({}),
+        taskStatus: async () => null,
+      },
+      userText: "load the build skill",
+      history: [],
+      model: "gpt-5-mini",
+      sessionId: "sess_test",
+      pendingStartedAt: Date.now(),
+      createMessage: (role, content) => ({
+        id: "msg_assistant",
+        role,
+        content,
+        timestamp: "2026-02-20T00:00:00.000Z",
+      }),
+    });
+
+    expect(turn.activeSkills).toEqual(skills);
+  });
+
   test("runAssistantTurn marks assistant message as tool_payload when tools were used", async () => {
     const turn = await runAssistantTurn({
       client: {

--- a/src/chat-turn.ts
+++ b/src/chat-turn.ts
@@ -115,6 +115,7 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
   assistantMessage: ChatMessage;
   tokenEntry: SessionTokenUsageEntry;
   rows: ChatRow[];
+  activeSkills?: ActiveSkill[];
 }> {
   const reply = await params.client.replyStream({
     request: {
@@ -164,5 +165,6 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
     assistantMessage,
     tokenEntry,
     rows,
+    activeSkills: reply.activeSkills,
   };
 }

--- a/src/client-contract.ts
+++ b/src/client-contract.ts
@@ -4,6 +4,7 @@ import { invariant } from "./assert";
 import { checklistItemSchema } from "./checklist-contract";
 import { rpcServerMessageSchema } from "./rpc-protocol";
 import { promptBreakdownSchema, tokenUsageSchema } from "./session-contract";
+import { activeSkillsSchema } from "./skill-contract";
 import type { StatusFields } from "./status-contract";
 import { streamErrorSchema } from "./stream-error";
 import type { TaskId, TaskRecord } from "./task-contract";
@@ -157,6 +158,7 @@ const chatResponseSchema = z.object({
   toolCalls: z.array(z.string()).optional(),
   modelCalls: z.number().optional(),
   error: z.string().optional(),
+  activeSkills: activeSkillsSchema.optional(),
 });
 
 export function parseChatResponse(payload: unknown): ChatResponse | null {

--- a/src/lifecycle-finalize.test.ts
+++ b/src/lifecycle-finalize.test.ts
@@ -110,4 +110,42 @@ describe("phaseFinalize", () => {
     const response = phaseFinalize(ctx);
     expect(response.state).toBe("done");
   });
+
+  test("includes activeSkills when session has them", () => {
+    const skills = [{ name: "build", instructions: "Build instructions" }];
+    const ctx = createRunContext({
+      result: { text: "Done.", toolCalls: [] },
+    });
+    ctx.session.activeSkills = skills;
+    const response = phaseFinalize(ctx);
+    expect(response.activeSkills).toEqual(skills);
+  });
+
+  test("omits activeSkills when session has none", () => {
+    const ctx = createRunContext({
+      result: { text: "Done.", toolCalls: [] },
+    });
+    const response = phaseFinalize(ctx);
+    expect(response.activeSkills).toBeUndefined();
+  });
+});
+
+describe("parseChatResponse activeSkills", () => {
+  test("preserves activeSkills from response", () => {
+    const skills = [{ name: "build", instructions: "Build instructions" }];
+    const response = parseChatResponse({
+      output: "Hello",
+      model: "gpt-5-mini",
+      activeSkills: skills,
+    });
+    expect(response?.activeSkills).toEqual(skills);
+  });
+
+  test("omits activeSkills when not present", () => {
+    const response = parseChatResponse({
+      output: "Hello",
+      model: "gpt-5-mini",
+    });
+    expect(response?.activeSkills).toBeUndefined();
+  });
 });

--- a/src/lifecycle-finalize.ts
+++ b/src/lifecycle-finalize.ts
@@ -63,6 +63,7 @@ export function phaseFinalize(ctx: RunContext): ChatResponse {
     ...(ctx.currentError ? { error: ctx.currentError.message } : {}),
     toolCalls: callLog.map((entry) => entry.toolName),
     modelCalls: ctx.modelCallCount,
+    ...(ctx.session.activeSkills?.length ? { activeSkills: ctx.session.activeSkills } : {}),
     usage: {
       inputTokens,
       outputTokens,

--- a/src/skill-toolkit.ts
+++ b/src/skill-toolkit.ts
@@ -3,6 +3,7 @@ import { addActiveSkill } from "./chat-skill-activator";
 import { compactText } from "./compact-text";
 import { type SkillSource, skillSourceSchema } from "./skill-contract";
 import { findSkillByName, getLoadedSkills, readSkillInstructions, SKILL_BUDGET } from "./skill-ops";
+import { getSkillUseWhen } from "./skill-triggers";
 import type { ToolkitInput } from "./tool-contract";
 import { createTool } from "./tool-contract";
 import { runTool } from "./tool-execution";
@@ -29,11 +30,14 @@ function createListSkillsTool(input: ToolkitInput) {
     }),
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "skill-list", toolCallId, toolInput, async () => {
-        const skills = getLoadedSkills().map((s) => ({
-          name: s.name,
-          description: s.description,
-          source: s.source,
-        }));
+        const skills = getLoadedSkills().map((s) => {
+          const useWhen = getSkillUseWhen(s.name);
+          return {
+            name: s.name,
+            description: useWhen ? `${s.description} ${useWhen}` : s.description,
+            source: s.source,
+          };
+        });
         return { kind: "skill-list" as const, skills };
       });
     },

--- a/src/skill-triggers.test.ts
+++ b/src/skill-triggers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { createSkillSuggestion, matchSkillTriggers } from "./skill-triggers";
+import { createSkillSuggestion, getSkillUseWhen, matchSkillTriggers } from "./skill-triggers";
 
 describe("matchSkillTriggers", () => {
   test("matches build skill from keyword", () => {
@@ -42,6 +42,16 @@ describe("matchSkillTriggers", () => {
   test("does not match common words used in non-skill context", () => {
     expect(matchSkillTriggers("add error handling to the endpoint")).not.toContain("debug");
     expect(matchSkillTriggers("remove this line from the file")).not.toContain("deprecation");
+  });
+});
+
+describe("getSkillUseWhen", () => {
+  test("returns use-when text for bundled skill", () => {
+    expect(getSkillUseWhen("build")).toMatch(/^Use when /);
+  });
+
+  test("returns undefined for unknown skill", () => {
+    expect(getSkillUseWhen("nonexistent")).toBeUndefined();
   });
 });
 

--- a/src/skill-triggers.ts
+++ b/src/skill-triggers.ts
@@ -1,29 +1,84 @@
 import type { ActiveSkill } from "./skill-contract";
 
-const SKILL_TRIGGERS: Record<string, string[]> = {
-  build: ["implement", "add feature", "create feature", "new feature", "add functionality"],
-  debug: ["debug", "fix bug", "broken", "failing test", "not working", "investigate"],
-  tdd: ["test first", "red green", "tdd", "test driven"],
-  git: ["commit", "rebase", "cherry pick", "squash", "git log", "git diff"],
-  review: ["review", "pull request", "pr review", "code review"],
-  plan: ["plan this", "scope", "break down", "decompose"],
-  explore: ["explore", "how does", "what does", "walk me through"],
-  simplify: ["simplify", "reduce complexity", "clean up"],
-  security: ["security review", "vulnerability", "injection", "xss", "csrf"],
-  tests: ["test coverage", "missing tests", "add tests", "test quality"],
-  style: ["code style", "style review", "naming conventions"],
-  docs: ["documentation", "update docs"],
-  architecture: ["architecture", "module boundary"],
-  deprecation: ["deprecate", "migrate away", "phase out"],
-  design: ["api design", "design interface", "public api"],
+type SkillTriggerMeta = {
+  keywords: string[];
+  useWhen: string;
+};
+
+const SKILL_TRIGGER_META: Record<string, SkillTriggerMeta> = {
+  architecture: {
+    keywords: ["architecture", "module boundary"],
+    useWhen: "Use when reviewing module boundaries, extension seams, or contract drift.",
+  },
+  build: {
+    keywords: ["implement", "add feature", "create feature", "new feature", "add functionality"],
+    useWhen: "Use when building features, adding functionality, or implementing tasks that touch multiple files.",
+  },
+  debug: {
+    keywords: ["debug", "fix bug", "broken", "failing test", "not working", "investigate"],
+    useWhen: "Use when tests fail, builds break, or runtime behavior doesn't match expectations.",
+  },
+  deprecation: {
+    keywords: ["deprecate", "migrate away", "phase out"],
+    useWhen: "Use when replacing systems, removing unused features, or consolidating duplicate implementations.",
+  },
+  design: {
+    keywords: ["api design", "design interface", "public api"],
+    useWhen: "Use when defining contracts, module boundaries, or public APIs.",
+  },
+  docs: {
+    keywords: ["documentation", "update docs"],
+    useWhen: "Use when code changes should be reflected in documentation.",
+  },
+  explore: {
+    keywords: ["explore", "how does", "what does", "walk me through"],
+    useWhen: "Use before implementing complex or ambiguous work.",
+  },
+  git: {
+    keywords: ["commit", "rebase", "cherry pick", "squash", "git log", "git diff"],
+    useWhen: "Use when committing, branching, or managing version control.",
+  },
+  plan: {
+    keywords: ["plan this", "scope", "break down", "decompose"],
+    useWhen: "Use when asked to plan, scope, design, or break down work before coding.",
+  },
+  review: {
+    keywords: ["review", "pull request", "pr review", "code review"],
+    useWhen: "Use when reviewing a feature branch before merge.",
+  },
+  security: {
+    keywords: ["security review", "vulnerability", "injection", "xss", "csrf"],
+    useWhen: "Use when reviewing security posture or assessing risk before release.",
+  },
+  simplify: {
+    keywords: ["simplify", "reduce complexity", "clean up"],
+    useWhen:
+      "Use after a feature is working, during review when complexity is flagged, or when encountering unclear code.",
+  },
+  style: {
+    keywords: ["code style", "style review", "naming conventions"],
+    useWhen: "Use when reviewing code quality or style drift.",
+  },
+  tdd: {
+    keywords: ["test first", "red green", "tdd", "test driven"],
+    useWhen: "Use when building features or fixing bugs test-first.",
+  },
+  tests: {
+    keywords: ["test coverage", "missing tests", "add tests", "test quality"],
+    useWhen: "Use when reviewing whether changed code has adequate tests.",
+  },
 };
 
 function buildTriggerPatterns(): { name: string; pattern: RegExp }[] {
-  return Object.entries(SKILL_TRIGGERS).map(([name, keywords]) => {
-    const escaped = keywords.map((kw) => kw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  return Object.entries(SKILL_TRIGGER_META).map(([name, meta]) => {
+    const escaped = meta.keywords.map((kw) => kw.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
     const pattern = new RegExp(`\\b(?:${escaped.join("|")})\\b`, "i");
     return { name, pattern };
   });
+}
+
+export function getSkillUseWhen(name: string): string | undefined {
+  return SKILL_TRIGGER_META[name]?.useWhen;
 }
 
 const triggerPatterns = buildTriggerPatterns();


### PR DESCRIPTION
## Motivation

When the model calls `skill-activate` as a tool, the skill is added to the server's session but never returned to the client. On the next turn, `activeSkills` is empty and the skill's instructions are lost. Additionally, the "Use when..." text in bundled skill descriptions was duplicated — once in the frontmatter and again via keyword triggers.

## Summary

- add `activeSkills` to `ChatResponse` interface and Zod schema
- return `ctx.session.activeSkills` from `phaseFinalize` in the response
- propagate `activeSkills` through `runAssistantTurn` to the client session
- combine `SKILL_TRIGGERS` and use-when text into a single `SKILL_TRIGGER_META` map
- append use-when context programmatically in `skill-list` tool output
- remove "Use when..." sentences from all 15 bundled skill description frontmatter

Fixes #205