### PR TITLE
feat(session): on-demand session search

### DIFF
--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -34,7 +34,7 @@ Two backends, selected via the `cloudSync` feature flag (default: file):
 - **File** (default): `sessions.json` in the data directory (see [Paths](paths.md)), entire state read/written as JSON
 - **Cloud** (feature-flagged): configured via `acolyte login`, backed by Postgres with JSONB messages. See [Cloud](cloud.md).
 
-The `SessionStore` interface provides granular operations (`listSessions`, `getSession`, `saveSession`, `removeSession`, active session tracking).
+The `SessionStore` interface provides granular operations (`listSessions`, `getSession`, `saveSession`, `removeSession`, `searchSession`, active session tracking).
 
 ## Session vs task
 
@@ -51,6 +51,8 @@ The `SessionStore` interface provides granular operations (`listSessions`, `getS
 
 - `src/session-contract.ts` — session types, schemas, and `SessionStore` interface
 - `src/session-store.ts` — file-based session store and store factory
+- `src/session-ops.ts` — session operations (message search)
+- `src/session-toolkit.ts` — session tools (`session-search`)
 - `src/cloud-client.ts` — cloud API session store (feature-flagged)
 - `src/session-lock.ts` — PID-based file locking for concurrent access
 

--- a/docs/sessions.md
+++ b/docs/sessions.md
@@ -34,7 +34,7 @@ Two backends, selected via the `cloudSync` feature flag (default: file):
 - **File** (default): `sessions.json` in the data directory (see [Paths](paths.md)), entire state read/written as JSON
 - **Cloud** (feature-flagged): configured via `acolyte login`, backed by Postgres with JSONB messages. See [Cloud](cloud.md).
 
-The `SessionStore` interface provides granular operations (`listSessions`, `getSession`, `saveSession`, `removeSession`, `searchSession`, active session tracking).
+The `SessionStore` interface provides CRUD, search, and active session tracking.
 
 ## Session vs task
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -21,6 +21,10 @@ Use the smallest test type that gives strong confidence.
 - Effect integration tests must wire handlers via `attachLifecycleEffectHandlers(ctx, session)` and verify behavior through debug events, not call `effect.run()` directly.
 - Direct function calls (e.g., `editFile()`, `runShellCommand()`) belong in unit tests when testing the function contract itself. Integration tests test wiring.
 
+## Test suites
+
+`*.test-suite.ts` files define reusable assertions for store interfaces. They export a function that an `*.int.test.ts` file calls with a specific backend, so the same contract runs against every implementation.
+
 ## Commands
 
 - Full baseline: `bun run verify`

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -9,8 +9,24 @@ lifecycle → budget → cache → toolkit → registry
 ## Layers
 
 - **budget**: step-budget check (`checkStepBudget()`) inlined into tool execution
-- **toolkit**: domain tool definitions (`file-toolkit`, `code-toolkit`, `git-toolkit`, `shell-toolkit`, `web-toolkit`, `checklist-toolkit`, `session-toolkit`, `memory-toolkit`, `skill-toolkit`)
+- **toolkit**: domain tool definitions (see table below)
 - **registry**: tool registration and agent-facing tool surface
+
+## Toolkits
+
+| Toolkit | Purpose |
+|---------|---------|
+| `file` | file operations |
+| `code` | AST-aware code scanning and editing |
+| `undo` | revert file edits |
+| `session` | search current session history |
+| `memory` | persistent cross-session knowledge |
+| `skill` | engineering skill discovery and activation |
+| `test` | run workspace tests |
+| `checklist` | multi-step task tracking |
+| `git` | version control |
+| `web` | external information retrieval |
+| `shell` | shell command execution |
 
 ## Tool execution
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -16,17 +16,17 @@ lifecycle → budget → cache → toolkit → registry
 
 | Toolkit | Purpose |
 |---------|---------|
-| `file` | file operations |
+| `file` | File operations |
 | `code` | AST-aware code scanning and editing |
-| `undo` | revert file edits |
-| `session` | search current session history |
-| `memory` | persistent cross-session knowledge |
-| `skill` | engineering skill discovery and activation |
-| `test` | run workspace tests |
-| `checklist` | multi-step task tracking |
-| `git` | version control |
-| `web` | external information retrieval |
-| `shell` | shell command execution |
+| `undo` | Revert file edits |
+| `session` | Search current session history |
+| `memory` | Persistent cross-session knowledge |
+| `skill` | Skill discovery and activation |
+| `test` | Run workspace tests |
+| `checklist` | Multi-step task tracking |
+| `git` | Version control |
+| `web` | External information retrieval |
+| `shell` | Shell command execution |
 
 ## Tool execution
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -9,7 +9,7 @@ lifecycle → budget → cache → toolkit → registry
 ## Layers
 
 - **budget**: step-budget check (`checkStepBudget()`) inlined into tool execution
-- **toolkit**: domain tool definitions (`file-toolkit`, `code-toolkit`, `git-toolkit`, `shell-toolkit`, `web-toolkit`, `checklist-toolkit`, `memory-toolkit`, `skill-toolkit`)
+- **toolkit**: domain tool definitions (`file-toolkit`, `code-toolkit`, `git-toolkit`, `shell-toolkit`, `web-toolkit`, `checklist-toolkit`, `session-toolkit`, `memory-toolkit`, `skill-toolkit`)
 - **registry**: tool registration and agent-facing tool surface
 
 ## Tool execution

--- a/src/agent-input.test.ts
+++ b/src/agent-input.test.ts
@@ -13,19 +13,26 @@ const charsPerToken = 4;
 beforeAll(() => setTokenEncoder({ encode: (input: string) => ({ length: Math.ceil(input.length / charsPerToken) }) }));
 afterAll(() => setTokenEncoder(null));
 
+type HistoryMessage = ChatRequest["history"][number];
+
+function msg(id: string, role: HistoryMessage["role"], content: string, kind?: HistoryMessage["kind"]): HistoryMessage {
+  return { id: `msg_${id}`, role, content, kind, timestamp: "2026-02-20T10:00:00.000Z" };
+}
+
+function exchange(i: number, extra?: HistoryMessage[]): HistoryMessage[] {
+  return [msg(`u${i}`, "user", `USER_${i}`), ...(extra ?? []), msg(`a${i}`, "assistant", `ASSISTANT_${i}`)];
+}
+
+function exchanges(count: number): HistoryMessage[] {
+  return Array.from({ length: count }, (_, i) => exchange(i)).flat();
+}
+
+function req(message: string, history: HistoryMessage[], extras?: Partial<ChatRequest>): ChatRequest {
+  return { model: "gpt-5-mini", message, history, ...extras };
+}
+
 function createRequest(content: string): ChatRequest {
-  return {
-    model: "gpt-5-mini",
-    message: "review this",
-    history: [
-      {
-        id: "msg_context",
-        role: "user",
-        content,
-        timestamp: "2026-02-20T10:00:00.000Z",
-      },
-    ],
-  };
+  return req("review this", [msg("context", "user", content)]);
 }
 
 describe("createAgentInput", () => {
@@ -69,20 +76,7 @@ describe("createAgentInput", () => {
   });
 
   test("reports requested system/tool tokens even when they exceed context budget", () => {
-    const req: ChatRequest = {
-      model: "gpt-5-mini",
-      message: "continue",
-      history: [
-        {
-          id: "msg_history",
-          role: "assistant",
-          content: "HISTORY_SENTINEL",
-          timestamp: "2026-02-20T10:00:00.000Z",
-        },
-      ],
-    };
-
-    const { input, usage } = createAgentInput(req, {
+    const { input, usage } = createAgentInput(req("continue", [msg("history", "assistant", "HISTORY_SENTINEL")]), {
       ...defaultOptions,
       contextMaxTokens: 100,
       systemPromptTokens: 70,
@@ -94,266 +88,112 @@ describe("createAgentInput", () => {
   });
 
   test("keeps pinned skill context before recent chat when budget is tight", () => {
-    const req: ChatRequest = {
-      model: "gpt-5-mini",
-      message: "use repo conventions",
-      activeSkills: [{ name: "build", instructions: "keep slices small." }],
-      history: [
-        {
-          id: "msg_user",
-          role: "user",
-          content: "x".repeat(10_000),
-          timestamp: "2026-02-20T10:00:01.000Z",
-        },
-      ],
-    };
-
-    const { input } = createAgentInput(req, defaultOptions);
+    const { input } = createAgentInput(
+      req("use repo conventions", [msg("user", "user", "x".repeat(10_000))], {
+        activeSkills: [{ name: "build", instructions: "keep slices small." }],
+      }),
+      defaultOptions,
+    );
     expect(input).toContain("SYSTEM: Active skill (build)");
     expect(input).toContain("USER: use repo conventions");
   });
 
   test("respects hard context token budget approximately", () => {
-    const req: ChatRequest = {
-      model: "gpt-5-mini",
-      message: "review",
-      history: Array.from({ length: 100 }).map((_, index) => ({
-        id: `msg_${index}`,
-        role: index % 2 === 0 ? ("user" as const) : ("assistant" as const),
-        content: `line-${index} ${"z".repeat(1000)}`,
-        timestamp: `2026-02-20T10:00:${String(index).padStart(2, "0")}.000Z`,
-      })),
-    };
-
-    const { input } = createAgentInput(req, defaultOptions);
+    const { input } = createAgentInput(req("review", exchanges(50)), defaultOptions);
     expect(input.length).toBeLessThanOrEqual(120_000);
     expect(input).toContain("USER: review");
   });
 
   test("includes full tool payload content when budget allows", () => {
     const toolHeavy = `stdout:\n${"A".repeat(5000)}\nstderr:\n${"B".repeat(2000)}`;
-    const req: ChatRequest = {
-      model: "gpt-5-mini",
-      message: "continue",
-      history: [
-        {
-          id: "msg_old_tool",
-          role: "assistant",
-          content: toolHeavy,
-          kind: "tool_payload",
-          timestamp: "2026-02-20T10:00:00.000Z",
-        },
-        {
-          id: "msg_old_user",
-          role: "user",
-          content: "thanks",
-          timestamp: "2026-02-20T10:00:01.000Z",
-        },
-        {
-          id: "msg_recent_assistant",
-          role: "assistant",
-          content: "Ready for the next step.",
-          timestamp: "2026-02-20T10:00:02.000Z",
-        },
-      ],
-    };
-
-    const { input } = createAgentInput(req, defaultOptions);
+    const { input } = createAgentInput(
+      req("continue", [
+        msg("tool", "assistant", toolHeavy, "tool_payload"),
+        msg("user", "user", "thanks"),
+        msg("reply", "assistant", "Ready for the next step."),
+      ]),
+      defaultOptions,
+    );
     expect(input).toContain("A".repeat(5000));
     expect(input).toContain("B".repeat(2000));
     expect(input).toContain("ASSISTANT: Ready for the next step.");
   });
 
   test("keeps newest oversized history turn by truncating to remaining budget", () => {
-    const req: ChatRequest = {
-      model: "gpt-5-mini",
-      message: "U".repeat(380),
-      history: [
-        {
-          id: "msg_old",
-          role: "assistant",
-          content: "older context that should lose to newest turn",
-          timestamp: "2026-02-20T10:00:00.000Z",
-        },
-        {
-          id: "msg_new",
-          role: "assistant",
-          content: `LATEST ${"x".repeat(4000)}`,
-          timestamp: "2026-02-20T10:00:01.000Z",
-        },
-      ],
-    };
-
-    const { input } = createAgentInput(req, { ...defaultOptions, contextMaxTokens: 120 });
+    const { input } = createAgentInput(
+      req("U".repeat(380), [
+        msg("old", "assistant", "older context that should lose to newest turn"),
+        msg("new", "assistant", `LATEST ${"x".repeat(4000)}`),
+      ]),
+      { ...defaultOptions, contextMaxTokens: 120 },
+    );
     expect(input).toContain("ASSISTANT: LATEST");
     expect(input).toContain("…");
     expect(input).not.toContain("older context that should lose to newest turn");
   });
 
   test("prioritizes conversational turns before old tool payloads under tight budget", () => {
-    const req: ChatRequest = {
-      model: "gpt-5-mini",
-      message: "U".repeat(380),
-      history: [
-        {
-          id: "msg_old_tool",
-          role: "assistant",
-          kind: "tool_payload",
-          content: `TOOL_SENTINEL ${"A".repeat(5000)}`,
-          timestamp: "2026-02-20T10:00:00.000Z",
-        },
-        {
-          id: "msg_keep_1",
-          role: "assistant",
-          content: `KEEP_ONE ${"x".repeat(500)}`,
-          timestamp: "2026-02-20T10:00:01.000Z",
-        },
-        {
-          id: "msg_keep_2",
-          role: "user",
-          content: `KEEP_TWO ${"y".repeat(500)}`,
-          timestamp: "2026-02-20T10:00:02.000Z",
-        },
-      ],
-    };
-
-    const { input } = createAgentInput(req, { ...defaultOptions, contextMaxTokens: 120 });
+    const { input } = createAgentInput(
+      req("U".repeat(380), [
+        msg("tool", "assistant", `TOOL_SENTINEL ${"A".repeat(5000)}`, "tool_payload"),
+        msg("keep1", "assistant", `KEEP_ONE ${"x".repeat(500)}`),
+        msg("keep2", "user", `KEEP_TWO ${"y".repeat(500)}`),
+      ]),
+      { ...defaultOptions, contextMaxTokens: 120 },
+    );
     expect(input).toContain("KEEP_TWO");
     expect(input).not.toContain("TOOL_SENTINEL");
   });
 
-  test("excludes exchanges beyond the window even when budget allows", () => {
-    // Build MAX_RECENT_TURNS + 3 exchanges (user + assistant pairs)
-    const exchanges = MAX_RECENT_TURNS + 3;
-    const history: ChatRequest["history"] = [];
-    for (let i = 0; i < exchanges; i++) {
-      history.push({
-        id: `msg_u${i}`,
-        role: "user",
-        content: `USER_EXCHANGE_${i}`,
-        timestamp: `2026-02-20T10:${String(i).padStart(2, "0")}:00.000Z`,
-      });
-      history.push({
-        id: `msg_a${i}`,
-        role: "assistant",
-        content: `ASSISTANT_EXCHANGE_${i}`,
-        timestamp: `2026-02-20T10:${String(i).padStart(2, "0")}:01.000Z`,
-      });
-    }
-    const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
-
-    const { input, usage } = createAgentInput(req, defaultOptions);
-    // Last MAX_RECENT_TURNS turns should be included
-    expect(input).toContain(`USER_EXCHANGE_${exchanges - 1}`);
-    expect(input).toContain(`ASSISTANT_EXCHANGE_${exchanges - 1}`);
-    expect(input).toContain(`USER_EXCHANGE_${exchanges - MAX_RECENT_TURNS}`);
-    // Older turns should be excluded
-    expect(input).not.toContain("USER_EXCHANGE_0");
-    expect(input).not.toContain("ASSISTANT_EXCHANGE_0");
-    expect(usage.totalHistoryMessages).toBe(history.length);
+  test("excludes turns beyond the window even when budget allows", () => {
+    const count = MAX_RECENT_TURNS + 3;
+    const { input, usage } = createAgentInput(req("go", exchanges(count)), defaultOptions);
+    expect(input).toContain(`USER_${count - 1}`);
+    expect(input).toContain(`ASSISTANT_${count - 1}`);
+    expect(input).toContain(`USER_${count - MAX_RECENT_TURNS}`);
+    expect(input).not.toContain("USER_0");
+    expect(input).not.toContain("ASSISTANT_0");
+    expect(usage.totalHistoryMessages).toBe(count * 2);
   });
 
-  test("includes tool payloads that belong to a windowed exchange", () => {
-    // One old exchange, then one recent exchange with tool payloads
-    const history: ChatRequest["history"] = [
-      { id: "msg_old_u", role: "user", content: "OLD_USER", timestamp: "2026-02-20T10:00:00.000Z" },
-      { id: "msg_old_a", role: "assistant", content: "OLD_ASSISTANT", timestamp: "2026-02-20T10:00:01.000Z" },
+  test("includes tool payloads that belong to a windowed turn", () => {
+    const history = [
+      ...exchange(99),
+      ...exchanges(MAX_RECENT_TURNS - 1),
+      ...exchange(MAX_RECENT_TURNS - 1, [msg("tool", "assistant", "TOOL_IN_WINDOW", "tool_payload")]),
     ];
-    // Add MAX_RECENT_TURNS exchanges, last one has tool payloads
-    for (let i = 0; i < MAX_RECENT_TURNS; i++) {
-      history.push({
-        id: `msg_u${i}`,
-        role: "user",
-        content: `RECENT_USER_${i}`,
-        timestamp: `2026-02-20T10:${String(i + 1).padStart(2, "0")}:00.000Z`,
-      });
-      if (i === MAX_RECENT_TURNS - 1) {
-        history.push({
-          id: `msg_tool${i}`,
-          role: "assistant",
-          kind: "tool_payload",
-          content: "TOOL_OUTPUT_IN_WINDOW",
-          timestamp: `2026-02-20T10:${String(i + 1).padStart(2, "0")}:01.000Z`,
-        });
-      }
-      history.push({
-        id: `msg_a${i}`,
-        role: "assistant",
-        content: `RECENT_ASSISTANT_${i}`,
-        timestamp: `2026-02-20T10:${String(i + 1).padStart(2, "0")}:02.000Z`,
-      });
-    }
-    const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
-
-    const { input } = createAgentInput(req, defaultOptions);
-    expect(input).toContain("TOOL_OUTPUT_IN_WINDOW");
-    expect(input).not.toContain("OLD_USER");
-    expect(input).not.toContain("OLD_ASSISTANT");
+    const { input } = createAgentInput(req("go", history), defaultOptions);
+    expect(input).toContain("TOOL_IN_WINDOW");
+    expect(input).not.toContain("USER_99");
+    expect(input).not.toContain("ASSISTANT_99");
   });
 
-  test("includes all messages when exchanges are within the window", () => {
-    const exchanges = MAX_RECENT_TURNS - 1;
-    const history: ChatRequest["history"] = [];
-    for (let i = 0; i < exchanges; i++) {
-      history.push({
-        id: `msg_u${i}`,
-        role: "user",
-        content: `TURN_U${i}`,
-        timestamp: `2026-02-20T10:${String(i).padStart(2, "0")}:00.000Z`,
-      });
-      history.push({
-        id: `msg_a${i}`,
-        role: "assistant",
-        content: `TURN_A${i}`,
-        timestamp: `2026-02-20T10:${String(i).padStart(2, "0")}:01.000Z`,
-      });
-    }
-    const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
-
-    const { input } = createAgentInput(req, defaultOptions);
-    expect(input).toContain("TURN_U0");
-    expect(input).toContain(`TURN_A${exchanges - 1}`);
+  test("includes all messages when turns are within the window", () => {
+    const count = MAX_RECENT_TURNS - 1;
+    const { input } = createAgentInput(req("go", exchanges(count)), defaultOptions);
+    expect(input).toContain("USER_0");
+    expect(input).toContain(`ASSISTANT_${count - 1}`);
   });
 
-  test("windowed messages are still truncated normally when individually large", () => {
-    const history: ChatRequest["history"] = [];
-    for (let i = 0; i < MAX_RECENT_TURNS; i++) {
-      history.push({
-        id: `msg_u${i}`,
-        role: "user",
-        content: `BIG_${i} ${"x".repeat(50_000)}`,
-        timestamp: `2026-02-20T10:${String(i).padStart(2, "0")}:00.000Z`,
-      });
-      history.push({
-        id: `msg_a${i}`,
-        role: "assistant",
-        content: `RESP_${i}`,
-        timestamp: `2026-02-20T10:${String(i).padStart(2, "0")}:01.000Z`,
-      });
-    }
-    const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
-
-    const { input } = createAgentInput(req, { ...defaultOptions, contextMaxTokens: 500 });
+  test("windowed messages are still truncated under tight budget", () => {
+    const history = Array.from({ length: MAX_RECENT_TURNS }, (_, i) =>
+      exchange(i, [msg(`big${i}`, "user", `BIG_${i} ${"x".repeat(50_000)}`)]),
+    ).flat();
+    const { input } = createAgentInput(req("go", history), { ...defaultOptions, contextMaxTokens: 500 });
     expect(input).toContain("…");
     expect(input).toContain("USER: go");
   });
 
   test("excludes system and status messages from the window", () => {
-    const history: ChatRequest["history"] = [
-      { id: "msg_sys", role: "system", content: "SYSTEM_NOISE", timestamp: "2026-02-20T10:00:00.000Z" },
-      { id: "msg_u0", role: "user", content: "ONLY_USER", timestamp: "2026-02-20T10:00:01.000Z" },
-      {
-        id: "msg_status",
-        role: "assistant",
-        kind: "status",
-        content: "STATUS_NOISE",
-        timestamp: "2026-02-20T10:00:02.000Z",
-      },
-      { id: "msg_a0", role: "assistant", content: "ONLY_REPLY", timestamp: "2026-02-20T10:00:03.000Z" },
-    ];
-    const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
-
-    const { input } = createAgentInput(req, defaultOptions);
+    const { input } = createAgentInput(
+      req("go", [
+        msg("sys", "system", "SYSTEM_NOISE"),
+        msg("u0", "user", "ONLY_USER"),
+        msg("status", "assistant", "STATUS_NOISE", "status"),
+        msg("a0", "assistant", "ONLY_REPLY"),
+      ]),
+      defaultOptions,
+    );
     expect(input).toContain("ONLY_USER");
     expect(input).toContain("ONLY_REPLY");
     expect(input).not.toContain("SYSTEM_NOISE");
@@ -361,38 +201,21 @@ describe("createAgentInput", () => {
   });
 
   test("includes all assistant messages when history has no user messages", () => {
-    const history: ChatRequest["history"] = [
-      { id: "msg_a0", role: "assistant", content: "REPLY_0", timestamp: "2026-02-20T10:00:00.000Z" },
-      { id: "msg_a1", role: "assistant", content: "REPLY_1", timestamp: "2026-02-20T10:00:01.000Z" },
-      { id: "msg_a2", role: "assistant", content: "REPLY_2", timestamp: "2026-02-20T10:00:02.000Z" },
-    ];
-    const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
-
-    const { input } = createAgentInput(req, defaultOptions);
+    const { input } = createAgentInput(
+      req("go", [
+        msg("a0", "assistant", "REPLY_0"),
+        msg("a1", "assistant", "REPLY_1"),
+        msg("a2", "assistant", "REPLY_2"),
+      ]),
+      defaultOptions,
+    );
     expect(input).toContain("REPLY_0");
     expect(input).toContain("REPLY_1");
     expect(input).toContain("REPLY_2");
   });
 
   test("totalHistoryMessages reflects full history, not windowed subset", () => {
-    const history: ChatRequest["history"] = [];
-    for (let i = 0; i < 25; i++) {
-      history.push({
-        id: `msg_u${i}`,
-        role: "user",
-        content: `msg ${i}`,
-        timestamp: `2026-02-20T10:${String(i).padStart(2, "0")}:00.000Z`,
-      });
-      history.push({
-        id: `msg_a${i}`,
-        role: "assistant",
-        content: `reply ${i}`,
-        timestamp: `2026-02-20T10:${String(i).padStart(2, "0")}:01.000Z`,
-      });
-    }
-    const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
-
-    const { usage } = createAgentInput(req, defaultOptions);
+    const { usage } = createAgentInput(req("go", exchanges(25)), defaultOptions);
     expect(usage.totalHistoryMessages).toBe(50);
   });
 });

--- a/src/agent-input.test.ts
+++ b/src/agent-input.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { createAgentInput, HISTORY_WINDOW, setTokenEncoder } from "./agent-input";
+import { createAgentInput, setTokenEncoder } from "./agent-input";
 import type { ChatRequest } from "./api";
+import { MAX_RECENT_TURNS } from "./lifecycle-constants";
 import { defaultLifecyclePolicy } from "./lifecycle-policy";
 
 const defaultOptions = {
@@ -222,8 +223,8 @@ describe("createAgentInput", () => {
   });
 
   test("excludes exchanges beyond the window even when budget allows", () => {
-    // Build HISTORY_WINDOW + 3 exchanges (user + assistant pairs)
-    const exchanges = HISTORY_WINDOW + 3;
+    // Build MAX_RECENT_TURNS + 3 exchanges (user + assistant pairs)
+    const exchanges = MAX_RECENT_TURNS + 3;
     const history: ChatRequest["history"] = [];
     for (let i = 0; i < exchanges; i++) {
       history.push({
@@ -242,10 +243,10 @@ describe("createAgentInput", () => {
     const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
 
     const { input, usage } = createAgentInput(req, defaultOptions);
-    // Last HISTORY_WINDOW turns should be included
+    // Last MAX_RECENT_TURNS turns should be included
     expect(input).toContain(`USER_EXCHANGE_${exchanges - 1}`);
     expect(input).toContain(`ASSISTANT_EXCHANGE_${exchanges - 1}`);
-    expect(input).toContain(`USER_EXCHANGE_${exchanges - HISTORY_WINDOW}`);
+    expect(input).toContain(`USER_EXCHANGE_${exchanges - MAX_RECENT_TURNS}`);
     // Older turns should be excluded
     expect(input).not.toContain("USER_EXCHANGE_0");
     expect(input).not.toContain("ASSISTANT_EXCHANGE_0");
@@ -258,15 +259,15 @@ describe("createAgentInput", () => {
       { id: "msg_old_u", role: "user", content: "OLD_USER", timestamp: "2026-02-20T10:00:00.000Z" },
       { id: "msg_old_a", role: "assistant", content: "OLD_ASSISTANT", timestamp: "2026-02-20T10:00:01.000Z" },
     ];
-    // Add HISTORY_WINDOW exchanges, last one has tool payloads
-    for (let i = 0; i < HISTORY_WINDOW; i++) {
+    // Add MAX_RECENT_TURNS exchanges, last one has tool payloads
+    for (let i = 0; i < MAX_RECENT_TURNS; i++) {
       history.push({
         id: `msg_u${i}`,
         role: "user",
         content: `RECENT_USER_${i}`,
         timestamp: `2026-02-20T10:${String(i + 1).padStart(2, "0")}:00.000Z`,
       });
-      if (i === HISTORY_WINDOW - 1) {
+      if (i === MAX_RECENT_TURNS - 1) {
         history.push({
           id: `msg_tool${i}`,
           role: "assistant",
@@ -291,7 +292,7 @@ describe("createAgentInput", () => {
   });
 
   test("includes all messages when exchanges are within the window", () => {
-    const exchanges = HISTORY_WINDOW - 1;
+    const exchanges = MAX_RECENT_TURNS - 1;
     const history: ChatRequest["history"] = [];
     for (let i = 0; i < exchanges; i++) {
       history.push({
@@ -316,7 +317,7 @@ describe("createAgentInput", () => {
 
   test("windowed messages are still truncated normally when individually large", () => {
     const history: ChatRequest["history"] = [];
-    for (let i = 0; i < HISTORY_WINDOW; i++) {
+    for (let i = 0; i < MAX_RECENT_TURNS; i++) {
       history.push({
         id: `msg_u${i}`,
         role: "user",
@@ -357,6 +358,20 @@ describe("createAgentInput", () => {
     expect(input).toContain("ONLY_REPLY");
     expect(input).not.toContain("SYSTEM_NOISE");
     expect(input).not.toContain("STATUS_NOISE");
+  });
+
+  test("includes all assistant messages when history has no user messages", () => {
+    const history: ChatRequest["history"] = [
+      { id: "msg_a0", role: "assistant", content: "REPLY_0", timestamp: "2026-02-20T10:00:00.000Z" },
+      { id: "msg_a1", role: "assistant", content: "REPLY_1", timestamp: "2026-02-20T10:00:01.000Z" },
+      { id: "msg_a2", role: "assistant", content: "REPLY_2", timestamp: "2026-02-20T10:00:02.000Z" },
+    ];
+    const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
+
+    const { input } = createAgentInput(req, defaultOptions);
+    expect(input).toContain("REPLY_0");
+    expect(input).toContain("REPLY_1");
+    expect(input).toContain("REPLY_2");
   });
 
   test("totalHistoryMessages reflects full history, not windowed subset", () => {

--- a/src/agent-input.test.ts
+++ b/src/agent-input.test.ts
@@ -18,8 +18,8 @@ function createRequest(content: string): ChatRequest {
     message: "review this",
     history: [
       {
-        id: "msg_system",
-        role: "system",
+        id: "msg_context",
+        role: "user",
         content,
         timestamp: "2026-02-20T10:00:00.000Z",
       },
@@ -221,46 +221,115 @@ describe("createAgentInput", () => {
     expect(input).not.toContain("TOOL_SENTINEL");
   });
 
-  test("excludes history beyond the window even when budget allows", () => {
-    const history = Array.from({ length: HISTORY_WINDOW + 5 }).map((_, i) => ({
-      id: `msg_${i}`,
-      role: i % 2 === 0 ? ("user" as const) : ("assistant" as const),
-      content: `TURN_${i}`,
-      timestamp: `2026-02-20T10:00:${String(i).padStart(2, "0")}.000Z`,
-    }));
+  test("excludes exchanges beyond the window even when budget allows", () => {
+    // Build HISTORY_WINDOW + 3 exchanges (user + assistant pairs)
+    const exchanges = HISTORY_WINDOW + 3;
+    const history: ChatRequest["history"] = [];
+    for (let i = 0; i < exchanges; i++) {
+      history.push({
+        id: `msg_u${i}`,
+        role: "user",
+        content: `USER_EXCHANGE_${i}`,
+        timestamp: `2026-02-20T10:${String(i).padStart(2, "0")}:00.000Z`,
+      });
+      history.push({
+        id: `msg_a${i}`,
+        role: "assistant",
+        content: `ASSISTANT_EXCHANGE_${i}`,
+        timestamp: `2026-02-20T10:${String(i).padStart(2, "0")}:01.000Z`,
+      });
+    }
     const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
 
     const { input, usage } = createAgentInput(req, defaultOptions);
-    expect(input).toContain(`TURN_${history.length - 1}`);
-    expect(input).toContain(`TURN_${history.length - HISTORY_WINDOW}`);
-    expect(input).not.toContain("TURN_0");
-    expect(usage.includedHistoryMessages).toBeLessThanOrEqual(HISTORY_WINDOW);
+    // Last HISTORY_WINDOW turns should be included
+    expect(input).toContain(`USER_EXCHANGE_${exchanges - 1}`);
+    expect(input).toContain(`ASSISTANT_EXCHANGE_${exchanges - 1}`);
+    expect(input).toContain(`USER_EXCHANGE_${exchanges - HISTORY_WINDOW}`);
+    // Older turns should be excluded
+    expect(input).not.toContain("USER_EXCHANGE_0");
+    expect(input).not.toContain("ASSISTANT_EXCHANGE_0");
     expect(usage.totalHistoryMessages).toBe(history.length);
   });
 
-  test("includes all messages when history is within the window", () => {
-    const count = HISTORY_WINDOW - 1;
-    const history = Array.from({ length: count }).map((_, i) => ({
-      id: `msg_${i}`,
-      role: i % 2 === 0 ? ("user" as const) : ("assistant" as const),
-      content: `TURN_${i}`,
-      timestamp: `2026-02-20T10:00:${String(i).padStart(2, "0")}.000Z`,
-    }));
+  test("includes tool payloads that belong to a windowed exchange", () => {
+    // One old exchange, then one recent exchange with tool payloads
+    const history: ChatRequest["history"] = [
+      { id: "msg_old_u", role: "user", content: "OLD_USER", timestamp: "2026-02-20T10:00:00.000Z" },
+      { id: "msg_old_a", role: "assistant", content: "OLD_ASSISTANT", timestamp: "2026-02-20T10:00:01.000Z" },
+    ];
+    // Add HISTORY_WINDOW exchanges, last one has tool payloads
+    for (let i = 0; i < HISTORY_WINDOW; i++) {
+      history.push({
+        id: `msg_u${i}`,
+        role: "user",
+        content: `RECENT_USER_${i}`,
+        timestamp: `2026-02-20T10:${String(i + 1).padStart(2, "0")}:00.000Z`,
+      });
+      if (i === HISTORY_WINDOW - 1) {
+        history.push({
+          id: `msg_tool${i}`,
+          role: "assistant",
+          kind: "tool_payload",
+          content: "TOOL_OUTPUT_IN_WINDOW",
+          timestamp: `2026-02-20T10:${String(i + 1).padStart(2, "0")}:01.000Z`,
+        });
+      }
+      history.push({
+        id: `msg_a${i}`,
+        role: "assistant",
+        content: `RECENT_ASSISTANT_${i}`,
+        timestamp: `2026-02-20T10:${String(i + 1).padStart(2, "0")}:02.000Z`,
+      });
+    }
     const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
 
-    const { input, usage } = createAgentInput(req, defaultOptions);
-    expect(input).toContain("TURN_0");
-    expect(input).toContain(`TURN_${count - 1}`);
-    expect(usage.includedHistoryMessages).toBe(count);
+    const { input } = createAgentInput(req, defaultOptions);
+    expect(input).toContain("TOOL_OUTPUT_IN_WINDOW");
+    expect(input).not.toContain("OLD_USER");
+    expect(input).not.toContain("OLD_ASSISTANT");
   });
 
-  test("last N turns are still truncated normally when individually large", () => {
-    const history = Array.from({ length: HISTORY_WINDOW }).map((_, i) => ({
-      id: `msg_${i}`,
-      role: "user" as const,
-      content: `BIG_${i} ${"x".repeat(50_000)}`,
-      timestamp: `2026-02-20T10:00:${String(i).padStart(2, "0")}.000Z`,
-    }));
+  test("includes all messages when exchanges are within the window", () => {
+    const exchanges = HISTORY_WINDOW - 1;
+    const history: ChatRequest["history"] = [];
+    for (let i = 0; i < exchanges; i++) {
+      history.push({
+        id: `msg_u${i}`,
+        role: "user",
+        content: `TURN_U${i}`,
+        timestamp: `2026-02-20T10:${String(i).padStart(2, "0")}:00.000Z`,
+      });
+      history.push({
+        id: `msg_a${i}`,
+        role: "assistant",
+        content: `TURN_A${i}`,
+        timestamp: `2026-02-20T10:${String(i).padStart(2, "0")}:01.000Z`,
+      });
+    }
+    const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
+
+    const { input } = createAgentInput(req, defaultOptions);
+    expect(input).toContain("TURN_U0");
+    expect(input).toContain(`TURN_A${exchanges - 1}`);
+  });
+
+  test("windowed messages are still truncated normally when individually large", () => {
+    const history: ChatRequest["history"] = [];
+    for (let i = 0; i < HISTORY_WINDOW; i++) {
+      history.push({
+        id: `msg_u${i}`,
+        role: "user",
+        content: `BIG_${i} ${"x".repeat(50_000)}`,
+        timestamp: `2026-02-20T10:${String(i).padStart(2, "0")}:00.000Z`,
+      });
+      history.push({
+        id: `msg_a${i}`,
+        role: "assistant",
+        content: `RESP_${i}`,
+        timestamp: `2026-02-20T10:${String(i).padStart(2, "0")}:01.000Z`,
+      });
+    }
     const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
 
     const { input } = createAgentInput(req, { ...defaultOptions, contextMaxTokens: 500 });
@@ -268,17 +337,47 @@ describe("createAgentInput", () => {
     expect(input).toContain("USER: go");
   });
 
+  test("excludes system and status messages from the window", () => {
+    const history: ChatRequest["history"] = [
+      { id: "msg_sys", role: "system", content: "SYSTEM_NOISE", timestamp: "2026-02-20T10:00:00.000Z" },
+      { id: "msg_u0", role: "user", content: "ONLY_USER", timestamp: "2026-02-20T10:00:01.000Z" },
+      {
+        id: "msg_status",
+        role: "assistant",
+        kind: "status",
+        content: "STATUS_NOISE",
+        timestamp: "2026-02-20T10:00:02.000Z",
+      },
+      { id: "msg_a0", role: "assistant", content: "ONLY_REPLY", timestamp: "2026-02-20T10:00:03.000Z" },
+    ];
+    const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
+
+    const { input } = createAgentInput(req, defaultOptions);
+    expect(input).toContain("ONLY_USER");
+    expect(input).toContain("ONLY_REPLY");
+    expect(input).not.toContain("SYSTEM_NOISE");
+    expect(input).not.toContain("STATUS_NOISE");
+  });
+
   test("totalHistoryMessages reflects full history, not windowed subset", () => {
-    const history = Array.from({ length: 50 }).map((_, i) => ({
-      id: `msg_${i}`,
-      role: "user" as const,
-      content: `msg ${i}`,
-      timestamp: `2026-02-20T10:00:${String(i).padStart(2, "0")}.000Z`,
-    }));
+    const history: ChatRequest["history"] = [];
+    for (let i = 0; i < 25; i++) {
+      history.push({
+        id: `msg_u${i}`,
+        role: "user",
+        content: `msg ${i}`,
+        timestamp: `2026-02-20T10:${String(i).padStart(2, "0")}:00.000Z`,
+      });
+      history.push({
+        id: `msg_a${i}`,
+        role: "assistant",
+        content: `reply ${i}`,
+        timestamp: `2026-02-20T10:${String(i).padStart(2, "0")}:01.000Z`,
+      });
+    }
     const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
 
     const { usage } = createAgentInput(req, defaultOptions);
     expect(usage.totalHistoryMessages).toBe(50);
-    expect(usage.includedHistoryMessages).toBeLessThanOrEqual(HISTORY_WINDOW);
   });
 });

--- a/src/agent-input.test.ts
+++ b/src/agent-input.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { createAgentInput, setTokenEncoder } from "./agent-input";
+import { createAgentInput, HISTORY_WINDOW, setTokenEncoder } from "./agent-input";
 import type { ChatRequest } from "./api";
 import { defaultLifecyclePolicy } from "./lifecycle-policy";
 
@@ -219,5 +219,66 @@ describe("createAgentInput", () => {
     const { input } = createAgentInput(req, { ...defaultOptions, contextMaxTokens: 120 });
     expect(input).toContain("KEEP_TWO");
     expect(input).not.toContain("TOOL_SENTINEL");
+  });
+
+  test("excludes history beyond the window even when budget allows", () => {
+    const history = Array.from({ length: HISTORY_WINDOW + 5 }).map((_, i) => ({
+      id: `msg_${i}`,
+      role: i % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      content: `TURN_${i}`,
+      timestamp: `2026-02-20T10:00:${String(i).padStart(2, "0")}.000Z`,
+    }));
+    const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
+
+    const { input, usage } = createAgentInput(req, defaultOptions);
+    expect(input).toContain(`TURN_${history.length - 1}`);
+    expect(input).toContain(`TURN_${history.length - HISTORY_WINDOW}`);
+    expect(input).not.toContain("TURN_0");
+    expect(usage.includedHistoryMessages).toBeLessThanOrEqual(HISTORY_WINDOW);
+    expect(usage.totalHistoryMessages).toBe(history.length);
+  });
+
+  test("includes all messages when history is within the window", () => {
+    const count = HISTORY_WINDOW - 1;
+    const history = Array.from({ length: count }).map((_, i) => ({
+      id: `msg_${i}`,
+      role: i % 2 === 0 ? ("user" as const) : ("assistant" as const),
+      content: `TURN_${i}`,
+      timestamp: `2026-02-20T10:00:${String(i).padStart(2, "0")}.000Z`,
+    }));
+    const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
+
+    const { input, usage } = createAgentInput(req, defaultOptions);
+    expect(input).toContain("TURN_0");
+    expect(input).toContain(`TURN_${count - 1}`);
+    expect(usage.includedHistoryMessages).toBe(count);
+  });
+
+  test("last N turns are still truncated normally when individually large", () => {
+    const history = Array.from({ length: HISTORY_WINDOW }).map((_, i) => ({
+      id: `msg_${i}`,
+      role: "user" as const,
+      content: `BIG_${i} ${"x".repeat(50_000)}`,
+      timestamp: `2026-02-20T10:00:${String(i).padStart(2, "0")}.000Z`,
+    }));
+    const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
+
+    const { input } = createAgentInput(req, { ...defaultOptions, contextMaxTokens: 500 });
+    expect(input).toContain("…");
+    expect(input).toContain("USER: go");
+  });
+
+  test("totalHistoryMessages reflects full history, not windowed subset", () => {
+    const history = Array.from({ length: 50 }).map((_, i) => ({
+      id: `msg_${i}`,
+      role: "user" as const,
+      content: `msg ${i}`,
+      timestamp: `2026-02-20T10:00:${String(i).padStart(2, "0")}.000Z`,
+    }));
+    const req: ChatRequest = { model: "gpt-5-mini", message: "go", history };
+
+    const { usage } = createAgentInput(req, defaultOptions);
+    expect(usage.totalHistoryMessages).toBe(50);
+    expect(usage.includedHistoryMessages).toBeLessThanOrEqual(HISTORY_WINDOW);
   });
 });

--- a/src/agent-input.ts
+++ b/src/agent-input.ts
@@ -89,7 +89,7 @@ function isConversationalMessage(message: ChatRequest["history"][number]): boole
   return true;
 }
 
-function windowHistory(messages: ChatRequest["history"], n: number): ChatRequest["history"] {
+function recentTurns(messages: ChatRequest["history"], n: number): ChatRequest["history"] {
   const conversational = messages.filter(isConversationalMessage);
   let turns = 0;
   let cutIndex = 0;
@@ -209,8 +209,8 @@ export function createAgentInput(
     }
   }
 
-  const recentHistory = windowHistory(req.history, MAX_RECENT_TURNS);
-  const recentResult = collectLinesWithinBudget(recentHistory, usedIds, tokenBudget.remaining());
+  const turns = recentTurns(req.history, MAX_RECENT_TURNS);
+  const recentResult = collectLinesWithinBudget(turns, usedIds, tokenBudget.remaining());
   lines.push(...recentResult.lines);
 
   if (lines.length > 0) lines.push("");

--- a/src/agent-input.ts
+++ b/src/agent-input.ts
@@ -84,6 +84,26 @@ function truncateByTokens(input: string, maxTokens: number): string {
   return `${input.slice(0, lo)}…`;
 }
 
+function isConversationalMessage(message: ChatRequest["history"][number]): boolean {
+  if (message.role === "system") return false;
+  if (message.kind === "status") return false;
+  return true;
+}
+
+function lastNTurns(messages: ChatRequest["history"], n: number): ChatRequest["history"] {
+  const conversational = messages.filter(isConversationalMessage);
+  let turns = 0;
+  let cutIndex = 0;
+  for (let i = conversational.length - 1; i >= 0; i--) {
+    if (conversational[i].role === "user") {
+      turns++;
+      if (turns > n) return conversational.slice(cutIndex);
+      cutIndex = i;
+    }
+  }
+  return conversational;
+}
+
 function isAssistantToolPayloadMessage(message: ChatRequest["history"][number]): boolean {
   return message.role === "assistant" && message.kind === "tool_payload";
 }
@@ -190,7 +210,7 @@ export function createAgentInput(
     }
   }
 
-  const recentHistory = req.history.slice(-HISTORY_WINDOW);
+  const recentHistory = lastNTurns(req.history, HISTORY_WINDOW);
   const recentResult = collectLinesWithinBudget(recentHistory, usedIds, tokenBudget.remaining());
   lines.push(...recentResult.lines);
 

--- a/src/agent-input.ts
+++ b/src/agent-input.ts
@@ -1,7 +1,6 @@
 import type { ChatRequest } from "./api";
+import { MAX_RECENT_TURNS } from "./lifecycle-constants";
 import { log } from "./log";
-
-export const HISTORY_WINDOW = 5;
 
 type TokenEncoder = { encode(input: string): { length: number } };
 
@@ -90,7 +89,7 @@ function isConversationalMessage(message: ChatRequest["history"][number]): boole
   return true;
 }
 
-function lastNTurns(messages: ChatRequest["history"], n: number): ChatRequest["history"] {
+function windowHistory(messages: ChatRequest["history"], n: number): ChatRequest["history"] {
   const conversational = messages.filter(isConversationalMessage);
   let turns = 0;
   let cutIndex = 0;
@@ -210,7 +209,7 @@ export function createAgentInput(
     }
   }
 
-  const recentHistory = lastNTurns(req.history, HISTORY_WINDOW);
+  const recentHistory = windowHistory(req.history, MAX_RECENT_TURNS);
   const recentResult = collectLinesWithinBudget(recentHistory, usedIds, tokenBudget.remaining());
   lines.push(...recentResult.lines);
 

--- a/src/agent-input.ts
+++ b/src/agent-input.ts
@@ -1,6 +1,8 @@
 import type { ChatRequest } from "./api";
 import { log } from "./log";
 
+export const HISTORY_WINDOW = 5;
+
 type TokenEncoder = { encode(input: string): { length: number } };
 
 function createApproxEncoder(): TokenEncoder {
@@ -188,7 +190,8 @@ export function createAgentInput(
     }
   }
 
-  const recentResult = collectLinesWithinBudget(req.history, usedIds, tokenBudget.remaining());
+  const recentHistory = req.history.slice(-HISTORY_WINDOW);
+  const recentResult = collectLinesWithinBudget(recentHistory, usedIds, tokenBudget.remaining());
   lines.push(...recentResult.lines);
 
   if (lines.length > 0) lines.push("");

--- a/src/agent-instructions.ts
+++ b/src/agent-instructions.ts
@@ -7,6 +7,7 @@ const CORE_INSTRUCTIONS = [
   "If implementation intent is clear, do the work and stay with it until the task is complete.",
   "If the user asks for explanation or planning only, answer directly and wait for an implementation request.",
   "You have engineering skills. ALWAYS use `skill-activate` to load the matching skill before starting implementation work. Use `skill-list` to discover project-specific skills. Do not begin implementation directly — activate the skill first. The skill's workflow is the way you do the work.",
+  "Use `session-search` to find earlier conversation turns when you need context beyond the recent messages shown. The last few turns are included automatically; everything older is searchable via this tool.",
   "ALWAYS use `memory-search` to recall prior context before starting work. Use `memory-add` to persist decisions, conventions, or instructions the user gives you. Do not forget what the user taught you — save it to memory.",
   "Make the smallest root-cause change that matches local conventions.",
   "Skip unrelated or speculative detours.",

--- a/src/agent-instructions.ts
+++ b/src/agent-instructions.ts
@@ -7,7 +7,7 @@ const CORE_INSTRUCTIONS = [
   "If implementation intent is clear, do the work and stay with it until the task is complete.",
   "If the user asks for explanation or planning only, answer directly and wait for an implementation request.",
   "You have engineering skills. ALWAYS use `skill-activate` to load the matching skill before starting implementation work. Use `skill-list` to discover project-specific skills. Do not begin implementation directly — activate the skill first. The skill's workflow is the way you do the work.",
-  "Use `session-search` to find earlier conversation turns when you need context beyond the recent messages shown. The last few turns are included automatically; everything older is searchable via this tool.",
+  "Only recent turns are visible. When the user references something you cannot see — a prior decision, an earlier error, a file discussed before — use `session-search` to find it. Do not ask the user to repeat themselves.",
   "ALWAYS use `memory-search` to recall prior context before starting work. Use `memory-add` to persist decisions, conventions, or instructions the user gives you. Do not forget what the user taught you — save it to memory.",
   "Make the smallest root-cause change that matches local conventions.",
   "Skip unrelated or speculative detours.",

--- a/src/agent-instructions.ts
+++ b/src/agent-instructions.ts
@@ -8,7 +8,7 @@ const CORE_INSTRUCTIONS = [
   "If the user asks for explanation or planning only, answer directly and wait for an implementation request.",
   "You have engineering skills. ALWAYS use `skill-activate` to load the matching skill before starting implementation work. Use `skill-list` to discover project-specific skills. Do not begin implementation directly — activate the skill first. The skill's workflow is the way you do the work.",
   "Only recent turns are visible. When the user references something you cannot see — a prior decision, an earlier error, a file discussed before — use `session-search` to find it. Do not ask the user to repeat themselves.",
-  "ALWAYS use `memory-search` to recall prior context before starting work. Use `memory-add` to persist decisions, conventions, or instructions the user gives you. Do not forget what the user taught you — save it to memory.",
+  "Use `memory-search` when starting new work or when the user references conventions, preferences, or decisions from past sessions. Use `memory-add` to persist what the user teaches you — do not forget it.",
   "Make the smallest root-cause change that matches local conventions.",
   "Skip unrelated or speculative detours.",
   "Avoid repeating tool calls without new information.",

--- a/src/agent-instructions.ts
+++ b/src/agent-instructions.ts
@@ -6,7 +6,7 @@ const CORE_INSTRUCTIONS = [
   "Prefer dedicated project tools; use shell only when it helps.",
   "If implementation intent is clear, do the work and stay with it until the task is complete.",
   "If the user asks for explanation or planning only, answer directly and wait for an implementation request.",
-  "You have engineering skills. ALWAYS use `skill-activate` to load the matching skill before starting implementation work. Use `skill-list` to discover project-specific skills. Do not begin implementation directly — activate the skill first. The skill's workflow is the way you do the work.",
+  "Skills are activated automatically when the task matches. Use `skill-list` to discover project-specific skills. Use `skill-activate` to load a skill manually when auto-activation did not trigger.",
   "Only recent turns are visible. When the user references something you cannot see — a prior decision, an earlier error, a file discussed before — use `session-search` to find it. Do not ask the user to repeat themselves.",
   "Use `memory-search` when starting new work or when the user references conventions, preferences, or decisions from past sessions. Use `memory-add` to persist what the user teaches you — do not forget it.",
   "Make the smallest root-cause change that matches local conventions.",

--- a/src/cli-history.test.ts
+++ b/src/cli-history.test.ts
@@ -19,6 +19,9 @@ function createMockStore(sessions: Session[] = []): SessionStore {
       return undefined;
     },
     async setActiveSessionId() {},
+    async searchSession() {
+      return [];
+    },
     close() {},
   };
 }

--- a/src/cloud-client.test.ts
+++ b/src/cloud-client.test.ts
@@ -144,6 +144,22 @@ describe("cloud sync client", () => {
     expect(body.messages[0].id).toBe("msg_2");
   });
 
+  test("session.searchSession sends POST with query", async () => {
+    const fn = jsonFetch(200, [
+      { id: "msg_1", role: "user", content: "fix auth", kind: "text", timestamp: "2026-01-01T00:00:00.000Z" },
+    ]);
+    const client = new CloudClient("https://api.example.com", "t");
+    const results = await client.session.searchSession("sess_1", "auth", { limit: 5 });
+    const [url, init] = callArgs(fn);
+    expect(url).toContain("/sessions/sess_1/search");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string);
+    expect(body.query).toBe("auth");
+    expect(body.limit).toBe(5);
+    expect(results).toHaveLength(1);
+    expect(results[0].content).toBe("fix auth");
+  });
+
   test("gzips large request bodies", async () => {
     const fn = jsonFetch(200, { ok: true });
     const client = new CloudClient("https://api.example.com", "t");

--- a/src/cloud-client.ts
+++ b/src/cloud-client.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { type ChatMessage, messageSchema } from "./chat-contract";
 import { CodedError } from "./coded-error";
 import { CLOUD_ERROR_CODES, type CloudErrorCode } from "./error-contract";
 import { type MemoryRecord, type MemoryScope, type MemoryStore, memoryRecordSchema } from "./memory-contract";
@@ -26,6 +27,7 @@ const ROUTES = {
     get: (id: string) => `/api/v1/sessions/${encodeURIComponent(id)}`,
     remove: (id: string) => `/api/v1/sessions/${encodeURIComponent(id)}`,
     append: (id: string) => `/api/v1/sessions/${encodeURIComponent(id)}/append`,
+    search: (id: string) => `/api/v1/sessions/${encodeURIComponent(id)}/search`,
     getActive: "/api/v1/sessions/active",
     setActive: "/api/v1/sessions/active",
   },
@@ -84,6 +86,7 @@ export class CloudClient {
       removeSession: (id) => this.removeSession(id),
       getActiveSessionId: () => this.getActiveSessionId(),
       setActiveSessionId: (id) => this.setActiveSessionId(id),
+      searchSession: (id, query, options) => this.searchSessionMessages(id, query, options),
       close: () => {},
     };
   }
@@ -218,6 +221,17 @@ export class CloudClient {
 
   private async setActiveSessionId(id: SessionId | undefined): Promise<void> {
     await this.put(ROUTES.sessions.setActive, { body: { id: id ?? null } });
+  }
+
+  private async searchSessionMessages(
+    id: SessionId,
+    query: string,
+    options?: { limit?: number },
+  ): Promise<readonly ChatMessage[]> {
+    return this.post(ROUTES.sessions.search(id), {
+      schema: z.array(messageSchema),
+      body: { query, limit: options?.limit },
+    });
   }
 
   private async request<T = void>(

--- a/src/cloud-client.ts
+++ b/src/cloud-client.ts
@@ -86,7 +86,7 @@ export class CloudClient {
       removeSession: (id) => this.removeSession(id),
       getActiveSessionId: () => this.getActiveSessionId(),
       setActiveSessionId: (id) => this.setActiveSessionId(id),
-      searchSession: (id, query, options) => this.searchSessionMessages(id, query, options),
+      searchSession: (id, query, options) => this.searchSession(id, query, options),
       close: () => {},
     };
   }
@@ -223,7 +223,7 @@ export class CloudClient {
     await this.put(ROUTES.sessions.setActive, { body: { id: id ?? null } });
   }
 
-  private async searchSessionMessages(
+  private async searchSession(
     id: SessionId,
     query: string,
     options?: { limit?: number },

--- a/src/lifecycle-constants.ts
+++ b/src/lifecycle-constants.ts
@@ -4,3 +4,4 @@ export const STEP_TIMEOUT_MS = 120_000;
 export const MAX_UNKNOWN_ERRORS_PER_REQUEST = 2;
 export const TOOL_TIMEOUT_MS = 10_000;
 export const CONTEXT_MAX_TOKENS = 100_000;
+export const MAX_RECENT_TURNS = 5;

--- a/src/session-contract.ts
+++ b/src/session-contract.ts
@@ -90,5 +90,6 @@ export interface SessionStore {
   removeSession(id: SessionId): Promise<void>;
   getActiveSessionId(): Promise<SessionId | undefined>;
   setActiveSessionId(id: SessionId | undefined): Promise<void>;
+  searchSession(id: SessionId, query: string, options?: { limit?: number }): Promise<readonly ChatMessage[]>;
   close(): void;
 }

--- a/src/session-ops.test.ts
+++ b/src/session-ops.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import type { ChatMessage } from "./chat-contract";
+import { searchMessages } from "./session-ops";
+
+function msg(id: string, content: string, kind?: ChatMessage["kind"], role?: ChatMessage["role"]): ChatMessage {
+  return {
+    id: `msg_${id}`,
+    role: role ?? "user",
+    content,
+    kind: kind ?? "text",
+    timestamp: "2026-04-15T10:00:00.000Z",
+  };
+}
+
+describe("searchMessages", () => {
+  test("returns matching messages in chronological order", () => {
+    const messages = [msg("1", "fix the auth bug"), msg("2", "done with tests"), msg("3", "auth flow looks good")];
+    const results = searchMessages(messages, "auth");
+    expect(results.map((r) => r.id)).toEqual(["msg_1", "msg_3"]);
+  });
+
+  test("returns empty array on no match", () => {
+    const messages = [msg("1", "fix the auth bug"), msg("2", "done with tests")];
+    expect(searchMessages(messages, "database")).toEqual([]);
+  });
+
+  test("respects limit", () => {
+    const messages = [msg("1", "error in foo"), msg("2", "error in bar"), msg("3", "error in baz")];
+    const results = searchMessages(messages, "error", { limit: 2 });
+    expect(results).toHaveLength(2);
+    expect(results.map((r) => r.id)).toEqual(["msg_1", "msg_2"]);
+  });
+
+  test("matches case-insensitively", () => {
+    const messages = [msg("1", "TypeError: null is not a function")];
+    const results = searchMessages(messages, "typeerror");
+    expect(results).toHaveLength(1);
+  });
+
+  test("skips status messages", () => {
+    const messages = [msg("1", "searching files", "status"), msg("2", "searching files", "text")];
+    const results = searchMessages(messages, "searching");
+    expect(results.map((r) => r.id)).toEqual(["msg_2"]);
+  });
+
+  test("includes tool_payload messages", () => {
+    const messages = [msg("1", "stdout: connection refused", "tool_payload")];
+    const results = searchMessages(messages, "connection refused");
+    expect(results).toHaveLength(1);
+  });
+});

--- a/src/session-ops.ts
+++ b/src/session-ops.ts
@@ -1,0 +1,20 @@
+import type { ChatMessage } from "./chat-contract";
+
+type SearchableMessage = Pick<ChatMessage, "id" | "role" | "content" | "kind" | "timestamp">;
+
+export function searchMessages(
+  messages: readonly SearchableMessage[],
+  query: string,
+  options?: { limit?: number },
+): SearchableMessage[] {
+  const limit = options?.limit ?? 10;
+  const lower = query.toLowerCase();
+  const results: SearchableMessage[] = [];
+  for (const m of messages) {
+    if (m.kind === "status") continue;
+    if (!m.content.toLowerCase().includes(lower)) continue;
+    results.push(m);
+    if (results.length >= limit) break;
+  }
+  return results;
+}

--- a/src/session-store-contract.test-suite.ts
+++ b/src/session-store-contract.test-suite.ts
@@ -119,6 +119,66 @@ export function sessionStoreContractTests(
     });
   });
 
+  describe(`${name} searchSession`, () => {
+    test("finds matching messages by keyword", async () => {
+      const s = await getStore();
+      const msg = (id: string, role: string, content: string, ts: string) =>
+        ({ id, role, content, kind: "text", timestamp: ts }) as Session["messages"][number];
+      await s.saveSession(
+        makeSession({
+          id: "sess_search01",
+          messages: [
+            msg("msg_1", "user", "fix the auth bug", "2026-03-04T12:00:00.000Z"),
+            msg("msg_2", "assistant", "done", "2026-03-04T12:00:01.000Z"),
+            msg("msg_3", "user", "auth still broken", "2026-03-04T12:00:02.000Z"),
+          ],
+        }),
+      );
+      const results = await s.searchSession("sess_search01", "auth");
+      expect(results).toHaveLength(2);
+      expect(results[0]?.content).toBe("fix the auth bug");
+      expect(results[1]?.content).toBe("auth still broken");
+    });
+
+    test("returns empty array for no match", async () => {
+      const s = await getStore();
+      await s.saveSession(
+        makeSession({
+          id: "sess_search02",
+          messages: [
+            { id: "msg_1", role: "user", content: "hello", kind: "text", timestamp: "2026-03-04T12:00:00.000Z" },
+          ] as Session["messages"],
+        }),
+      );
+      const results = await s.searchSession("sess_search02", "database");
+      expect(results).toHaveLength(0);
+    });
+
+    test("returns empty array for nonexistent session", async () => {
+      const s = await getStore();
+      const results = await s.searchSession("sess_missing1", "anything");
+      expect(results).toHaveLength(0);
+    });
+
+    test("respects limit", async () => {
+      const s = await getStore();
+      const msg = (id: string, content: string, ts: string) =>
+        ({ id, role: "user", content, kind: "text", timestamp: ts }) as Session["messages"][number];
+      await s.saveSession(
+        makeSession({
+          id: "sess_search03",
+          messages: [
+            msg("msg_1", "error one", "2026-03-04T12:00:00.000Z"),
+            msg("msg_2", "error two", "2026-03-04T12:00:01.000Z"),
+            msg("msg_3", "error three", "2026-03-04T12:00:02.000Z"),
+          ],
+        }),
+      );
+      const results = await s.searchSession("sess_search03", "error", { limit: 2 });
+      expect(results).toHaveLength(2);
+    });
+  });
+
   describe(`${name} active session`, () => {
     test("getActiveSessionId returns undefined initially", async () => {
       const s = await getStore();

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -5,6 +5,7 @@ import { t } from "./i18n";
 import { dataDir } from "./paths";
 import type { SessionStore } from "./session-contract";
 import { type Session, type SessionId, type SessionState, sessionStateSchema } from "./session-contract";
+import { searchMessages } from "./session-ops";
 import { createId } from "./short-id";
 
 const DEFAULT_SESSION_STATE: SessionState = { sessions: [] };
@@ -89,6 +90,13 @@ export function createFileSessionStore(storePath?: string): SessionStore {
       const state = await readState();
       state.activeSessionId = id;
       await writeState(state);
+    },
+
+    async searchSession(id, query, options) {
+      const state = await readState();
+      const session = state.sessions.find((s) => s.id === id);
+      if (!session) return [];
+      return searchMessages(session.messages, query, options);
     },
 
     close() {},

--- a/src/session-toolkit.ts
+++ b/src/session-toolkit.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+import { messageKindSchema, roleSchema } from "./chat-contract";
+import { isoDateTimeSchema } from "./datetime";
+import { searchMessages } from "./session-ops";
+import { getSessionStore } from "./session-store";
+import type { ToolkitInput } from "./tool-contract";
+import { createTool } from "./tool-contract";
+import { runTool } from "./tool-execution";
+
+function createSessionSearchTool(input: ToolkitInput) {
+  return createTool({
+    id: "session-search",
+    toolkit: "session",
+    category: "search",
+    description:
+      "Search the current session's conversation history by keyword. Returns matching messages in chronological order.",
+    instruction:
+      "Use `session-search` to find earlier conversation turns by keyword. The last few messages are included in context automatically; older history is only available through this tool.",
+    inputSchema: z.object({
+      query: z.string().min(1),
+      limit: z.number().int().min(1).max(50).optional(),
+    }),
+    outputSchema: z.object({
+      kind: z.literal("session-search"),
+      results: z.array(
+        z.object({
+          id: z.string(),
+          role: roleSchema,
+          content: z.string(),
+          kind: messageKindSchema,
+          timestamp: isoDateTimeSchema,
+        }),
+      ),
+    }),
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "session-search", toolCallId, toolInput, async () => {
+        if (!input.sessionId) return { kind: "session-search" as const, results: [] };
+        const store = await getSessionStore();
+        const session = await store.getSession(input.sessionId);
+        if (!session) return { kind: "session-search" as const, results: [] };
+        const results = searchMessages(session.messages, toolInput.query, { limit: toolInput.limit });
+        return {
+          kind: "session-search" as const,
+          results: results.map((m) => ({
+            id: m.id,
+            role: m.role,
+            content: m.content,
+            kind: m.kind ?? "text",
+            timestamp: m.timestamp,
+          })),
+        };
+      });
+    },
+  });
+}
+
+export function createSessionToolkit(input: ToolkitInput) {
+  return {
+    sessionSearch: createSessionSearchTool(input),
+  };
+}

--- a/src/session-toolkit.ts
+++ b/src/session-toolkit.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 import { messageKindSchema, roleSchema } from "./chat-contract";
 import { isoDateTimeSchema } from "./datetime";
-import { searchMessages } from "./session-ops";
 import { getSessionStore } from "./session-store";
 import type { ToolkitInput } from "./tool-contract";
 import { createTool } from "./tool-contract";
@@ -36,9 +35,7 @@ function createSessionSearchTool(input: ToolkitInput) {
       return runTool(input.session, "session-search", toolCallId, toolInput, async () => {
         if (!input.sessionId) return { kind: "session-search" as const, results: [] };
         const store = await getSessionStore();
-        const session = await store.getSession(input.sessionId);
-        if (!session) return { kind: "session-search" as const, results: [] };
-        const results = searchMessages(session.messages, toolInput.query, { limit: toolInput.limit });
+        const results = await store.searchSession(input.sessionId, toolInput.query, { limit: toolInput.limit });
         return {
           kind: "session-search" as const,
           results: results.map((m) => ({

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -31,6 +31,7 @@ describe("toolsets", () => {
       "runTests",
       "scanCode",
       "searchFiles",
+      "sessionSearch",
       "updateChecklist",
       "webFetch",
       "webSearch",
@@ -106,6 +107,7 @@ describe("localization baseline", () => {
     const webFetchInstruction = toolDefinitionsById["web-fetch"]?.instruction ?? "";
     const checklistCreateInstruction = toolDefinitionsById["checklist-create"]?.instruction ?? "";
     const checklistUpdateInstruction = toolDefinitionsById["checklist-update"]?.instruction ?? "";
+    const sessionSearchInstruction = toolDefinitionsById["session-search"]?.instruction ?? "";
     const memorySearchInstruction = toolDefinitionsById["memory-search"]?.instruction ?? "";
     const memoryAddInstruction = toolDefinitionsById["memory-add"]?.instruction ?? "";
     const memoryRemoveInstruction = toolDefinitionsById["memory-remove"]?.instruction ?? "";
@@ -145,6 +147,7 @@ describe("localization baseline", () => {
     expectIntent(webFetchInstruction, [["read specific urls"]]);
     expectIntent(checklistCreateInstruction, [["checklist-create"], ["multi-step tasks"], ["checklist-update"]]);
     expectIntent(checklistUpdateInstruction, [["checklist-update"], ["status"], ["checklist-create"]]);
+    expectIntent(sessionSearchInstruction, [["session-search"], ["keyword"], ["older history"]]);
     expectIntent(memorySearchInstruction, [["memory-search"], ["recall"], ["prior context"]]);
     expectIntent(memoryAddInstruction, [["memory-add"], ["persist"], ["sessions"]]);
     expectIntent(memoryRemoveInstruction, [["memory-remove"], ["outdated"], ["memory-search"]]);

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -28,8 +28,8 @@ type RegisteredToolkit = ReturnType<typeof createFileToolkit> &
   ReturnType<typeof createTestToolkit> &
   ReturnType<typeof createGitToolkit> &
   ReturnType<typeof createChecklistToolkit> &
-  ReturnType<typeof createMemoryToolkit> &
   ReturnType<typeof createSessionToolkit> &
+  ReturnType<typeof createMemoryToolkit> &
   ReturnType<typeof createSkillToolkit> &
   ReturnType<typeof createUndoToolkit>;
 
@@ -56,12 +56,12 @@ export const TOOLKIT_REGISTRY: {
     createToolkit: (input) => createUndoToolkit(input),
   },
   {
-    id: "memory",
-    createToolkit: (input) => createMemoryToolkit(input),
-  },
-  {
     id: "session",
     createToolkit: (input) => createSessionToolkit(input),
+  },
+  {
+    id: "memory",
+    createToolkit: (input) => createMemoryToolkit(input),
   },
   {
     id: "skill",

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -6,6 +6,7 @@ import { createFileToolkit } from "./file-toolkit";
 import { createGitToolkit } from "./git-toolkit";
 import { bindMcpTools, type McpToolListing } from "./mcp-client";
 import { createMemoryToolkit } from "./memory-toolkit";
+import { createSessionToolkit } from "./session-toolkit";
 import { createShellToolkit } from "./shell-toolkit";
 import { createSkillToolkit } from "./skill-toolkit";
 import { createTestToolkit } from "./test-toolkit";
@@ -28,6 +29,7 @@ type RegisteredToolkit = ReturnType<typeof createFileToolkit> &
   ReturnType<typeof createGitToolkit> &
   ReturnType<typeof createChecklistToolkit> &
   ReturnType<typeof createMemoryToolkit> &
+  ReturnType<typeof createSessionToolkit> &
   ReturnType<typeof createSkillToolkit> &
   ReturnType<typeof createUndoToolkit>;
 
@@ -56,6 +58,10 @@ export const TOOLKIT_REGISTRY: {
   {
     id: "memory",
     createToolkit: (input) => createMemoryToolkit(input),
+  },
+  {
+    id: "session",
+    createToolkit: (input) => createSessionToolkit(input),
   },
   {
     id: "skill",


### PR DESCRIPTION
## Motivation

`agent-input.ts` pre-packs all conversation history into the prompt, growing with conversation length and wasting tokens on stale tool output. The model should pull what it needs on demand — same pattern as memory search.

## Summary

- add `session-search` tool with substring matching over current session messages
- add `searchMessages` pure function in `session-ops.ts`
- add `searchSession` to `SessionStore` interface with contract tests
- window `agent-input.ts` history to last N user turns instead of filling token budget
- filter system and status messages from the history window
- add `session-search` to core instructions so the model uses it automatically
- soften `memory-search` and `skill-activate` instructions from "always" to trigger-based
- update tooling, sessions, and testing docs

Fixes #216