### PR TITLE
feat(agent): microcompact tool results

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -30,6 +30,12 @@ One generation pass runs, effects apply inline during tool execution, and the li
 - when the budget is exhausted, the tool call is blocked with a `budgetExhausted` error code
 - this is the only pre-tool policy check; there is no guard abstraction
 
+## Microcompaction
+
+- between model calls, prior tool results in the message history are replaced with a short marker so they stop consuming input tokens on re-send
+- `file-read` results are preserved intact so the model can still reference file contents when producing later edits
+- implemented in `compactPriorToolResults()` in `agent-stream.ts`
+
 ## Run control
 
 - `RunControl` is a first-class abstraction that owns yield and cancellation behavior for a lifecycle run

--- a/src/agent-stream.test.ts
+++ b/src/agent-stream.test.ts
@@ -188,8 +188,8 @@ describe("compactPriorToolResults", () => {
   test("replaces tool result output with compact marker", () => {
     const messages: LanguageModelV3Message[] = [
       { role: "system", content: "you are helpful" },
-      { role: "user", content: [{ type: "text", text: "read foo.ts" }] },
-      toolMsg([{ id: "tc_1", name: "file-read", value: "const x = 1;\n".repeat(500) }]),
+      { role: "user", content: [{ type: "text", text: "search for foo" }] },
+      toolMsg([{ id: "tc_1", name: "file-search", value: "hit:\n".repeat(500) }]),
     ];
     compactPriorToolResults(messages);
     const tool = messages[2];
@@ -200,7 +200,7 @@ describe("compactPriorToolResults", () => {
     if (part.type !== "tool-result") throw new Error("unexpected");
     expect(part.output).toEqual(COMPACTED_OUTPUT);
     expect(part.toolCallId).toBe("tc_1");
-    expect(part.toolName).toBe("file-read");
+    expect(part.toolName).toBe("file-search");
   });
 
   test("skips non-tool messages", () => {
@@ -217,8 +217,8 @@ describe("compactPriorToolResults", () => {
   test("compacts multiple tool messages", () => {
     const messages: LanguageModelV3Message[] = [
       { role: "system", content: "sys" },
-      toolMsg([{ id: "tc_1", name: "file-read", value: "file1 content" }]),
-      toolMsg([{ id: "tc_2", name: "file-read", value: "file2 content" }]),
+      toolMsg([{ id: "tc_1", name: "file-search", value: "hit1" }]),
+      toolMsg([{ id: "tc_2", name: "file-search", value: "hit2" }]),
     ];
     compactPriorToolResults(messages);
     for (const msg of messages.filter((m) => m.role === "tool")) {
@@ -230,10 +230,27 @@ describe("compactPriorToolResults", () => {
     }
   });
 
+  test("preserves file-read results across compaction", () => {
+    const fileContent = "File: src/foo.ts\n1: const x = 1;\n2: const y = 2;\n";
+    const messages: LanguageModelV3Message[] = [
+      toolMsg([{ id: "tc_1", name: "file-read", value: fileContent }]),
+      toolMsg([{ id: "tc_2", name: "file-search", value: "hits" }]),
+    ];
+    compactPriorToolResults(messages);
+    if (messages[0].role !== "tool") throw new Error("unexpected");
+    const readPart = messages[0].content[0];
+    if (readPart.type !== "tool-result") throw new Error("unexpected");
+    expect(readPart.output).toEqual({ type: "text", value: fileContent });
+    if (messages[1].role !== "tool") throw new Error("unexpected");
+    const searchPart = messages[1].content[0];
+    if (searchPart.type !== "tool-result") throw new Error("unexpected");
+    expect(searchPart.output).toEqual(COMPACTED_OUTPUT);
+  });
+
   test("compacts multiple results within a single tool message", () => {
     const messages: LanguageModelV3Message[] = [
       toolMsg([
-        { id: "tc_1", name: "file-read", value: "content1" },
+        { id: "tc_1", name: "file-search", value: "content1" },
         { id: "tc_2", name: "shell-exec", value: "output2" },
       ]),
     ];
@@ -247,7 +264,7 @@ describe("compactPriorToolResults", () => {
   });
 
   test("is idempotent", () => {
-    const messages: LanguageModelV3Message[] = [toolMsg([{ id: "tc_1", name: "file-read", value: "content" }])];
+    const messages: LanguageModelV3Message[] = [toolMsg([{ id: "tc_1", name: "file-search", value: "content" }])];
     compactPriorToolResults(messages);
     compactPriorToolResults(messages);
     if (messages[0].role !== "tool") throw new Error("unexpected");

--- a/src/agent-stream.test.ts
+++ b/src/agent-stream.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test";
+import type { LanguageModelV3Message } from "@ai-sdk/provider";
+import { COMPACTED_OUTPUT, compactPriorToolResults } from "./agent-stream";
 import {
   appendLifecycleTextDelta,
   createLifecycleTextStreamState,
@@ -167,5 +169,90 @@ describe("lifecycle text streaming", () => {
     const fin = finalizeLifecycleText(state);
     expect(fin.signal).toBe("done");
     expect(fin.text).toBe("");
+  });
+});
+
+describe("compactPriorToolResults", () => {
+  function toolMsg(results: Array<{ id: string; name: string; value: string }>): LanguageModelV3Message {
+    return {
+      role: "tool",
+      content: results.map((r) => ({
+        type: "tool-result" as const,
+        toolCallId: r.id,
+        toolName: r.name,
+        output: { type: "text" as const, value: r.value },
+      })),
+    };
+  }
+
+  test("replaces tool result output with compact marker", () => {
+    const messages: LanguageModelV3Message[] = [
+      { role: "system", content: "you are helpful" },
+      { role: "user", content: [{ type: "text", text: "read foo.ts" }] },
+      toolMsg([{ id: "tc_1", name: "file-read", value: "const x = 1;\n".repeat(500) }]),
+    ];
+    compactPriorToolResults(messages);
+    const tool = messages[2];
+    expect(tool.role).toBe("tool");
+    if (tool.role !== "tool") throw new Error("unexpected");
+    const part = tool.content[0];
+    expect(part.type).toBe("tool-result");
+    if (part.type !== "tool-result") throw new Error("unexpected");
+    expect(part.output).toEqual(COMPACTED_OUTPUT);
+    expect(part.toolCallId).toBe("tc_1");
+    expect(part.toolName).toBe("file-read");
+  });
+
+  test("skips non-tool messages", () => {
+    const systemContent = "you are helpful";
+    const messages: LanguageModelV3Message[] = [
+      { role: "system", content: systemContent },
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+    ];
+    compactPriorToolResults(messages);
+    expect(messages[0]).toEqual({ role: "system", content: systemContent });
+    expect(messages[1]).toEqual({ role: "user", content: [{ type: "text", text: "hello" }] });
+  });
+
+  test("compacts multiple tool messages", () => {
+    const messages: LanguageModelV3Message[] = [
+      { role: "system", content: "sys" },
+      toolMsg([{ id: "tc_1", name: "file-read", value: "file1 content" }]),
+      toolMsg([{ id: "tc_2", name: "file-read", value: "file2 content" }]),
+    ];
+    compactPriorToolResults(messages);
+    for (const msg of messages.filter((m) => m.role === "tool")) {
+      if (msg.role !== "tool") continue;
+      for (const part of msg.content) {
+        if (part.type !== "tool-result") continue;
+        expect(part.output).toEqual(COMPACTED_OUTPUT);
+      }
+    }
+  });
+
+  test("compacts multiple results within a single tool message", () => {
+    const messages: LanguageModelV3Message[] = [
+      toolMsg([
+        { id: "tc_1", name: "file-read", value: "content1" },
+        { id: "tc_2", name: "shell-exec", value: "output2" },
+      ]),
+    ];
+    compactPriorToolResults(messages);
+    if (messages[0].role !== "tool") throw new Error("unexpected");
+    expect(messages[0].content).toHaveLength(2);
+    for (const part of messages[0].content) {
+      if (part.type !== "tool-result") continue;
+      expect(part.output).toEqual(COMPACTED_OUTPUT);
+    }
+  });
+
+  test("is idempotent", () => {
+    const messages: LanguageModelV3Message[] = [toolMsg([{ id: "tc_1", name: "file-read", value: "content" }])];
+    compactPriorToolResults(messages);
+    compactPriorToolResults(messages);
+    if (messages[0].role !== "tool") throw new Error("unexpected");
+    const part = messages[0].content[0];
+    if (part.type !== "tool-result") throw new Error("unexpected");
+    expect(part.output).toEqual(COMPACTED_OUTPUT);
   });
 });

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -203,6 +203,7 @@ export function createAgentStream(
           }
         }
 
+        compactPriorToolResults(messages);
         messages.push({ role: "assistant", content: assistantContent });
         messages.push({ role: "tool", content: toolResultParts });
 
@@ -272,6 +273,20 @@ function emitStreamPart(
         payload: { error: part.error, message },
       });
       break;
+    }
+  }
+}
+
+export const COMPACTED_OUTPUT = { type: "text" as const, value: "[previous tool result]" };
+
+export function compactPriorToolResults(messages: LanguageModelV3Message[]): void {
+  for (const message of messages) {
+    if (message.role !== "tool") continue;
+    for (let i = 0; i < message.content.length; i++) {
+      const part = message.content[i];
+      if (part.type === "tool-result") {
+        message.content[i] = { ...part, output: COMPACTED_OUTPUT };
+      }
     }
   }
 }

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -279,14 +279,16 @@ function emitStreamPart(
 
 export const COMPACTED_OUTPUT = { type: "text" as const, value: "[previous tool result]" };
 
+const PRESERVE_TOOL_RESULTS = new Set<string>(["file-read"]);
+
 export function compactPriorToolResults(messages: LanguageModelV3Message[]): void {
   for (const message of messages) {
     if (message.role !== "tool") continue;
     for (let i = 0; i < message.content.length; i++) {
       const part = message.content[i];
-      if (part.type === "tool-result") {
-        message.content[i] = { ...part, output: COMPACTED_OUTPUT };
-      }
+      if (part.type !== "tool-result") continue;
+      if (PRESERVE_TOOL_RESULTS.has(part.toolName)) continue;
+      message.content[i] = { ...part, output: COMPACTED_OUTPUT };
     }
   }
 }


### PR DESCRIPTION
## Motivation

Each model call re-sends the whole message history, so prior tool results inflate input tokens on every iteration. Microcompaction replaces processed tool results with a short marker between calls so they stop paying for themselves forever.

## Summary

- microcompact prior tool results between model calls
- preserve `file-read` results across compaction so the model can edit from them