### PR TITLE
refactor(tools): tool output hardening

### DIFF
--- a/src/chat-contract.ts
+++ b/src/chat-contract.ts
@@ -3,7 +3,7 @@ import { checklistOutputSchema } from "./checklist-contract";
 import { isoDateTimeSchema } from "./datetime";
 import { domainIdSchema } from "./id-contract";
 import { createId } from "./short-id";
-import { toolOutputPartSchema } from "./tool-output-content";
+import { toolOutputPartSchema } from "./tool-output-contract";
 
 export const roleSchema = z.enum(["system", "user", "assistant"]);
 export type Role = z.infer<typeof roleSchema>;

--- a/src/chat-message-handler-stream.ts
+++ b/src/chat-message-handler-stream.ts
@@ -3,7 +3,8 @@ import type { ChecklistItem } from "./checklist-contract";
 import { LIFECYCLE_ERROR_CODES } from "./error-contract";
 import { palette } from "./palette";
 import { createId } from "./short-id";
-import { createToolOutputState, type ToolOutputPart } from "./tool-output-content";
+import type { ToolOutputPart } from "./tool-output-contract";
+import { createToolOutputState } from "./tool-output-render";
 
 export type MessageStreamState = {
   onDelta: (delta: string) => void;

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -160,24 +160,27 @@ function renderHeader(part: ToolOutputPart): React.ReactNode {
     );
   }
   if (part.kind === "file-header") {
-    const targets = part.targets.filter((t) => t !== ".");
-    const shown = targets.join(", ");
-    const omitted = part.omitted && part.omitted > 0 ? `, +${part.omitted}` : "";
-    const detail = shown ? ` ${shown}${omitted}` : omitted ? ` ${omitted.slice(2)}` : "";
+    const detail =
+      part.count === 1 && part.targets.length === 1
+        ? ` ${part.targets[0]}`
+        : ` ${t("unit.file", { count: part.count })}`;
     return (
       <>
         <Text bold>{tDynamic(part.labelKey)}</Text>
-        {detail ? <Text dimColor>{detail}</Text> : null}
+        <Text dimColor>{detail}</Text>
       </>
     );
   }
   if (part.kind === "scope-header") {
-    const patternsDisplay = part.patterns.join(", ");
     const scopeSuffix = part.scope !== "workspace" ? ` in ${part.scope}` : "";
+    const detail =
+      part.patterns.length === 1
+        ? ` ${part.patterns[0]}${scopeSuffix}`
+        : ` ${t("unit.pattern", { count: part.patterns.length })}${scopeSuffix}`;
     return (
       <>
         <Text bold>{tDynamic(part.labelKey)}</Text>
-        <Text dimColor>{` ${patternsDisplay}${scopeSuffix}`}</Text>
+        <Text dimColor>{detail}</Text>
       </>
     );
   }

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -8,7 +8,8 @@ import { ShimmerText } from "./chat-shimmer";
 import type { PendingState } from "./client-contract";
 import { t, tDynamic } from "./i18n";
 import { palette } from "./palette";
-import { renderToolOutputPart as renderToolOutputText, type ToolOutputPart } from "./tool-output-content";
+import type { ToolOutputPart } from "./tool-output-contract";
+import { renderToolOutputPart as renderToolOutputText } from "./tool-output-render";
 import { Box, Text } from "./tui";
 import { DEFAULT_COLUMNS } from "./tui/constants";
 

--- a/src/cli-format.ts
+++ b/src/cli-format.ts
@@ -2,8 +2,9 @@ import { relative } from "node:path";
 import { wrapAssistantContent } from "./chat-content";
 import { formatCompactNumber } from "./chat-format";
 import { t, tDynamic } from "./i18n";
-import { formatToolOutput, type ToolOutputPart } from "./tool-output-content";
+import type { ToolOutputPart } from "./tool-output-contract";
 import { toolLabelKey } from "./tool-output-format";
