### PR TITLE
refactor(lifecycle): per-call input budget

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -30,6 +30,12 @@ One generation pass runs, effects apply inline during tool execution, and the li
 - when the budget is exhausted, the tool call is blocked with a `budgetExhausted` error code
 - this is the only pre-tool policy check; there is no guard abstraction
 
+## Per-call input budget
+
+- before each model call, `agent-stream.ts` estimates the composed prompt size (system + messages + tools) and compares it against `SessionFlags.preCallInputTokenLimit` (defaulted from `MAX_CONTEXT_TOKENS`)
+- overflow throws `E_BUDGET_EXHAUSTED` with a composition breakdown (system, tools, messages tokens)
+- sessions are bounded by context pressure per call, not by cumulative tokens across calls; microcompaction keeps prior iterations lean
+
 ## Microcompaction
 
 - between model calls, prior tool results in the message history are replaced with a short marker so they stop consuming input tokens on re-send

--- a/src/agent-contract.ts
+++ b/src/agent-contract.ts
@@ -15,6 +15,7 @@ export type StreamOptions = {
   toolChoice?: "auto" | "none" | "required";
   temperature?: number;
   providerOptions?: SharedV3ProviderOptions;
+  preCallInputTokenLimit?: number;
 };
 
 export type StreamOutput = {

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -8,6 +8,7 @@ import type {
   LanguageModelV3ToolResultPart,
 } from "@ai-sdk/provider";
 import type { Agent, StreamOptions, StreamOutput } from "./agent-contract";
+import { ERROR_KINDS, LIFECYCLE_ERROR_CODES } from "./error-contract";
 import { serializeToolError } from "./error-handling";
 import { MAX_TOOL_RESULT_CHARS } from "./lifecycle-constants";
 import type { GenerateResult, LifecycleSignal, StreamChunk, ToolCallEntry } from "./lifecycle-contract";
@@ -19,6 +20,7 @@ import {
 } from "./lifecycle-signal";
 import { log } from "./log";
 import { createModel } from "./model-factory";
+import { estimatePromptSize, promptBudgetError } from "./prompt-size";
 import { normalizeModel, providerFromModel } from "./provider-config";
 import { type RateLimiter, sharedRateLimiter } from "./rate-limiter";
 import type { ToolDefinition } from "./tool-contract";
@@ -74,6 +76,27 @@ export function createAgentStream(
         loopIteration++;
         if (loopIteration > 1) streamController.enqueue({ type: "step-start" });
         log.debug("agent-stream.loop.start", { iteration: loopIteration, pending_messages: messages.length });
+
+        if (typeof options.preCallInputTokenLimit === "number") {
+          const size = estimatePromptSize(systemPrompt, messages, functionTools);
+          const message = promptBudgetError(size, options.preCallInputTokenLimit);
+          if (message) {
+            log.debug("agent-stream.precall.overflow", {
+              iteration: loopIteration,
+              limit: options.preCallInputTokenLimit,
+              total: size.total,
+              system: size.system,
+              tools: size.tools,
+              messages: size.messages,
+              message_count: messages.length,
+            });
+            const err = new Error(message) as Error & { code: string; kind: string };
+            err.code = LIFECYCLE_ERROR_CODES.budgetExhausted;
+            err.kind = ERROR_KINDS.budgetExhausted;
+            throw err;
+          }
+        }
+
         await rateLimiter.beforeCall();
         let streamResult: Awaited<ReturnType<typeof model.doStream>>;
         try {

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -78,7 +78,7 @@ export function createAgentStream(
         log.debug("agent-stream.loop.start", { iteration: loopIteration, pending_messages: messages.length });
 
         if (typeof options.preCallInputTokenLimit === "number") {
-          const size = estimatePromptSize(systemPrompt, messages, functionTools);
+          const size = estimatePromptSize(messages, functionTools);
           const message = promptBudgetError(size, options.preCallInputTokenLimit);
           if (message) {
             log.debug("agent-stream.precall.overflow", {

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -77,13 +77,14 @@ export function createAgentStream(
         if (loopIteration > 1) streamController.enqueue({ type: "step-start" });
         log.debug("agent-stream.loop.start", { iteration: loopIteration, pending_messages: messages.length });
 
-        if (typeof options.preCallInputTokenLimit === "number") {
+        const preCallLimit = options.preCallInputTokenLimit;
+        if (typeof preCallLimit === "number" && preCallLimit > 0) {
           const size = estimatePromptSize(messages, functionTools);
-          const message = promptBudgetError(size, options.preCallInputTokenLimit);
+          const message = promptBudgetError(size, preCallLimit);
           if (message) {
             log.debug("agent-stream.precall.overflow", {
               iteration: loopIteration,
-              limit: options.preCallInputTokenLimit,
+              limit: preCallLimit,
               total: size.total,
               system: size.system,
               tools: size.tools,

--- a/src/lifecycle-constants.ts
+++ b/src/lifecycle-constants.ts
@@ -6,7 +6,6 @@ export const STEP_TIMEOUT_MS = 120_000;
 export const MAX_UNKNOWN_ERRORS_PER_REQUEST = 2;
 export const TOOL_TIMEOUT_MS = 10_000;
 export const MAX_CONTEXT_TOKENS = 100_000;
-export const MAX_TOTAL_TOKENS = 150_000;
 export const MAX_CONSECUTIVE_TOOL_FAILURES = 3;
 export const MAX_TOOL_RESULT_CHARS = 30_000;
 export const MAX_RECENT_TURNS = 5;

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -162,11 +162,9 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
     const temperature = providerOptions ? undefined : (ctx.temperature ?? appConfig.temperature);
     const streamOutput = await ctx.agent.stream(prompt, {
       toolChoice: "auto",
+      preCallInputTokenLimit: ctx.policy.contextMaxTokens,
       ...(typeof temperature === "number" ? { temperature } : {}),
       ...(providerOptions ? { providerOptions } : {}),
-      ...(typeof ctx.session.flags.preCallInputTokenLimit === "number"
-        ? { preCallInputTokenLimit: ctx.session.flags.preCallInputTokenLimit }
-        : {}),
     });
     const fullOutput = streamOutput.getFullOutput();
     // If the AI SDK rejects an internal promise outside the reader chain, pipe it into the

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -164,6 +164,9 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
       toolChoice: "auto",
       ...(typeof temperature === "number" ? { temperature } : {}),
       ...(providerOptions ? { providerOptions } : {}),
+      ...(typeof ctx.session.flags.preCallInputTokenLimit === "number"
+        ? { preCallInputTokenLimit: ctx.session.flags.preCallInputTokenLimit }
+        : {}),
     });
     const fullOutput = streamOutput.getFullOutput();
     // If the AI SDK rejects an internal promise outside the reader chain, pipe it into the

--- a/src/lifecycle-policy.ts
+++ b/src/lifecycle-policy.ts
@@ -2,7 +2,6 @@ import {
   MAX_CONSECUTIVE_TOOL_FAILURES,
   MAX_CONTEXT_TOKENS,
   MAX_TOTAL_STEPS,
-  MAX_TOTAL_TOKENS,
   MAX_TURN_STEPS,
   MAX_UNKNOWN_ERRORS_PER_REQUEST,
   STEP_TIMEOUT_MS,
@@ -20,7 +19,6 @@ export type LifecyclePolicy = {
   toolTimeoutMs: number;
   // Input budgets
   contextMaxTokens: number;
-  maxTotalTokens: number;
   maxConsecutiveToolFailures: number;
   // Workspace commands
   installCommand?: WorkspaceCommand;
@@ -35,7 +33,6 @@ export const defaultLifecyclePolicy: LifecyclePolicy = {
   maxUnknownErrorsPerRequest: MAX_UNKNOWN_ERRORS_PER_REQUEST,
   toolTimeoutMs: TOOL_TIMEOUT_MS,
   contextMaxTokens: MAX_CONTEXT_TOKENS,
-  maxTotalTokens: MAX_TOTAL_TOKENS,
   maxConsecutiveToolFailures: MAX_CONSECUTIVE_TOOL_FAILURES,
 };
 

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -299,7 +299,6 @@ export async function runLifecycle(input: LifecycleInput, deps: LifecycleDeps = 
   ctxRef = ctx;
   attachToolOutputHandler(ctx);
   ctx.session.flags.totalStepLimit = policy.totalMaxSteps;
-  ctx.session.flags.preCallInputTokenLimit = policy.contextMaxTokens;
   ctx.session.maxConsecutiveToolFailures = policy.maxConsecutiveToolFailures;
   if (profile.ecosystem) ctx.session.workspaceProfile = profile;
 

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -299,8 +299,7 @@ export async function runLifecycle(input: LifecycleInput, deps: LifecycleDeps = 
   ctxRef = ctx;
   attachToolOutputHandler(ctx);
   ctx.session.flags.totalStepLimit = policy.totalMaxSteps;
-  ctx.session.flags.totalTokenLimit = policy.maxTotalTokens;
-  ctx.session.flags.totalTokens = () => ctx.inputTokensAccum + ctx.outputTokensAccum;
+  ctx.session.flags.preCallInputTokenLimit = policy.contextMaxTokens;
   ctx.session.maxConsecutiveToolFailures = policy.maxConsecutiveToolFailures;
   if (profile.ecosystem) ctx.session.workspaceProfile = profile;
 

--- a/src/prompt-size.test.ts
+++ b/src/prompt-size.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test";
+import type { LanguageModelV3FunctionTool, LanguageModelV3Message } from "@ai-sdk/provider";
+import { estimatePromptSize, promptBudgetError } from "./prompt-size";
+
+describe("estimatePromptSize", () => {
+  test("returns zero totals when inputs are empty", () => {
+    const size = estimatePromptSize("", [], []);
+    expect(size).toEqual({ total: 0, system: 0, tools: 0, messages: 0 });
+  });
+
+  test("counts the system prompt", () => {
+    const size = estimatePromptSize("you are helpful", [], []);
+    expect(size.system).toBeGreaterThan(0);
+    expect(size.tools).toBe(0);
+    expect(size.messages).toBe(0);
+    expect(size.total).toBe(size.system);
+  });
+
+  test("counts tool definitions", () => {
+    const tools: LanguageModelV3FunctionTool[] = [
+      { type: "function", name: "file-read", description: "Read a file", inputSchema: { type: "object" } },
+    ];
+    const size = estimatePromptSize("", [], tools);
+    expect(size.tools).toBeGreaterThan(0);
+    expect(size.total).toBe(size.tools);
+  });
+
+  test("counts structured messages", () => {
+    const messages: LanguageModelV3Message[] = [
+      { role: "user", content: [{ type: "text", text: "hello from the user" }] },
+      {
+        role: "tool",
+        content: [
+          {
+            type: "tool-result",
+            toolCallId: "tc_1",
+            toolName: "file-read",
+            output: { type: "text", value: "file contents here".repeat(10) },
+          },
+        ],
+      },
+    ];
+    const size = estimatePromptSize("", messages, []);
+    expect(size.messages).toBeGreaterThan(0);
+    expect(size.total).toBe(size.messages);
+  });
+
+  test("total is the sum of system, tools, and messages", () => {
+    const messages: LanguageModelV3Message[] = [{ role: "user", content: [{ type: "text", text: "hello" }] }];
+    const tools: LanguageModelV3FunctionTool[] = [
+      { type: "function", name: "t", description: "t", inputSchema: { type: "object" } },
+    ];
+    const size = estimatePromptSize("sys", messages, tools);
+    expect(size.total).toBe(size.system + size.tools + size.messages);
+  });
+});
+
+describe("promptBudgetError", () => {
+  test("returns undefined when total is under the limit", () => {
+    expect(promptBudgetError({ total: 50, system: 10, tools: 10, messages: 30 }, 100)).toBeUndefined();
+  });
+
+  test("returns undefined when total equals the limit", () => {
+    expect(promptBudgetError({ total: 100, system: 10, tools: 10, messages: 80 }, 100)).toBeUndefined();
+  });
+
+  test("returns a message with the breakdown when total exceeds the limit", () => {
+    const msg = promptBudgetError({ total: 150, system: 20, tools: 30, messages: 100 }, 100);
+    expect(msg).toBeDefined();
+    expect(msg).toContain("150");
+    expect(msg).toContain("100");
+    expect(msg).toContain("system=20");
+    expect(msg).toContain("tools=30");
+    expect(msg).toContain("messages=100");
+  });
+});

--- a/src/prompt-size.test.ts
+++ b/src/prompt-size.test.ts
@@ -4,12 +4,13 @@ import { estimatePromptSize, promptBudgetError } from "./prompt-size";
 
 describe("estimatePromptSize", () => {
   test("returns zero totals when inputs are empty", () => {
-    const size = estimatePromptSize("", [], []);
+    const size = estimatePromptSize([], []);
     expect(size).toEqual({ total: 0, system: 0, tools: 0, messages: 0 });
   });
 
-  test("counts the system prompt", () => {
-    const size = estimatePromptSize("you are helpful", [], []);
+  test("counts system-role messages under system", () => {
+    const messages: LanguageModelV3Message[] = [{ role: "system", content: "you are helpful" }];
+    const size = estimatePromptSize(messages, []);
     expect(size.system).toBeGreaterThan(0);
     expect(size.tools).toBe(0);
     expect(size.messages).toBe(0);
@@ -20,13 +21,14 @@ describe("estimatePromptSize", () => {
     const tools: LanguageModelV3FunctionTool[] = [
       { type: "function", name: "file-read", description: "Read a file", inputSchema: { type: "object" } },
     ];
-    const size = estimatePromptSize("", [], tools);
+    const size = estimatePromptSize([], tools);
     expect(size.tools).toBeGreaterThan(0);
     expect(size.total).toBe(size.tools);
   });
 
-  test("counts structured messages", () => {
+  test("counts non-system messages separately from system", () => {
     const messages: LanguageModelV3Message[] = [
+      { role: "system", content: "sys" },
       { role: "user", content: [{ type: "text", text: "hello from the user" }] },
       {
         role: "tool",
@@ -40,17 +42,35 @@ describe("estimatePromptSize", () => {
         ],
       },
     ];
-    const size = estimatePromptSize("", messages, []);
+    const size = estimatePromptSize(messages, []);
+    expect(size.system).toBeGreaterThan(0);
     expect(size.messages).toBeGreaterThan(0);
-    expect(size.total).toBe(size.messages);
+    expect(size.total).toBe(size.system + size.messages);
+  });
+
+  test("does not double-count the system message", () => {
+    const systemOnly = estimatePromptSize([{ role: "system", content: "sys" }], []);
+    const both = estimatePromptSize(
+      [
+        { role: "system", content: "sys" },
+        { role: "user", content: [{ type: "text", text: "hi" }] },
+      ],
+      [],
+    );
+    expect(both.system).toBe(systemOnly.system);
+    expect(both.messages).toBeGreaterThan(0);
+    expect(both.total).toBe(both.system + both.messages);
   });
 
   test("total is the sum of system, tools, and messages", () => {
-    const messages: LanguageModelV3Message[] = [{ role: "user", content: [{ type: "text", text: "hello" }] }];
+    const messages: LanguageModelV3Message[] = [
+      { role: "system", content: "sys" },
+      { role: "user", content: [{ type: "text", text: "hello" }] },
+    ];
     const tools: LanguageModelV3FunctionTool[] = [
       { type: "function", name: "t", description: "t", inputSchema: { type: "object" } },
     ];
-    const size = estimatePromptSize("sys", messages, tools);
+    const size = estimatePromptSize(messages, tools);
     expect(size.total).toBe(size.system + size.tools + size.messages);
   });
 });

--- a/src/prompt-size.ts
+++ b/src/prompt-size.ts
@@ -9,13 +9,14 @@ export type PromptSize = {
 };
 
 export function estimatePromptSize(
-  systemPrompt: string,
   messages: LanguageModelV3Message[],
   tools: LanguageModelV3FunctionTool[],
 ): PromptSize {
-  const system = estimateTokens(systemPrompt);
+  const systemMessages = messages.filter((m) => m.role === "system");
+  const otherMessages = messages.filter((m) => m.role !== "system");
+  const system = systemMessages.length === 0 ? 0 : estimateTokens(JSON.stringify(systemMessages));
   const toolsTokens = tools.length === 0 ? 0 : estimateTokens(JSON.stringify(tools));
-  const messagesTokens = messages.length === 0 ? 0 : estimateTokens(JSON.stringify(messages));
+  const messagesTokens = otherMessages.length === 0 ? 0 : estimateTokens(JSON.stringify(otherMessages));
   return {
     total: system + toolsTokens + messagesTokens,
     system,

--- a/src/prompt-size.ts
+++ b/src/prompt-size.ts
@@ -1,0 +1,30 @@
+import type { LanguageModelV3FunctionTool, LanguageModelV3Message } from "@ai-sdk/provider";
+import { estimateTokens } from "./agent-input";
+
+export type PromptSize = {
+  total: number;
+  system: number;
+  tools: number;
+  messages: number;
+};
+
+export function estimatePromptSize(
+  systemPrompt: string,
+  messages: LanguageModelV3Message[],
+  tools: LanguageModelV3FunctionTool[],
+): PromptSize {
+  const system = estimateTokens(systemPrompt);
+  const toolsTokens = tools.length === 0 ? 0 : estimateTokens(JSON.stringify(tools));
+  const messagesTokens = messages.length === 0 ? 0 : estimateTokens(JSON.stringify(messages));
+  return {
+    total: system + toolsTokens + messagesTokens,
+    system,
+    tools: toolsTokens,
+    messages: messagesTokens,
+  };
+}
+
+export function promptBudgetError(size: PromptSize, limit: number): string | undefined {
+  if (size.total <= limit) return undefined;
+  return `Prompt exceeds per-call input budget (${size.total} tokens, limit ${limit}; system=${size.system} tools=${size.tools} messages=${size.messages}).`;
+}

--- a/src/tool-session.test.ts
+++ b/src/tool-session.test.ts
@@ -46,34 +46,6 @@ describe("step budget", () => {
   });
 });
 
-describe("token ceiling", () => {
-  test("blocks when total tokens exceed limit", () => {
-    const session = createSessionContext();
-    session.flags.totalTokenLimit = 1000;
-    session.flags.totalTokens = () => 1500;
-    expect(checkStepBudget(session)).toContain("Token budget exhausted");
-  });
-
-  test("blocks when total tokens equal limit", () => {
-    const session = createSessionContext();
-    session.flags.totalTokenLimit = 1000;
-    session.flags.totalTokens = () => 1000;
-    expect(checkStepBudget(session)).toContain("Token budget exhausted");
-  });
-
-  test("allows when under limit", () => {
-    const session = createSessionContext();
-    session.flags.totalTokenLimit = 1000;
-    session.flags.totalTokens = () => 500;
-    expect(checkStepBudget(session)).toBeUndefined();
-  });
-
-  test("skips when not configured", () => {
-    const session = createSessionContext();
-    expect(checkStepBudget(session)).toBeUndefined();
-  });
-});
-
 describe("consecutive failures", () => {
   test("blocks tool after 3 consecutive failures", () => {
     const session = createSessionContext();

--- a/src/tool-session.ts
+++ b/src/tool-session.ts
@@ -18,8 +18,7 @@ export type SessionFlags = {
   turnStepCount?: number;
   turnStepLimit?: number;
   totalStepLimit?: number;
-  totalTokenLimit?: number;
-  totalTokens?: () => number;
+  preCallInputTokenLimit?: number;
 };
 
 export type ToolErrorSummary = { message: string; code?: string; kind?: string };
@@ -84,15 +83,6 @@ export function resetTurnStepCount(session: SessionContext, limit?: number): voi
 }
 
 export function checkStepBudget(session: SessionContext, toolId?: string): string | undefined {
-  const tokenLimit = session.flags.totalTokenLimit;
-  const getTokens = session.flags.totalTokens;
-  if (tokenLimit && getTokens) {
-    const tokens = getTokens();
-    if (tokens >= tokenLimit) {
-      return `Token budget exhausted (${tokens} tokens, limit ${tokenLimit}). Commit what you have.`;
-    }
-  }
-
   if (toolId) {
     const limit = session.maxConsecutiveToolFailures ?? MAX_CONSECUTIVE_TOOL_FAILURES;
     const failures = session.consecutiveFailures.get(toolId) ?? 0;

--- a/src/tool-session.ts
+++ b/src/tool-session.ts
@@ -18,7 +18,6 @@ export type SessionFlags = {
   turnStepCount?: number;
   turnStepLimit?: number;
   totalStepLimit?: number;
-  preCallInputTokenLimit?: number;
 };
 
 export type ToolErrorSummary = { message: string; code?: string; kind?: string };


### PR DESCRIPTION
## Motivation

Sessions were dying on the cumulative `MAX_TOTAL_TOKENS = 150k` cap even when each individual call was lean — a 17-turn session at ~9k/call hit the ceiling without any call approaching the model's context window. Test run before this change: 17 model calls, 0 writes. After: 31 model calls, 7 writes. Fixes #236.

## Summary

- add prompt token size estimator in `src/prompt-size.ts` with composition breakdown (system, tools, messages)
- enforce a per-call input budget in `src/agent-stream.ts` before each `model.doStream`
- overflow throws `E_BUDGET_EXHAUSTED` with a composition breakdown and debug event
- remove `MAX_TOTAL_TOKENS` and the cumulative `totalTokenLimit` / `totalTokens` wiring
- wire `SessionFlags.preCallInputTokenLimit` from lifecycle policy into `StreamOptions`
- document the per-call input budget in `docs/lifecycle.md`

Fixes #236