### PR TITLE
feat(chat): pulsing indicator for awaiting-input

### DIFF
--- a/src/chat-message-handler.int.test.ts
+++ b/src/chat-message-handler.int.test.ts
@@ -554,4 +554,22 @@ describe("chat message handler", () => {
     // to cancel the remote task polling.
     expect(interruptHandler).not.toBeNull();
   });
+
+  test("awaiting-input preserves pending state after turn completes", async () => {
+    const { handleMessage, calls } = createMessageHandlerHarness({
+      client: createClient({
+        replyStream: async (input) => {
+          input.onEvent({ type: "text-delta", text: "What input?" });
+          return { state: "awaiting-input" as const, model: "gpt-5-mini", output: "What input?" };
+        },
+        status: async () => ({}),
+      }),
+    });
+
+    await handleMessage("ask me for some input");
+
+    const last = calls.pendingStates[calls.pendingStates.length - 1];
+    expect(last).toEqual({ kind: "awaiting-input" });
+    expect(calls.pendingTransitions.at(-1)).toBe(true);
+  });
 });

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -179,7 +179,9 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
       // Clear the pending indicator in the same synchronous block as
       // adding the worked/status rows so React batches them into one
       // commit — avoids a frame where both "Working" and "Worked" show.
-      input.setPendingState(null);
+      // When awaiting input, transition to the awaiting-input pending
+      // state instead of clearing — keeps the pulsing indicator alive.
+      input.setPendingState(turn.awaitingInput ? { kind: "awaiting-input" } : null);
       input.setRows((current) => [...current, ...turn.rows]);
       invalidateRepoPathCandidates();
       input.currentSession.tokenUsage.push(turn.tokenEntry);

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -102,7 +102,7 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
     });
 
     await input.persist();
-    let keepPendingForRemoteTask = false;
+    let cleanup: "full" | "turn-only" | "none" = "full";
 
     try {
       const suggestions: string[] = [];
@@ -179,9 +179,14 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
       // Clear the pending indicator in the same synchronous block as
       // adding the worked/status rows so React batches them into one
       // commit — avoids a frame where both "Working" and "Worked" show.
-      // When awaiting input, transition to the awaiting-input pending
-      // state instead of clearing — keeps the pulsing indicator alive.
-      input.setPendingState(turn.awaitingInput ? { kind: "awaiting-input" } : null);
+      // For awaiting-input, keep the indicator alive and tell the
+      // finally block to skip pending cleanup.
+      if (turn.awaitingInput) {
+        cleanup = "turn-only";
+        input.setPendingState({ kind: "awaiting-input" });
+      } else {
+        input.setPendingState(null);
+      }
       input.setRows((current) => [...current, ...turn.rows]);
       invalidateRepoPathCandidates();
       input.currentSession.tokenUsage.push(turn.tokenEntry);
@@ -202,7 +207,7 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
         });
         if (startedFollowup) {
           input.setInterrupt(() => followupController.abort());
-          keepPendingForRemoteTask = true;
+          cleanup = "none";
           return;
         }
       }
@@ -235,11 +240,13 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
         ]);
       }
     } finally {
-      if (!keepPendingForRemoteTask) {
+      if (cleanup !== "none") {
         releaseTurn();
         input.setInterrupt(null);
-        stopPending();
-        input.setPendingState(null);
+        if (cleanup === "full") {
+          stopPending();
+          input.setPendingState(null);
+        }
       }
     }
   };