+import { formatToolOutput } from "./tool-output-render";
 import { CLI_TOOL_OUTPUT_LIMITS } from "./tool-policy";
 import { printDim, printToolHeader } from "./ui";
 

--- a/src/cli-prompt.test.ts
+++ b/src/cli-prompt.test.ts
@@ -5,7 +5,7 @@ import { captureCliOutput } from "./cli-test-harness";
 import type { Client, StreamEvent } from "./client-contract";
 import type { Session } from "./session-contract";
 import { expectIntent } from "./test-utils";
-import type { ToolOutputPart } from "./tool-output-content";
+import type { ToolOutputPart } from "./tool-output-contract";
 
 function createTestSession(): Session {
   return {

--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -11,7 +11,7 @@ import { t } from "./i18n";
 import type { ResourceId } from "./resource-id";
 import type { Session } from "./session-contract";
 import { createSkillSuggestion } from "./skill-triggers";
-import { createToolOutputState, formatToolOutput } from "./tool-output-content";
+import { createToolOutputState, formatToolOutput } from "./tool-output-render";
 import { printDim, printError, printOutput, streamText } from "./ui";
 
 function setSessionTitle(session: Session, inputText: string): void {

--- a/src/client-contract.ts
+++ b/src/client-contract.ts
@@ -8,8 +8,7 @@ import { activeSkillsSchema } from "./skill-contract";
 import type { StatusFields } from "./status-contract";
 import { streamErrorSchema } from "./stream-error";
 import type { TaskId, TaskRecord } from "./task-contract";
-import type { ToolOutputPart } from "./tool-output-content";
-import { toolOutputPartSchema } from "./tool-output-content";
+import { type ToolOutputPart, toolOutputPartSchema } from "./tool-output-contract";
 
 export const pendingStateSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("queued"), position: z.number().int().nonnegative().optional() }),

--- a/src/code-toolkit.ts
+++ b/src/code-toolkit.ts
@@ -76,16 +76,13 @@ function createScanCodeTool(input: ToolkitInput) {
         const paths = normalizeUniquePaths(toolInput.paths);
         const unique = Array.from(new Set(paths.map((path) => toDisplayPath(path, input.workspace))));
         if (unique.length > 0) {
-          const shown = unique.slice(0, 4);
-          const remaining = unique.length - shown.length;
           input.onOutput({
             toolName: "code-scan",
             content: {
               kind: "file-header",
               labelKey: "tool.label.code_scan",
               count: unique.length,
-              targets: shown,
-              omitted: remaining > 0 ? remaining : undefined,
+              targets: unique.slice(0, 1),
             },
             toolCallId: callId,
           });

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -10,7 +10,7 @@ import {
   searchResultSummaryStats,
   summarizeUnifiedDiff,
 } from "./tool-output-parse";
-import { MAX_READ_PATHS, TOOL_PROGRESS_LIMITS } from "./tool-policy";
+import { MAX_READ_PATHS } from "./tool-policy";
 
 function normalizeUniquePaths(paths: string[]): string[] {
   const normalized = paths.map((path) => path.trim()).filter((path) => path.length > 0);
@@ -180,16 +180,13 @@ function createReadFileTool(input: ToolkitInput) {
           throw new Error(`Too many files (${paths.length}). Split into batches of ${MAX_READ_PATHS} or fewer.`);
         }
         const displayPaths = paths.map((p) => toDisplayPath(p, input.workspace));
-        const shown = displayPaths.slice(0, TOOL_PROGRESS_LIMITS.inlineFiles);
-        const remaining = displayPaths.length - shown.length;
         input.onOutput({
           toolName: "file-read",
           content: {
             kind: "file-header",
             labelKey: "tool.label.file_read",
             count: displayPaths.length,
-            targets: shown,
-            omitted: remaining > 0 ? remaining : undefined,
+            targets: displayPaths.slice(0, 1),
           },
           toolCallId: callId,
         });

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -10,7 +10,7 @@ import {
   searchResultSummaryStats,
   summarizeUnifiedDiff,
 } from "./tool-output-parse";
-import { TOOL_PROGRESS_LIMITS } from "./tool-policy";
+import { MAX_READ_PATHS, TOOL_PROGRESS_LIMITS } from "./tool-policy";
 
 function normalizeUniquePaths(paths: string[]): string[] {
   const normalized = paths.map((path) => path.trim()).filter((path) => path.length > 0);
@@ -162,10 +162,8 @@ function createReadFileTool(input: ToolkitInput) {
     id: "file-read",
     toolkit: "file",
     category: "read",
-    description:
-      "Read one or more text files. Pass `paths` as an array of {path} objects. Never re-read a file you already have.",
-    instruction:
-      "Use `file-read` before `file-edit` or `code-edit`. Batch discovery reads; for named edits, re-read the target file immediately before editing.",
+    description: `Read one or more text files (max ${MAX_READ_PATHS} per call). Pass \`paths\` as an array of {path} objects. Never re-read a file you already have.`,
+    instruction: `Use \`file-read\` before \`file-edit\` or \`code-edit\`. Batch up to ${MAX_READ_PATHS} files per call; for named edits, re-read the target file immediately before editing.`,
     inputSchema: z.object({
       paths: z.array(z.object({ path: z.string().min(1) })).min(1),
     }),
@@ -178,6 +176,9 @@ function createReadFileTool(input: ToolkitInput) {
       return runTool(input.session, "file-read", toolCallId, toolInput, async (callId) => {
         const paths = deduplicatePaths(toolInput.paths);
         if (paths.length === 0) throw new Error("Read requires at least one non-empty path");
+        if (paths.length > MAX_READ_PATHS) {
+          throw new Error(`Too many files (${paths.length}). Split into batches of ${MAX_READ_PATHS} or fewer.`);
+        }
         const displayPaths = paths.map((p) => toDisplayPath(p, input.workspace));
         const shown = displayPaths.slice(0, TOOL_PROGRESS_LIMITS.inlineFiles);
         const remaining = displayPaths.length - shown.length;

--- a/src/git-toolkit.ts
+++ b/src/git-toolkit.ts
@@ -6,7 +6,6 @@ import type { ToolkitInput } from "./tool-contract";
 import { createTool } from "./tool-contract";
 import { runTool } from "./tool-execution";
 import { emitParts, resultChunkParts, textHeadTailParts } from "./tool-output-format";
-import { TOOL_PROGRESS_LIMITS } from "./tool-policy";
 
 const DEFAULT_CONTEXT_LINES = 3;
 
@@ -270,16 +269,7 @@ function createGitAddTool(git: GitOps, input: ToolkitInput) {
         });
         const rawAdd = await git.add({ paths: toolInput.paths, all: toolInput.all });
         if (paths.length > 0) {
-          for (const p of paths.slice(0, TOOL_PROGRESS_LIMITS.files)) {
-            input.onOutput({ toolName: "git-add", content: { kind: "text", text: p }, toolCallId: callId });
-          }
-          if (paths.length > TOOL_PROGRESS_LIMITS.files) {
-            input.onOutput({
-              toolName: "git-add",
-              content: { kind: "truncated", count: paths.length - TOOL_PROGRESS_LIMITS.files, unit: "files" },
-              toolCallId: callId,
-            });
-          }
+          emitParts(textHeadTailParts(paths.join("\n")), "git-add", input.onOutput, callId);
         }
         return { kind: "git-add" as const, all: toolInput.all, paths: toolInput.paths, output: rawAdd };
       });
@@ -315,18 +305,8 @@ function createGitCommitTool(git: GitOps, input: ToolkitInput) {
           content: { kind: "tool-header", labelKey: "tool.label.git_commit", detail },
           toolCallId: callId,
         });
-        if (toolInput.body && toolInput.body.length > 0) {
-          const maxBodyLines = TOOL_PROGRESS_LIMITS.files;
-          for (const line of toolInput.body.slice(0, maxBodyLines)) {
-            input.onOutput({ toolName: "git-commit", content: { kind: "text", text: line }, toolCallId: callId });
-          }
-          if (toolInput.body.length > maxBodyLines) {
-            input.onOutput({
-              toolName: "git-commit",
-              content: { kind: "truncated", count: toolInput.body.length - maxBodyLines, unit: "lines" },
-              toolCallId: callId,
-            });
-          }
+        for (const line of toolInput.body ?? []) {
+          input.onOutput({ toolName: "git-commit", content: { kind: "text", text: line }, toolCallId: callId });
         }
         return { kind: "git-commit" as const, message: toolInput.message, body: toolInput.body, output: rawCommit };
       });

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -264,6 +264,8 @@ export const EN_MESSAGES = {
   "unit.match.one": "{count} match",
   "unit.more": "{count} more",
   "unit.more.one": "{count} more",
+  "unit.pattern": "{count} patterns",
+  "unit.pattern.one": "{count} pattern",
   "unit.replacement": "{count} replacements",
   "unit.replacement.one": "{count} replacement",
   "unit.result": "{count} results",

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -8,7 +8,7 @@ import type { LifecyclePolicy } from "./lifecycle-policy";
 import type { McpToolListing } from "./mcp-client";
 import type { MemoryCommitMetrics } from "./memory-contract";
 import type { ChecklistListener } from "./tool-contract";
-import type { ToolOutputPart } from "./tool-output-content";
+import type { ToolOutputPart } from "./tool-output-contract";
 import type { Toolset } from "./tool-registry";
 import type { SessionContext } from "./tool-session";
 

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -19,7 +19,7 @@ import { listMcpTools } from "./mcp-client";
 import type { MemoryCommitContext, MemoryCommitMetrics } from "./memory-contract";
 import { commitDistiller, estimateDistillPromptTokens } from "./memory-distiller";
 import { createInMemoryTaskQueue } from "./task-queue";
-import { renderToolOutputPart } from "./tool-output-content";
+import { renderToolOutputPart } from "./tool-output-render";
 import { WRITE_TOOL_SET } from "./tool-registry";
 import { scopedCallLog } from "./tool-session";
 import { attachUndoCheckpointSideEffects } from "./undo-checkpoints-effects";

--- a/src/tool-output-content.ts
+++ b/src/tool-output-content.ts
@@ -64,15 +64,14 @@ export function renderToolOutputPart(content: ToolOutputPart): string {
       return content.text;
     case "file-header": {
       const label = tDynamic(content.labelKey);
-      const shown = content.targets.join(", ");
-      const omitted = content.omitted && content.omitted > 0 ? `, +${content.omitted}` : "";
-      return `${label} ${shown}${omitted}`;
+      if (content.count === 1 && content.targets.length === 1) return `${label} ${content.targets[0]}`;
+      return `${label} ${t("unit.file", { count: content.count })}`;
     }
     case "scope-header": {
       const label = tDynamic(content.labelKey);
-      const patternsDisplay = content.patterns.join(", ");
       const scopeSuffix = content.scope !== "workspace" ? ` in ${content.scope}` : "";
-      return `${label} ${patternsDisplay}${scopeSuffix}`;
+      if (content.patterns.length === 1) return `${label} ${content.patterns[0]}${scopeSuffix}`;
+      return `${label} ${t("unit.pattern", { count: content.patterns.length })}${scopeSuffix}`;
     }
     case "edit-header":
       return `${tDynamic(content.labelKey)} ${content.path} (+${content.added} -${content.removed})`;

--- a/src/tool-output-contract.ts
+++ b/src/tool-output-contract.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+
+export const toolOutputDiffMarkerSchema = z.enum(["add", "remove", "context"]);
+
+export const toolOutputPartSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("tool-header"),
+    labelKey: z.string().trim().min(1),
+    detail: z.string().optional(),
+  }),
+  z.object({ kind: z.literal("text"), text: z.string().trim().min(1) }),
+  z.object({
+    kind: z.literal("file-header"),
+    labelKey: z.string().trim().min(1),
+    count: z.number().int().nonnegative(),
+    targets: z.array(z.string().trim().min(1)),
+  }),
+  z.object({
+    kind: z.literal("scope-header"),
+    labelKey: z.string().trim().min(1),
+    scope: z.string().trim().min(1),
+    patterns: z.array(z.string()),
+    matches: z.number().int().nonnegative(),
+  }),
+  z.object({
+    kind: z.literal("edit-header"),
+    labelKey: z.string().trim().min(1),
+    path: z.string().trim().min(1),
+    files: z.number().int().nonnegative(),
+    added: z.number().int().nonnegative(),
+    removed: z.number().int().nonnegative(),
+  }),
+  z.object({
+    kind: z.literal("diff"),
+    marker: toolOutputDiffMarkerSchema,
+    lineNumber: z.number().int().positive(),
+    text: z.string(),
+  }),
+  z.object({
+    kind: z.literal("shell-output"),
+    stream: z.enum(["stdout", "stderr"]),
+    text: z.string(),
+  }),
+  z.object({ kind: z.literal("no-output") }),
+  z.object({
+    kind: z.literal("truncated"),
+    count: z.number().int().nonnegative().optional(),
+    unit: z.string().optional(),
+  }),
+]);
+
+export type ToolOutputPart = z.infer<typeof toolOutputPartSchema>;

--- a/src/tool-output-format.ts
+++ b/src/tool-output-format.ts
@@ -3,7 +3,6 @@ import type { TranslationKey } from "./i18n";
 import { t } from "./i18n";
 import type { ToolOutputPart } from "./tool-output-content";
 import { compactPatternLabels, type SearchSummaryStats, summarizeUnifiedDiff } from "./tool-output-parse";
-import { TOOL_PROGRESS_LIMITS } from "./tool-policy";
 
 export type ToolOutputListener = (event: { toolName: string; content: ToolOutputPart; toolCallId?: string }) => void;
 
@@ -116,23 +115,6 @@ export function resultChunkParts(result: string, maxLines = 80): ToolOutputPart[
   const parts: ToolOutputPart[] = allLines.slice(0, maxLines).map((text) => ({ kind: "text", text }));
   if (allLines.length > maxLines) {
     parts.push({ kind: "truncated", count: allLines.length - maxLines, unit: "lines" });
-  }
-  return parts;
-}
-
-export function fileListSummaryParts(
-  filePaths: string[],
-  maxFiles = TOOL_PROGRESS_LIMITS.files,
-  workspace?: string,
-): ToolOutputPart[] {
-  const unique = uniquePaths(filePaths);
-  if (unique.length === 0) return [];
-  const parts: ToolOutputPart[] = [{ kind: "text", text: `files=${unique.length}` }];
-  for (const path of unique.slice(0, maxFiles)) {
-    parts.push({ kind: "text", text: toDisplayPath(path, workspace) });
-  }
-  if (unique.length > maxFiles) {
-    parts.push({ kind: "truncated", count: unique.length - maxFiles, unit: "matches" });
   }
   return parts;
 }

--- a/src/tool-output-format.ts
+++ b/src/tool-output-format.ts
@@ -1,7 +1,7 @@
 import { isAbsolute, relative } from "node:path";
 import type { TranslationKey } from "./i18n";
 import { t } from "./i18n";
-import type { ToolOutputPart } from "./tool-output-content";
+import type { ToolOutputPart } from "./tool-output-contract";
 import { compactPatternLabels, type SearchSummaryStats, summarizeUnifiedDiff } from "./tool-output-parse";
 
 export type ToolOutputListener = (event: { toolName: string; content: ToolOutputPart; toolCallId?: string }) => void;

--- a/src/tool-output-parse.ts
+++ b/src/tool-output-parse.ts
@@ -1,4 +1,4 @@
-import type { ToolOutputPart } from "./tool-output-content";
+import type { ToolOutputPart } from "./tool-output-contract";
 
 export type UnifiedDiffSummary = {
   files: number;

--- a/src/tool-output-render.ts
+++ b/src/tool-output-render.ts
@@ -1,58 +1,6 @@
-import { z } from "zod";
 import { unreachable } from "./assert";
 import { t, tDynamic } from "./i18n";
-
-export const toolOutputDiffMarkerSchema = z.enum(["add", "remove", "context"]);
-
-export const toolOutputPartSchema = z.discriminatedUnion("kind", [
-  z.object({
-    kind: z.literal("tool-header"),
-    labelKey: z.string().trim().min(1),
-    detail: z.string().optional(),
-  }),
-  z.object({ kind: z.literal("text"), text: z.string().trim().min(1) }),
-  z.object({
-    kind: z.literal("file-header"),
-    labelKey: z.string().trim().min(1),
-    count: z.number().int().nonnegative(),
-    targets: z.array(z.string().trim().min(1)),
-    omitted: z.number().int().nonnegative().optional(),
-  }),
-  z.object({
-    kind: z.literal("scope-header"),
-    labelKey: z.string().trim().min(1),
-    scope: z.string().trim().min(1),
-    patterns: z.array(z.string()),
-    matches: z.number().int().nonnegative(),
-  }),
-  z.object({
-    kind: z.literal("edit-header"),
-    labelKey: z.string().trim().min(1),
-    path: z.string().trim().min(1),
-    files: z.number().int().nonnegative(),
-    added: z.number().int().nonnegative(),
-    removed: z.number().int().nonnegative(),
-  }),
-  z.object({
-    kind: z.literal("diff"),
-    marker: toolOutputDiffMarkerSchema,
-    lineNumber: z.number().int().positive(),
-    text: z.string(),
-  }),
-  z.object({
-    kind: z.literal("shell-output"),
-    stream: z.enum(["stdout", "stderr"]),
-    text: z.string(),
-  }),
-  z.object({ kind: z.literal("no-output") }),
-  z.object({
-    kind: z.literal("truncated"),
-    count: z.number().int().nonnegative().optional(),
-    unit: z.string().optional(),
-  }),
-]);
-
-export type ToolOutputPart = z.infer<typeof toolOutputPartSchema>;
+import type { ToolOutputPart } from "./tool-output-contract";
 
 export function renderToolOutputPart(content: ToolOutputPart): string {
   switch (content.kind) {

--- a/src/tool-output-state.test.ts
+++ b/src/tool-output-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { createToolOutputState, formatToolOutput, type ToolOutputPart } from "./tool-output-content";
+import type { ToolOutputPart } from "./tool-output-contract";
+import { createToolOutputState, formatToolOutput } from "./tool-output-render";
 
 function setup() {
   const state = createToolOutputState();

--- a/src/tool-output.tui.test.tsx
+++ b/src/tool-output.tui.test.tsx
@@ -2,7 +2,8 @@ import { describe, expect, test } from "bun:test";
 import type { ChatRow } from "./chat-contract";
 import { ChatTranscript } from "./chat-transcript";
 import { dedent } from "./test-utils";
-import { formatToolOutput, type ToolOutputPart } from "./tool-output-content";
+import type { ToolOutputPart } from "./tool-output-contract";
+import { formatToolOutput } from "./tool-output-render";
 import { renderPlain } from "./tui-test-utils";
 
 function renderChat(toolOutput: ToolOutputPart[]): string {

--- a/src/tool-output.tui.test.tsx
+++ b/src/tool-output.tui.test.tsx
@@ -29,20 +29,14 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
     const items: ToolOutputPart[] = [
       { kind: "file-header", labelKey: "tool.label.file_read", count: 2, targets: ["a.ts", "b.ts"] },
     ];
-    expect(formatToolOutput(items)).toBe("Read a.ts, b.ts");
+    expect(formatToolOutput(items)).toBe("Read 2 files");
   });
 
-  test("file-header with omitted targets", () => {
+  test("file-header with single file shows path", () => {
     const items: ToolOutputPart[] = [
-      {
-        kind: "file-header",
-        labelKey: "tool.label.file_read",
-        count: 4,
-        targets: ["a.ts", "b.ts", "c.ts"],
-        omitted: 1,
-      },
+      { kind: "file-header", labelKey: "tool.label.file_read", count: 1, targets: ["a.ts"] },
     ];
-    expect(formatToolOutput(items)).toBe("Read a.ts, b.ts, c.ts, +1");
+    expect(formatToolOutput(items)).toBe("Read a.ts");
   });
 
   test("scope-header for search with summary", () => {
@@ -423,7 +417,7 @@ describe("tool output TUI — chat (Ink rendering)", () => {
   test("file-header renders label and targets", () => {
     expect(
       renderChat([{ kind: "file-header", labelKey: "tool.label.file_read", count: 2, targets: ["a.ts", "b.ts"] }]),
-    ).toBe("• Read a.ts, b.ts");
+    ).toBe("• Read 2 files");
   });
 
   test("scope-header with summary", () => {

--- a/src/tool-output.tui.test.tsx
+++ b/src/tool-output.tui.test.tsx
@@ -84,6 +84,25 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
     );
   });
 
+  test("scope-header with multiple patterns shows count", () => {
+    const items: ToolOutputPart[] = [
+      {
+        kind: "scope-header",
+        labelKey: "tool.label.file_search",
+        scope: "workspace",
+        patterns: ["foo", "bar", "baz"],
+        matches: 5,
+      },
+      { kind: "text", text: "5 matches in 3 files" },
+    ];
+    expect(formatToolOutput(items)).toBe(
+      dedent(`
+        Search 3 patterns
+          5 matches in 3 files
+      `),
+    );
+  });
+
   test("edit-header with diff lines", () => {
     const items: ToolOutputPart[] = [
       { kind: "edit-header", labelKey: "tool.label.file_edit", path: "notes.ts", files: 1, added: 1, removed: 1 },

--- a/src/tool-policy.ts
+++ b/src/tool-policy.ts
@@ -3,6 +3,8 @@ export const TOOL_PROGRESS_LIMITS = {
   inlineFiles: 3,
 } as const;
 
+export const MAX_READ_PATHS = 5;
+
 export const CLI_TOOL_OUTPUT_LIMITS = {
   files: 5,
   run: 5,

--- a/src/tool-policy.ts
+++ b/src/tool-policy.ts
@@ -1,8 +1,3 @@
-export const TOOL_PROGRESS_LIMITS = {
-  files: 5,
-  inlineFiles: 3,
-} as const;
-
 export const MAX_READ_PATHS = 5;
 
 export const CLI_TOOL_OUTPUT_LIMITS = {

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { expectIntent } from "./test-utils";
-import { renderToolOutputPart } from "./tool-output-content";
+import { renderToolOutputPart } from "./tool-output-render";
 import { toolDefinitionsById, toolIds, toolIdsByCategory, toolsForAgent } from "./tool-registry";
 
 describe("toolsets", () => {


### PR DESCRIPTION
## Motivation

Tool output was inconsistent — file-read accepted unbounded batch sizes (causing truncated cache entries), display listed individual file paths (verbose with deep paths), git-add used ad-hoc inline truncation instead of the shared head/tail pattern, and `tool-output-content.ts` mixed shared types with rendering logic.

## Summary

- cap file-read batch size to 5 paths per call to prevent truncated sub-entry cache pollution
- compact display: show count instead of listing paths (`Read 3 files`, `Search 2 patterns`)
- single file/pattern still shows the value (`Read src/foo.ts`, `Search needle`)
- remove `TOOL_PROGRESS_LIMITS` and dead `fileListSummaryParts`
- git-add uses `textHeadTailParts` instead of inline truncation
- git-commit body lines emit without truncation (schema already caps at 10)
- split `tool-output-content.ts` into `tool-output-part.ts` (shared schema/types) and `tool-output-render.ts` (rendering logic)

Fixes #222