### PR TITLE
refactor(tools): tool output hardening

### DIFF
--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -160,24 +160,27 @@ function renderHeader(part: ToolOutputPart): React.ReactNode {
     );
   }
   if (part.kind === "file-header") {
-    const targets = part.targets.filter((t) => t !== ".");
-    const shown = targets.join(", ");
-    const omitted = part.omitted && part.omitted > 0 ? `, +${part.omitted}` : "";
-    const detail = shown ? ` ${shown}${omitted}` : omitted ? ` ${omitted.slice(2)}` : "";
+    const detail =
+      part.count === 1 && part.targets.length === 1
+        ? ` ${part.targets[0]}`
+        : ` ${t("unit.file", { count: part.count })}`;
     return (
       <>
         <Text bold>{tDynamic(part.labelKey)}</Text>
-        {detail ? <Text dimColor>{detail}</Text> : null}
+        <Text dimColor>{detail}</Text>
       </>
     );
   }
   if (part.kind === "scope-header") {
-    const patternsDisplay = part.patterns.join(", ");
     const scopeSuffix = part.scope !== "workspace" ? ` in ${part.scope}` : "";
+    const detail =
+      part.patterns.length === 1
+        ? ` ${part.patterns[0]}${scopeSuffix}`
+        : ` ${t("unit.pattern", { count: part.patterns.length })}${scopeSuffix}`;
     return (
       <>
         <Text bold>{tDynamic(part.labelKey)}</Text>
-        <Text dimColor>{` ${patternsDisplay}${scopeSuffix}`}</Text>
+        <Text dimColor>{detail}</Text>
       </>
     );
   }

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -10,7 +10,7 @@ import {
   searchResultSummaryStats,
   summarizeUnifiedDiff,
 } from "./tool-output-parse";