--- a/src/chat-pending.ts
+++ b/src/chat-pending.ts
@@ -25,7 +25,8 @@ export type PendingStateResult = {
 
 export function usePendingState(): PendingStateResult {
   const [pendingState, setPendingState] = useState<PendingState | null>(null);
-  const isPending = pendingState !== null;
+  const hasIndicator = pendingState !== null;
+  const isPending = hasIndicator && pendingState.kind !== "awaiting-input";
   const [pendingFrame, setPendingFrame] = useState(0);
   const [pendingStartedAt, setPendingStartedAt] = useState<number | null>(null);
   const [ctrlCPending, setCtrlCPending] = useState(false);
@@ -37,13 +38,13 @@ export function usePendingState(): PendingStateResult {
       setPendingStartedAt((current) => current ?? Date.now());
     } else {
       setPendingStartedAt(null);
-      setPendingFrame(0);
+      if (!hasIndicator) setPendingFrame(0);
     }
-  }, [isPending]);
+  }, [isPending, hasIndicator]);
 
   useInterval(
     () => setPendingFrame((current) => nextPendingFrame(current, PENDING_PULSE_FRAMES)),
-    isPending ? PENDING_ANIMATION_INTERVAL_MS : null,
+    hasIndicator ? PENDING_ANIMATION_INTERVAL_MS : null,
   );
 
   return {

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -244,14 +244,22 @@ export function ChatTranscript(props: ChatTranscriptProps): React.ReactNode {
   const isQueued = pendingState?.kind === "queued";
   const isAccepted = pendingState?.kind === "accepted";
   const isRunning = pendingState?.kind === "running";
+  const isAwaitingInput = pendingState?.kind === "awaiting-input";
   const isPending = pendingState !== null && pendingState !== undefined;
   const elapsedSec =
     isRunning && typeof pendingStartedAt === "number"
       ? Math.max(0, Math.floor((Date.now() - pendingStartedAt) / 1000))
       : 0;
-  const runningBlinkOn = Math.abs(pendingFrame) % pulsePeriod < pulsePeriod / 2;
-  const pulseGlyph = isRunning ? (runningBlinkOn ? "•" : " ") : "•";
-  const indicatorColor: string = isQueued ? palette.queued : isAccepted ? palette.accepted : palette.running;
+  const isAnimated = isRunning || isAwaitingInput;
+  const blinkOn = Math.abs(pendingFrame) % pulsePeriod < pulsePeriod / 2;
+  const marker = isAnimated ? (blinkOn ? "•" : " ") : "•";
+  const indicatorColor: string = isAwaitingInput
+    ? palette.brand
+    : isQueued
+      ? palette.queued
+      : isAccepted
+        ? palette.accepted
+        : palette.running;
   const tokenText = runningUsage ? formatTokenCount(runningUsage.inputTokens + runningUsage.outputTokens) : "";
   const pendingText = (() => {
     if (!pendingState) return "";
@@ -269,6 +277,9 @@ export function ChatTranscript(props: ChatTranscriptProps): React.ReactNode {
     }
     if (pendingState.kind === "accepted") {
       return t("rpc.status.accepted");
+    }
+    if (pendingState.kind === "awaiting-input") {
+      return t("chat.awaiting_input");
     }
     return "";
   })();
@@ -289,10 +300,10 @@ export function ChatTranscript(props: ChatTranscriptProps): React.ReactNode {
           {rows.length > 0 ? <Text> </Text> : null}
           <Box>
             <Box width={2}>
-              <Text color={indicatorColor}>{`${pulseGlyph} `}</Text>
+              <Text color={indicatorColor}>{`${marker} `}</Text>
             </Box>
             <Box width={contentWidth}>
-              {isRunning ? (
+              {isAnimated ? (
                 <ShimmerText text={pendingText} frame={pendingFrame} totalFrames={16} />
               ) : (
                 <Text dimColor>{pendingText}</Text>

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -21,6 +21,13 @@ const MARKERS: Record<ChatRow["kind"], string> = {
   system: "  ",
 };
 
+const PENDING_MARKER_COLORS: Record<PendingState["kind"], string> = {
+  "awaiting-input": palette.brand,
+  queued: palette.queued,
+  accepted: palette.accepted,
+  running: palette.running,
+};
+
 function renderCommandOutput(output: CommandOutput): React.ReactNode {
   const colWidth = commandOutputColWidth(output.sections);
   return (
@@ -240,26 +247,17 @@ type ChatTranscriptProps = {
 export function ChatTranscript(props: ChatTranscriptProps): React.ReactNode {
   const { rows, pendingState, pendingFrame, pendingStartedAt, runningUsage } = props;
   const pulsePeriod = 16;
-  const hasContent = rows.length > 0 || (pendingState !== null && pendingState !== undefined);
-  const isQueued = pendingState?.kind === "queued";
-  const isAccepted = pendingState?.kind === "accepted";
-  const isRunning = pendingState?.kind === "running";
-  const isAwaitingInput = pendingState?.kind === "awaiting-input";
-  const isPending = pendingState !== null && pendingState !== undefined;
+  const kind = pendingState?.kind;
+  const isPending = kind !== undefined;
+  const hasContent = rows.length > 0 || isPending;
   const elapsedSec =
-    isRunning && typeof pendingStartedAt === "number"
+    kind === "running" && typeof pendingStartedAt === "number"
       ? Math.max(0, Math.floor((Date.now() - pendingStartedAt) / 1000))
       : 0;
-  const isAnimated = isRunning || isAwaitingInput;
+  const isAnimated = kind === "running" || kind === "awaiting-input";
   const blinkOn = Math.abs(pendingFrame) % pulsePeriod < pulsePeriod / 2;
-  const marker = isAnimated ? (blinkOn ? "•" : " ") : "•";
-  const indicatorColor: string = isAwaitingInput
-    ? palette.brand
-    : isQueued
-      ? palette.queued
-      : isAccepted
-        ? palette.accepted
-        : palette.running;
+  const marker = isAnimated && !blinkOn ? " " : "•";
+  const markerColor = kind ? PENDING_MARKER_COLORS[kind] : "";
   const tokenText = runningUsage ? formatTokenCount(runningUsage.inputTokens + runningUsage.outputTokens) : "";
   const pendingText = (() => {
     if (!pendingState) return "";
@@ -300,7 +298,7 @@ export function ChatTranscript(props: ChatTranscriptProps): React.ReactNode {
           {rows.length > 0 ? <Text> </Text> : null}
           <Box>
             <Box width={2}>
-              <Text color={indicatorColor}>{`${marker} `}</Text>
+              <Text color={markerColor}>{`${marker} `}</Text>
             </Box>
             <Box width={contentWidth}>
               {isAnimated ? (

--- a/src/chat-turn.ts
+++ b/src/chat-turn.ts
@@ -116,6 +116,7 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
   tokenEntry: SessionTokenUsageEntry;
   rows: ChatRow[];
   activeSkills?: ActiveSkill[];
+  awaitingInput: boolean;
 }> {
   const reply = await params.client.replyStream({
     request: {
@@ -145,9 +146,8 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
 
     modelCalls: reply.modelCalls,
   };
-  if (reply.state === "awaiting-input") {
-    rows.push(createRow("status", t("chat.awaiting_input"), { marker: palette.brand, dim: true }));
-  } else {
+  const awaitingInput = reply.state === "awaiting-input";
+  if (!awaitingInput) {
     const durationMs = Date.now() - params.pendingStartedAt;
     if (durationMs >= 300) {
       const duration = formatDuration(durationMs);
@@ -166,5 +166,6 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
     tokenEntry,
     rows,
     activeSkills: reply.activeSkills,
+    awaitingInput,
   };
 }

--- a/src/client-contract.ts
+++ b/src/client-contract.ts
@@ -18,6 +18,7 @@ export const pendingStateSchema = z.discriminatedUnion("kind", [
     kind: z.literal("running"),
     toolCalls: z.number().int().nonnegative().optional(),
   }),
+  z.object({ kind: z.literal("awaiting-input") }),
 ]);
 export type PendingState = z.infer<typeof pendingStateSchema>;
 


### PR DESCRIPTION
## Motivation

When the agent signals `blocked` and waits for user input, the static "Waiting for your reply" text doesn't communicate that the session is alive. A pulsing indicator makes the state visually active.

## Summary

- add `awaiting-input` to `PendingState` discriminated union
- move awaiting-input from a static status row to the dynamic pending indicator with pulse animation and brand color
- split `isPending` into `hasIndicator` (drives animation) and `isPending` (gates input) so awaiting-input doesn't block user input
- replace boolean cleanup flags with a `cleanup` enum (`full` | `turn-only` | `none`) in the message handler finally block
- add regression test for pending state preservation

Fixes #204