### PR TITLE
refactor(tools): thread generic types through runTool

### DIFF
--- a/src/code-ops.int.test.ts
+++ b/src/code-ops.int.test.ts
@@ -36,7 +36,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.debug($ARG)" }] },
       "call_2",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('logger.debug("hello")');
     expect(content).not.toContain("console.log");
@@ -76,7 +76,7 @@ describe("editCode", () => {
       },
       "call_3",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("const result = 1;");
     expect(content).toContain("return result;");
@@ -118,7 +118,7 @@ describe("editCode", () => {
       },
       "call_4",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("for (const patternResult of items)");
     expect(content).toContain("output.push(patternResult.toUpperCase());");
@@ -159,7 +159,7 @@ describe("editCode", () => {
       },
       "call_5",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("for (const patternResult of items)");
     expect(content).toContain("output.push(patternResult.toUpperCase());");
@@ -186,7 +186,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "rename", from: "item", to: "entry", withinSymbol: "Processor" }] },
       "call_6",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("(entry) => entry.toUpperCase()");
   });
@@ -211,7 +211,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "rename", from: "result", to: "patternResult", withinSymbol: "scanFile" }] },
       "call_7",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(5);
+    expect(result.result.matches).toBe(5);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("const patternResult = items[0] ?? '';");
     expect(content).toContain("const { result: alias, other = patternResult } = source;");
@@ -254,7 +254,7 @@ describe("editCode", () => {
       },
       "call_8",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('defaultAlias = "acolyte-mini";');
     expect(content).toContain("return this.defaultAlias + config.alias;");
@@ -284,7 +284,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "rename", from: "label", to: "displayLabel", withinSymbol: "ProviderConfig" }] },
       "call_9",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("displayLabel() {");
     expect(content).toContain("return this.labelText + config.label;");
@@ -317,7 +317,7 @@ describe("editCode", () => {
       },
       "call_10",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(3);
+    expect(result.result.matches).toBe(3);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('defaultAlias = "x";');
     expect(content).toContain("const alias = this.defaultAlias;");
@@ -350,7 +350,7 @@ describe("editCode", () => {
       },
       "call_11",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("const localAlias = this.alias;");
     expect(content).toContain("return { alias: localAlias, member: this.alias, other: config.alias };");
@@ -431,7 +431,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "rename", from: "result", to: "patternResult", withinSymbol: "scanFile" }] },
       "call_14",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("const scanFile = ({ result: patternResult }: { result: string }) => {");
     expect(content).toContain("return patternResult.toUpperCase();");
@@ -457,7 +457,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "rename", from: "result", to: "patternResult", withinSymbol: "scanFile" }] },
       "call_15",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("const patternResult = items[0] ?? '';");
     expect(content).toContain("return [patternResult, String(resultCount)];");
@@ -497,7 +497,7 @@ describe("editCode", () => {
       },
       "call_16",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(1);
+    expect(result.result.matches).toBe(1);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('defaultAlias = "acolyte-mini";');
     expect(content).toContain('const alias = "outside";');
@@ -528,7 +528,7 @@ describe("editCode", () => {
       },
       "call_17",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('logger.debug("first");');
     expect(content).toContain('logger.debug("second");');
@@ -580,7 +580,7 @@ describe("editCode", () => {
       },
       "call_18",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('logger.debug("first");');
     expect(content).toContain('logger.debug("second");');
@@ -629,7 +629,7 @@ describe("editCode", () => {
       },
       "call_19",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('logger.debug("inner");');
     expect(content).toContain('logger.debug("outer");');
@@ -683,9 +683,9 @@ describe("editCode", () => {
       { path: workspace, edits: [{ op: "rename", from: "oldName", to: "newName" }] },
       "call_22",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
-    expect((result.result as Record<string, unknown>).output).toContain("a.ts");
-    expect((result.result as Record<string, unknown>).output).toContain("b.ts");
+    expect(result.result.matches).toBe(2);
+    expect(result.result.output).toContain("a.ts");
+    expect(result.result.output).toContain("b.ts");
     const aContent = await readFile(join(workspace, "a.ts"), "utf8");
     const bContent = await readFile(join(workspace, "b.ts"), "utf8");
     expect(aContent).toContain("newName");
@@ -704,7 +704,7 @@ describe("editCode", () => {
       },
       "call_23",
     );
-    expect((result.result as Record<string, unknown>).matches).toBeGreaterThanOrEqual(3);
+    expect(result.result.matches).toBeGreaterThanOrEqual(3);
     const libContent = await readFile(join(workspace, "lib.ts"), "utf8");
     const mainContent = await readFile(join(workspace, "main.ts"), "utf8");
     expect(libContent).toContain("newName");
@@ -724,7 +724,7 @@ describe("editCode", () => {
       },
       "call_24",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const aContent = await readFile(join(workspace, "a.ts"), "utf8");
     const bContent = await readFile(join(workspace, "b.ts"), "utf8");
     expect(aContent).toContain("logger.info");
@@ -788,7 +788,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "replace", rule: "sum($$$ARGS)", replacement: "total($$$ARGS)" }] },
       "call_28",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("total(a, b);");
     expect(content).toContain("total(c);");
@@ -804,7 +804,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "replace", rule: "print($ARG)", replacement: "log($ARG)" }] },
       "call_29",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain('log("hello")');
     expect(content).not.toContain("print");
@@ -819,7 +819,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "replace", rule: "println!($ARGS)", replacement: "eprintln!($ARGS)" }] },
       "call_30",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("eprintln!");
     expect(content).not.toMatch(/(?<!e)println!/);
