### PR TITLE
refactor(skills): remove skill budget

### DIFF
--- a/src/chat-skill-activator.ts
+++ b/src/chat-skill-activator.ts
@@ -1,18 +1,13 @@
 import { type ChatRow, createRow } from "./chat-contract";
-import { type CompactBudget, compactText } from "./compact-text";
 import type { Session } from "./session-contract";
 import type { ActiveSkill } from "./skill-contract";
-import { findSkillByName, readSkillInstructions, SKILL_BUDGET } from "./skill-ops";
+import { findSkillByName, readSkillInstructions } from "./skill-ops";
 import { toolLabelKey } from "./tool-output-format";
 
 export function addActiveSkill(target: { activeSkills?: ActiveSkill[] }, skill: ActiveSkill): void {
   const skills = target.activeSkills ?? [];
   target.activeSkills = [...skills.filter((s) => s.name !== skill.name), skill];
 }
-
-type CreateSkillActivatorDeps = {
-  skillBudget?: CompactBudget;
-};
 
 type CreateSkillActivatorInput = {
   currentSession: Session;
@@ -28,17 +23,14 @@ export function skillActivationRow(skillName: string): ChatRow {
 }
 
 export function createSkillActivator(
-  deps: CreateSkillActivatorDeps,
   input: CreateSkillActivatorInput,
 ): (skillName: string, args: string) => Promise<boolean> {
-  const skillBudget = deps.skillBudget ?? SKILL_BUDGET;
   return async (skillName, args) => {
     const skill = findSkillByName(skillName);
     if (!skill) return false;
     try {
       const instructions = await readSkillInstructions(skill.path, args || undefined);
-      const compactedInstructions = compactText(instructions, skillBudget);
-      addActiveSkill(input.currentSession, { name: skill.name, instructions: compactedInstructions });
+      addActiveSkill(input.currentSession, { name: skill.name, instructions });
       input.currentSession.updatedAt = input.nowIso();
       input.setRows((current) => [...current, skillActivationRow(skill.name)]);
       await input.persist();

--- a/src/chat-state.ts
+++ b/src/chat-state.ts
@@ -149,15 +149,12 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
     }
   }, []);
 
-  const activateSkill = createSkillActivator(
-    {},
-    {
-      currentSession,
-      setRows,
-      nowIso,
-      persist,
-    },
-  );
+  const activateSkill = createSkillActivator({
+    currentSession,
+    setRows,
+    nowIso,
+    persist,
+  });
 
   const { openSkillsPanel, openResumePanel, openModelPanel, handlePickerSelect } = createPickerHandlers({
     sessionState,

--- a/src/cli-command-registry.ts
+++ b/src/cli-command-registry.ts
@@ -22,7 +22,6 @@ import { toolMode } from "./cli-tool";
 import { traceMode } from "./cli-trace";
 import { updateMode } from "./cli-update";
 import { createClient } from "./client-factory";
-import { compactText } from "./compact-text";
 import { readConfig, readConfigForScope, readResolvedConfigSync, setConfigValue, unsetConfigValue } from "./config";
 import { removeCredential, writeCredential } from "./credentials";
 import { serverLogPath } from "./daemon-ops";
@@ -39,7 +38,7 @@ import {
 } from "./server-daemon";
 import { createSession, getSessionStore } from "./session-store";
 import { createId } from "./short-id";
-import { findSkillByName, loadSkills, readSkillInstructions, SKILL_BUDGET } from "./skill-ops";
+import { findSkillByName, loadSkills, readSkillInstructions } from "./skill-ops";
 import { formatStatus } from "./status-format";
 import { openTraceStore } from "./trace-store";
 import { formatCliTitle, printDim, printError, printOutput } from "./ui";
@@ -315,7 +314,6 @@ const COMMAND_REGISTRY: Record<string, CliCommand> = {
         apiUrlForPort,
         appModel: appConfig.model,
         attachFileToSession,
-        compactText,
         createClient,
         createSession,
         ensureLocalServer,
@@ -330,7 +328,6 @@ const COMMAND_REGISTRY: Record<string, CliCommand> = {
         serverApiKey: appConfig.server.apiKey,
         serverEntry: `${import.meta.dir}/server.ts`,
         serverPort: appConfig.server.port,
-        skillBudget: SKILL_BUDGET,
         commandError,
         commandHelp,
       }),

--- a/src/cli-skill.model.test.ts
+++ b/src/cli-skill.model.test.ts
@@ -9,7 +9,6 @@ function createSkillDeps(): { deps: SkillDeps; calls: { errors: string[]; dims: 
     apiUrlForPort: (port) => `http://127.0.0.1:${port}`,
     appModel: "openai/gpt-5-mini",
     attachFileToSession: async () => undefined as never,
-    compactText: (t) => t,
     createClient: () => ({}) as never,
     createSession: (model?: string) =>
       ({ id: "sess_123", title: "skill", createdAt: "", updatedAt: "", messages: [], tokenUsage: [], model }) as never,
@@ -25,7 +24,6 @@ function createSkillDeps(): { deps: SkillDeps; calls: { errors: string[]; dims: 
     serverApiKey: "",
     serverEntry: "",
     serverPort: 6767,
-    skillBudget: {},
     commandError: () => undefined,
     commandHelp: () => undefined,
   };

--- a/src/cli-skill.ts
+++ b/src/cli-skill.ts
@@ -4,7 +4,6 @@ import type { attachFileToSession as attachFileToSessionType } from "./cli-chat"
 import { formatRunSummary } from "./cli-format";
 import type { handlePrompt as handlePromptType } from "./cli-prompt";
 import type { createClient as createClientType } from "./client-factory";
-import type { CompactBudget } from "./compact-text";
 import type { readResolvedConfigSync as readResolvedConfigSyncType } from "./config";
 import { t } from "./i18n";
 import { userResourceIdFor } from "./resource-id";
@@ -18,7 +17,6 @@ type SkillModeDeps = {
   apiUrlForPort: typeof apiUrlForPortType;
   appModel: typeof appConfigType.model;
   attachFileToSession: typeof attachFileToSessionType;
-  compactText: (text: string, budget: CompactBudget) => string;
   createClient: typeof createClientType;
   createSession: typeof createSessionType;
   ensureLocalServer: typeof ensureLocalServerType;
@@ -33,7 +31,6 @@ type SkillModeDeps = {
   serverApiKey: typeof appConfigType.server.apiKey;
   serverEntry: string;
   serverPort: typeof appConfigType.server.port;
-  skillBudget: CompactBudget;
   commandError: (name: string, message?: string) => void;
   commandHelp: (name: string) => void;
 };
@@ -71,7 +68,6 @@ export async function skillMode(args: string[], deps: SkillModeDeps): Promise<vo
     apiUrlForPort,
     appModel,
     attachFileToSession,
-    compactText,
     createClient,
     createSession,
     ensureLocalServer,
@@ -86,7 +82,6 @@ export async function skillMode(args: string[], deps: SkillModeDeps): Promise<vo
     serverApiKey,
     serverEntry,
     serverPort,
-    skillBudget,
     commandError,
     commandHelp,
   } = deps;
@@ -120,11 +115,10 @@ export async function skillMode(args: string[], deps: SkillModeDeps): Promise<vo
   }
 
   const instructions = await readSkillInstructions(skill.path, parsed.prompt);
-  const compacted = compactText(instructions, skillBudget);
 
   const resolvedConfig = readResolvedConfigSync();
   const session = createSession(parsed.model ?? appModel);
-  session.activeSkills = [{ name: skill.name, instructions: compacted }];
+  session.activeSkills = [{ name: skill.name, instructions }];
 
   const daemon = await ensureLocalServer({ port: serverPort, apiKey: serverApiKey, serverEntry });
   const apiUrl = apiUrlForPort(serverPort);

--- a/src/skill-ops.ts
+++ b/src/skill-ops.ts
@@ -2,15 +2,12 @@ import { type Dirent, existsSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { BUNDLED_SKILLS } from "./bundled-skills";
-import type { CompactBudget } from "./compact-text";
 import {
   createEmptySkillLoadDiagnostics,
   type SkillLoadDiagnostics,
   type SkillMeta,
   validateSkillName,
 } from "./skill-contract";
-
-export const SKILL_BUDGET: CompactBudget = { maxChars: 4_000, maxLines: 120 };
 
 type ParsedFrontmatter = {
   name?: string;

--- a/src/skill-toolkit.ts
+++ b/src/skill-toolkit.ts
@@ -1,8 +1,7 @@
 import { z } from "zod";
 import { addActiveSkill } from "./chat-skill-activator";
-import { compactText } from "./compact-text";
 import { type SkillSource, skillSourceSchema } from "./skill-contract";
-import { findSkillByName, getLoadedSkills, readSkillInstructions, SKILL_BUDGET } from "./skill-ops";
+import { findSkillByName, getLoadedSkills, readSkillInstructions } from "./skill-ops";
 import { getSkillUseWhen } from "./skill-triggers";
 import type { ToolkitInput } from "./tool-contract";
 import { createTool } from "./tool-contract";
@@ -78,8 +77,7 @@ function createActivateSkillTool(input: ToolkitInput) {
             content: { kind: "tool-header", labelKey: toolLabelKey("skill-activate"), detail: skill.name },
             toolCallId: callId,
           });
-          const raw = await readSkillInstructions(skill.path, toolInput.args);
-          const instructions = compactText(raw, SKILL_BUDGET);
+          const instructions = await readSkillInstructions(skill.path, toolInput.args);
           addActiveSkill(input.session, { name: skill.name, instructions });
           activated.push({ name: skill.name, source: skill.source, instructions });
         }


### PR DESCRIPTION
## Motivation

Skill instructions were truncated twice — once via `compactText` at the activation call site, and again by the tool `outputBudget` in `createTool`. The skill-level truncation used middle-cut which destroys content coherence. The tool output budget is the correct single enforcement point, matching the pattern used by every other tool.

## Summary

- remove `compactText` calls from all 3 skill activation paths (tool, TUI, CLI)
- remove `SKILL_BUDGET` constant and `CompactBudget` imports from skill modules
- simplify `createSkillActivator` by removing the `deps` parameter
- update test mocks to match the new interface

Relates to #212