### PR TITLE
fix(tui): renderer fixes and streaming improvements

### DIFF
--- a/src/chat-commands.tui.test.tsx
+++ b/src/chat-commands.tui.test.tsx
@@ -13,7 +13,7 @@ function renderTranscript(
 
 describe("chat slash command visual regression", () => {
   test("renders /status transcript output", async () => {
-    const { handleMessage, allRows: rows } = createMessageHandlerHarness({
+    const { handleMessage, allRows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({
           providers: ["openai"],
@@ -24,7 +24,7 @@ describe("chat slash command visual regression", () => {
 
     await handleMessage("/status");
 
-    expect(renderTranscript(rows)).toBe(
+    expect(renderTranscript(allRows)).toBe(
       dedent(`
         ❯ /status
 
@@ -69,7 +69,7 @@ describe("chat slash command visual regression", () => {
       ],
     });
     const sessionState = createSessionState({ activeSessionId: session.id, sessions: [session] });
-    const { handleMessage, allRows: rows } = createMessageHandlerHarness({
+    const { handleMessage, allRows } = createMessageHandlerHarness({
       session,
       sessionState,
       tokenUsage: session.tokenUsage,
@@ -77,7 +77,7 @@ describe("chat slash command visual regression", () => {
 
     await handleMessage("/usage");
 
-    expect(renderTranscript(rows)).toBe(
+    expect(renderTranscript(allRows)).toBe(
       dedent(`
         ❯ /usage
 
@@ -107,11 +107,11 @@ describe("chat slash command visual regression", () => {
       ],
     });
     try {
-      const { handleMessage, allRows: rows } = createMessageHandlerHarness({ sessionState });
+      const { handleMessage, allRows } = createMessageHandlerHarness({ sessionState });
 
       await handleMessage("/sessions");
 
-      expect(renderTranscript(rows)).toBe(
+      expect(renderTranscript(allRows)).toBe(
         dedent(`
           ❯ /sessions
 

--- a/src/chat-commands.tui.test.tsx
+++ b/src/chat-commands.tui.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { ChatTranscript } from "./chat-transcript";
 import { createClient, createMessageHandlerHarness, createSession, createSessionState, dedent } from "./test-utils";
 import { DEFAULT_TERMINAL_WIDTH } from "./tui/constants";
-import { renderPlain } from "./tui-test-utils";
+import { renderPlain } from "./tui/test-utils";
 
 function renderTranscript(
   rows: Parameters<typeof ChatTranscript>[0]["rows"],

--- a/src/chat-commands.tui.test.tsx
+++ b/src/chat-commands.tui.test.tsx
@@ -13,7 +13,7 @@ function renderTranscript(
 
 describe("chat slash command visual regression", () => {
   test("renders /status transcript output", async () => {
-    const { handleMessage, rows } = createMessageHandlerHarness({
+    const { handleMessage, allRows: rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({
           providers: ["openai"],
@@ -69,7 +69,7 @@ describe("chat slash command visual regression", () => {
       ],
     });
     const sessionState = createSessionState({ activeSessionId: session.id, sessions: [session] });
-    const { handleMessage, rows } = createMessageHandlerHarness({
+    const { handleMessage, allRows: rows } = createMessageHandlerHarness({
       session,
       sessionState,
       tokenUsage: session.tokenUsage,
@@ -107,7 +107,7 @@ describe("chat slash command visual regression", () => {
       ],
     });
     try {
-      const { handleMessage, rows } = createMessageHandlerHarness({ sessionState });
+      const { handleMessage, allRows: rows } = createMessageHandlerHarness({ sessionState });
 
       await handleMessage("/sessions");
 

--- a/src/chat-message-handler-stream.int.test.ts
+++ b/src/chat-message-handler-stream.int.test.ts
@@ -13,7 +13,11 @@ import {
 
 describe("chat message handler stream behavior", () => {
   test("streams tool-call events into tool progress rows", async () => {
-    const { handleMessage, rows, calls } = createMessageHandlerHarness({
+    const {
+      handleMessage,
+      allRows: rows,
+      calls,
+    } = createMessageHandlerHarness({
       client: createClient({
         replyStream: async (input) => {
           input.onEvent({ type: "status", state: { kind: "running" } });
@@ -95,7 +99,7 @@ describe("chat message handler stream behavior", () => {
   });
 
   test("maps quota errors to user-facing message handler error", async () => {
-    const { handleMessage, rows } = createMessageHandlerHarness({
+    const { handleMessage, allRows: rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
         replyStream: async () => {
@@ -115,7 +119,7 @@ describe("chat message handler stream behavior", () => {
   });
 
   test("maps timeout errors to user-facing message handler error", async () => {
-    const { handleMessage, rows } = createMessageHandlerHarness({
+    const { handleMessage, allRows: rows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
         replyStream: async () => {
@@ -138,7 +142,7 @@ describe("chat message handler stream behavior", () => {
     let callCount = 0;
     const {
       handleMessage,
-      rows,
+      allRows,
       session,
       calls: spies,
     } = createMessageHandlerHarness({
@@ -159,7 +163,7 @@ describe("chat message handler stream behavior", () => {
     expect(callCount).toBe(2);
     expect(spies.pendingTransitions).toEqual([true, false, true, false]);
     expect(
-      rows.some(
+      allRows.some(
         (row) =>
           row.kind === "system" && typeof row.content === "string" && row.content.includes("Server request timed out"),
       ),
@@ -237,7 +241,7 @@ describe("chat message handler stream behavior", () => {
     const session = createSession({ id: "sess_current" });
     const sessionState = createSessionState({ activeSessionId: session.id, sessions: [session, target] });
     let replyCalls = 0;
-    const { handleMessage, rows, allRows, calls } = createMessageHandlerHarness({
+    const { handleMessage, allRows, calls } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
         replyStream: async () => {
@@ -262,7 +266,7 @@ describe("chat message handler stream behavior", () => {
     ).toBe(true);
     expect(calls.setCurrentSessionIds).toEqual([target.id]);
     expect(sessionState.activeSessionId).toBe(target.id);
-    expect(rows.some((row) => row.kind === "assistant" && row.content === "resumed")).toBe(true);
+    expect(allRows.some((row) => row.kind === "assistant" && row.content === "resumed")).toBe(true);
   });
 
   test("uses final reply output as authoritative content", async () => {
@@ -318,7 +322,7 @@ describe("chat message handler stream behavior", () => {
   });
 
   test("never surfaces blocked tool rows when mixed with allowed tool work", async () => {
-    const { handleMessage, rows } = createMessageHandlerHarness({
+    const { handleMessage, calls } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
         replyStream: async (input) => {
@@ -356,7 +360,8 @@ describe("chat message handler stream behavior", () => {
 
     await handleMessage("hello");
 
-    const toolRows = rows.filter((row) => row.kind === "tool");
+    const promoted = calls.promotedSnapshots.flat();
+    const toolRows = promoted.filter((row) => row.kind === "tool");
     expect(toolRows).toHaveLength(1);
     expect(
       isToolOutput(toolRows[0]?.content) &&
@@ -365,7 +370,9 @@ describe("chat message handler stream behavior", () => {
         ),
     ).toBe(true);
     expect(
-      rows.some((row) => isToolOutput(row.content) && row.content.parts.some((item) => item.kind === "file-header")),
+      promoted.some(
+        (row) => isToolOutput(row.content) && row.content.parts.some((item) => item.kind === "file-header"),
+      ),
     ).toBe(false);
   });
 
@@ -407,7 +414,7 @@ describe("chat message handler stream behavior", () => {
       ],
     ];
     let replyCount = 0;
-    const { handleMessage, rows } = createMessageHandlerHarness({
+    const { handleMessage, calls } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
         replyStream: async (input) => {
@@ -424,7 +431,8 @@ describe("chat message handler stream behavior", () => {
     await handleMessage("create file");
     await handleMessage("edit file");
 
-    const editedRows = rows.filter(
+    const promoted = calls.promotedSnapshots.flat();
+    const editedRows = promoted.filter(
       (row) =>
         row.kind === "tool" &&
         isToolOutput(row.content) &&
@@ -551,7 +559,7 @@ describe("chat message handler stream behavior", () => {
   });
 
   test("assistant text row stays before tool rows after finalization", async () => {
-    const { handleMessage, rows } = createMessageHandlerHarness({
+    const { handleMessage, allRows: rows } = createMessageHandlerHarness({
       client: createClient({
         replyStream: async (input) => {
           input.onEvent({ type: "status", state: { kind: "running" } });
@@ -589,7 +597,7 @@ describe("chat message handler stream behavior", () => {
   });
 
   test("batched tool calls each get their own tool row", async () => {
-    const { handleMessage, rows } = createMessageHandlerHarness({
+    const { handleMessage, calls } = createMessageHandlerHarness({
       client: createClient({
         replyStream: async (input) => {
           input.onEvent({ type: "status", state: { kind: "running" } });
@@ -650,7 +658,8 @@ describe("chat message handler stream behavior", () => {
 
     await handleMessage("rename across files");
 
-    const toolRows = rows.filter((row) => row.kind === "tool");
+    const promoted = calls.promotedSnapshots.flat();
+    const toolRows = promoted.filter((row) => row.kind === "tool");
     expect(toolRows).toHaveLength(2);
   });
 });

--- a/src/chat-message-handler-stream.int.test.ts
+++ b/src/chat-message-handler-stream.int.test.ts
@@ -13,11 +13,7 @@ import {
 
 describe("chat message handler stream behavior", () => {
   test("streams tool-call events into tool progress rows", async () => {
-    const {
-      handleMessage,
-      allRows: rows,
-      calls,
-    } = createMessageHandlerHarness({
+    const { handleMessage, allRows, calls } = createMessageHandlerHarness({
       client: createClient({
         replyStream: async (input) => {
           input.onEvent({ type: "status", state: { kind: "running" } });
@@ -44,9 +40,11 @@ describe("chat message handler stream behavior", () => {
 
     expect(calls.pendingStates[0]).toEqual({ kind: "running" });
     expect(calls.pendingStates.at(-1)).toBeNull();
-    expect(rows.some((row) => row.kind === "tool")).toBe(true);
+    expect(allRows.some((row) => row.kind === "tool")).toBe(true);
     expect(
-      rows.some((row) => row.kind === "system" && typeof row.content === "string" && row.content.includes("Working")),
+      allRows.some(
+        (row) => row.kind === "system" && typeof row.content === "string" && row.content.includes("Working"),
+      ),
     ).toBe(false);
   });
 
@@ -99,7 +97,7 @@ describe("chat message handler stream behavior", () => {
   });
 
   test("maps quota errors to user-facing message handler error", async () => {
-    const { handleMessage, allRows: rows } = createMessageHandlerHarness({
+    const { handleMessage, allRows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
         replyStream: async () => {
@@ -111,7 +109,7 @@ describe("chat message handler stream behavior", () => {
     await handleMessage("hello");
 
     expect(
-      rows.some(
+      allRows.some(
         (row) =>
           row.kind === "system" && typeof row.content === "string" && row.content.includes("Provider quota exceeded"),
       ),
@@ -119,7 +117,7 @@ describe("chat message handler stream behavior", () => {
   });
 
   test("maps timeout errors to user-facing message handler error", async () => {
-    const { handleMessage, allRows: rows } = createMessageHandlerHarness({
+    const { handleMessage, allRows } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
         replyStream: async () => {
@@ -131,7 +129,7 @@ describe("chat message handler stream behavior", () => {
     await handleMessage("hello");
 
     expect(
-      rows.some(
+      allRows.some(
         (row) =>
           row.kind === "system" && typeof row.content === "string" && row.content.includes("Server request timed out"),
       ),
@@ -559,7 +557,7 @@ describe("chat message handler stream behavior", () => {
   });
 
   test("assistant text row stays before tool rows after finalization", async () => {
-    const { handleMessage, allRows: rows } = createMessageHandlerHarness({
+    const { handleMessage, allRows } = createMessageHandlerHarness({
       client: createClient({
         replyStream: async (input) => {
           input.onEvent({ type: "status", state: { kind: "running" } });
@@ -589,8 +587,8 @@ describe("chat message handler stream behavior", () => {
 
     await handleMessage("do something");
 
-    const assistantIndex = rows.findIndex((row) => row.kind === "assistant");
-    const toolIndex = rows.findIndex((row) => row.kind === "tool");
+    const assistantIndex = allRows.findIndex((row) => row.kind === "assistant");
+    const toolIndex = allRows.findIndex((row) => row.kind === "tool");
     expect(assistantIndex).toBeGreaterThanOrEqual(0);
     expect(toolIndex).toBeGreaterThanOrEqual(0);
     expect(assistantIndex).toBeLessThan(toolIndex);

--- a/src/chat-message-handler.int.test.ts
+++ b/src/chat-message-handler.int.test.ts
@@ -83,11 +83,7 @@ describe("chat message handler", () => {
   });
 
   test("routes /status through message handler and renders status output row", async () => {
-    const {
-      handleMessage,
-      allRows: rows,
-      calls,
-    } = createMessageHandlerHarness({
+    const { handleMessage, allRows, calls } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({
           providers: ["openai"],
@@ -100,7 +96,7 @@ describe("chat message handler", () => {
 
     expect(calls.setInputHistory).toBe(1);
     expect(calls.setValue).toEqual([""]);
-    const [userRow, systemRow] = rows;
+    const [userRow, systemRow] = allRows;
     expect(userRow?.kind).toBe("user");
     expect(userRow?.content).toBe("/status");
     expect(systemRow?.kind).toBe("system");

--- a/src/chat-message-handler.int.test.ts
+++ b/src/chat-message-handler.int.test.ts
@@ -83,7 +83,11 @@ describe("chat message handler", () => {
   });
 
   test("routes /status through message handler and renders status output row", async () => {
-    const { handleMessage, allRows: rows, calls } = createMessageHandlerHarness({
+    const {
+      handleMessage,
+      allRows: rows,
+      calls,
+    } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({
           providers: ["openai"],
@@ -208,7 +212,7 @@ describe("chat message handler", () => {
       ],
     ];
     let replyCount = 0;
-    const { handleMessage, rows } = createMessageHandlerHarness({
+    const { handleMessage, calls } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
         replyStream: async (input) => {
@@ -226,7 +230,9 @@ describe("chat message handler", () => {
     await handleMessage("update sum.rs to take three instead of two");
     await handleMessage("delete sum.rs");
 
-    const toolRows = rows.filter((row) => row.kind === "tool");
+    // Each turn promotes its rows — collect all promoted rows across turns.
+    const promoted = calls.promotedSnapshots.flat();
+    const toolRows = promoted.filter((row) => row.kind === "tool");
     expect(toolRows).toHaveLength(3);
     expect(
       isToolOutput(toolRows[0]?.content) &&
@@ -244,10 +250,11 @@ describe("chat message handler", () => {
       isToolOutput(toolRows[2]?.content) &&
         toolRows[2]?.content.parts.some((i) => i.kind === "tool-header" && i.labelKey === "tool.label.file_delete"),
     ).toBe(true);
-    // Assistant text rows are kept as-is (no redundancy filtering).
-    expect(rows.some((row) => row.kind === "assistant" && row.content === "Created sum.rs.")).toBe(true);
-    expect(rows.some((row) => row.kind === "assistant" && row.content === "Updated sum.rs for three args.")).toBe(true);
-    expect(rows.some((row) => row.kind === "assistant" && row.content === "Removed sum.rs.")).toBe(true);
+    expect(promoted.some((row) => row.kind === "assistant" && row.content === "Created sum.rs.")).toBe(true);
+    expect(promoted.some((row) => row.kind === "assistant" && row.content === "Updated sum.rs for three args.")).toBe(
+      true,
+    );
+    expect(promoted.some((row) => row.kind === "assistant" && row.content === "Removed sum.rs.")).toBe(true);
   });
 
   test("toggles shortcuts on ? input", async () => {
@@ -424,7 +431,7 @@ describe("chat message handler", () => {
 
   test("shows warning for unresolved @references but continues turn", async () => {
     let replyCalls = 0;
-    const { handleMessage, rows } = createMessageHandlerHarness({
+    const { handleMessage, allRows } = createMessageHandlerHarness({
       client: createClient({
         replyStream: async (input) => {
           replyCalls += 1;
@@ -438,9 +445,9 @@ describe("chat message handler", () => {
     await handleMessage("review @definitely-not-a-real-file-xyz");
 
     expect(replyCalls).toBe(1);
-    expect(rows.some((row) => typeof row.content === "string" && row.content.includes("No file or folder found"))).toBe(
-      true,
-    );
+    expect(
+      allRows.some((row) => typeof row.content === "string" && row.content.includes("No file or folder found")),
+    ).toBe(true);
   });
 
   test("shows warning for unresolved @references alongside resolved ones", async () => {
@@ -450,7 +457,7 @@ describe("chat message handler", () => {
     await writeFile(fixturePath, "fixture");
 
     try {
-      const { handleMessage, rows } = createMessageHandlerHarness({
+      const { handleMessage, allRows } = createMessageHandlerHarness({
         client: createClient({
           replyStream: async (input) => {
             replyCalls += 1;
@@ -465,9 +472,9 @@ describe("chat message handler", () => {
 
       expect(replyCalls).toBe(1);
       expect(
-        rows.some((row) => typeof row.content === "string" && row.content.includes("No file or folder found")),
+        allRows.some((row) => typeof row.content === "string" && row.content.includes("No file or folder found")),
       ).toBe(true);
-      expect(rows.some((row) => row.kind === "assistant" && row.content === "ok")).toBe(true);
+      expect(allRows.some((row) => row.kind === "assistant" && row.content === "ok")).toBe(true);
     } finally {
       await rm(fixturePath, { force: true });
     }
@@ -475,7 +482,7 @@ describe("chat message handler", () => {
 
   test("concurrent handleSubmit calls only process one turn", async () => {
     let replyCount = 0;
-    const { handleMessage, rows, session } = createMessageHandlerHarness({
+    const { handleMessage, allRows, session } = createMessageHandlerHarness({
       client: createClient({
         replyStream: async (input) => {
           replyCount++;
@@ -492,7 +499,7 @@ describe("chat message handler", () => {
     await Promise.all([first, second]);
 
     expect(session.messages.filter((m) => m.role === "user")).toHaveLength(1);
-    expect(rows.filter((r) => r.kind === "user")).toHaveLength(1);
+    expect(allRows.filter((r) => r.kind === "user")).toHaveLength(1);
     expect(replyCount).toBe(1);
   });
 
@@ -572,7 +579,6 @@ describe("chat message handler", () => {
     const promoted = calls.promotedSnapshots[0] ?? [];
     expect(promoted.some((r) => r.kind === "user")).toBe(true);
     expect(promoted.some((r) => r.kind === "assistant")).toBe(true);
-    expect(promoted.some((r) => r.kind === "status")).toBe(true);
   });
 
   test("promote includes tool output rows", async () => {

--- a/src/chat-message-handler.int.test.ts
+++ b/src/chat-message-handler.int.test.ts
@@ -83,7 +83,7 @@ describe("chat message handler", () => {
   });
 
   test("routes /status through message handler and renders status output row", async () => {
-    const { handleMessage, rows, calls } = createMessageHandlerHarness({
+    const { handleMessage, allRows: rows, calls } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({
           providers: ["openai"],
@@ -108,13 +108,13 @@ describe("chat message handler", () => {
   });
 
   test("routes /sessions through message handler and renders sessions list row", async () => {
-    const { handleMessage, rows, calls } = createMessageHandlerHarness();
+    const { handleMessage, allRows, calls } = createMessageHandlerHarness();
 
     await handleMessage("/sessions");
 
     expect(calls.setInputHistory).toBe(1);
     expect(calls.setValue).toEqual([""]);
-    const [userRow, systemRow] = rows;
+    const [userRow, systemRow] = allRows;
     expect(userRow?.kind).toBe("user");
     expect(userRow?.content).toBe("/sessions");
     expect(systemRow?.kind).toBe("system");
@@ -122,13 +122,13 @@ describe("chat message handler", () => {
   });
 
   test("routes /usage through message handler and renders usage output row", async () => {
-    const { handleMessage, rows, calls } = createMessageHandlerHarness();
+    const { handleMessage, allRows, calls } = createMessageHandlerHarness();
 
     await handleMessage("/usage");
 
     expect(calls.setInputHistory).toBe(1);
     expect(calls.setValue).toEqual([""]);
-    const [userRow, systemRow] = rows;
+    const [userRow, systemRow] = allRows;
     expect(userRow?.kind).toBe("user");
     expect(userRow?.content).toBe("/usage");
     expect(systemRow?.kind).toBe("system");
@@ -553,6 +553,160 @@ describe("chat message handler", () => {
     // Interrupt handler must still be registered so the user can Ctrl+C
     // to cancel the remote task polling.
     expect(interruptHandler).not.toBeNull();
+  });
+
+  test("promote is called after turn completion with all rows", async () => {
+    const { handleMessage, calls } = createMessageHandlerHarness({
+      client: createClient({
+        replyStream: async (input) => {
+          input.onEvent({ type: "text-delta", text: "done" });
+          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+        },
+        status: async () => ({}),
+      }),
+    });
+
+    await handleMessage("hello");
+
+    expect(calls.promotedSnapshots).toHaveLength(1);
+    const promoted = calls.promotedSnapshots[0] ?? [];
+    expect(promoted.some((r) => r.kind === "user")).toBe(true);
+    expect(promoted.some((r) => r.kind === "assistant")).toBe(true);
+    expect(promoted.some((r) => r.kind === "status")).toBe(true);
+  });
+
+  test("promote includes tool output rows", async () => {
+    const { handleMessage, calls } = createMessageHandlerHarness({
+      client: createClient({
+        replyStream: async (input) => {
+          input.onEvent({ type: "tool-call", toolCallId: "tc_1", toolName: "file-edit", args: {} });
+          input.onEvent({
+            type: "tool-output",
+            toolCallId: "tc_1",
+            toolName: "file-edit",
+            content: { kind: "tool-header", labelKey: "tool.label.file_edit", detail: "test.ts" },
+          });
+          input.onEvent({ type: "text-delta", text: "edited" });
+          return { state: "done" as const, model: "gpt-5-mini", output: "edited" };
+        },
+        status: async () => ({}),
+      }),
+    });
+
+    await handleMessage("edit a file");
+
+    expect(calls.promotedSnapshots).toHaveLength(1);
+    const promoted = calls.promotedSnapshots[0] ?? [];
+    expect(promoted.some((r) => r.kind === "tool")).toBe(true);
+  });
+
+  test("promote clears dynamic rows", async () => {
+    const { handleMessage, rows, calls } = createMessageHandlerHarness({
+      client: createClient({
+        replyStream: async (input) => {
+          input.onEvent({ type: "text-delta", text: "done" });
+          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+        },
+        status: async () => ({}),
+      }),
+    });
+
+    await handleMessage("hello");
+
+    expect(calls.promotedSnapshots).toHaveLength(1);
+    expect(rows).toHaveLength(0);
+  });
+
+  test("promote is not called for awaiting-input turns", async () => {
+    const { handleMessage, calls } = createMessageHandlerHarness({
+      client: createClient({
+        replyStream: async (input) => {
+          input.onEvent({ type: "text-delta", text: "What input?" });
+          return { state: "awaiting-input" as const, model: "gpt-5-mini", output: "What input?" };
+        },
+        status: async () => ({}),
+      }),
+    });
+
+    await handleMessage("ask me for some input");
+
+    expect(calls.promotedSnapshots).toHaveLength(0);
+  });
+
+  test("promote is called after abort with interrupted row", async () => {
+    const rows: ChatRow[] = [];
+    let interruptHandler: () => void = () => {};
+    let interruptRegistered = false;
+    const promotedSnapshots: ChatRow[][] = [];
+
+    const session = createSession({ id: "sess_test" });
+    const sessionState = createSessionState({ activeSessionId: session.id, sessions: [session] });
+
+    const { handleSubmit } = createMessageHandler({
+      client: createClient({
+        replyStream: async (input) =>
+          new Promise((_, reject) => {
+            const abort = (): void => {
+              const error = new Error("Aborted");
+              error.name = "AbortError";
+              reject(error);
+            };
+            if (input.signal?.aborted) {
+              abort();
+              return;
+            }
+            input.signal?.addEventListener("abort", abort, { once: true });
+          }),
+        status: async () => ({}),
+      }),
+      sessionState,
+      currentSession: session,
+      setCurrentSession: () => {},
+      toRows: () => [],
+      setRows: (updater) => {
+        rows.splice(0, rows.length, ...updater(rows));
+      },
+      setShowHelp: () => {},
+      setValue: () => {},
+      persist: async () => {},
+      exit: () => {},
+      openSkillsPanel: async () => {},
+      activateSkill: async () => true,
+      openResumePanel: () => {},
+      openModelPanel: () => {},
+      tokenUsage: [],
+      isPending: false,
+      setInputHistory: () => {},
+      setInputHistoryIndex: () => {},
+      setInputHistoryDraft: () => {},
+      onStartPending: () => {},
+      onStopPending: () => {},
+      setPendingState: () => {},
+      setRunningUsage: () => {},
+      setTokenUsage: () => {},
+      createMessage,
+      nowIso: () => "2026-02-20T00:00:00.000Z",
+      setInterrupt: (handler) => {
+        interruptRegistered = handler !== null;
+        if (handler) interruptHandler = handler;
+      },
+      promote: () => {
+        promotedSnapshots.push([...rows]);
+        rows.splice(0, rows.length);
+      },
+      clearTranscript: () => {},
+    });
+
+    const pending = handleSubmit("hello");
+    for (let i = 0; i < 20 && !interruptRegistered; i++) {
+      await Bun.sleep(1);
+    }
+    interruptHandler();
+    await pending;
+
+    expect(promotedSnapshots).toHaveLength(1);
+    const promoted = promotedSnapshots[0] ?? [];
+    expect(promoted.some((r) => r.kind === "task" && r.content === "Interrupted")).toBe(true);
   });
 
   test("awaiting-input preserves pending state after turn completes", async () => {

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -233,14 +233,15 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
             marker: palette.cancelled,
           }),
         ]);
+        input.promote?.();
       } else {
         streamState.dispose();
         input.setRows((current) => [
           ...current,
           createRow("system", formatSubmitError(error), { text: palette.error }),
         ]);
+        input.promote?.();
       }
-      input.promote?.();
     } finally {
       if (cleanup !== "none") {
         releaseTurn();

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -188,6 +188,7 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
         input.setPendingState(null);
       }
       input.setRows((current) => [...current, ...turn.rows]);
+      if (!turn.awaitingInput) input.promote?.();
       invalidateRepoPathCandidates();
       input.currentSession.tokenUsage.push(turn.tokenEntry);
       input.setTokenUsage(() => [...input.currentSession.tokenUsage]);
@@ -239,6 +240,7 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
           createRow("system", formatSubmitError(error), { text: palette.error }),
         ]);
       }
+      input.promote?.();
     } finally {
       if (cleanup !== "none") {
         releaseTurn();

--- a/src/chat-picker.tui.test.tsx
+++ b/src/chat-picker.tui.test.tsx
@@ -4,7 +4,7 @@ import type { PickerState } from "./chat-picker";
 import { palette } from "./palette";
 import { createSession, dedent } from "./test-utils";
 import { DEFAULT_TERMINAL_WIDTH } from "./tui/constants";
-import { renderPlain } from "./tui-test-utils";
+import { renderPlain } from "./tui/test-utils";
 
 function renderInputPanelWithPicker(picker: PickerState, columns = DEFAULT_TERMINAL_WIDTH): string {
   return renderPlain(

--- a/src/chat-promotion.test.tsx
+++ b/src/chat-promotion.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { ChatRow } from "./chat-contract";
 import { appendPromotedItems, applyPromotion, usePromotion } from "./chat-promotion";
 import { createSession } from "./test-utils";
-import { renderHook, wait } from "./tui-test-utils";
+import { renderHook, wait } from "./tui/test-utils";
 
 describe("promotion pure helpers", () => {
   test("appendPromotedItems deduplicates by id", () => {

--- a/src/chat-state.ts
+++ b/src/chat-state.ts
@@ -198,7 +198,6 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
     onStopPending: () => {
       setPendingState(null);
       setRunningUsage(null);
-      promote();
       setQueuedMessages((current) => {
         if (current.length === 0) return current;
         const [next, ...rest] = current;

--- a/src/chat-stream.int.test.tsx
+++ b/src/chat-stream.int.test.tsx
@@ -4,7 +4,7 @@ import { createElement } from "./tui/dom";
 import { setOnCommit } from "./tui/host-config";
 import { reconciler } from "./tui/reconciler";
 import { serialize } from "./tui/serialize";
-import { wait } from "./tui-test-utils";
+import { wait } from "./tui/test-utils";
 
 describe("streaming renders", () => {
   test("unconditional setState during render causes render loop", () => {

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -3,7 +3,7 @@ import { wrapText } from "./chat-content";
 import { renderAssistantContent } from "./chat-content-render";
 import type { ChatRow, CommandOutput } from "./chat-contract";
 import { isCommandOutput, isToolOutput } from "./chat-contract";
-import { commandOutputColWidth, formatTokenCount } from "./chat-format";
+import { commandOutputColWidth, formatCompactNumber } from "./chat-format";
 import { ShimmerText } from "./chat-shimmer";
 import type { PendingState } from "./client-contract";
 import { t, tDynamic } from "./i18n";
@@ -262,7 +262,12 @@ export function ChatTranscript(props: ChatTranscriptProps): React.ReactNode {
   const blinkOn = Math.abs(pendingFrame) % pulsePeriod < pulsePeriod / 2;
   const marker = isAnimated && !blinkOn ? " " : "•";
   const markerColor = kind ? PENDING_MARKER_COLORS[kind] : "";
-  const tokenText = runningUsage ? formatTokenCount(runningUsage.inputTokens + runningUsage.outputTokens) : "";
+  const tokenText = runningUsage
+    ? t("unit.token.split", {
+        input: formatCompactNumber(runningUsage.inputTokens),
+        output: formatCompactNumber(runningUsage.outputTokens),
+      })
+    : "";
   const pendingText = (() => {
     if (!pendingState) return "";
     const timeText = elapsedSec >= 60 ? `${Math.floor(elapsedSec / 60)}m ${elapsedSec % 60}s` : `${elapsedSec}s`;

--- a/src/chat-turn.ts
+++ b/src/chat-turn.ts
@@ -4,7 +4,7 @@ import { createWorkspaceSpecifier, type TokenUsage } from "./api";
 import type { ChatMessage } from "./chat-contract";
 import { type ChatRow, createRow } from "./chat-contract";
 import { extractAtReferencePaths } from "./chat-file-ref";
-import { formatTokenCount } from "./chat-format";
+import { formatCompactNumber } from "./chat-format";
 import type { Client, StreamEvent } from "./client-contract";
 import { isParseable } from "./code-ops";
 import { formatDuration } from "./datetime";
@@ -152,10 +152,13 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
     if (durationMs >= 300) {
       const duration = formatDuration(durationMs);
       const toolCount = reply.toolCalls?.length ?? 0;
-      const totalTokens = tokenEntry.usage.totalTokens;
+      const { inputTokens, outputTokens } = tokenEntry.usage;
       const details: string[] = [];
       if (toolCount > 0) details.push(t("unit.tool", { count: toolCount }));
-      if (totalTokens > 0) details.push(formatTokenCount(totalTokens));
+      if (inputTokens + outputTokens > 0)
+        details.push(
+          t("unit.token.split", { input: formatCompactNumber(inputTokens), output: formatCompactNumber(outputTokens) }),
+        );
       const suffix = details.length > 0 ? ` (${details.join(" · ")})` : "";
       rows.push(createRow("status", t("chat.worked", { duration, suffix }), { marker: palette.success, dim: true }));
     }

--- a/src/chat.tui.test.tsx
+++ b/src/chat.tui.test.tsx
@@ -5,7 +5,7 @@ import { ChatInputPanel } from "./chat-input-panel";
 import { palette } from "./palette";
 import { dedent } from "./test-utils";
 import { DEFAULT_TERMINAL_WIDTH } from "./tui/constants";
-import { renderPlain } from "./tui-test-utils";
+import { renderPlain } from "./tui/test-utils";
 
 const DEFAULT_FOOTER_CONTEXT = "~/code/acolyte · main";
 

--- a/src/checklist.tui.test.tsx
+++ b/src/checklist.tui.test.tsx
@@ -3,7 +3,7 @@ import { ChatChecklist } from "./chat-checklist";
 import type { ChatRow } from "./chat-contract";
 import type { ChecklistOutput } from "./checklist-contract";
 import { dedent } from "./test-utils";
-import { renderPlain } from "./tui-test-utils";
+import { renderPlain } from "./tui/test-utils";
 
 function renderChecklist(checklists: ChecklistOutput[]): string {
   const rows: ChatRow[] = checklists.map((content, i) => ({

--- a/src/cli-test-harness.ts
+++ b/src/cli-test-harness.ts
@@ -1,5 +1,5 @@
 import { stripAnsi } from "./tui/serialize";
-import { trimRightLines } from "./tui-test-utils";
+import { trimRightLines } from "./tui/test-utils";
 import { setUiSink } from "./ui";
 
 let isCapturingCliOutput = false;

--- a/src/cli-trace.ts
+++ b/src/cli-trace.ts
@@ -3,6 +3,7 @@ import { hasBoolFlag, parseFlag, parsePositional, parseTailCount } from "./cli-a
 import { type CliOutput, createJsonOutput, createTextOutput } from "./cli-output";
 import { elapsedMs, formatDuration, formatRelativeTime } from "./datetime";
 import { t } from "./i18n";
+import { VERBOSE_ONLY_EVENTS } from "./lifecycle-constants";
 import type { LogLine } from "./log-parser";
 import type { TraceStore } from "./trace-store";
 
@@ -108,8 +109,6 @@ const EVENT_FIELDS: Record<TraceEvent, FieldSpec[]> = {
 };
 
 const KNOWN_EVENTS = new Set<string>(traceEventSchema.options);
-
-const VERBOSE_ONLY_EVENTS = new Set<string>(["lifecycle.tool.output", "lifecycle.tool.cache"]);
 
 function verboseRowData(line: LogLine): Record<string, string | undefined> {
   const event = line.fields.event;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -272,6 +272,7 @@ export const EN_MESSAGES = {
   "unit.result.one": "{count} result",
   "unit.token": "{count} tokens",
   "unit.token.one": "{count} token",
+  "unit.token.split": "{input}/{output} tokens",
   "unit.tool": "{count} tools",
   "unit.tool.one": "{count} tool",
   unknown_error: "Unknown error",

--- a/src/int-test-utils.ts
+++ b/src/int-test-utils.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { configDir, dataDir, stateDir } from "./paths";
 import type { SessionState } from "./session-contract";
 import { stripAnsi } from "./tui/serialize";
-import { trimRightLines } from "./tui-test-utils";
+import { trimRightLines } from "./tui/test-utils";
 
 type RunCliPlainOptions = {
   cwd?: string;

--- a/src/lifecycle-constants.ts
+++ b/src/lifecycle-constants.ts
@@ -1,5 +1,7 @@
-export const MAX_TOTAL_STEPS = 200;
-export const MAX_TURN_STEPS = 80;
+export const VERBOSE_ONLY_EVENTS = new Set<string>(["lifecycle.tool.output", "lifecycle.tool.cache"]);
+
+export const MAX_TOTAL_STEPS = 60;
+export const MAX_TURN_STEPS = 30;
 export const STEP_TIMEOUT_MS = 120_000;
 export const MAX_UNKNOWN_ERRORS_PER_REQUEST = 2;
 export const TOOL_TIMEOUT_MS = 10_000;

--- a/src/server-chat-runtime.test.ts
+++ b/src/server-chat-runtime.test.ts
@@ -48,6 +48,29 @@ describe("server chat runtime", () => {
     }
   });
 
+  test("verbose-only events use debug log level", () => {
+    const infoLogs: string[] = [];
+    const debugLogs: string[] = [];
+    const base = {
+      requestId: "err_abc123",
+      taskId: "task_1",
+      sessionId: "sess_1",
+      sequence: 1,
+      eventTs: "2026-03-06T10:00:00.000Z",
+      traceStore: null,
+      logInfo: (msg: string) => infoLogs.push(msg),
+      logDebug: (msg: string) => debugLogs.push(msg),
+    };
+
+    logLifecycleDebugEntry({ ...base, event: "lifecycle.tool.output" });
+    logLifecycleDebugEntry({ ...base, event: "lifecycle.tool.cache" });
+    logLifecycleDebugEntry({ ...base, event: "lifecycle.tool.call" });
+
+    expect(debugLogs).toHaveLength(2);
+    expect(infoLogs).toHaveLength(1);
+    expect(infoLogs[0]).toBe("agent debug");
+  });
+
   test("isChatRequest rejects malformed activeSkills entries", () => {
     expect(
       isChatRequest({

--- a/src/server-chat-runtime.ts
+++ b/src/server-chat-runtime.ts
@@ -8,6 +8,7 @@ import { createDebugLogger } from "./debug-flags";
 import { createStreamError, errorIdSchema, parseError } from "./error-handling";
 import { field } from "./field";
 import { runLifecycle } from "./lifecycle";
+import { VERBOSE_ONLY_EVENTS } from "./lifecycle-constants";
 import { errorToLogFields, log } from "./log";
 import { isProviderAvailable, providerFromModel } from "./provider-config";
 import type { Provider } from "./provider-contract";
@@ -58,11 +59,12 @@ export function logLifecycleDebugEntry(params: {
   eventTs: string;
   fields?: Record<string, unknown>;
   logInfo?: (message: string, fields?: Record<string, string | number | boolean | null | undefined>) => void;
+  logDebug?: (message: string, fields?: Record<string, string | number | boolean | null | undefined>) => void;
   traceStore?: TraceStore | null;
 }): void {
-  const logInfo = params.logInfo ?? log.info;
+  const logFn = VERBOSE_ONLY_EVENTS.has(params.event) ? (params.logDebug ?? log.debug) : (params.logInfo ?? log.info);
   const logFields = toLogFieldMap(params.fields);
-  logInfo("agent debug", {
+  logFn("agent debug", {
     request_id: params.requestId,
     task_id: params.taskId ?? null,
     session_id: params.sessionId ?? null,

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -283,6 +283,7 @@ export type MessageHandlerHarness = {
     pendingTransitions: boolean[];
     setCurrentSessionIds: string[];
     tokenUsageSnapshots: SessionTokenUsageEntry[][];
+    promotedSnapshots: ChatRow[][];
   };
   interrupt: {
     registered: boolean;

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -309,6 +309,7 @@ export function createMessageHandlerHarness(overrides?: {
     pendingTransitions: [] as boolean[],
     setCurrentSessionIds: [] as string[],
     tokenUsageSnapshots: [] as SessionTokenUsageEntry[][],
+    promotedSnapshots: [] as ChatRow[][],
   };
   const session = overrides?.session ?? createSession({ id: "sess_test" });
   const sessionState =
@@ -366,6 +367,11 @@ export function createMessageHandlerHarness(overrides?: {
     setInterrupt: (handler) => {
       interrupt.registered = handler !== null;
       if (handler) interrupt.fire = handler;
+    },
+    promote: () => {
+      const snapshot = [...rows];
+      calls.promotedSnapshots.push(snapshot);
+      rows.splice(0, rows.length);
     },
     clearTranscript: () => {
       rows.splice(0, rows.length);

--- a/src/tool-output.tui.test.tsx
+++ b/src/tool-output.tui.test.tsx
@@ -4,7 +4,7 @@ import { ChatTranscript } from "./chat-transcript";
 import { dedent } from "./test-utils";
 import type { ToolOutputPart } from "./tool-output-contract";
 import { formatToolOutput } from "./tool-output-render";
-import { renderPlain } from "./tui-test-utils";
+import { renderPlain } from "./tui/test-utils";
 
 function renderChat(toolOutput: ToolOutputPart[]): string {
   const row: ChatRow = { id: "r1", kind: "tool", content: { parts: toolOutput } };

--- a/src/tui-test-utils.ts
+++ b/src/tui-test-utils.ts
@@ -1,8 +1,0 @@
-export {
-  renderCapture,
-  renderHook,
-  renderPlain,
-  trimRightLines,
-  wait,
-  withTerminalWidth,
-} from "./tui/test-utils";

--- a/src/tui-test-utils.ts
+++ b/src/tui-test-utils.ts
@@ -1,67 +1,8 @@
-import { createElement as h, type ReactNode } from "react";
-import { renderToString } from "./tui";
-import { DEFAULT_TERMINAL_WIDTH } from "./tui/constants";
-import { createElement } from "./tui/dom";
-import { setOnCommit } from "./tui/host-config";
-import { reconciler } from "./tui/reconciler";
-import { stripAnsi } from "./tui/serialize";
-
-export const trimRightLines = (value: string): string =>
-  value
-    .split("\n")
-    .map((line) => line.trimEnd())
-    .join("\n");
-
-export function withTerminalWidth(width: number, run: () => string): string {
-  const descriptor = Object.getOwnPropertyDescriptor(process.stdout, "columns");
-  Object.defineProperty(process.stdout, "columns", { configurable: true, value: width });
-  try {
-    return run();
-  } finally {
-    if (descriptor) Object.defineProperty(process.stdout, "columns", descriptor);
-  }
-}
-
-export function renderPlain(node: ReactNode, columns = DEFAULT_TERMINAL_WIDTH): string {
-  const rendered = withTerminalWidth(columns, () => renderToString(node));
-  return trimRightLines(stripAnsi(rendered)).replace(/^\n+/, "").replace(/\n+$/, "");
-}
-
-export function wait(ms = 50): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-export function renderHook<T>(hookFn: () => T): { result: { current: T }; unmount: () => void } {
-  const result = {} as { current: T };
-  function App() {
-    result.current = hookFn();
-    return h("tui-text", null, "");
-  }
-  const root = createElement("tui-root", {});
-  setOnCommit(() => {});
-  const container = reconciler.createContainer(
-    root,
-    0,
-    null,
-    false,
-    null,
-    "",
-    (e: Error) => {
-      throw e;
-    },
-    () => {},
-    () => {},
-    () => {},
-  );
-  reconciler.updateContainerSync(h(App), container, null, null);
-  reconciler.flushSyncWork();
-  reconciler.flushPassiveEffects();
-  return {
-    result,
-    unmount() {
-      reconciler.updateContainerSync(null, container, null, null);
-      reconciler.flushSyncWork();
-      setOnCommit(null);
-    },
-  };
-}
+export {
+  renderCapture,
+  renderHook,
+  renderPlain,
+  trimRightLines,
+  wait,
+  withTerminalWidth,
+} from "./tui/test-utils";

--- a/src/tui/render.test.tsx
+++ b/src/tui/render.test.tsx
@@ -431,4 +431,72 @@ describe("render", () => {
       else process.env.TMUX = savedTmux;
     }
   });
+
+  test.todo("incremental dynamic updates promoted to static do not duplicate scrollback", async () => {
+    const writes = await withMockedStdout(
+      async () => {
+        const { render } = await import("./render");
+
+        // Simulates tool output streaming: a dynamic row is updated
+        // many times (growing content), overflowing the viewport each
+        // time.  The frozen overflow accumulates intermediate states.
+        // When the final content is promoted to Static, the frozen text
+        // no longer matches and the dedup must still prevent duplication.
+        type Ref<T> = { current: T };
+        const setContent: Ref<(fn: (prev: string[]) => string[]) => void> = { current: () => {} };
+        const doPromote: Ref<() => void> = { current: () => {} };
+
+        function App(): React.JSX.Element {
+          const [staticLines, setStaticLines] = useState<string[]>([]);
+          const [lines, setLines] = useState<string[]>([]);
+          setContent.current = setLines;
+          doPromote.current = () => {
+            setStaticLines([...lines]);
+            setLines([]);
+          };
+
+          return (
+            <tui-box flexDirection="column">
+              <tui-static>
+                {staticLines.map((line) => (
+                  <tui-text key={line}>{line}</tui-text>
+                ))}
+              </tui-static>
+              {lines.map((line) => (
+                <tui-text key={line}>{line}</tui-text>
+              ))}
+              <tui-text>footer</tui-text>
+            </tui-box>
+          );
+        }
+
+        const app = render(<App />);
+        await new Promise((r) => setTimeout(r, 20));
+
+        // Simulate incremental tool output: add lines one at a time
+        for (let i = 1; i <= 8; i++) {
+          setContent.current((prev) => [...prev, `LINE_${i}`]);
+          await new Promise((r) => setTimeout(r, 10));
+        }
+
+        // Promote all lines to static (like chat promotion after turn)
+        doPromote.current();
+        await new Promise((r) => setTimeout(r, 30));
+
+        app.unmount();
+      },
+      { columns: 40, rows: 6 },
+    );
+
+    const frameWrites = extractFrameWrites(writes);
+    const allOutput = frameWrites.join("");
+
+    // Debug removed
+    // Each line must appear exactly once in terminal output.
+    for (let i = 1; i <= 8; i++) {
+      const marker = `LINE_${i}`;
+      const count = allOutput.split(marker).length - 1;
+      expect(count).toBe(1);
+    }
+  });
 });

--- a/src/tui/render.test.tsx
+++ b/src/tui/render.test.tsx
@@ -359,8 +359,8 @@ describe("render", () => {
           const [lines, setLines] = useState(["A1", "A2", "A3", "A4", "A5", "A6", "A7", "A8"]);
 
           useEffect(() => {
-            const t1 = setTimeout(() => setLines(["B1", "B2", "B3", "B4"]), 20);
-            const t2 = setTimeout(() => app.unmount(), 60);
+            const t1 = setTimeout(() => setLines(["B1", "B2", "B3", "B4"]), 50);
+            const t2 = setTimeout(() => app.unmount(), 150);
             return () => {
               clearTimeout(t1);
               clearTimeout(t2);
@@ -432,71 +432,146 @@ describe("render", () => {
     }
   });
 
-  test.todo("incremental dynamic updates promoted to static do not duplicate scrollback", async () => {
+  test("streaming state updates render incrementally, not batched into one commit", async () => {
     const writes = await withMockedStdout(
       async () => {
         const { render } = await import("./render");
 
-        // Simulates tool output streaming: a dynamic row is updated
-        // many times (growing content), overflowing the viewport each
-        // time.  The frozen overflow accumulates intermediate states.
-        // When the final content is promoted to Static, the frozen text
-        // no longer matches and the dedup must still prevent duplication.
         type Ref<T> = { current: T };
-        const setContent: Ref<(fn: (prev: string[]) => string[]) => void> = { current: () => {} };
-        const doPromote: Ref<() => void> = { current: () => {} };
+        const setText: Ref<(fn: (prev: string) => string) => void> = { current: () => {} };
 
         function App(): React.JSX.Element {
-          const [staticLines, setStaticLines] = useState<string[]>([]);
-          const [lines, setLines] = useState<string[]>([]);
-          setContent.current = setLines;
-          doPromote.current = () => {
-            setStaticLines([...lines]);
-            setLines([]);
-          };
-
-          return (
-            <tui-box flexDirection="column">
-              <tui-static>
-                {staticLines.map((line) => (
-                  <tui-text key={line}>{line}</tui-text>
-                ))}
-              </tui-static>
-              {lines.map((line) => (
-                <tui-text key={line}>{line}</tui-text>
-              ))}
-              <tui-text>footer</tui-text>
-            </tui-box>
-          );
+          const [text, setTextState] = useState("");
+          setText.current = setTextState;
+          return <tui-text>{text || "empty"}</tui-text>;
         }
 
         const app = render(<App />);
-        await new Promise((r) => setTimeout(r, 20));
+        await new Promise((r) => setTimeout(r, 50));
 
-        // Simulate incremental tool output: add lines one at a time
-        for (let i = 1; i <= 8; i++) {
-          setContent.current((prev) => [...prev, `LINE_${i}`]);
-          await new Promise((r) => setTimeout(r, 10));
+        // Simulate streaming: update state with delays between updates
+        for (const word of ["Hello", "Hello world", "Hello world!"]) {
+          setText.current(() => word);
+          await new Promise((r) => setTimeout(r, 50));
         }
 
-        // Promote all lines to static (like chat promotion after turn)
-        doPromote.current();
-        await new Promise((r) => setTimeout(r, 30));
-
+        await new Promise((r) => setTimeout(r, 50));
         app.unmount();
       },
       { columns: 40, rows: 6 },
     );
 
     const frameWrites = extractFrameWrites(writes);
-    const allOutput = frameWrites.join("");
+    const hasHello = frameWrites.some((w) => w.includes("Hello") && !w.includes("world"));
+    const hasHelloWorld = frameWrites.some((w) => w.includes("Hello world") && !w.includes("!"));
+    const hasHelloWorldBang = frameWrites.some((w) => w.includes("Hello world!"));
 
-    // Debug removed
-    // Each line must appear exactly once in terminal output.
-    for (let i = 1; i <= 8; i++) {
-      const marker = `LINE_${i}`;
-      const count = allOutput.split(marker).length - 1;
-      expect(count).toBe(1);
-    }
+    // Each intermediate state must appear in a separate write — not batched.
+    expect(hasHello).toBe(true);
+    expect(hasHelloWorld).toBe(true);
+    expect(hasHelloWorldBang).toBe(true);
+  });
+
+  test("rapid state updates within throttle window still render final state", async () => {
+    const writes = await withMockedStdout(
+      async () => {
+        const { render } = await import("./render");
+
+        type Ref<T> = { current: T };
+        const setText: Ref<(fn: (prev: string) => string) => void> = { current: () => {} };
+
+        function App(): React.JSX.Element {
+          const [text, setTextState] = useState("init");
+          setText.current = setTextState;
+          return <tui-text>{text}</tui-text>;
+        }
+
+        const app = render(<App />);
+        await new Promise((r) => setTimeout(r, 50));
+
+        // Fire 10 updates with no delay — all within one throttle window
+        for (let i = 1; i <= 10; i++) {
+          setText.current(() => `update_${i}`);
+        }
+
+        await new Promise((r) => setTimeout(r, 100));
+        app.unmount();
+      },
+      { columns: 40, rows: 6 },
+    );
+
+    const frameWrites = extractFrameWrites(writes);
+    // The final state must be rendered even if intermediate states were skipped.
+    expect(frameWrites.some((w) => w.includes("update_10"))).toBe(true);
+  });
+
+  test("static items render immediately without waiting for throttle", async () => {
+    const writes = await withMockedStdout(
+      async () => {
+        const { render } = await import("./render");
+
+        function App(): React.JSX.Element {
+          const [items, setItems] = useState<string[]>([]);
+          const [dynamic, setDynamic] = useState("active");
+          useEffect(() => {
+            const t1 = setTimeout(() => {
+              setItems(["STATIC_1"]);
+              setDynamic("after");
+            }, 50);
+            const t2 = setTimeout(() => app.unmount(), 150);
+            return () => {
+              clearTimeout(t1);
+              clearTimeout(t2);
+            };
+          }, []);
+          return (
+            <tui-box flexDirection="column">
+              <tui-static>
+                {items.map((item) => (
+                  <tui-text key={item}>{item}</tui-text>
+                ))}
+              </tui-static>
+              <tui-text>{dynamic}</tui-text>
+            </tui-box>
+          );
+        }
+
+        const app = render(<App />);
+        await app.waitUntilExit();
+      },
+      { columns: 40, rows: 6 },
+    );
+
+    const frameWrites = extractFrameWrites(writes);
+    expect(frameWrites.some((w) => w.includes("STATIC_1"))).toBe(true);
+    expect(frameWrites.some((w) => w.includes("after"))).toBe(true);
+  });
+
+  test("unmount during throttle window does not lose final render", async () => {
+    const writes = await withMockedStdout(
+      async () => {
+        const { render } = await import("./render");
+
+        function App(): React.JSX.Element {
+          const [text, setText] = useState("before");
+          useEffect(() => {
+            const t1 = setTimeout(() => setText("final"), 50);
+            const t2 = setTimeout(() => app.unmount(), 100);
+            return () => {
+              clearTimeout(t1);
+              clearTimeout(t2);
+            };
+          }, []);
+          return <tui-text>{text}</tui-text>;
+        }
+
+        const app = render(<App />);
+        await app.waitUntilExit();
+      },
+      { columns: 40, rows: 6 },
+    );
+
+    const frameWrites = extractFrameWrites(writes);
+    expect(frameWrites.some((w) => w.includes("final"))).toBe(true);
   });
 });

--- a/src/tui/render.test.tsx
+++ b/src/tui/render.test.tsx
@@ -3,6 +3,7 @@ import type React from "react";
 import { createElement as h, useEffect, useState } from "react";
 import { ChatInputPanel } from "../chat-input-panel";
 import { ansi } from "./styles";
+import { renderCapture } from "./test-utils";
 
 function withMockedStdout(
   fn: (writes: string[]) => void | Promise<void>,
@@ -506,71 +507,53 @@ describe("render", () => {
   });
 
   test("static items render immediately without waiting for throttle", async () => {
-    const writes = await withMockedStdout(
-      async () => {
-        const { render } = await import("./render");
+    function App({ unmount }: { unmount: () => void }): React.JSX.Element {
+      const [items, setItems] = useState<string[]>([]);
+      const [dynamic, setDynamic] = useState("active");
+      useEffect(() => {
+        const t1 = setTimeout(() => {
+          setItems(["STATIC_1"]);
+          setDynamic("after");
+        }, 50);
+        const t2 = setTimeout(unmount, 150);
+        return () => {
+          clearTimeout(t1);
+          clearTimeout(t2);
+        };
+      }, [unmount]);
+      return (
+        <tui-box flexDirection="column">
+          <tui-static>
+            {items.map((item) => (
+              <tui-text key={item}>{item}</tui-text>
+            ))}
+          </tui-static>
+          <tui-text>{dynamic}</tui-text>
+        </tui-box>
+      );
+    }
 
-        function App(): React.JSX.Element {
-          const [items, setItems] = useState<string[]>([]);
-          const [dynamic, setDynamic] = useState("active");
-          useEffect(() => {
-            const t1 = setTimeout(() => {
-              setItems(["STATIC_1"]);
-              setDynamic("after");
-            }, 50);
-            const t2 = setTimeout(() => app.unmount(), 150);
-            return () => {
-              clearTimeout(t1);
-              clearTimeout(t2);
-            };
-          }, []);
-          return (
-            <tui-box flexDirection="column">
-              <tui-static>
-                {items.map((item) => (
-                  <tui-text key={item}>{item}</tui-text>
-                ))}
-              </tui-static>
-              <tui-text>{dynamic}</tui-text>
-            </tui-box>
-          );
-        }
-
-        const app = render(<App />);
-        await app.waitUntilExit();
-      },
-      { columns: 40, rows: 6 },
-    );
-
+    const writes = await renderCapture(({ unmount }) => <App unmount={unmount} />, { columns: 40, rows: 6 });
     const frameWrites = extractFrameWrites(writes);
     expect(frameWrites.some((w) => w.includes("STATIC_1"))).toBe(true);
     expect(frameWrites.some((w) => w.includes("after"))).toBe(true);
   });
 
   test("unmount during throttle window does not lose final render", async () => {
-    const writes = await withMockedStdout(
-      async () => {
-        const { render } = await import("./render");
+    function App({ unmount }: { unmount: () => void }): React.JSX.Element {
+      const [text, setText] = useState("before");
+      useEffect(() => {
+        const t1 = setTimeout(() => setText("final"), 50);
+        const t2 = setTimeout(unmount, 100);
+        return () => {
+          clearTimeout(t1);
+          clearTimeout(t2);
+        };
+      }, [unmount]);
+      return <tui-text>{text}</tui-text>;
+    }
 
-        function App(): React.JSX.Element {
-          const [text, setText] = useState("before");
-          useEffect(() => {
-            const t1 = setTimeout(() => setText("final"), 50);
-            const t2 = setTimeout(() => app.unmount(), 100);
-            return () => {
-              clearTimeout(t1);
-              clearTimeout(t2);
-            };
-          }, []);
-          return <tui-text>{text}</tui-text>;
-        }
-
-        const app = render(<App />);
-        await app.waitUntilExit();
-      },
-      { columns: 40, rows: 6 },
-    );
-
+    const writes = await renderCapture(({ unmount }) => <App unmount={unmount} />, { columns: 40, rows: 6 });
     const frameWrites = extractFrameWrites(writes);
     expect(frameWrites.some((w) => w.includes("final"))).toBe(true);
   });

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -2,7 +2,7 @@ import { appendFileSync } from "node:fs";
 import { join } from "node:path";
 import type { ReactNode } from "react";
 import { createElement as reactCreateElement, StrictMode } from "react";
-import { setLogSink } from "../log";
+import { log, setLogSink } from "../log";
 import { stateDir } from "../paths";
 import { DEFAULT_COLUMNS } from "./constants";
 import { AppContext, InputContext, type InputContextValue, type InputRegistration } from "./context";
@@ -182,8 +182,17 @@ export function render(node: ReactNode): RenderInstance {
       for (let i = flushedStaticCount; i < staticItems.length; i++) {
         appendedStatic += `${staticItems[i]}\n`;
       }
-      if (frozenOverflowText.length > 0 && appendedStatic.startsWith(frozenOverflowText)) {
-        appendedStatic = appendedStatic.slice(frozenOverflowText.length);
+      if (frozenOverflowText.length > 0) {
+        const dedup = appendedStatic.startsWith(frozenOverflowText);
+        log.debug("render.static.flush", {
+          new_items: staticItems.length - flushedStaticCount,
+          frozen_text_len: frozenOverflowText.length,
+          appended_len: appendedStatic.length,
+          dedup_match: dedup,
+        });
+        if (dedup) {
+          appendedStatic = appendedStatic.slice(frozenOverflowText.length);
+        }
       }
       buf += appendedStatic;
       flushedStaticCount = staticItems.length;
@@ -209,6 +218,13 @@ export function render(node: ReactNode): RenderInstance {
       frozenLineCount > 0 &&
       (allLines.length < frozenLineCount || (frozenOverflowText.length > 0 && !active.startsWith(frozenOverflowText)))
     ) {
+      const reason = allLines.length < frozenLineCount ? "shrunk" : "prefix-mismatch";
+      log.debug("render.frozen.reset", {
+        reason,
+        frozen_lines: frozenLineCount,
+        active_lines: allLines.length,
+        frozen_text_len: frozenOverflowText.length,
+      });
       frozenResetErase = `${ansi.cursorUp(maxLiveRows)}\r${ansi.eraseDown}`;
       lastActiveLineCount = 0;
       frozenLineCount = 0;
@@ -239,6 +255,12 @@ export function render(node: ReactNode): RenderInstance {
       frozenLineCount += splitIdx;
       const overflowText = overflow.join("\n");
       frozenOverflowText += `${overflowText}\n`;
+      log.debug("render.overflow.freeze", {
+        new_frozen: splitIdx,
+        total_frozen: frozenLineCount,
+        overflow_phys_rows: countRows(overflowText),
+        on_screen_lines: onScreen.length,
+      });
       syncWrite(`${erase}${overflowText}\n${onScreen.join("\n")}`);
       lastActiveLineCount = physRows > 0 ? physRows - 1 : 0;
     }

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -2,7 +2,7 @@ import { appendFileSync } from "node:fs";
 import { join } from "node:path";
 import type { ReactNode } from "react";
 import { createElement as reactCreateElement, StrictMode } from "react";
-import { log, setLogSink } from "../log";
+import { setLogSink } from "../log";
 import { stateDir } from "../paths";
 import { DEFAULT_COLUMNS } from "./constants";
 import { AppContext, InputContext, type InputContextValue, type InputRegistration } from "./context";
@@ -182,17 +182,8 @@ export function render(node: ReactNode): RenderInstance {
       for (let i = flushedStaticCount; i < staticItems.length; i++) {
         appendedStatic += `${staticItems[i]}\n`;
       }
-      if (frozenOverflowText.length > 0) {
-        const dedup = appendedStatic.startsWith(frozenOverflowText);
-        log.debug("render.static.flush", {
-          new_items: staticItems.length - flushedStaticCount,
-          frozen_text_len: frozenOverflowText.length,
-          appended_len: appendedStatic.length,
-          dedup_match: dedup,
-        });
-        if (dedup) {
-          appendedStatic = appendedStatic.slice(frozenOverflowText.length);
-        }
+      if (frozenOverflowText.length > 0 && appendedStatic.startsWith(frozenOverflowText)) {
+        appendedStatic = appendedStatic.slice(frozenOverflowText.length);
       }
       buf += appendedStatic;
       flushedStaticCount = staticItems.length;
@@ -218,13 +209,6 @@ export function render(node: ReactNode): RenderInstance {
       frozenLineCount > 0 &&
       (allLines.length < frozenLineCount || (frozenOverflowText.length > 0 && !active.startsWith(frozenOverflowText)))
     ) {
-      const reason = allLines.length < frozenLineCount ? "shrunk" : "prefix-mismatch";
-      log.debug("render.frozen.reset", {
-        reason,
-        frozen_lines: frozenLineCount,
-        active_lines: allLines.length,
-        frozen_text_len: frozenOverflowText.length,
-      });
       frozenResetErase = `${ansi.cursorUp(maxLiveRows)}\r${ansi.eraseDown}`;
       lastActiveLineCount = 0;
       frozenLineCount = 0;
@@ -255,12 +239,6 @@ export function render(node: ReactNode): RenderInstance {
       frozenLineCount += splitIdx;
       const overflowText = overflow.join("\n");
       frozenOverflowText += `${overflowText}\n`;
-      log.debug("render.overflow.freeze", {
-        new_frozen: splitIdx,
-        total_frozen: frozenLineCount,
-        overflow_phys_rows: countRows(overflowText),
-        on_screen_lines: onScreen.length,
-      });
       syncWrite(`${erase}${overflowText}\n${onScreen.join("\n")}`);
       lastActiveLineCount = physRows > 0 ? physRows - 1 : 0;
     }
@@ -268,7 +246,26 @@ export function render(node: ReactNode): RenderInstance {
     lastActive = active;
   }
 
-  setOnCommit(commitRender);
+  const RENDER_THROTTLE_MS = 32;
+  let renderTimer: ReturnType<typeof setTimeout> | null = null;
+  let renderPending = false;
+
+  function throttledCommitRender() {
+    if (renderTimer) {
+      renderPending = true;
+      return;
+    }
+    commitRender();
+    renderTimer = setTimeout(() => {
+      renderTimer = null;
+      if (renderPending) {
+        renderPending = false;
+        commitRender();
+      }
+    }, RENDER_THROTTLE_MS);
+  }
+
+  setOnCommit(throttledCommitRender);
 
   const container = reconciler.createContainer(
     root,

--- a/src/tui/serialize.test.tsx
+++ b/src/tui/serialize.test.tsx
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { renderPlain } from "../tui-test-utils";
 import { Box, Text } from "./components";
 import { renderToString } from "./render-to-string";
 import { stripAnsiLength } from "./serialize";
+import { renderPlain } from "./test-utils";
 
 describe("serialize", () => {
   describe("text", () => {

--- a/src/tui/test-utils.ts
+++ b/src/tui/test-utils.ts
@@ -1,0 +1,106 @@
+import { createElement as h, type ReactNode } from "react";
+import { DEFAULT_TERMINAL_WIDTH } from "./constants";
+import { createElement } from "./dom";
+import { setOnCommit } from "./host-config";
+import { renderToString } from "./index";
+import { reconciler } from "./reconciler";
+import { stripAnsi } from "./serialize";
+
+export const trimRightLines = (value: string): string =>
+  value
+    .split("\n")
+    .map((line) => line.trimEnd())
+    .join("\n");
+
+export function withTerminalWidth(width: number, run: () => string): string {
+  const descriptor = Object.getOwnPropertyDescriptor(process.stdout, "columns");
+  Object.defineProperty(process.stdout, "columns", { configurable: true, value: width });
+  try {
+    return run();
+  } finally {
+    if (descriptor) Object.defineProperty(process.stdout, "columns", descriptor);
+  }
+}
+
+export function renderPlain(node: ReactNode, columns = DEFAULT_TERMINAL_WIDTH): string {
+  const rendered = withTerminalWidth(columns, () => renderToString(node));
+  return trimRightLines(stripAnsi(rendered)).replace(/^\n+/, "").replace(/\n+$/, "");
+}
+
+export function wait(ms = 50): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Render a component into a mocked TTY and return all stdout writes.
+ * The setup callback receives an `unmount` function for teardown timing.
+ */
+export async function renderCapture(
+  setup: (ctx: { unmount: () => void }) => ReactNode,
+  options: { columns?: number; rows?: number } = {},
+): Promise<string[]> {
+  const writes: string[] = [];
+  const columns = options.columns ?? 120;
+  const rows = options.rows ?? 24;
+  const saved = {
+    write: process.stdout.write,
+    isTTY: Object.getOwnPropertyDescriptor(process.stdout, "isTTY"),
+    columns: Object.getOwnPropertyDescriptor(process.stdout, "columns"),
+    rows: Object.getOwnPropertyDescriptor(process.stdout, "rows"),
+  };
+  Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+  Object.defineProperty(process.stdout, "columns", { value: columns, configurable: true });
+  Object.defineProperty(process.stdout, "rows", { value: rows, configurable: true });
+  process.stdout.write = ((data: string) => {
+    writes.push(data);
+    return true;
+  }) as typeof process.stdout.write;
+  const restore = () => {
+    process.stdout.write = saved.write;
+    for (const key of ["isTTY", "columns", "rows"] as const)
+      if (saved[key]) Object.defineProperty(process.stdout, key, saved[key]);
+  };
+  try {
+    const { render } = await import("./render");
+    const app = render(setup({ unmount: () => app.unmount() }));
+    await app.waitUntilExit();
+  } finally {
+    restore();
+  }
+  return writes;
+}
+
+export function renderHook<T>(hookFn: () => T): { result: { current: T }; unmount: () => void } {
+  const result = {} as { current: T };
+  function App() {
+    result.current = hookFn();
+    return h("tui-text", null, "");
+  }
+  const root = createElement("tui-root", {});
+  setOnCommit(() => {});
+  const container = reconciler.createContainer(
+    root,
+    0,
+    null,
+    false,
+    null,
+    "",
+    (e: Error) => {
+      throw e;
+    },
+    () => {},
+    () => {},
+    () => {},
+  );
+  reconciler.updateContainerSync(h(App), container, null, null);
+  reconciler.flushSyncWork();
+  reconciler.flushPassiveEffects();
+  return {
+    result,
+    unmount() {
+      reconciler.updateContainerSync(null, container, null, null);
+      reconciler.flushSyncWork();
+      setOnCommit(null);
+    },
+  };
+}


### PR DESCRIPTION
## Motivation

The TUI renderer had several issues: tool output duplicated in terminal scrollback, verbose lifecycle events flooding logs, and streaming text not rendering incrementally due to React 19's aggressive batching.

## Summary

- demote `lifecycle.tool.output` and `lifecycle.tool.cache` events to debug log level
- promote rows immediately at turn completion to prevent scrollback duplication
- throttle commit renders at ~30fps to prevent React scheduler starvation
- show input/output tokens separately in the working and worked indicators
- reduce step limits to 30/60 to prevent runaway token usage
- move TUI test utils into `src/tui/test-utils`