@@ -834,7 +834,7 @@ describe("editCode", () => {
       { path: filePath, edits: [{ op: "replace", rule: "println($ARG)", replacement: "print($ARG)" }] },
       "call_31",
     );
-    expect((result.result as Record<string, unknown>).matches).toBe(2);
+    expect(result.result.matches).toBe(2);
     const content = await readFile(filePath, "utf8");
     expect(content).toContain("print(");
     expect(content).not.toContain("println(");
@@ -860,7 +860,7 @@ describe("editCode", () => {
       },
       "call_32",
     );
-    expect((result.result as Record<string, unknown>).affectedSymbols).toEqual(["processItems"]);
+    expect(result.result.affectedSymbols).toEqual(["processItems"]);
   });
 });
 
@@ -893,7 +893,7 @@ describe("scanCode", () => {
     await writeFile(filePath, 'console.log("hello");\nconsole.log("world");\nconst x = 1;\n', "utf8");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.scanCode.execute({ paths: [filePath], patterns: ["console.log($ARG)"] }, "call_35");
-    const output = (result.result as Record<string, unknown>).output;
+    const output = result.result.output;
     expect(output).toContain("scanned=1 matches=2");
     expect(output).toContain('{$ARG="hello"}');
   });
@@ -904,7 +904,7 @@ describe("scanCode", () => {
     await writeFile(filePath, "const x = 1;\n", "utf8");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.scanCode.execute({ paths: [filePath], patterns: ["console.log($ARG)"] }, "call_36");
-    const output = (result.result as Record<string, unknown>).output;
+    const output = result.result.output;
     expect(output).toContain("scanned=1 matches=0");
     expect(output).toContain("No matches.");
   });
@@ -916,7 +916,7 @@ describe("scanCode", () => {
     await writeFile(join(workspace, "sub", "b.ts"), 'console.log("b");\nconst y = 2;\n', "utf8");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.scanCode.execute({ paths: [workspace], patterns: ["console.log($ARG)"] }, "call_37");
-    const output = (result.result as Record<string, unknown>).output;
+    const output = result.result.output;
     expect(output).toContain("scanned=2 matches=2");
   });
 
@@ -930,7 +930,7 @@ describe("scanCode", () => {
       { paths: [filePath], patterns: ["console.log($ARG)"], maxResults: 3 },
       "call_38",
     );
-    const output = (result.result as Record<string, unknown>).output;
+    const output = result.result.output;
     expect(output).toContain("matches=3");
   });
 
@@ -943,7 +943,7 @@ describe("scanCode", () => {
       { paths: [filePath], patterns: ["export function $NAME() {}", "console.log($ARG)"] },
       "call_39",
     );
-    const output = (result.result as Record<string, unknown>).output;
+    const output = result.result.output;
     expect(output).toContain("matches=2");
     expect(output).toContain("{$NAME=hello}");
     expect(output).toContain('{$ARG="test"}');
@@ -959,7 +959,7 @@ describe("scanCode", () => {
     );
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.scanCode.execute({ paths: [filePath], patterns: ["console.log($ARG)"] }, "call_40");
-    const output = (result.result as Record<string, unknown>).output;
+    const output = result.result.output;
     expect(output).toContain("[processItems]");
   });
 
@@ -973,7 +973,7 @@ describe("scanCode", () => {
     );
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.scanCode.execute({ paths: [filePath], patterns: ["console.log($ARG)"] }, "call_41");
-    const output = (result.result as Record<string, unknown>).output;
+    const output = result.result.output;
     expect(output).toContain("[run]");
   });
 
