### PR TITLE
refactor(tools): unify tool output rendering

### DIFF
--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -6,10 +6,10 @@ import { isCommandOutput, isToolOutput } from "./chat-contract";
 import { commandOutputColWidth, formatCompactNumber } from "./chat-format";
 import { ShimmerText } from "./chat-shimmer";
 import type { PendingState } from "./client-contract";
-import { t, tDynamic } from "./i18n";
+import { t } from "./i18n";
 import { palette } from "./palette";
 import type { ToolOutputPart } from "./tool-output-contract";
-import { renderToolOutputPart as renderToolOutputText } from "./tool-output-render";
+import { renderToolOutput as renderToolOutputText, resolveHeader } from "./tool-output-render";
 import { Box, Text } from "./tui";
 import { DEFAULT_COLUMNS } from "./tui/constants";
 
@@ -71,7 +71,7 @@ function renderToolPart(
     const num = String(part.lineNumber).padStart(lineNumWidth);
     const prefix = ` ${num} `;
     const marker = part.marker === "add" ? "+" : part.marker === "remove" ? "-" : " ";
-    const content = `${part.text}`;
+    const content = part.text;
     const padWidth = Math.max(0, toolContentWidth - 2 - prefix.length - 1 - content.length);
     const padded = content + " ".repeat(padWidth);
     if (part.marker === "add" || part.marker === "remove") {
@@ -137,51 +137,29 @@ function renderToolPart(
   );
 }
 
-function renderHeader(part: ToolOutputPart): React.ReactNode {
-  if (part.kind === "edit-header") {
-    const path = part.path === "." ? "" : part.path;
+function renderHeaderMeta(meta: Record<string, unknown>): React.ReactNode {
+  if ("added" in meta && "removed" in meta) {
     return (
       <>
-        <Text bold>{tDynamic(part.labelKey)}</Text>
-        <Text dimColor>{path ? ` ${path}` : ""} (</Text>
-        <Text color={palette.diffAddText}>{`+${part.added}`}</Text>
+        <Text dimColor> (</Text>
+        <Text color={palette.diffAddText}>{`+${meta.added}`}</Text>
         <Text dimColor> </Text>
-        <Text color={palette.diffRemoveText}>{`-${part.removed}`}</Text>
+        <Text color={palette.diffRemoveText}>{`-${meta.removed}`}</Text>
         <Text dimColor>)</Text>
       </>
     );
   }
-  if (part.kind === "tool-header") {
-    const detail = part.detail === "." ? undefined : part.detail;
+  return null;
+}
+
+function renderHeader(part: ToolOutputPart): React.ReactNode {
+  const header = resolveHeader(part);
+  if (header) {
     return (
       <>
-        <Text bold>{tDynamic(part.labelKey)}</Text>
-        {detail ? <Text dimColor>{` ${detail}`}</Text> : null}
-      </>
-    );
-  }
-  if (part.kind === "file-header") {
-    const detail =
-      part.count === 1 && part.targets.length === 1
-        ? ` ${part.targets[0]}`
-        : ` ${t("unit.file", { count: part.count })}`;
-    return (
-      <>
-        <Text bold>{tDynamic(part.labelKey)}</Text>
-        <Text dimColor>{detail}</Text>
-      </>
-    );
-  }
-  if (part.kind === "scope-header") {
-    const scopeSuffix = part.scope !== "workspace" ? ` in ${part.scope}` : "";
-    const detail =
-      part.patterns.length === 1
-        ? ` ${part.patterns[0]}${scopeSuffix}`
-        : ` ${t("unit.pattern", { count: part.patterns.length })}${scopeSuffix}`;
-    return (
-      <>
-        <Text bold>{tDynamic(part.labelKey)}</Text>
-        <Text dimColor>{detail}</Text>
+        <Text bold>{header.label}</Text>
+        {header.detail ? <Text dimColor>{` ${header.detail}`}</Text> : null}
+        {header.meta ? renderHeaderMeta(header.meta) : null}
       </>
     );
   }

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -154,17 +154,14 @@ function renderHeaderMeta(meta: Record<string, unknown>): React.ReactNode {
 
 function renderHeader(part: ToolOutputPart): React.ReactNode {
   const header = resolveHeader(part);
-  if (header) {
-    return (
-      <>
-        <Text bold>{header.label}</Text>
-        {header.detail ? <Text dimColor>{` ${header.detail}`}</Text> : null}
-        {header.meta ? renderHeaderMeta(header.meta) : null}
-      </>
-    );
-  }
-  const text = renderToolOutputText(part);
-  return <Text dimColor>{text}</Text>;
+  if (!header) return null;
+  return (
+    <>
+      <Text bold>{header.label}</Text>
+      {header.detail ? <Text dimColor>{` ${header.detail}`}</Text> : null}
+      {header.meta ? renderHeaderMeta(header.meta) : null}
+    </>
+  );
 }
 
 function renderToolOutput(parts: ToolOutputPart[], toolContentWidth: number): React.ReactNode {

--- a/src/cli-format.ts
+++ b/src/cli-format.ts
@@ -4,7 +4,7 @@ import { formatCompactNumber } from "./chat-format";
 import { t, tDynamic } from "./i18n";
 import type { ToolOutputPart } from "./tool-output-contract";
 import { toolLabelKey } from "./tool-output-format";
-import { formatToolOutput } from "./tool-output-render";
+import { renderToolOutput } from "./tool-output-render";
 import { CLI_TOOL_OUTPUT_LIMITS } from "./tool-policy";
 import { printDim, printToolHeader } from "./ui";
 
@@ -32,7 +32,7 @@ export function printToolResult(toolId: string, raw: string, detail?: string): v
       if (trimmed.length > 0) items.push({ kind: "text", text: trimmed });
     }
   }
-  const rendered = formatToolOutput(items);
+  const rendered = renderToolOutput(items);
   const lines = rendered.split("\n");
   if (lines[0]) printToolHeader(tDynamic(labelKey), detail);
   for (const line of lines.slice(1)) {

--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -11,7 +11,7 @@ import { t } from "./i18n";
 import type { ResourceId } from "./resource-id";
 import type { Session } from "./session-contract";
 import { createSkillSuggestion } from "./skill-triggers";
-import { createToolOutputState, formatToolOutput } from "./tool-output-render";
+import { createToolOutputState, renderToolOutput } from "./tool-output-render";
 import { printDim, printError, printOutput, streamText } from "./ui";
 
 function setSessionTitle(session: Session, inputText: string): void {
@@ -121,7 +121,7 @@ export async function handlePrompt(
             const update = toolOutput.push(event);
             if (!update) break;
             if (update.items.length === 1 && update.items[0]?.kind === "tool-header" && !update.items[0].detail) break;
-            const rendered = formatToolOutput(update.items);
+            const rendered = renderToolOutput(update.items);
             if (!rendered) break;
             const previous = snapshotByCallId.get(event.toolCallId);
             snapshotByCallId.set(event.toolCallId, rendered);

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -19,7 +19,7 @@ import { listMcpTools } from "./mcp-client";
 import type { MemoryCommitContext, MemoryCommitMetrics } from "./memory-contract";
 import { commitDistiller, estimateDistillPromptTokens } from "./memory-distiller";
 import { createInMemoryTaskQueue } from "./task-queue";
-import { renderToolOutputPart } from "./tool-output-render";
+import { renderToolOutput } from "./tool-output-render";
 import { WRITE_TOOL_SET } from "./tool-registry";
 import { scopedCallLog } from "./tool-session";
 import { attachUndoCheckpointSideEffects } from "./undo-checkpoints-effects";
@@ -205,7 +205,7 @@ function acceptResult(ctx: RunContext): void {
 
 function attachToolOutputHandler(ctx: RunContext) {
   ctx.toolOutputHandler = (event) => {
-    const rendered = renderToolOutputPart(event.content);
+    const rendered = renderToolOutput(event.content);
     if (!rendered.trim()) return;
     const toolName = event.toolName;
     const resolvedToolCallId = event.toolCallId ?? toolName;

--- a/src/tool-output-render.ts
+++ b/src/tool-output-render.ts
@@ -1,52 +1,85 @@
-import { unreachable } from "./assert";
 import { t, tDynamic } from "./i18n";
 import type { ToolOutputPart } from "./tool-output-contract";
 
-export function renderToolOutputPart(content: ToolOutputPart): string {
+export type ResolvedHeader = { label: string; detail?: string; meta?: Record<string, unknown> };
+
+export function resolveHeader(content: ToolOutputPart): ResolvedHeader | null {
   switch (content.kind) {
     case "tool-header": {
       const label = tDynamic(content.labelKey);
-      return content.detail ? `${label} ${content.detail}` : label;
+      const detail = content.detail && content.detail !== "." ? content.detail : undefined;
+      return { label, detail };
     }
-    case "text":
-      return content.text;
     case "file-header": {
       const label = tDynamic(content.labelKey);
-      if (content.count === 1 && content.targets.length === 1) return `${label} ${content.targets[0]}`;
-      return `${label} ${t("unit.file", { count: content.count })}`;
+      const detail =
+        content.count === 1 && content.targets.length === 1
+          ? content.targets[0]
+          : t("unit.file", { count: content.count });
+      return { label, detail };
     }
     case "scope-header": {
       const label = tDynamic(content.labelKey);
       const scopeSuffix = content.scope !== "workspace" ? ` in ${content.scope}` : "";
-      if (content.patterns.length === 1) return `${label} ${content.patterns[0]}${scopeSuffix}`;
-      return `${label} ${t("unit.pattern", { count: content.patterns.length })}${scopeSuffix}`;
+      const detail =
+        content.patterns.length === 1
+          ? `${content.patterns[0]}${scopeSuffix}`
+          : `${t("unit.pattern", { count: content.patterns.length })}${scopeSuffix}`;
+      return { label, detail };
     }
-    case "edit-header":
-      return `${tDynamic(content.labelKey)} ${content.path} (+${content.added} -${content.removed})`;
-    case "diff": {
-      const prefix = content.marker === "add" ? "+" : content.marker === "remove" ? "-" : " ";
-      return `${content.lineNumber} ${prefix}${content.text}`;
-    }
-    case "shell-output": {
-      const label = content.stream === "stdout" ? "out" : "err";
-      return `${label} | ${content.text}`;
-    }
-    case "no-output":
-      return t("tool.content.no_output");
-    case "truncated": {
-      if (!content.count) return "…";
-      const unitKey =
-        content.unit === "lines"
-          ? "unit.line"
-          : content.unit === "matches"
-            ? "unit.match"
-            : content.unit === "files"
-              ? "unit.file"
-              : "unit.more";
-      return `… +${t(unitKey, { count: content.count })}`;
+    case "edit-header": {
+      const label = tDynamic(content.labelKey);
+      const path = content.path === "." ? undefined : content.path;
+      return { label, detail: path, meta: { added: content.added, removed: content.removed } };
     }
     default:
-      return unreachable(content);
+      return null;
+  }
+}
+
+function formatMeta(meta: Record<string, unknown>): string {
+  if ("added" in meta && "removed" in meta) return `(+${meta.added} -${meta.removed})`;
+  return "";
+}
+
+function formatHeader(header: ResolvedHeader): string {
+  const parts = [header.label];
+  if (header.detail) parts.push(header.detail);
+  if (header.meta) parts.push(formatMeta(header.meta));
+  return parts.join(" ");
+}
+
+function formatTruncated(count: number | undefined, unit: string | undefined): string {
+  if (!count) return "…";
+  switch (unit) {
+    case "lines":
+      return `… +${t("unit.line", { count })}`;
+    case "matches":
+      return `… +${t("unit.match", { count })}`;
+    case "files":
+      return `… +${t("unit.file", { count })}`;
+    default:
+      return `… +${t("unit.more", { count })}`;
+  }
+}
+
+function renderPart(content: ToolOutputPart): string {
+  const header = resolveHeader(content);
+  if (header) return formatHeader(header);
+
+  switch (content.kind) {
+    case "text":
+      return content.text;
+    case "diff":
+      return `${content.lineNumber} ${content.marker === "add" ? "+" : content.marker === "remove" ? "-" : " "}${content.text}`;
+    case "shell-output":
+      return `${content.stream === "stdout" ? "out" : "err"} | ${content.text}`;
+    case "no-output":
+      return t("tool.content.no_output");
+    case "truncated":
+      return formatTruncated(content.count, content.unit);
+    default:
+      return "";
   }
 }
 
@@ -56,11 +89,10 @@ function renderDiffLine(item: Extract<ToolOutputPart, { kind: "diff" }>, numWidt
   return `${num} ${prefix}${item.text}`;
 }
 
-export function formatToolOutput(items: ToolOutputPart[]): string {
-  if (items.length === 0) return "";
+function renderList(items: ToolOutputPart[]): string {
   const first = items[0];
   if (!first) return "";
-  const header = renderToolOutputPart(first);
+  const header = renderPart(first);
   const body = items.slice(1);
   if (body.length === 0) return header;
   const numWidth = body.reduce(
@@ -72,12 +104,16 @@ export function formatToolOutput(items: ToolOutputPart[]): string {
   const lines = body.map((item) => {
     if (item.kind === "diff") return `${diffIndent}${renderDiffLine(item, numWidth)}`;
     if (item.kind === "truncated" && numWidth > 0) {
-      const suffix = renderToolOutputPart(item).slice(2);
+      const suffix = renderPart(item).slice(2);
       return suffix ? `${diffIndent}${"⋮".padStart(numWidth)} ${suffix}` : `${diffIndent}${"⋮".padStart(numWidth)}`;
     }
-    return renderToolOutputPart(item);
+    return renderPart(item);
   });
   return `${header}\n${lines.map((line) => `  ${line}`).join("\n")}`;
+}
+
+export function renderToolOutput(content: ToolOutputPart | ToolOutputPart[]): string {
+  return Array.isArray(content) ? renderList(content) : renderPart(content);
 }
 
 export type ToolOutputUpdate = {
@@ -95,16 +131,12 @@ export function createToolOutputState(): {
   return {
     push(entry) {
       const items = contentByCallId.get(entry.toolCallId) ?? [];
-      const incoming = renderToolOutputPart(entry.content);
+      const incoming = renderPart(entry.content);
       if (lastRenderedByCallId.get(entry.toolCallId) === incoming) return null;
       lastRenderedByCallId.set(entry.toolCallId, incoming);
       items.push(entry.content);
       contentByCallId.set(entry.toolCallId, items);
-      const firstItem = items[0];
-      const label =
-        firstItem && "labelKey" in firstItem && typeof firstItem.labelKey === "string"
-          ? tDynamic(firstItem.labelKey)
-          : undefined;
+      const label = items[0] ? resolveHeader(items[0])?.label : undefined;
       return { label, items };
     },
     delete(toolCallId) {

--- a/src/tool-output-render.ts
+++ b/src/tool-output-render.ts
@@ -49,18 +49,16 @@ function formatHeader(header: ResolvedHeader): string {
   return parts.join(" ");
 }
 
+const TRUNCATED_UNIT_KEYS: Record<string, string> = {
+  lines: "unit.line",
+  matches: "unit.match",
+  files: "unit.file",
+};
+
 function formatTruncated(count: number | undefined, unit: string | undefined): string {
   if (!count) return "…";
-  switch (unit) {
-    case "lines":
-      return `… +${t("unit.line", { count })}`;
-    case "matches":
-      return `… +${t("unit.match", { count })}`;
-    case "files":
-      return `… +${t("unit.file", { count })}`;
-    default:
-      return `… +${t("unit.more", { count })}`;
-  }
+  const text = tDynamic(TRUNCATED_UNIT_KEYS[unit ?? ""] ?? "unit.more", { count });
+  return `… +${text}`;
 }
 
 function renderPart(content: ToolOutputPart): string {

--- a/src/tool-output-state.test.ts
+++ b/src/tool-output-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { ToolOutputPart } from "./tool-output-contract";
-import { createToolOutputState, formatToolOutput } from "./tool-output-render";
+import { createToolOutputState, renderToolOutput } from "./tool-output-render";
 
 function setup() {
   const state = createToolOutputState();
@@ -83,8 +83,8 @@ describe("createToolOutputState", () => {
     const u2 = state.push({ toolCallId: "tc_2", content: { kind: "text", text: "b" } });
     expect(u1?.items).toHaveLength(2);
     expect(u2?.items).toHaveLength(2);
-    expect(formatToolOutput(u1?.items ?? [])).toBe("Run cmd1\n  a");
-    expect(formatToolOutput(u2?.items ?? [])).toBe("Run cmd2\n  b");
+    expect(renderToolOutput(u1?.items ?? [])).toBe("Run cmd1\n  a");
+    expect(renderToolOutput(u2?.items ?? [])).toBe("Run cmd2\n  b");
   });
 
   test("delete removes state for a tool call", () => {

--- a/src/tool-output.tui.test.tsx
+++ b/src/tool-output.tui.test.tsx
@@ -3,7 +3,7 @@ import type { ChatRow } from "./chat-contract";
 import { ChatTranscript } from "./chat-transcript";
 import { dedent } from "./test-utils";
 import type { ToolOutputPart } from "./tool-output-contract";
-import { formatToolOutput } from "./tool-output-render";
+import { renderToolOutput } from "./tool-output-render";
 import { renderPlain } from "./tui/test-utils";
 
 function renderChat(toolOutput: ToolOutputPart[]): string {
@@ -11,33 +11,33 @@ function renderChat(toolOutput: ToolOutputPart[]): string {
   return renderPlain(<ChatTranscript rows={[row]} pendingFrame={0} />, 96);
 }
 
-describe("tool output TUI — CLI (formatToolOutput)", () => {
+describe("tool output TUI — CLI (renderToolOutput)", () => {
   test("empty content returns empty string", () => {
-    expect(formatToolOutput([])).toBe("");
+    expect(renderToolOutput([])).toBe("");
   });
 
   test("tool-header only", () => {
-    expect(formatToolOutput([{ kind: "tool-header", labelKey: "tool.label.file_read", detail: "a.ts" }])).toBe(
+    expect(renderToolOutput([{ kind: "tool-header", labelKey: "tool.label.file_read", detail: "a.ts" }])).toBe(
       "Read a.ts",
     );
   });
 
   test("tool-header without detail", () => {
-    expect(formatToolOutput([{ kind: "tool-header", labelKey: "tool.label.git_status" }])).toBe("Git Status");
+    expect(renderToolOutput([{ kind: "tool-header", labelKey: "tool.label.git_status" }])).toBe("Git Status");
   });
 
   test("file-header renders label and targets", () => {
     const items: ToolOutputPart[] = [
       { kind: "file-header", labelKey: "tool.label.file_read", count: 2, targets: ["a.ts", "b.ts"] },
     ];
-    expect(formatToolOutput(items)).toBe("Read 2 files");
+    expect(renderToolOutput(items)).toBe("Read 2 files");
   });
 
   test("file-header with single file shows path", () => {
     const items: ToolOutputPart[] = [
       { kind: "file-header", labelKey: "tool.label.file_read", count: 1, targets: ["a.ts"] },
     ];
-    expect(formatToolOutput(items)).toBe("Read a.ts");
+    expect(renderToolOutput(items)).toBe("Read a.ts");
   });
 
   test("scope-header for search with summary", () => {
@@ -51,7 +51,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       },
       { kind: "text", text: "3 matches in 2 files" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Search needle
           3 matches in 2 files
@@ -64,7 +64,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "scope-header", labelKey: "tool.label.file_search", scope: "src/", patterns: ["needle"], matches: 1 },
       { kind: "text", text: "1 match in 1 file" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Search needle in src/
           1 match in 1 file
@@ -77,7 +77,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "scope-header", labelKey: "tool.label.file_find", scope: "workspace", patterns: ["*.ts"], matches: 2 },
       { kind: "text", text: "2 files" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Find *.ts
           2 files
@@ -96,7 +96,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       },
       { kind: "text", text: "5 matches in 3 files" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Search 3 patterns
           5 matches in 3 files
@@ -111,7 +111,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "diff", lineNumber: 10, marker: "remove", text: "const y = 2;" },
       { kind: "diff", lineNumber: 10, marker: "add", text: "const y = 3;" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Edit notes.ts (+1 -1)
            9  const x = 1;
@@ -127,7 +127,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "shell-output", stream: "stdout", text: "hello" },
       { kind: "shell-output", stream: "stdout", text: "world" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Run echo hello
           out | hello
@@ -144,7 +144,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "text", text: "⋮ +3 lines" },
       { kind: "shell-output", stream: "stdout", text: "line6" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Run cmd
           out | line1
@@ -160,7 +160,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "cmd" },
       { kind: "no-output" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Run cmd
           (No output)
@@ -174,7 +174,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "text", text: "M src/cli.ts" },
       { kind: "text", text: "?? src/new.ts" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Git Status
           M src/cli.ts
@@ -189,7 +189,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "text", text: "diff --git a/src/agent.ts b/src/agent.ts" },
       { kind: "text", text: "+const x = 1;" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Git Diff src/agent.ts
           diff --git a/src/agent.ts b/src/agent.ts
@@ -206,7 +206,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "text", text: "⋮ +10 lines" },
       { kind: "text", text: "+line13" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Git Diff
           +line1
@@ -223,7 +223,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "text", text: "abc1234 feat: add feature" },
       { kind: "text", text: "def5678 fix: resolve bug" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Git Log src/cli.ts
           abc1234 feat: add feature
@@ -240,7 +240,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "truncated", count: 8, unit: "lines" },
       { kind: "text", text: "ghi9012 last" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Git Log
           abc1234 first
@@ -257,7 +257,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "text", text: "feat: add feature" },
       { kind: "text", text: "+const x = 1;" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Git Show abc1234
           feat: add feature
@@ -273,7 +273,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "text", text: "src/b.ts" },
       { kind: "text", text: "src/c.ts" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Git Add 3 files
           src/a.ts
@@ -290,7 +290,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "text", text: "src/b.ts" },
       { kind: "truncated", count: 6, unit: "files" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Git Add 8 files
           src/a.ts
@@ -302,14 +302,14 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
 
   test("git-add all", () => {
     const items: ToolOutputPart[] = [{ kind: "tool-header", labelKey: "tool.label.git_add", detail: "all" }];
-    expect(formatToolOutput(items)).toBe("Git Add all");
+    expect(renderToolOutput(items)).toBe("Git Add all");
   });
 
   test("git-commit with hash", () => {
     const items: ToolOutputPart[] = [
       { kind: "tool-header", labelKey: "tool.label.git_commit", detail: "feat: add feature (abc1234)" },
     ];
-    expect(formatToolOutput(items)).toBe("Git Commit feat: add feature (abc1234)");
+    expect(renderToolOutput(items)).toBe("Git Commit feat: add feature (abc1234)");
   });
 
   test("git-commit with body lines", () => {
@@ -318,7 +318,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "text", text: "Added new auth module" },
       { kind: "text", text: "Updated config schema" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Git Commit feat: add feature (abc1234)
           Added new auth module
@@ -334,7 +334,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "text", text: "Line 2" },
       { kind: "truncated", count: 5, unit: "lines" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Git Commit refactor: cleanup (def5678)
           Line 1
@@ -353,7 +353,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "diff", lineNumber: 10, marker: "add", text: "const y = 3;" },
       { kind: "diff", lineNumber: 11, marker: "context", text: "const b = 4;" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Edit notes.ts (+1 -1)
            1  const a = 1;
@@ -375,7 +375,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "diff", lineNumber: 4, marker: "remove", text: 'import { generateId } from "./short-id";' },
       { kind: "diff", lineNumber: 4, marker: "add", text: 'import { generateId } from "./short-id";' },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Edit 14 files (+28 -28)
           src/short-id.ts (+1 -1)
@@ -394,7 +394,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "diff", lineNumber: 2, marker: "remove", text: "old" },
       { kind: "diff", lineNumber: 2, marker: "add", text: "new" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Edit notes.ts (+1 -1)
           2 -old
@@ -404,7 +404,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
   });
 
   test("skill-activate with name", () => {
-    expect(formatToolOutput([{ kind: "tool-header", labelKey: "tool.label.skill", detail: "build" }])).toBe(
+    expect(renderToolOutput([{ kind: "tool-header", labelKey: "tool.label.skill", detail: "build" }])).toBe(
       "Skill build",
     );
   });
@@ -415,7 +415,7 @@ describe("tool output TUI — CLI (formatToolOutput)", () => {
       { kind: "text", text: "a.ts" },
       { kind: "truncated", count: 5, unit: "matches" },
     ];
-    expect(formatToolOutput(items)).toBe(
+    expect(renderToolOutput(items)).toBe(
       dedent(`
         Find *.ts
           a.ts

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { expectIntent } from "./test-utils";
-import { renderToolOutputPart } from "./tool-output-render";
+import { renderToolOutput } from "./tool-output-render";
 import { toolDefinitionsById, toolIds, toolIdsByCategory, toolsForAgent } from "./tool-registry";
 
 describe("toolsets", () => {
@@ -82,11 +82,11 @@ describe("localization baseline", () => {
   });
 
   test("tool output content renders marker tokens", () => {
-    expect(renderToolOutputPart({ kind: "truncated", count: 3, unit: "lines" })).toBe("… +3 lines");
-    expect(renderToolOutputPart({ kind: "truncated", count: 1, unit: "lines" })).toBe("… +1 line");
-    expect(renderToolOutputPart({ kind: "truncated", count: 5, unit: "matches" })).toBe("… +5 matches");
-    expect(renderToolOutputPart({ kind: "truncated", count: 1, unit: "matches" })).toBe("… +1 match");
-    expect(renderToolOutputPart({ kind: "no-output" })).toBe("(No output)");
+    expect(renderToolOutput({ kind: "truncated", count: 3, unit: "lines" })).toBe("… +3 lines");
+    expect(renderToolOutput({ kind: "truncated", count: 1, unit: "lines" })).toBe("… +1 line");
+    expect(renderToolOutput({ kind: "truncated", count: 5, unit: "matches" })).toBe("… +5 matches");
+    expect(renderToolOutput({ kind: "truncated", count: 1, unit: "matches" })).toBe("… +1 match");
+    expect(renderToolOutput({ kind: "no-output" })).toBe("(No output)");
   });
 
   test("tool instructions encode behavioral intent by tool type", () => {


### PR DESCRIPTION
## Motivation

Tool output header rendering was duplicated between CLI (`renderToolOutputPart`) and TUI (`renderHeader` in `chat-transcript.tsx`). Both computed the same label+detail strings independently, and the TUI had a special case for `edit-header` that bypassed the shared logic.

## Summary

- add `resolveHeader` that returns `{ label, detail, meta }` for all header kinds
- TUI and CLI both consume `resolveHeader` — no duplicated logic
- `edit-header` passes diff stats via `meta` instead of TUI special-casing
- merge `renderToolOutputPart` and `formatToolOutput` into one `renderToolOutput` overload
- use `resolveHeader` in `createToolOutputState` instead of manual `labelKey` check
- drop fallback text rendering in TUI `renderHeader`
- remove redundant template literal and double emptiness check

Fixes #225