### PR TITLE
refactor(input): remove per-message limits

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -54,8 +54,7 @@ The observation model is inspired by [Mastra's Observational Memory](https://mas
 
 - commit scheduling is best-effort background work at lifecycle finalize
 - commits are serialized per session per process through a keyed task queue seam
-- agent input assembly applies deterministic rolling history fitting (newest-first, truncate-to-fit under remaining budget)
-- aggressive old-turn compaction is driven by typed message metadata (`kind: tool_payload`), not regex heuristics
+- agent input assembly applies deterministic rolling history fitting (newest-first, truncate-to-fit under remaining budget, conversational turns prioritized over tool payloads)
 - debug observability uses lifecycle-scoped events (`lifecycle.memory.load_*`, `lifecycle.memory.commit_*`) through standard debug channels
 - commit debug includes promotion counters (`project_promoted_facts`, `user_promoted_facts`, `session_scoped_facts`, `dropped_untagged_facts`)
 - repeated malformed-directive drops emit `lifecycle.memory.quality_warning` with `malformed_reject_streak` after 3 consecutive commits

--- a/src/agent-input.test.ts
+++ b/src/agent-input.test.ts
@@ -1,14 +1,10 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { createAgentInput, type InputBudget, setTokenEncoder } from "./agent-input";
+import { createAgentInput, setTokenEncoder } from "./agent-input";
 import type { ChatRequest } from "./api";
 import { defaultLifecyclePolicy } from "./lifecycle-policy";
 
 const defaultOptions = {
   contextMaxTokens: defaultLifecyclePolicy.contextMaxTokens,
-  budget: {
-    maxHistoryMessages: defaultLifecyclePolicy.maxHistoryMessages,
-    maxMessageTokens: defaultLifecyclePolicy.maxMessageTokens,
-  } satisfies InputBudget,
 };
 
 // Use a deterministic chars/4 estimator so budget tests don't depend on the tiktoken encoding.
@@ -32,11 +28,12 @@ function createRequest(content: string): ChatRequest {
 }
 
 describe("createAgentInput", () => {
-  test("truncates long system messages", () => {
+  test("includes full message content when budget allows", () => {
     const longSystem = `General note: ${"B".repeat(4000)}`;
     const { input } = createAgentInput(createRequest(longSystem), defaultOptions);
     expect(input).toContain("General note:");
-    expect(input).toContain("…");
+    expect(input).toContain("B".repeat(4000));
+    expect(input).not.toContain("…");
   });
 
   test("includes skill context in input when activeSkills present", () => {
@@ -128,12 +125,11 @@ describe("createAgentInput", () => {
     };
 
     const { input } = createAgentInput(req, defaultOptions);
-    // 100 messages × ~1000 chars each = ~100k chars; budget allows ~100k tokens so all fit
     expect(input.length).toBeLessThanOrEqual(120_000);
     expect(input).toContain("USER: review");
   });
 
-  test("aggressively compacts older tool-heavy assistant turns", () => {
+  test("includes full tool payload content when budget allows", () => {
     const toolHeavy = `stdout:\n${"A".repeat(5000)}\nstderr:\n${"B".repeat(2000)}`;
     const req: ChatRequest = {
       model: "gpt-5-mini",
@@ -162,111 +158,9 @@ describe("createAgentInput", () => {
     };
 
     const { input } = createAgentInput(req, defaultOptions);
-    const oldToolLine = input.split("\n").find((line) => line.startsWith("ASSISTANT: stdout:"));
-    expect(oldToolLine).toBeDefined();
-    expect(oldToolLine?.length).toBeLessThanOrEqual(900);
+    expect(input).toContain("A".repeat(5000));
+    expect(input).toContain("B".repeat(2000));
     expect(input).toContain("ASSISTANT: Ready for the next step.");
-  });
-
-  test("does not compact prose that casually mentions stdout", () => {
-    const prose = `Summary: We discussed stdout: formatting for status rows.\n${"N".repeat(1100)}TAIL_SENTINEL`;
-    const req: ChatRequest = {
-      model: "gpt-5-mini",
-      message: "continue",
-      history: [
-        {
-          id: "msg_old_prose",
-          role: "assistant",
-          content: prose,
-          timestamp: "2026-02-20T10:00:00.000Z",
-        },
-        {
-          id: "msg_old_user",
-          role: "user",
-          content: "thanks",
-          timestamp: "2026-02-20T10:00:01.000Z",
-        },
-        {
-          id: "msg_recent_assistant",
-          role: "assistant",
-          content: "Ready for the next step.",
-          timestamp: "2026-02-20T10:00:02.000Z",
-        },
-      ],
-    };
-
-    const { input } = createAgentInput(req, defaultOptions);
-    expect(input).toContain("TAIL_SENTINEL");
-  });
-
-  test("compacts structured search/find tool payload turns", () => {
-    const structuredPayload = [
-      "scope=workspace patterns=[*.ts] matches=42",
-      ...Array.from({ length: 400 }, (_, i) => `src/components/feature-${i}/index.ts`),
-      "TAIL_STRUCTURED",
-    ].join("\n");
-    const req: ChatRequest = {
-      model: "gpt-5-mini",
-      message: "continue",
-      history: [
-        {
-          id: "msg_old_structured",
-          role: "assistant",
-          content: structuredPayload,
-          kind: "tool_payload",
-          timestamp: "2026-02-20T10:00:00.000Z",
-        },
-        {
-          id: "msg_old_user",
-          role: "user",
-          content: "thanks",
-          timestamp: "2026-02-20T10:00:01.000Z",
-        },
-        {
-          id: "msg_recent_assistant",
-          role: "assistant",
-          content: "Ready for the next step.",
-          timestamp: "2026-02-20T10:00:02.000Z",
-        },
-      ],
-    };
-
-    const { input } = createAgentInput(req, defaultOptions);
-    const oldStructuredLine = input.split("\n").find((line) => line.startsWith("ASSISTANT: scope=workspace"));
-    expect(oldStructuredLine).toBeDefined();
-    expect(oldStructuredLine?.length).toBeLessThanOrEqual(900);
-    expect(input).not.toContain("TAIL_STRUCTURED");
-  });
-
-  test("does not aggressively compact unflagged tool-like assistant content", () => {
-    const toolHeavy = `stdout:\n${"A".repeat(5000)}\nstderr:\n${"B".repeat(2000)}\nTAIL_UNFLAGGED`;
-    const req: ChatRequest = {
-      model: "gpt-5-mini",
-      message: "continue",
-      history: [
-        {
-          id: "msg_old_unflagged",
-          role: "assistant",
-          content: toolHeavy,
-          timestamp: "2026-02-20T10:00:00.000Z",
-        },
-        {
-          id: "msg_old_user",
-          role: "user",
-          content: "thanks",
-          timestamp: "2026-02-20T10:00:01.000Z",
-        },
-        {
-          id: "msg_recent_assistant",
-          role: "assistant",
-          content: "Ready for the next step.",
-          timestamp: "2026-02-20T10:00:02.000Z",
-        },
-      ],
-    };
-
-    const { input } = createAgentInput(req, defaultOptions);
-    expect(input).toContain("A".repeat(1500));
   });
 
   test("keeps newest oversized history turn by truncating to remaining budget", () => {
@@ -325,37 +219,5 @@ describe("createAgentInput", () => {
     const { input } = createAgentInput(req, { ...defaultOptions, contextMaxTokens: 120 });
     expect(input).toContain("KEEP_TWO");
     expect(input).not.toContain("TOOL_SENTINEL");
-  });
-
-  test("applies stronger caps for very old tool payload turns", () => {
-    const history: ChatRequest["history"] = [
-      {
-        id: "msg_old_tool",
-        role: "assistant",
-        kind: "tool_payload",
-        content: `stdout:\n${"A".repeat(6000)}\nTAIL_OLD_TOOL`,
-        timestamp: "2026-02-20T10:00:00.000Z",
-      },
-    ];
-    for (let i = 1; i <= 12; i++) {
-      history.push({
-        id: `msg_${i}`,
-        role: i % 2 === 0 ? "assistant" : "user",
-        content: `recent-${i}`,
-        timestamp: `2026-02-20T10:00:${String(i).padStart(2, "0")}.000Z`,
-      });
-    }
-
-    const req: ChatRequest = {
-      model: "gpt-5-mini",
-      message: "continue",
-      history,
-    };
-
-    const { input } = createAgentInput(req, defaultOptions);
-    const oldToolLine = input.split("\n").find((line) => line.startsWith("ASSISTANT: stdout:"));
-    expect(oldToolLine).toBeDefined();
-    expect(oldToolLine?.length).toBeLessThanOrEqual(300);
-    expect(input).not.toContain("TAIL_OLD_TOOL");
   });
 });

--- a/src/agent-input.ts
+++ b/src/agent-input.ts
@@ -82,12 +82,8 @@ function truncateByTokens(input: string, maxTokens: number): string {
   return `${input.slice(0, lo)}…`;
 }
 
-function isToolPayloadMessage(message: ChatRequest["history"][number]): boolean {
-  return message.kind === "tool_payload";
-}
-
 function isAssistantToolPayloadMessage(message: ChatRequest["history"][number]): boolean {
-  return message.role === "assistant" && isToolPayloadMessage(message);
+  return message.role === "assistant" && message.kind === "tool_payload";
 }
 
 function lineForMessage(message: ChatRequest["history"][number], maxTokens: number): { line: string; tokens: number } {
@@ -98,11 +94,10 @@ function lineForMessage(message: ChatRequest["history"][number], maxTokens: numb
 
 function lineForMessageWithinBudget(
   message: ChatRequest["history"][number],
-  maxTokens: number,
   remainingTokens: number,
 ): { line: string; tokens: number } | null {
   if (remainingTokens <= 0) return null;
-  let tokenLimit = Math.min(maxTokens, remainingTokens);
+  let tokenLimit = remainingTokens;
   while (tokenLimit > 0) {
     const candidate = lineForMessage(message, tokenLimit);
     if (candidate.tokens <= remainingTokens) return candidate;
@@ -115,18 +110,13 @@ function collectLinesWithinBudget(
   messages: ChatRequest["history"],
   usedIds: Set<string>,
   remainingTokens: number,
-  maxPerMessageTokens: number,
-  maxHistoryMessages: number,
 ): { lines: string[]; consumedTokens: number } {
   const lines: string[] = [];
   let consumed = 0;
-  const recent = messages.slice(-maxHistoryMessages);
   const includeMessage = (i: number): void => {
-    const message = recent[i];
+    const message = messages[i];
     if (usedIds.has(message.id)) return;
-    const ageFromLatest = recent.length - 1 - i;
-    const maxTokens = resolveMessageTokenCap(message, ageFromLatest, maxPerMessageTokens);
-    const candidate = lineForMessageWithinBudget(message, maxTokens, remainingTokens - consumed);
+    const candidate = lineForMessageWithinBudget(message, remainingTokens - consumed);
     if (!candidate || candidate.tokens === 0) return;
     usedIds.add(message.id);
     lines.unshift(candidate.line);
@@ -134,37 +124,20 @@ function collectLinesWithinBudget(
   };
 
   // Prefer conversational turns first and only then spend remaining budget on tool payloads.
-  for (let i = recent.length - 1; i >= 0; i -= 1) {
-    if (isAssistantToolPayloadMessage(recent[i])) continue;
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (isAssistantToolPayloadMessage(messages[i])) continue;
     includeMessage(i);
   }
-  for (let i = recent.length - 1; i >= 0; i -= 1) {
-    if (!isAssistantToolPayloadMessage(recent[i])) continue;
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    if (!isAssistantToolPayloadMessage(messages[i])) continue;
     includeMessage(i);
   }
   return { lines, consumedTokens: consumed };
 }
 
-function resolveMessageTokenCap(
-  message: ChatRequest["history"][number],
-  ageFromLatest: number,
-  maxPerMessageTokens: number,
-): number {
-  if (!isAssistantToolPayloadMessage(message)) return maxPerMessageTokens;
-  if (ageFromLatest <= 1) return maxPerMessageTokens;
-  if (ageFromLatest <= 4) return Math.min(maxPerMessageTokens, 500);
-  if (ageFromLatest <= 10) return Math.min(maxPerMessageTokens, 300);
-  return Math.min(maxPerMessageTokens, 200);
-}
-
-export type InputBudget = {
-  maxHistoryMessages: number;
-  maxMessageTokens: number;
-};
-
 export function createAgentInput(
   req: ChatRequest,
-  options: { systemPromptTokens?: number; toolTokens?: number; contextMaxTokens: number; budget: InputBudget },
+  options: { systemPromptTokens?: number; toolTokens?: number; contextMaxTokens: number },
 ): {
   input: string;
   usage: {
@@ -185,12 +158,11 @@ export function createAgentInput(
   const lines: string[] = [];
   const usedIds = new Set<string>();
   let includedSkillTokens = 0;
-  const budget = options.budget;
   const tokenBudget = createPromptTokenBudget(contextMaxTokens);
   tokenBudget.consume(requestedSystemTokens);
   tokenBudget.consume(requestedToolTokens);
 
-  const userLine = `USER: ${truncateByTokens(req.message.trim(), budget.maxMessageTokens)}`;
+  const userLine = `USER: ${req.message.trim()}`;
   const userTokens = estimateTokens(userLine);
   tokenBudget.consume(userTokens);
 
@@ -216,13 +188,7 @@ export function createAgentInput(
     }
   }
 
-  const recentResult = collectLinesWithinBudget(
-    req.history,
-    usedIds,
-    tokenBudget.remaining(),
-    budget.maxMessageTokens,
-    budget.maxHistoryMessages,
-  );
+  const recentResult = collectLinesWithinBudget(req.history, usedIds, tokenBudget.remaining());
   lines.push(...recentResult.lines);
 
   if (lines.length > 0) lines.push("");

--- a/src/lifecycle-constants.ts
+++ b/src/lifecycle-constants.ts
@@ -4,5 +4,3 @@ export const STEP_TIMEOUT_MS = 120_000;
 export const MAX_UNKNOWN_ERRORS_PER_REQUEST = 2;
 export const TOOL_TIMEOUT_MS = 10_000;
 export const CONTEXT_MAX_TOKENS = 100_000;
-export const MAX_HISTORY_MESSAGES = 40;
-export const MAX_MESSAGE_TOKENS = 600;

--- a/src/lifecycle-policy.ts
+++ b/src/lifecycle-policy.ts
@@ -1,8 +1,6 @@
 import {
   CONTEXT_MAX_TOKENS,
   INITIAL_MAX_STEPS,
-  MAX_HISTORY_MESSAGES,
-  MAX_MESSAGE_TOKENS,
   MAX_UNKNOWN_ERRORS_PER_REQUEST,
   STEP_TIMEOUT_MS,
   TOOL_TIMEOUT_MS,
@@ -20,8 +18,6 @@ export type LifecyclePolicy = {
   toolTimeoutMs: number;
   // Input budgets
   contextMaxTokens: number;
-  maxHistoryMessages: number;
-  maxMessageTokens: number;
   // Workspace commands
   installCommand?: WorkspaceCommand;
   formatCommand?: WorkspaceCommand;
@@ -35,8 +31,6 @@ export const defaultLifecyclePolicy: LifecyclePolicy = {
   maxUnknownErrorsPerRequest: MAX_UNKNOWN_ERRORS_PER_REQUEST,
   toolTimeoutMs: TOOL_TIMEOUT_MS,
   contextMaxTokens: CONTEXT_MAX_TOKENS,
-  maxHistoryMessages: MAX_HISTORY_MESSAGES,
-  maxMessageTokens: MAX_MESSAGE_TOKENS,
 };
 
 export function createLifecyclePolicy(override?: Partial<LifecyclePolicy>): LifecyclePolicy {

--- a/src/lifecycle-prepare.ts
+++ b/src/lifecycle-prepare.ts
@@ -31,10 +31,6 @@ export function phasePrepare(input: PhasePrepareInput): PhasePrepareResult {
     systemPromptTokens,
     toolTokens,
     contextMaxTokens: policy.contextMaxTokens,
-    budget: {
-      maxHistoryMessages: policy.maxHistoryMessages,
-      maxMessageTokens: policy.maxMessageTokens,
-    },
   });
   const baseAgentInput = requestInput.input;
 


### PR DESCRIPTION
## Motivation

The agent input assembly silently discards context through per-message token caps (600 tokens), a history message cap (40 messages), and age-based compaction that progressively shrinks old tool output. These are premature optimizations that degrade model behavior — the model works with incomplete information. The overall context budget already handles overflow.

## Summary

- remove MAX_MESSAGE_TOKENS and per-message truncation via truncateByTokens
- remove MAX_HISTORY_MESSAGES cap — let the token budget decide how much history fits
- remove resolveMessageTokenCap age-based compaction
- simplify collectLinesWithinBudget to include messages at full size until the budget is exhausted
- remove InputBudget type and maxHistoryMessages/maxMessageTokens from LifecyclePolicy
- update docs/memory.md runtime guarantees to reflect removal of compaction

Fixes #215