@@ -983,7 +983,7 @@ describe("scanCode", () => {
     await writeFile(filePath, "console.log('top-level');\n", "utf8");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.scanCode.execute({ paths: [filePath], patterns: ["console.log($ARG)"] }, "call_42");
-    const output = (result.result as Record<string, unknown>).output;
+    const output = result.result.output;
     expect(output).not.toMatch(/\[.*\]/);
     expect(output).toContain("console.log('top-level')");
   });
@@ -994,7 +994,7 @@ describe("scanCode", () => {
     await writeFile(filePath, 'type Status = "active" | "inactive";\n', "utf8");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.scanCode.execute({ paths: [filePath], patterns: ['"active"'] }, "call_43");
-    const output = (result.result as Record<string, unknown>).output;
+    const output = result.result.output;
     expect(output).toContain("[Status]");
   });
 });

--- a/src/code-toolkit.ts
+++ b/src/code-toolkit.ts
@@ -98,7 +98,12 @@ function createScanCodeTool(input: ToolkitInput) {
           language: toolInput.language,
           maxResults: toolInput.maxResults ?? 50,
         });
-        return { kind: "code-scan", paths, patterns: toolInput.patterns, output: formatScanCodeResult(rawScan) };
+        return {
+          kind: "code-scan" as const,
+          paths,
+          patterns: toolInput.patterns,
+          output: formatScanCodeResult(rawScan),
+        };
       });
     },
   });
@@ -151,7 +156,7 @@ function createEditCodeTool(input: ToolkitInput) {
         emitParts(diffParts, "code-edit", input.onOutput, callId);
         const totals = summarizeUnifiedDiff(editResult.output);
         return {
-          kind: "code-edit",
+          kind: "code-edit" as const,
           path: toolInput.path,
           files: totals.files > 0 ? totals.files : 1,
           added: totals.added,

--- a/src/file-ops.int.test.ts
+++ b/src/file-ops.int.test.ts
@@ -16,7 +16,7 @@ describe("path validation — fs", () => {
     await writeFile(filePath, "hello from workspace", "utf8");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.readFile.execute({ paths: [{ path: filePath }] }, "call_read_ws");
-    expect((result.result as Record<string, unknown>).output).toContain("hello from workspace");
+    expect(result.result.output).toContain("hello from workspace");
   });
 
   test("readFileContent rejects files exceeding maxLines", async () => {
@@ -54,7 +54,7 @@ describe("path validation — fs", () => {
       { path: filePath, edits: [{ find: "beta", replace: "gamma" }] },
       "call_edit_ws",
     );
-    expect((result.result as Record<string, unknown>).output).toContain("edits=1");
+    expect(result.result.output).toContain("edits=1");
     expect(session.callLog[0]?.toolName).toBe("file-edit");
   });
 });
@@ -69,7 +69,7 @@ describe("editFile", () => {
       { path: filePath, edits: [{ find: "beta", replace: "gamma" }] },
       "call_edit_fr",
     );
-    expect((result.result as Record<string, unknown>).output).toContain("edits=1");
+    expect(result.result.output).toContain("edits=1");
     expect(session.callLog).toHaveLength(1);
   });
 
@@ -122,7 +122,7 @@ describe("editFile", () => {
       },
       "call_edit_snippet",
     );
-    expect((result.result as Record<string, unknown>).output).toContain("edits=1");
+    expect(result.result.output).toContain("edits=1");
     await expect(readFile(filePath, "utf8")).resolves.toContain("docs/contributing.md");
   });
 
@@ -206,7 +206,7 @@ describe("editFile", () => {
       { path: filePath, edits: [{ startLine: 2, endLine: 3, replace: "replaced2\nreplaced3\n" }] },
       "call_edit_lr",
     );
-    expect((result.result as Record<string, unknown>).output).toContain("edits=1");
+    expect(result.result.output).toContain("edits=1");
     const content = await readFile(filePath, "utf8");
     expect(content).toBe("line1\nreplaced2\nreplaced3\nline4\nline5\n");
   });
@@ -259,7 +259,7 @@ describe("editFile", () => {
       },
       "call_edit_lr5",
     );
-    expect((result.result as Record<string, unknown>).output).toContain("edits=2");
+    expect(result.result.output).toContain("edits=2");
     const content = await readFile(filePath, "utf8");
     expect(content).toBe("AAA\nbbb\nccc\nDDD\nEEE\n");
   });