-import { MAX_READ_PATHS, TOOL_PROGRESS_LIMITS } from "./tool-policy";
+import { MAX_READ_PATHS } from "./tool-policy";
 
 function normalizeUniquePaths(paths: string[]): string[] {
   const normalized = paths.map((path) => path.trim()).filter((path) => path.length > 0);
@@ -180,16 +180,13 @@ function createReadFileTool(input: ToolkitInput) {
           throw new Error(`Too many files (${paths.length}). Split into batches of ${MAX_READ_PATHS} or fewer.`);
         }
         const displayPaths = paths.map((p) => toDisplayPath(p, input.workspace));
-        const shown = displayPaths.slice(0, TOOL_PROGRESS_LIMITS.inlineFiles);
-        const remaining = displayPaths.length - shown.length;
         input.onOutput({
           toolName: "file-read",
           content: {
             kind: "file-header",
             labelKey: "tool.label.file_read",
             count: displayPaths.length,
-            targets: shown,
-            omitted: remaining > 0 ? remaining : undefined,
+            targets: displayPaths.slice(0, 1),
           },
           toolCallId: callId,
         });

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -10,7 +10,7 @@ import {
   searchResultSummaryStats,
   summarizeUnifiedDiff,
 } from "./tool-output-parse";
-import { TOOL_PROGRESS_LIMITS } from "./tool-policy";
+import { MAX_READ_PATHS, TOOL_PROGRESS_LIMITS } from "./tool-policy";
 
 function normalizeUniquePaths(paths: string[]): string[] {
   const normalized = paths.map((path) => path.trim()).filter((path) => path.length > 0);
@@ -162,10 +162,8 @@ function createReadFileTool(input: ToolkitInput) {
     id: "file-read",
     toolkit: "file",
     category: "read",
-    description:
-      "Read one or more text files. Pass `paths` as an array of {path} objects. Never re-read a file you already have.",
-    instruction:
-      "Use `file-read` before `file-edit` or `code-edit`. Batch discovery reads; for named edits, re-read the target file immediately before editing.",
+    description: `Read one or more text files (max ${MAX_READ_PATHS} per call). Pass \`paths\` as an array of {path} objects. Never re-read a file you already have.`,
+    instruction: `Use \`file-read\` before \`file-edit\` or \`code-edit\`. Batch up to ${MAX_READ_PATHS} files per call; for named edits, re-read the target file immediately before editing.`,
     inputSchema: z.object({
       paths: z.array(z.object({ path: z.string().min(1) })).min(1),
     }),
@@ -178,6 +176,9 @@ function createReadFileTool(input: ToolkitInput) {
       return runTool(input.session, "file-read", toolCallId, toolInput, async (callId) => {
         const paths = deduplicatePaths(toolInput.paths);
         if (paths.length === 0) throw new Error("Read requires at least one non-empty path");
+        if (paths.length > MAX_READ_PATHS) {
+          throw new Error(`Too many files (${paths.length}). Split into batches of ${MAX_READ_PATHS} or fewer.`);
+        }
         const displayPaths = paths.map((p) => toDisplayPath(p, input.workspace));
         const shown = displayPaths.slice(0, TOOL_PROGRESS_LIMITS.inlineFiles);
         const remaining = displayPaths.length - shown.length;

--- a/src/git-toolkit.ts
+++ b/src/git-toolkit.ts
@@ -6,7 +6,6 @@ import type { ToolkitInput } from "./tool-contract";
 import { createTool } from "./tool-contract";
 import { runTool } from "./tool-execution";
 import { emitParts, resultChunkParts, textHeadTailParts } from "./tool-output-format";
-import { TOOL_PROGRESS_LIMITS } from "./tool-policy";
 
 const DEFAULT_CONTEXT_LINES = 3;
 
@@ -270,16 +269,7 @@ function createGitAddTool(git: GitOps, input: ToolkitInput) {
         });
         const rawAdd = await git.add({ paths: toolInput.paths, all: toolInput.all });
         if (paths.length > 0) {
-          for (const p of paths.slice(0, TOOL_PROGRESS_LIMITS.files)) {
-            input.onOutput({ toolName: "git-add", content: { kind: "text", text: p }, toolCallId: callId });
-          }
-          if (paths.length > TOOL_PROGRESS_LIMITS.files) {
-            input.onOutput({
-              toolName: "git-add",
-              content: { kind: "truncated", count: paths.length - TOOL_PROGRESS_LIMITS.files, unit: "files" },
-              toolCallId: callId,
-            });
-          }
+          emitParts(textHeadTailParts(paths.join("\n")), "git-add", input.onOutput, callId);
         }
         return { kind: "git-add" as const, all: toolInput.all, paths: toolInput.paths, output: rawAdd };
       });
@@ -315,18 +305,8 @@ function createGitCommitTool(git: GitOps, input: ToolkitInput) {
           content: { kind: "tool-header", labelKey: "tool.label.git_commit", detail },
           toolCallId: callId,
         });
-        if (toolInput.body && toolInput.body.length > 0) {
-          const maxBodyLines = TOOL_PROGRESS_LIMITS.files;
-          for (const line of toolInput.body.slice(0, maxBodyLines)) {
-            input.onOutput({ toolName: "git-commit", content: { kind: "text", text: line }, toolCallId: callId });
-          }
-          if (toolInput.body.length > maxBodyLines) {
-            input.onOutput({
-              toolName: "git-commit",
-              content: { kind: "truncated", count: toolInput.body.length - maxBodyLines, unit: "lines" },
-              toolCallId: callId,
-            });
-          }
+        for (const line of toolInput.body ?? []) {
+          input.onOutput({ toolName: "git-commit", content: { kind: "text", text: line }, toolCallId: callId });
         }
         return { kind: "git-commit" as const, message: toolInput.message, body: toolInput.body, output: rawCommit };
       });

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -264,6 +264,8 @@ export const EN_MESSAGES = {
   "unit.match.one": "{count} match",
   "unit.more": "{count} more",
   "unit.more.one": "{count} more",
+  "unit.pattern": "{count} patterns",
+  "unit.pattern.one": "{count} pattern",
   "unit.replacement": "{count} replacements",
   "unit.replacement.one": "{count} replacement",
   "unit.result": "{count} results",

--- a/src/tool-output-content.ts
+++ b/src/tool-output-content.ts
@@ -64,15 +64,14 @@ export function renderToolOutputPart(content: ToolOutputPart): string {
       return content.text;
     case "file-header": {
       const label = tDynamic(content.labelKey);
-      const shown = content.targets.join(", ");
-      const omitted = content.omitted && content.omitted > 0 ? `, +${content.omitted}` : "";
-      return `${label} ${shown}${omitted}`;
+      if (content.count === 1 && content.targets.length === 1) return `${label} ${content.targets[0]}`;
+      return `${label} ${t("unit.file", { count: content.count })}`;
     }
     case "scope-header": {
       const label = tDynamic(content.labelKey);
-      const patternsDisplay = content.patterns.join(", ");
       const scopeSuffix = content.scope !== "workspace" ? ` in ${content.scope}` : "";
-      return `${label} ${patternsDisplay}${scopeSuffix}`;
+      if (content.patterns.length === 1) return `${label} ${content.patterns[0]}${scopeSuffix}`;
+      return `${label} ${t("unit.pattern", { count: content.patterns.length })}${scopeSuffix}`;
     }
     case "edit-header":
       return `${tDynamic(content.labelKey)} ${content.path} (+${content.added} -${content.removed})`;

--- a/src/tool-output-format.ts
+++ b/src/tool-output-format.ts
@@ -3,7 +3,6 @@ import type { TranslationKey } from "./i18n";
 import { t } from "./i18n";
 import type { ToolOutputPart } from "./tool-output-content";
 import { compactPatternLabels, type SearchSummaryStats, summarizeUnifiedDiff } from "./tool-output-parse";
-import { TOOL_PROGRESS_LIMITS } from "./tool-policy";
 
 export type ToolOutputListener = (event: { toolName: string; content: ToolOutputPart; toolCallId?: string }) => void;
 
@@ -116,23 +115,6 @@ export function resultChunkParts(result: string, maxLines = 80): ToolOutputPart[
   const parts: ToolOutputPart[] = allLines.slice(0, maxLines).map((text) => ({ kind: "text", text }));
   if (allLines.length > maxLines) {
     parts.push({ kind: "truncated", count: allLines.length - maxLines, unit: "lines" });
-  }
-  return parts;
-}
-
-export function fileListSummaryParts(
-  filePaths: string[],
-  maxFiles = TOOL_PROGRESS_LIMITS.files,
-  workspace?: string,
-): ToolOutputPart[] {
-  const unique = uniquePaths(filePaths);
-  if (unique.length === 0) return [];
-  const parts: ToolOutputPart[] = [{ kind: "text", text: `files=${unique.length}` }];
-  for (const path of unique.slice(0, maxFiles)) {
-    parts.push({ kind: "text", text: toDisplayPath(path, workspace) });
-  }
-  if (unique.length > maxFiles) {
-    parts.push({ kind: "truncated", count: unique.length - maxFiles, unit: "matches" });
   }
   return parts;
 }

--- a/src/tool-output.tui.test.tsx
+++ b/src/tool-output.tui.test.tsx
@@ -29,20 +29,14 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
     const items: ToolOutputPart[] = [
       { kind: "file-header", labelKey: "tool.label.file_read", count: 2, targets: ["a.ts", "b.ts"] },
     ];
-    expect(formatToolOutput(items)).toBe("Read a.ts, b.ts");
+    expect(formatToolOutput(items)).toBe("Read 2 files");
   });
 
-  test("file-header with omitted targets", () => {
+  test("file-header with single file shows path", () => {
     const items: ToolOutputPart[] = [
-      {
-        kind: "file-header",
-        labelKey: "tool.label.file_read",
-        count: 4,
-        targets: ["a.ts", "b.ts", "c.ts"],
-        omitted: 1,
-      },
+      { kind: "file-header", labelKey: "tool.label.file_read", count: 1, targets: ["a.ts"] },
     ];
-    expect(formatToolOutput(items)).toBe("Read a.ts, b.ts, c.ts, +1");
+    expect(formatToolOutput(items)).toBe("Read a.ts");
   });
 
   test("scope-header for search with summary", () => {
@@ -423,7 +417,7 @@ describe("tool output TUI — chat (Ink rendering)", () => {
   test("file-header renders label and targets", () => {
     expect(
       renderChat([{ kind: "file-header", labelKey: "tool.label.file_read", count: 2, targets: ["a.ts", "b.ts"] }]),
-    ).toBe("• Read a.ts, b.ts");
+    ).toBe("• Read 2 files");
   });
 
   test("scope-header with summary", () => {

--- a/src/tool-output.tui.test.tsx
+++ b/src/tool-output.tui.test.tsx
@@ -84,6 +84,25 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
     );
   });
 
+  test("scope-header with multiple patterns shows count", () => {
+    const items: ToolOutputPart[] = [
+      {
+        kind: "scope-header",
+        labelKey: "tool.label.file_search",
+        scope: "workspace",
+        patterns: ["foo", "bar", "baz"],
+        matches: 5,
+      },
+      { kind: "text", text: "5 matches in 3 files" },
+    ];
+    expect(formatToolOutput(items)).toBe(
+      dedent(`
+        Search 3 patterns
+          5 matches in 3 files
+      `),
+    );
+  });
+
   test("edit-header with diff lines", () => {
     const items: ToolOutputPart[] = [
       { kind: "edit-header", labelKey: "tool.label.file_edit", path: "notes.ts", files: 1, added: 1, removed: 1 },

--- a/src/tool-policy.ts
+++ b/src/tool-policy.ts
@@ -3,6 +3,8 @@ export const TOOL_PROGRESS_LIMITS = {
   inlineFiles: 3,
 } as const;
 
+export const MAX_READ_PATHS = 5;
+
 export const CLI_TOOL_OUTPUT_LIMITS = {
   files: 5,
   run: 5,

--- a/src/tool-policy.ts
+++ b/src/tool-policy.ts
@@ -1,8 +1,3 @@
-export const TOOL_PROGRESS_LIMITS = {
-  files: 5,
-  inlineFiles: 3,
-} as const;
-
 export const MAX_READ_PATHS = 5;
 
 export const CLI_TOOL_OUTPUT_LIMITS = {


### PR DESCRIPTION
## Motivation

Tool output was inconsistent — file-read accepted unbounded batch sizes (causing truncated cache entries), display listed individual file paths (verbose with deep paths), and git-add used ad-hoc inline truncation instead of the shared head/tail pattern.

## Summary

- cap file-read batch size to 5 paths per call to prevent truncated sub-entry cache pollution
- compact display: show count instead of listing paths (`Read 3 files`, `Search 2 patterns`)
- single file/pattern still shows the value (`Read src/foo.ts`, `Search needle`)
- remove `TOOL_PROGRESS_LIMITS` and dead `fileListSummaryParts`
- git-add uses `textHeadTailParts` instead of inline truncation
- git-commit body lines emit without truncation (schema already caps at 10)