@@ -292,7 +292,7 @@ describe("editFile", () => {
       { path: filePath, edits: [{ startLine: 1, endLine: 5, replace: "entirely\nnew\ncontent\n" }] },
       "call_edit_lr7",
     );
-    expect((result.result as Record<string, unknown>).output).toContain("edits=1");
+    expect(result.result.output).toContain("edits=1");
     const content = await readFile(filePath, "utf8");
     expect(content).toBe("entirely\nnew\ncontent\n");
   });
@@ -334,8 +334,8 @@ describe("searchFiles", () => {
       { patterns: ["needle"], maxResults: 20, paths: [first] },
       "call_search_scope",
     );
-    expect((result.result as Record<string, unknown>).output).toContain("first.ts:1:");
-    expect((result.result as Record<string, unknown>).output).not.toContain("second.ts");
+    expect(result.result.output).toContain("first.ts:1:");
+    expect(result.result.output).not.toContain("second.ts");
     expect(session.callLog[0]?.toolName).toBe("file-search");
   });
 
@@ -350,8 +350,8 @@ describe("searchFiles", () => {
       { patterns: ["needle"], maxResults: 20, paths: [join(workspace, "sub")] },
       "call_search_dir",
     );
-    expect((result.result as Record<string, unknown>).output).toContain("inside.ts:1:");
-    expect((result.result as Record<string, unknown>).output).not.toContain("outside");
+    expect(result.result.output).toContain("inside.ts:1:");
+    expect(result.result.output).not.toContain("outside");
   });
 
   test("accepts canonical absolute paths inside a symlinked workspace root", async () => {
@@ -367,7 +367,7 @@ describe("searchFiles", () => {
       { patterns: ["needle"], maxResults: 20, paths: [filePath] },
       "call_search_symlink",
     );
-    expect((result.result as Record<string, unknown>).output).toContain("inside.ts:1:");
+    expect(result.result.output).toContain("inside.ts:1:");
   });
 });
 
@@ -377,7 +377,7 @@ describe("createFile", () => {
     const filePath = join(workspace, `test-write-${testUuid()}.txt`);
     const { tools, session } = toolsForAgent({ workspace });
     const result = await tools.createFile.execute({ path: filePath, content: "hello" }, "call_create_ws");
-    expect((result.result as Record<string, unknown>).output).toContain("bytes=5");
+    expect(result.result.output).toContain("bytes=5");
     expect(session.callLog[0]?.toolName).toBe("file-create");
   });
 });
@@ -389,7 +389,7 @@ describe("deleteFile", () => {
     await writeFile(filePath, "alpha\nbeta\n", "utf8");
     const { tools, session } = toolsForAgent({ workspace });
     const result = await tools.deleteFile.execute({ paths: [filePath] }, "call_delete_ws");
-    expect((result.result as Record<string, unknown>).output).toContain("bytes=");
+    expect(result.result.output).toContain("bytes=");
     expect(session.callLog[0]?.toolName).toBe("file-delete");
     const { tools: tools2 } = toolsForAgent({ workspace });
     await expect(tools2.readFile.execute({ paths: [{ path: filePath }] }, "call_delete_verify")).rejects.toThrow();

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -145,11 +145,11 @@ function createSearchFilesTool(input: ToolkitInput) {
         );
         emitParts(summaryParts, "file-search", input.onOutput, callId);
         return {
-          kind: "file-search",
+          kind: "file-search" as const,
           scope: toolInput.paths && toolInput.paths.length > 0 ? "paths" : "workspace",
           patterns,
           matches: summaryStats.files,
-          entries: [],
+          entries: [] as { path: string; hits: string[] }[],
           output: result,
         };
       });

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -80,7 +80,7 @@ function createFindFilesTool(input: ToolkitInput) {
           callId,
         );
         return {
-          kind: "file-find",
+          kind: "file-find" as const,
           scope: "workspace",
           patterns: toolInput.patterns,
           matches: paths.length,
@@ -196,7 +196,7 @@ function createReadFileTool(input: ToolkitInput) {
           toolCallId: callId,
         });
         const output = await readFileContents(input.workspace, paths, FILE_READ_MAX_LINES);
-        return { kind: "file-read", paths, output };
+        return { kind: "file-read" as const, paths, output };
       });
     },
   });
@@ -255,7 +255,7 @@ function createEditFileTool(input: ToolkitInput) {
         emitParts(diffParts, "file-edit", input.onOutput, callId);
         const totals = summarizeUnifiedDiff(rawResult);
         return {
-          kind: "file-edit",
+          kind: "file-edit" as const,
           path: toolInput.path,
           files: totals.files > 0 ? totals.files : 1,
           added: totals.added,
@@ -302,7 +302,7 @@ function createCreateFileTool(input: ToolkitInput) {
         emitParts(diffParts, "file-create", input.onOutput, callId);
         const totals = summarizeUnifiedDiff(rawResult);
         return {
-          kind: "file-create",
+          kind: "file-create" as const,
           path: toolInput.path,
           files: totals.files > 0 ? totals.files : 1,
           added: totals.added,
@@ -346,7 +346,7 @@ function createDeleteFileTool(input: ToolkitInput) {
           resultParts.push(rawResult);
         }
         const rawResult = resultParts.join("\n\n");
-        return { kind: "file-delete", paths, deleted: paths.length, output: rawResult };
+        return { kind: "file-delete" as const, paths, deleted: paths.length, output: rawResult };
       });
     },
   });

--- a/src/git-toolkit.ts
+++ b/src/git-toolkit.ts
@@ -146,7 +146,7 @@ function createGitDiffTool(git: GitOps, input: ToolkitInput) {
         const rawDiff = await git.diff({ path: toolInput.path, contextLines: toolInput.contextLines ?? 3 });
         const previewParts = textHeadTailParts(rawDiff, { headRows: 2, tailRows: 2 });
         emitParts(previewParts, "git-diff", input.onOutput, callId);
-        return { kind: "git-diff", path: toolInput.path, contextLines: toolInput.contextLines ?? 3, output: rawDiff };
+        return { kind: "git-diff" as const, path: toolInput.path, contextLines: toolInput.contextLines ?? 3, output: rawDiff };
       });
     },
   });
@@ -180,7 +180,7 @@ function createGitLogTool(git: GitOps, input: ToolkitInput) {
         const rawLog = await git.log({ path: toolInput.path, limit: toolInput.limit });
         const previewParts = resultChunkParts(rawLog, 4);
         emitParts(previewParts, "git-log", input.onOutput, callId);
-        return { kind: "git-log", path: toolInput.path, limit: toolInput.limit, output: rawLog };
+        return { kind: "git-log" as const, path: toolInput.path, limit: toolInput.limit, output: rawLog };
       });
     },
   });
@@ -223,7 +223,7 @@ function createGitShowTool(git: GitOps, input: ToolkitInput) {
         const previewParts = textHeadTailParts(previewText);
         emitParts(previewParts, "git-show", input.onOutput, callId);
         return {
-          kind: "git-show",
+          kind: "git-show" as const,
           ref: toolInput.ref,
           path: toolInput.path,
           contextLines: toolInput.contextLines ?? 3,
@@ -275,7 +275,7 @@ function createGitAddTool(git: GitOps, input: ToolkitInput) {
             });
           }
         }
-        return { kind: "git-add", all: toolInput.all, paths: toolInput.paths, output: rawAdd };
+        return { kind: "git-add" as const, all: toolInput.all, paths: toolInput.paths, output: rawAdd };
       });
     },
   });
@@ -323,7 +323,7 @@ function createGitCommitTool(git: GitOps, input: ToolkitInput) {
             });
           }
         }
-        return { kind: "git-commit", message: toolInput.message, body: toolInput.body, output: rawCommit };
+        return { kind: "git-commit" as const, message: toolInput.message, body: toolInput.body, output: rawCommit };
       });
     },
   });

--- a/src/git-toolkit.ts
+++ b/src/git-toolkit.ts
@@ -146,7 +146,12 @@ function createGitDiffTool(git: GitOps, input: ToolkitInput) {
         const rawDiff = await git.diff({ path: toolInput.path, contextLines: toolInput.contextLines ?? 3 });
         const previewParts = textHeadTailParts(rawDiff, { headRows: 2, tailRows: 2 });
         emitParts(previewParts, "git-diff", input.onOutput, callId);
-        return { kind: "git-diff" as const, path: toolInput.path, contextLines: toolInput.contextLines ?? 3, output: rawDiff };
+        return {
+          kind: "git-diff" as const,
+          path: toolInput.path,
+          contextLines: toolInput.contextLines ?? 3,
+          output: rawDiff,
+        };
       });
     },
   });

--- a/src/git-toolkit.ts
+++ b/src/git-toolkit.ts
@@ -8,6 +8,8 @@ import { runTool } from "./tool-execution";
 import { emitParts, resultChunkParts, textHeadTailParts } from "./tool-output-format";
 import { TOOL_PROGRESS_LIMITS } from "./tool-policy";
 
+const DEFAULT_CONTEXT_LINES = 3;
+
 const GIT_OPS = ["statusShort", "diff", "log", "show", "add", "commit"] as const;
 type GitOp = (typeof GIT_OPS)[number];
 
@@ -56,14 +58,14 @@ async function runGitOp(operation: GitOp, execute: () => Promise<string>): Promi
 export function createGitOps(workspace: string, deps: GitOpsDeps = defaultDeps): GitOps {
   return {
     statusShort: () => runGitOp("statusShort", () => deps.gitStatusShort(workspace)),
-    diff: (input) => runGitOp("diff", () => deps.gitDiff(workspace, input?.path, input?.contextLines ?? 3)),
+    diff: (input) => runGitOp("diff", () => deps.gitDiff(workspace, input?.path, input?.contextLines ?? DEFAULT_CONTEXT_LINES)),
     log: (input) => runGitOp("log", () => deps.gitLog(workspace, { path: input?.path, limit: input?.limit })),
     show: (input) =>
       runGitOp("show", () =>
         deps.gitShow(workspace, {
           ref: input?.ref,
           path: input?.path,
-          contextLines: input?.contextLines ?? 3,
+          contextLines: input?.contextLines ?? DEFAULT_CONTEXT_LINES,
         }),
       ),
     add: (input) => runGitOp("add", () => deps.gitAdd(workspace, { paths: input?.paths, all: input?.all })),
@@ -143,13 +145,13 @@ function createGitDiffTool(git: GitOps, input: ToolkitInput) {
           content: { kind: "tool-header", labelKey: "tool.label.git_diff", detail: toolInput.path },
           toolCallId: callId,
         });
-        const rawDiff = await git.diff({ path: toolInput.path, contextLines: toolInput.contextLines ?? 3 });
+        const rawDiff = await git.diff({ path: toolInput.path, contextLines: toolInput.contextLines ?? DEFAULT_CONTEXT_LINES });
         const previewParts = textHeadTailParts(rawDiff, { headRows: 2, tailRows: 2 });
         emitParts(previewParts, "git-diff", input.onOutput, callId);
         return {
           kind: "git-diff" as const,
           path: toolInput.path,
-          contextLines: toolInput.contextLines ?? 3,
+          contextLines: toolInput.contextLines ?? DEFAULT_CONTEXT_LINES,
           output: rawDiff,
         };
       });
@@ -222,7 +224,7 @@ function createGitShowTool(git: GitOps, input: ToolkitInput) {
         const rawShow = await git.show({
           ref: toolInput.ref,
           path: toolInput.path,
-          contextLines: toolInput.contextLines ?? 3,
+          contextLines: toolInput.contextLines ?? DEFAULT_CONTEXT_LINES,
         });
         const previewText = stripGitShowMetadataForPreview(rawShow);
         const previewParts = textHeadTailParts(previewText);
@@ -231,7 +233,7 @@ function createGitShowTool(git: GitOps, input: ToolkitInput) {
           kind: "git-show" as const,
           ref: toolInput.ref,
           path: toolInput.path,
-          contextLines: toolInput.contextLines ?? 3,
+          contextLines: toolInput.contextLines ?? DEFAULT_CONTEXT_LINES,
           output: rawShow,
         };
       });

--- a/src/git-toolkit.ts
+++ b/src/git-toolkit.ts
@@ -58,7 +58,8 @@ async function runGitOp(operation: GitOp, execute: () => Promise<string>): Promi
 export function createGitOps(workspace: string, deps: GitOpsDeps = defaultDeps): GitOps {
   return {
     statusShort: () => runGitOp("statusShort", () => deps.gitStatusShort(workspace)),
-    diff: (input) => runGitOp("diff", () => deps.gitDiff(workspace, input?.path, input?.contextLines ?? DEFAULT_CONTEXT_LINES)),
+    diff: (input) =>
+      runGitOp("diff", () => deps.gitDiff(workspace, input?.path, input?.contextLines ?? DEFAULT_CONTEXT_LINES)),
     log: (input) => runGitOp("log", () => deps.gitLog(workspace, { path: input?.path, limit: input?.limit })),
     show: (input) =>
       runGitOp("show", () =>
@@ -145,7 +146,10 @@ function createGitDiffTool(git: GitOps, input: ToolkitInput) {
           content: { kind: "tool-header", labelKey: "tool.label.git_diff", detail: toolInput.path },
           toolCallId: callId,
         });
-        const rawDiff = await git.diff({ path: toolInput.path, contextLines: toolInput.contextLines ?? DEFAULT_CONTEXT_LINES });
+        const rawDiff = await git.diff({
+          path: toolInput.path,
+          contextLines: toolInput.contextLines ?? DEFAULT_CONTEXT_LINES,
+        });
         const previewParts = textHeadTailParts(rawDiff, { headRows: 2, tailRows: 2 });
         emitParts(previewParts, "git-diff", input.onOutput, callId);
         return {

--- a/src/git-toolkit.ts
+++ b/src/git-toolkit.ts
@@ -114,7 +114,7 @@ function createGitStatusTool(git: GitOps, input: ToolkitInput) {
         const rawStatus = await git.statusShort();
         const previewParts = textHeadTailParts(rawStatus);
         emitParts(previewParts, "git-status", input.onOutput, callId);
-        return { kind: "git-status", output: rawStatus };
+        return { kind: "git-status" as const, output: rawStatus };
       });
     },
   });

--- a/src/shell-ops.int.test.ts
+++ b/src/shell-ops.int.test.ts
@@ -13,8 +13,8 @@ describe("shell-run through registry dispatch", () => {
     const workspace = dirs.createDir("acolyte-shell-run-");
     const { tools, session } = toolsForAgent({ workspace });
     const result = await tools.runCommand.execute({ cmd: "printf", args: ["ok"] }, "call_1");
-    expect((result.result as Record<string, unknown>).output).toContain("ok");
-    expect((result.result as Record<string, unknown>).exitCode).toBe(0);
+    expect(result.result.output).toContain("ok");
+    expect(result.result.exitCode).toBe(0);
     expect(session.callLog[0]?.toolName).toBe("shell-run");
   });
 
@@ -24,7 +24,7 @@ describe("shell-run through registry dispatch", () => {
     await writeFile(filePath, "ok\n", "utf8");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.runCommand.execute({ cmd: "cat", args: [filePath] }, "call_2");
-    expect((result.result as Record<string, unknown>).output).toContain("ok");
+    expect(result.result.output).toContain("ok");
   });
 
   test("rejects with timeout error when command exceeds limit", async () => {
@@ -39,14 +39,14 @@ describe("shell-run through registry dispatch", () => {
     const workspace = dirs.createDir("acolyte-shell-flags-");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.runCommand.execute({ cmd: "echo", args: ["--format=json/pretty"] }, "call_4");
-    expect((result.result as Record<string, unknown>).output).toContain("--format=json/pretty");
+    expect(result.result.output).toContain("--format=json/pretty");
   });
 
   test("does not evaluate shell operators", async () => {
     const workspace = dirs.createDir("acolyte-shell-ops-");
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.runCommand.execute({ cmd: "echo", args: ["hello", "&&", "echo", "nope"] }, "call_5");
-    expect((result.result as Record<string, unknown>).output).toContain("hello && echo nope");
+    expect(result.result.output).toContain("hello && echo nope");
   });
 
   test("blocks bare relative symlink escapes", async () => {
@@ -67,6 +67,6 @@ describe("shell-run through registry dispatch", () => {
 
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.runCommand.execute({ cmd: "cat", args: ["nested/note.txt"] }, "call_7");
-    expect((result.result as Record<string, unknown>).output).toContain("nested-ok");
+    expect(result.result.output).toContain("nested-ok");
   });
 });

--- a/src/shell-toolkit.ts
+++ b/src/shell-toolkit.ts
@@ -92,7 +92,7 @@ function createRunCommandTool(input: ToolkitInput) {
           const previewParts = shellHeadTailParts(streamed);
           emitParts(previewParts, "shell-run", input.onOutput, callId);
           return {
-            kind: "shell-run",
+            kind: "shell-run" as const,
             command: displayCommand,
             exitCode: parseExitCode(rawResult),
             output: rawResult,

--- a/src/tool-execution.ts
+++ b/src/tool-execution.ts
@@ -122,7 +122,7 @@ export async function runTool<T = unknown>(
     }
 
     let taskFailed = false;
-    let taskResult: T = undefined!;
+    let taskResult = undefined as T;
     let taskError: unknown;
     try {
       taskResult = await withTimeout(() => execute(toolCallId), timeoutMs, toolId);

--- a/src/tool-execution.ts
+++ b/src/tool-execution.ts
@@ -55,14 +55,14 @@ export async function withToolError<T>(toolId: string, task: () => Promise<T>): 
 
 export type RunToolResult<T = unknown> = { result: T; effectOutput?: string };
 
-export async function runTool(
+export async function runTool<T = unknown>(
   session: SessionContext,
   toolId: string,
   toolCallId: string,
   args: Record<string, unknown>,
-  execute: (toolCallId: string) => Promise<unknown>,
+  execute: (toolCallId: string) => Promise<T>,
   options?: { timeoutMs?: number },
-): Promise<RunToolResult> {
+): Promise<RunToolResult<T>> {
   return withToolError(toolId, async () => {
     const budgetError = checkStepBudget(session);
     if (budgetError) {
@@ -116,13 +116,13 @@ export async function runTool(
           }
         }
         recordCall(session, toolId, args, hashResultValue(cached.result), "succeeded");
-        return { result: cached.result };
+        return { result: cached.result as T };
       }
       session.onDebug?.("lifecycle.tool.cache", { tool: toolId, hit: false, ...cache.stats() });
     }
 
     let taskFailed = false;
-    let taskResult: unknown;
+    let taskResult: T = undefined!;
     let taskError: unknown;
     try {
       taskResult = await withTimeout(() => execute(toolCallId), timeoutMs, toolId);

--- a/src/undo-toolkit.ts
+++ b/src/undo-toolkit.ts
@@ -35,7 +35,7 @@ function createUndoListTool(input: ToolkitInput) {
         const sessionId = input.sessionId ?? "";
         if (!sessionId || !input.session.featureFlags?.undoCheckpoints) {
           return {
-            kind: "undo-list",
+            kind: "undo-list" as const,
             sessionId: sessionId || "unknown",
             entries: [],
             output: "Undo checkpoints disabled.",
@@ -48,7 +48,7 @@ function createUndoListTool(input: ToolkitInput) {
         });
         const lines = entries.map((e) => `${e.id} ${e.toolId} ${e.paths.join(", ")}`);
         const output = lines.length > 0 ? lines.join("\n") : "No undo checkpoints.";
-        return { kind: "undo-list", sessionId, entries, output };
+        return { kind: "undo-list" as const, sessionId, entries, output };
       });
     },
   });

--- a/src/undo-toolkit.ts
+++ b/src/undo-toolkit.ts
@@ -82,7 +82,7 @@ function createUndoRestoreTool(input: ToolkitInput) {
         const sessionId = input.sessionId ?? "";
         if (!sessionId || !input.session.featureFlags?.undoCheckpoints) {
           return {
-            kind: "undo-restore",
+            kind: "undo-restore" as const,
             checkpointId: toolInput.checkpointId,
             restored: [],
             conflicts: [],
@@ -100,7 +100,7 @@ function createUndoRestoreTool(input: ToolkitInput) {
             ? `Conflicts:\n${result.conflicts.map((c) => `- ${c.path}: ${c.reason}`).join("\n")}`
             : `Restored ${result.restored.length} file(s).`;
         return {
-          kind: "undo-restore",
+          kind: "undo-restore" as const,
           checkpointId: toolInput.checkpointId,
           restored: result.restored,
           conflicts: result.conflicts.map((c) => ({ path: c.path, reason: c.reason })),

--- a/src/web-toolkit.ts
+++ b/src/web-toolkit.ts
@@ -88,7 +88,7 @@ function createWebSearchTool(input: ToolkitInput) {
         const previewRows = webSearchStreamRows(result, toolInput.query);
         const previewParts = resultChunkParts(previewRows, 80);
         emitParts(previewParts, "web-search", input.onOutput, callId);
-        return { kind: "web-search", query: toolInput.query, output: result };
+        return { kind: "web-search" as const, query: toolInput.query, output: result };
       });
     },
   });
@@ -120,7 +120,7 @@ function createWebFetchTool(input: ToolkitInput) {
           toolCallId: callId,
         });
         const result = await fetchWeb(toolInput.url, toolInput.maxChars ?? 5000);
-        return { kind: "web-fetch", url: toolInput.url, output: result };
+        return { kind: "web-fetch" as const, url: toolInput.url, output: result };
       });
     },
   });


### PR DESCRIPTION
## Motivation

`runTool` returned `RunToolResult<unknown>`, erasing the output type even though each toolkit defines a precise output schema. Integration tests needed `as Record<string, unknown>` casts to access structured fields on results.

## Summary

- make `runTool` generic: `runTool<T>` preserves the execute callback's return type
- add `as const` to `kind` fields in toolkit returns so literals match output schemas
- extract `DEFAULT_CONTEXT_LINES` constant in git-toolkit
- remove 55 redundant type casts from integration tests

Fixes #189