### PR TITLE
feat(memory): distill observations via tool call

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -24,7 +24,7 @@ The model uses the memory toolkit to search for relevant context when it determi
 
 ## Sources
 
-The observer runs after each request and promotes facts to the appropriate scope via `@observe` directives.
+The observer runs after each request and promotes facts to the appropriate scope via `memory_observe` tool calls.
 
 Memory kinds in storage: `stored` (explicit user/tool-created), `observation` (distill-extracted facts).
 
@@ -35,19 +35,18 @@ Memory kinds in storage: `stored` (explicit user/tool-created), `observation` (d
 
 ## Inspiration
 
-The observation model is inspired by [Mastra's Observational Memory](https://mastra.ai/docs/memory/observational-memory). Acolyte adapts this idea with explicit scope promotion via `@observe` directives and on-demand retrieval via the memory toolkit.
+The observation model is inspired by [Mastra's Observational Memory](https://mastra.ai/docs/memory/observational-memory). Acolyte adapts this idea with explicit scope promotion via `memory_observe` tool calls and on-demand retrieval via the memory toolkit.
 
 ## Distill behavior
 
-- the observer extracts facts from conversations, one per `@observe` directive
-- each fact is stored as an individual observation record with its own embedding
-- scope promotion via `@observe` directives:
-  - `@observe project` — project-scoped facts (architecture, tooling, conventions)
-  - `@observe user` — user-scoped facts (preferences that carry across projects)
-  - `@observe session` — session-scoped facts (in-progress state, temporary constraints)
-  - if a preference is project-scoped, use `@observe project` not `@observe user`
-  - untagged lines are dropped (strict directive promotion, no fallback)
-  - malformed directives (e.g. `@observe proj`) are silently dropped and logged
+- the observer extracts facts from conversations via `memory_observe(scope, content, topic?)` tool calls
+- each call produces one observation record with its own embedding
+- scope via the `scope` parameter:
+  - `"project"` — project-scoped facts (architecture, tooling, conventions)
+  - `"user"` — user-scoped facts (preferences that carry across projects)
+  - `"session"` — session-scoped facts (in-progress state, temporary constraints)
+  - if a preference is project-scoped, use `"project"` not `"user"`
+- topic via the optional `topic` parameter — single-word label (e.g. testing, auth, config)
 - dedup: exact duplicate observations are skipped at write time
 
 ## Runtime guarantees
@@ -56,8 +55,7 @@ The observation model is inspired by [Mastra's Observational Memory](https://mas
 - commits are serialized per session per process through a keyed task queue seam
 - agent input assembly applies deterministic rolling history fitting (newest-first, truncate-to-fit under remaining budget, conversational turns prioritized over tool payloads)
 - debug observability uses lifecycle-scoped events (`lifecycle.memory.load_*`, `lifecycle.memory.commit_*`) through standard debug channels
-- commit debug includes promotion counters (`project_promoted_facts`, `user_promoted_facts`, `session_scoped_facts`, `dropped_untagged_facts`)
-- repeated malformed-directive drops emit `lifecycle.memory.quality_warning` with `malformed_reject_streak` after 3 consecutive commits
+- commit debug includes promotion counters (`project_promoted_facts`, `user_promoted_facts`, `session_scoped_facts`)
 - distill record writes use the configured storage backend for atomic persistence
 - hybrid recall: entries scored by cosine similarity + TF-IDF weighted token overlap (see below). Falls back to recency when embeddings are unavailable
 

--- a/scripts/memory-bench-scenarios.ts
+++ b/scripts/memory-bench-scenarios.ts
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { z } from "zod";
-import { splitScopedObservation } from "../src/distill-ops";
+import type { DistillObservation } from "../src/memory-distiller";
 import { DISTILLER_PROMPT } from "../src/memory-distiller";
 import { cosineSimilarity, embedText } from "../src/memory-embedding";
 
@@ -396,18 +396,16 @@ type CachedDistillResult = {
 
 async function distillSession(
   sessionTurns: { speaker: string; text: string }[],
-  runner: (systemPrompt: string, userContent: string) => Promise<string>,
+  runner: (systemPrompt: string, userContent: string) => Promise<DistillObservation[]>,
 ): Promise<{ content: string; topic: string | null; scope: string }[]> {
   const conversationText = sessionTurns.map((t) => `${t.speaker}: ${t.text}`).join("\n");
-  const output = await runner(DISTILLER_PROMPT, conversationText);
-  if (!output.trim()) return [];
-  const parsed = splitScopedObservation(output);
-  return parsed.facts.map((f) => ({ content: f.content, topic: f.topic, scope: f.scope }));
+  const observations = await runner(DISTILLER_PROMPT, conversationText);
+  return observations.map((o) => ({ content: o.content, topic: o.topic, scope: o.scope }));
 }
 
 async function distillLoCoMoConversation(
   conv: Record<string, unknown>,
-  runner: (systemPrompt: string, userContent: string) => Promise<string>,
+  runner: (systemPrompt: string, userContent: string) => Promise<DistillObservation[]>,
   cachePath: string,
 ): Promise<CachedDistillResult> {
   if (existsSync(cachePath)) {

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -1,7 +1,6 @@
 import type {
   LanguageModelV3,
   LanguageModelV3FinishReason,
-  LanguageModelV3FunctionTool,
   LanguageModelV3Message,
   LanguageModelV3StreamPart,
   LanguageModelV3TextPart,
@@ -19,17 +18,8 @@ import { estimatePromptSize, promptBudgetError } from "./prompt-size";
 import { normalizeModel, providerFromModel } from "./provider-config";
 import { type RateLimiter, sharedRateLimiter } from "./rate-limiter";
 import { signalForToolName } from "./signal-toolkit";
-import type { ToolDefinition } from "./tool-contract";
+import { type ToolDefinition, toFunctionTools } from "./tool-contract";
 import { truncateMiddle } from "./truncate-text";
-
-function toolsToFunctionTools(tools: Record<string, ToolDefinition>): LanguageModelV3FunctionTool[] {
-  return Object.values(tools).map((tool) => ({
-    type: "function" as const,
-    name: tool.id,
-    description: tool.description,
-    inputSchema: tool.inputSchema as LanguageModelV3FunctionTool["inputSchema"],
-  }));
-}
 
 async function resolveInstructions(instructions: Agent["instructions"]): Promise<string> {
   if (typeof instructions === "string") return instructions;
@@ -49,7 +39,7 @@ export function createAgentStream(
 
   return async (prompt: string, options: StreamOptions): Promise<StreamOutput> => {
     const systemPrompt = await resolveInstructions(instructions);
-    const functionTools = toolsToFunctionTools(tools);
+    const functionTools = toFunctionTools(tools);
     const messages: LanguageModelV3Message[] = [
       { role: "system", content: systemPrompt },
       { role: "user", content: [{ type: "text", text: prompt }] },

--- a/src/distill-ops.test.ts
+++ b/src/distill-ops.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { clampToTokenEstimate, splitScopedObservation } from "./distill-ops";
+import { clampToTokenEstimate } from "./distill-ops";
 
 describe("clampToTokenEstimate", () => {
   test("does not produce lone surrogates when clamping emoji text", () => {
@@ -8,51 +8,5 @@ describe("clampToTokenEstimate", () => {
     expect(result.length).toBeGreaterThan(0);
     expect(result).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])/);
     expect(result).not.toMatch(/(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
-  });
-});
-
-describe("splitScopedObservation", () => {
-  test("parses scoped observations into facts", () => {
-    const result = splitScopedObservation("@observe project\nuses bun\n@observe user\nprefers terse output");
-    expect(result.projectCount).toBe(1);
-    expect(result.userCount).toBe(1);
-    expect(result.facts).toHaveLength(2);
-    expect(result.facts[0]).toMatchObject({ scope: "project", content: "uses bun" });
-  });
-
-  test("drops untagged lines without a preceding @observe", () => {
-    const result = splitScopedObservation("orphan line\n@observe session\ntagged line");
-    expect(result.droppedUntaggedCount).toBe(1);
-    expect(result.sessionCount).toBe(1);
-  });
-
-  test("drops malformed @observe directives", () => {
-    const result = splitScopedObservation("@observe badscope\nfollowing line");
-    expect(result.droppedMalformedCount).toBe(1);
-    expect(result.droppedUntaggedCount).toBe(1);
-    expect(result.facts).toHaveLength(0);
-  });
-
-  test("handles @observe at end of input with no content", () => {
-    const result = splitScopedObservation("@observe project");
-    expect(result.facts).toHaveLength(0);
-    expect(result.projectCount).toBe(0);
-  });
-
-  test("handles @topic directive", () => {
-    const result = splitScopedObservation("@observe project\n@topic testing\nuses bun test");
-    expect(result.facts[0]).toMatchObject({ scope: "project", content: "uses bun test", topic: "testing" });
-  });
-
-  test("@topic without preceding @observe — content is dropped as untagged", () => {
-    const result = splitScopedObservation("@topic orphan\nsome content");
-    expect(result.droppedUntaggedCount).toBe(1);
-    expect(result.facts).toHaveLength(0);
-  });
-
-  test("multiple @observe in sequence — only last one applies", () => {
-    const result = splitScopedObservation("@observe project\n@observe user\nactual fact");
-    expect(result.userCount).toBe(1);
-    expect(result.projectCount).toBe(0);
   });
 });

--- a/src/distill-ops.ts
+++ b/src/distill-ops.ts
@@ -2,17 +2,6 @@ import { estimateTokens } from "./agent-input";
 
 export type DistillScope = "session" | "project" | "user";
 
-type ParsedFact = { scope: DistillScope; content: string; topic: string | null };
-
-export type SplitResult = {
-  facts: ParsedFact[];
-  sessionCount: number;
-  projectCount: number;
-  userCount: number;
-  droppedUntaggedCount: number;
-  droppedMalformedCount: number;
-};
-
 function stripTrailingSurrogate(s: string): string {
   if (s.length === 0) return s;
   const last = s.charCodeAt(s.length - 1);
@@ -38,65 +27,4 @@ export function clampToTokenEstimate(content: string, maxTokens: number): string
 
 export function normalizeMemoryText(value: string): string {
   return value.replace(/\s+/g, " ").trim();
-}
-
-export function parseObserveDirective(line: string): DistillScope | null {
-  const match = line.trim().match(/^@observe\s+(project|user|session)$/i);
-  return match ? (match[1].toLowerCase() as DistillScope) : null;
-}
-
-export function parseTopicDirective(line: string): string | null {
-  const match = line.trim().match(/^@topic\s+(\S+)$/i);
-  return match ? match[1].toLowerCase() : null;
-}
-
-export function hasMalformedObserveDirective(line: string): boolean {
-  return /^@observe\b/i.test(line.trim()) && !parseObserveDirective(line);
-}
-
-export function splitScopedObservation(observed: string): SplitResult {
-  const lines = observed
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
-  const facts: ParsedFact[] = [];
-  let droppedUntaggedCount = 0;
-  let droppedMalformedCount = 0;
-  let pendingScope: DistillScope | null = null;
-  let pendingTopic: string | null = null;
-  for (const line of lines) {
-    const scope = parseObserveDirective(line);
-    if (scope) {
-      pendingScope = scope;
-      pendingTopic = null;
-      continue;
-    }
-    if (hasMalformedObserveDirective(line)) {
-      droppedMalformedCount += 1;
-      pendingScope = null;
-      pendingTopic = null;
-      continue;
-    }
-    const topic = parseTopicDirective(line);
-    if (topic) {
-      pendingTopic = topic;
-      continue;
-    }
-    if (!pendingScope) {
-      droppedUntaggedCount += 1;
-      continue;
-    }
-    facts.push({ scope: pendingScope, content: line, topic: pendingTopic });
-    pendingScope = null;
-    pendingTopic = null;
-  }
-
-  return {
-    facts,
-    sessionCount: facts.filter((f) => f.scope === "session").length,
-    projectCount: facts.filter((f) => f.scope === "project").length,
-    userCount: facts.filter((f) => f.scope === "user").length,
-    droppedUntaggedCount,
-    droppedMalformedCount,
-  };
 }

--- a/src/memory-contract.ts
+++ b/src/memory-contract.ts
@@ -39,7 +39,6 @@ export type MemoryPolicy = {
   messageThreshold: number;
   maxOutputTokens: number;
   contextMessageWindow: number;
-  malformedStreakWarningThreshold: number;
   cosineWeight: number;
   tokenWeight: number;
   topicThreshold: number;
@@ -50,7 +49,6 @@ export const defaultMemoryPolicy: MemoryPolicy = {
   messageThreshold: 4,
   maxOutputTokens: 1_000,
   contextMessageWindow: 20,
-  malformedStreakWarningThreshold: 3,
   cosineWeight: 0.8,
   tokenWeight: 0.2,
   topicThreshold: 0.6,

--- a/src/memory-distiller.int.test.ts
+++ b/src/memory-distiller.int.test.ts
@@ -1,0 +1,116 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from "bun:test";
+import {
+  createToolCallsPayload,
+  type FakeProviderServer,
+  startFakeProviderServer,
+} from "../scripts/fake-provider-server";
+import { appConfig } from "./app-config";
+import { createMemoryPolicy } from "./memory-contract";
+import { createMemoryDistiller } from "./memory-distiller";
+import { createSqliteMemoryStore } from "./memory-store";
+import { searchMemories } from "./memory-toolkit";
+import { tempDb } from "./test-utils";
+
+const testPolicy = createMemoryPolicy({ messageThreshold: 1 });
+
+const { create: createStore, cleanup: cleanupStores } = tempDb("acolyte-distiller-int-", createSqliteMemoryStore);
+
+let fake: FakeProviderServer;
+let savedBaseUrl: string;
+let savedApiKey: string | undefined;
+let savedDistillModel: string;
+
+beforeAll(() => {
+  savedBaseUrl = appConfig.openai.baseUrl;
+  savedApiKey = appConfig.openai.apiKey;
+  savedDistillModel = appConfig.distillModel;
+  fake = startFakeProviderServer({
+    handleRequest: (ctx) =>
+      createToolCallsPayload(ctx.model, ctx.responseCounter, [
+        {
+          id: `fc_proj_${ctx.responseCounter}`,
+          callId: `call_proj_${ctx.responseCounter}`,
+          name: "memory_observe",
+          args: JSON.stringify({ scope: "project", content: "project uses Bun as runtime", topic: "tooling" }),
+        },
+        {
+          id: `fc_user_${ctx.responseCounter}`,
+          callId: `call_user_${ctx.responseCounter}`,
+          name: "memory_observe",
+          args: JSON.stringify({ scope: "user", content: "prefers concise responses" }),
+        },
+        {
+          id: `fc_sess_${ctx.responseCounter}`,
+          callId: `call_sess_${ctx.responseCounter}`,
+          name: "memory_observe",
+          args: JSON.stringify({ scope: "session", content: "fixing memory search bug" }),
+        },
+      ]),
+  });
+  (appConfig.openai as { baseUrl: string }).baseUrl = fake.baseUrl;
+  (appConfig.openai as { apiKey: string | undefined }).apiKey = "fake-key";
+  (appConfig as { distillModel: string }).distillModel = "gpt-4o-mini";
+});
+
+afterAll(() => {
+  fake.stop();
+  (appConfig.openai as { baseUrl: string }).baseUrl = savedBaseUrl;
+  (appConfig.openai as { apiKey: string | undefined }).apiKey = savedApiKey;
+  (appConfig as { distillModel: string }).distillModel = savedDistillModel;
+});
+
+afterEach(cleanupStores);
+
+describe("memoryDistiller integration", () => {
+  test("defaultRunner emits memory_observe tool calls and stores all scopes", async () => {
+    const store = createStore();
+    const distiller = createMemoryDistiller({ store, policy: testPolicy });
+
+    const metrics = await distiller.commit({
+      sessionId: "sess_inttest001",
+      resourceId: "proj_inttest001",
+      messages: [
+        { role: "user", content: "what runtime does this project use?" },
+        { role: "assistant", content: "it uses Bun" },
+      ],
+      output: "it uses Bun",
+    });
+
+    expect(metrics).toBeDefined();
+    expect(metrics?.projectPromotedFacts).toBe(1);
+    expect(metrics?.userPromotedFacts).toBe(1);
+    expect(metrics?.sessionScopedFacts).toBe(1);
+
+    const all = await store.list();
+    const projectEntry = all.find((r) => r.scopeKey === "proj_inttest001");
+    expect(projectEntry?.content).toBe("project uses Bun as runtime");
+    expect(projectEntry?.topic).toBe("tooling");
+
+    const sessionEntry = all.find((r) => r.scopeKey === "sess_inttest001");
+    expect(sessionEntry?.content).toBe("fixing memory search bug");
+
+    const userEntry = all.find((r) => r.scopeKey.startsWith("user_"));
+    expect(userEntry?.content).toBe("prefers concise responses");
+  });
+
+  test("project and user observations are returned by searchMemories", async () => {
+    const store = createStore();
+    const distiller = createMemoryDistiller({ store, policy: testPolicy });
+
+    await distiller.commit({
+      sessionId: "sess_inttest002",
+      resourceId: "proj_inttest002",
+      messages: [
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "hi" },
+      ],
+      output: "hi",
+    });
+
+    const results = await searchMemories("Bun runtime tooling", { store });
+    const contents = results.map((r) => r.content);
+    expect(contents).toContain("project uses Bun as runtime");
+    expect(contents).toContain("prefers concise responses");
+    expect(contents).not.toContain("fixing memory search bug");
+  });
+});

--- a/src/memory-distiller.test.ts
+++ b/src/memory-distiller.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import type { MemoryKind, MemoryRecord, MemoryStore } from "./memory-contract";
 import { createMemoryPolicy } from "./memory-contract";
+import type { DistillObservation } from "./memory-distiller";
 import { createMemoryDistiller, DISTILLER_PROMPT } from "./memory-distiller";
 
 const testPolicy = createMemoryPolicy({ messageThreshold: 1, maxOutputTokens: 200 });
 
 function createTestDistiller(
   store: MemoryStore & { written: MemoryRecord[]; removed: string[] },
-  runner?: (systemPrompt: string, userContent: string) => Promise<string>,
+  runner?: (systemPrompt: string, userContent: string) => Promise<DistillObservation[]>,
   options?: { commitScope?: "session" | "project" | "user" | "none" },
 ) {
   return createMemoryDistiller({ store, runner, policy: testPolicy, ...options });
@@ -46,12 +47,18 @@ function createMockStore(records: MemoryRecord[] = []): MemoryStore & { written:
   };
 }
 
+function makeRunner(observations: DistillObservation[]) {
+  return async (systemPrompt: string): Promise<DistillObservation[]> => {
+    if (systemPrompt === DISTILLER_PROMPT) return observations;
+    return [];
+  };
+}
+
 describe("memoryDistiller", () => {
   describe("commit", () => {
     test("skips when no sessionId", async () => {
       const store = createMockStore();
-      const source = createTestDistiller(store);
-      if (!source.commit) throw new Error("expected commit handler");
+      const source = createTestDistiller(store, makeRunner([{ scope: "session", content: "a fact", topic: null }]));
       await source.commit({
         messages: Array.from({ length: 25 }, (_, i) => ({ role: "user", content: `msg ${i}` })),
         output: "response",
@@ -63,6 +70,7 @@ describe("memoryDistiller", () => {
       const store = createMockStore();
       const source = createMemoryDistiller({
         store,
+        runner: makeRunner([{ scope: "session", content: "a fact", topic: null }]),
         policy: createMemoryPolicy({ messageThreshold: 5 }),
       });
       await source.commit({
@@ -84,11 +92,10 @@ describe("memoryDistiller", () => {
           tokenEstimate: 6,
         },
       ]);
-      const source = createTestDistiller(store, async (systemPrompt) => {
-        if (systemPrompt === DISTILLER_PROMPT) return " @observe session\n prefers   short answers ";
-        return "";
-      });
-      if (!source.commit) throw new Error("expected commit handler");
+      const source = createTestDistiller(
+        store,
+        makeRunner([{ scope: "session", content: "prefers short answers", topic: null }]),
+      );
       await source.commit({
         sessionId: "sess_test0001",
         messages: [{ role: "user", content: "hello" }],
@@ -97,41 +104,15 @@ describe("memoryDistiller", () => {
       expect(store.written).toHaveLength(0);
     });
 
-    test("drops untagged fact lines during session commit", async () => {
+    test("stores topic on observations", async () => {
       const store = createMockStore();
-      const source = createTestDistiller(store, async (systemPrompt) => {
-        if (systemPrompt !== DISTILLER_PROMPT) return "";
-        return [
-          "untagged fact should be dropped",
-          "Current task: also dropped without directive",
-          "@observe session",
-          "tagged fact is kept",
-        ].join("\n");
-      });
-      if (!source.commit) throw new Error("expected commit handler");
-      await source.commit({
-        sessionId: "sess_test0001",
-        messages: [{ role: "user", content: "hello" }],
-        output: "done",
-      });
-      const sessionEntry = store.written.find((entry) => entry.scopeKey === "sess_test0001");
-      expect(sessionEntry?.content).toContain("tagged fact is kept");
-      expect(sessionEntry?.content).not.toContain("untagged fact should be dropped");
-      expect(sessionEntry?.content).not.toContain("Current task:");
-    });
-
-    test("parses @topic tags and stores them on observations", async () => {
-      const store = createMockStore();
-      const source = createTestDistiller(store, async (systemPrompt) => {
-        if (systemPrompt !== DISTILLER_PROMPT) return "";
-        return [
-          "@observe project",
-          "@topic testing",
-          "project uses Vitest",
-          "@observe project",
-          "repo has 18k lines of code",
-        ].join("\n");
-      });
+      const source = createTestDistiller(
+        store,
+        makeRunner([
+          { scope: "project", content: "project uses Vitest", topic: "testing" },
+          { scope: "project", content: "repo has 18k lines of code", topic: null },
+        ]),
+      );
       await source.commit({
         sessionId: "sess_test0001",
         resourceId: "proj_abc123",
@@ -144,45 +125,66 @@ describe("memoryDistiller", () => {
       expect(withoutTopic?.topic).toBeNull();
     });
 
-    test("silently drops malformed scope tags and commits valid facts", async () => {
+    test("session commit promotes project and user observations to scoped stores", async () => {
       const store = createMockStore();
-      const source = createTestDistiller(store, async (systemPrompt) => {
-        if (systemPrompt !== DISTILLER_PROMPT) return "";
-        return [
-          "@observe project",
-          "valid project fact",
-          "@observe user",
-          "valid user fact",
-          "@observe proj",
-          "malformed tag dropped",
-          "@observe usr",
-          "malformed tag dropped",
-          "@observe session",
-          "valid session fact",
-        ].join("\n");
+      const source = createTestDistiller(
+        store,
+        makeRunner([
+          { scope: "project", content: "repo uses Bun", topic: null },
+          { scope: "user", content: "prefers short answers", topic: null },
+          { scope: "session", content: "fix failing tests", topic: null },
+        ]),
+      );
+      await source.commit({
+        sessionId: "sess_test0001",
+        resourceId: "proj_abc123",
+        messages: [{ role: "user", content: "hello" }],
+        output: "done",
       });
-      if (!source.commit) throw new Error("expected commit handler");
+
+      const byScope = new Map(store.written.map((entry) => [entry.scopeKey, entry.content]));
+      expect(byScope.get("sess_test0001")).toBe("fix failing tests");
+      expect(byScope.get("proj_abc123")).toBe("repo uses Bun");
+      const userScopeKey = [...byScope.keys()].find((key) => key.startsWith("user_"));
+      expect(userScopeKey).toBeDefined();
+      expect(userScopeKey ? byScope.get(userScopeKey) : "").toBe("prefers short answers");
+    });
+
+    test("returns scoped promotion metrics", async () => {
+      const store = createMockStore();
+      const source = createTestDistiller(
+        store,
+        makeRunner([
+          { scope: "project", content: "project fact one", topic: null },
+          { scope: "project", content: "project fact two", topic: null },
+          { scope: "user", content: "user fact one", topic: null },
+          { scope: "session", content: "session fact one", topic: null },
+          { scope: "project", content: "project fact three", topic: null },
+        ]),
+      );
       const metrics = await source.commit({
         sessionId: "sess_test0001",
         resourceId: "proj_abc123",
         messages: [{ role: "user", content: "hello" }],
         output: "done",
       });
-      // Malformed tags are silently dropped; valid facts are committed.
-      expect(store.written.length).toBeGreaterThan(0);
       expect(metrics).toMatchObject({
-        projectPromotedFacts: 1,
+        projectPromotedFacts: 3,
         userPromotedFacts: 1,
         sessionScopedFacts: 1,
-        droppedUntaggedFacts: 2,
+        droppedUntaggedFacts: 0,
       });
     });
 
-    test("commitScope writes only the targeted scope", async () => {
+    test("commitScope filters to only commit matching scope", async () => {
       const store = createMockStore();
       const source = createMemoryDistiller({
         store,
-        runner: async (systemPrompt) => (systemPrompt === DISTILLER_PROMPT ? "scope fact" : ""),
+        runner: makeRunner([
+          { scope: "project", content: "a project fact", topic: null },
+          { scope: "session", content: "a session fact", topic: null },
+          { scope: "user", content: "a user fact", topic: null },
+        ]),
         policy: testPolicy,
         commitScope: "project",
       });
@@ -200,94 +202,18 @@ describe("memoryDistiller", () => {
       expect(keys.some((key) => key.startsWith("user_"))).toBe(false);
     });
 
-    test("session commit promotes @observe project and @observe user lines to scoped stores", async () => {
-      const store = createMockStore();
-      const source = createTestDistiller(store, async (systemPrompt) => {
-        if (systemPrompt !== DISTILLER_PROMPT) return "";
-        return [
-          "@observe project",
-          "repo uses Bun",
-          "@observe user",
-          "prefers short answers",
-          "@observe session",
-          "fix failing tests",
-        ].join("\n");
-      });
-      if (!source.commit) throw new Error("expected commit handler");
-      await source.commit({
-        sessionId: "sess_test0001",
-        resourceId: "proj_abc123",
-        messages: [{ role: "user", content: "hello" }],
-        output: "done",
-      });
-
-      const byScope = new Map(store.written.map((entry) => [entry.scopeKey, entry.content]));
-      expect(byScope.get("sess_test0001")).toContain("fix failing tests");
-      expect(byScope.get("sess_test0001")).not.toContain("@observe project");
-      expect(byScope.get("sess_test0001")).not.toContain("repo uses Bun");
-      expect(byScope.get("sess_test0001")).not.toContain("prefers short answers");
-      expect(byScope.get("proj_abc123")).toBe("repo uses Bun");
-      const userScopeKey = [...byScope.keys()].find((key) => key.startsWith("user_"));
-      expect(userScopeKey).toBeDefined();
-      expect(userScopeKey ? byScope.get(userScopeKey) : "").toBe("prefers short answers");
-    });
-
-    test("returns scoped promotion and drop metrics for mixed observations", async () => {
-      const store = createMockStore();
-      const source = createTestDistiller(store, async (systemPrompt) => {
-        if (systemPrompt !== DISTILLER_PROMPT) return "";
-        return [
-          "@observe project",
-          "project fact one",
-          "@observe project",
-          "project fact two",
-          "@observe user",
-          "user fact one",
-          "@observe session",
-          "session fact one",
-          "Current task: keep continuation",
-          "@observe project",
-          "Next step: continuation forced to session",
-          "untagged dropped fact",
-          "@observe proj",
-          "malformed tag dropped",
-        ].join("\n");
-      });
-      if (!source.commit) throw new Error("expected commit handler");
-      const metrics = await source.commit({
-        sessionId: "sess_test0001",
-        resourceId: "proj_abc123",
-        messages: [{ role: "user", content: "hello" }],
-        output: "done",
-      });
-      // "Current task:" and "Next step:" lines without @observe are dropped as untagged.
-      // The line after @observe proj (malformed) also becomes untagged.
-      expect(metrics).toMatchObject({
-        projectPromotedFacts: 3,
-        userPromotedFacts: 1,
-        sessionScopedFacts: 1,
-        droppedUntaggedFacts: 3,
-      });
-      expect(store.written.length).toBeGreaterThan(0);
-    });
-
-    test("quality fixtures classify observer output into promote, drop, or reject paths", async () => {
+    test("quality fixtures classify observations into the right scopes", async () => {
       const fixturePolicy = createMemoryPolicy({ messageThreshold: 1, maxOutputTokens: 10_000 });
       const fixtures = [
         {
           name: "good_scoped_output",
-          observed: [
-            "@observe project",
-            "uses bun test",
-            "@observe user",
-            "prefers concise responses",
-            "@observe session",
-            "fixing failing memory tests",
-            "@observe session",
-            "stabilize memory quality",
-            "@observe session",
-            "add regression coverage",
-          ].join("\n"),
+          observations: [
+            { scope: "project" as const, content: "uses bun test", topic: null },
+            { scope: "user" as const, content: "prefers concise responses", topic: null },
+            { scope: "session" as const, content: "fixing failing memory tests", topic: null },
+            { scope: "session" as const, content: "stabilize memory quality", topic: null },
+            { scope: "session" as const, content: "add regression coverage", topic: null },
+          ],
           expectedMetrics: {
             projectPromotedFacts: 1,
             userPromotedFacts: 1,
@@ -297,35 +223,13 @@ describe("memoryDistiller", () => {
           expectedWriteCount: 5,
         },
         {
-          name: "mixed_output_with_untagged_fact",
-          observed: [
-            "@observe project",
-            "uses bun test",
-            "untagged fact",
-            "Current task: also untagged without directive",
-          ].join("\n"),
+          name: "only_project_observations",
+          observations: [{ scope: "project" as const, content: "uses bun test", topic: null }],
           expectedMetrics: {
             projectPromotedFacts: 1,
             userPromotedFacts: 0,
             sessionScopedFacts: 0,
-            droppedUntaggedFacts: 2,
-          },
-          expectedWriteCount: 1,
-        },
-        {
-          name: "malformed_tag_silently_dropped",
-          observed: [
-            "@observe project",
-            "uses bun test",
-            "@observe proj",
-            "malformed tag silently dropped",
-            "Current task: also untagged without directive",
-          ].join("\n"),
-          expectedMetrics: {
-            projectPromotedFacts: 1,
-            userPromotedFacts: 0,
-            sessionScopedFacts: 0,
-            droppedUntaggedFacts: 2,
+            droppedUntaggedFacts: 0,
           },
           expectedWriteCount: 1,
         },
@@ -335,10 +239,7 @@ describe("memoryDistiller", () => {
         const store = createMockStore();
         const source = createMemoryDistiller({
           store,
-          runner: async (systemPrompt) => {
-            if (systemPrompt !== DISTILLER_PROMPT) return "";
-            return fixture.observed;
-          },
+          runner: makeRunner([...fixture.observations]),
           policy: fixturePolicy,
         });
         const metrics = await source.commit({
@@ -350,42 +251,6 @@ describe("memoryDistiller", () => {
         expect(metrics, fixture.name).toMatchObject(fixture.expectedMetrics);
         expect(store.written.length, fixture.name).toBe(fixture.expectedWriteCount);
       }
-    });
-
-    test("malformed streak is scoped per key, not shared across sessions", async () => {
-      const store = createMockStore();
-      let callCount = 0;
-      const source = createTestDistiller(store, async () => {
-        callCount += 1;
-        // All calls return malformed @observe tags
-        return "@observe badscope\nmalformed fact";
-      });
-      if (!source.commit) throw new Error("expected commit handler");
-
-      // Commit twice on session A — streak for sess_a should be 2
-      await source.commit({
-        sessionId: "sess_a",
-        messages: [{ role: "user", content: "hello" }],
-        output: "done",
-      });
-      await source.commit({
-        sessionId: "sess_a",
-        messages: [{ role: "user", content: "hello" }],
-        output: "done",
-      });
-
-      // Commit once on session B — streak for sess_b should be 1, NOT 3
-      const metrics = await source.commit({
-        sessionId: "sess_b",
-        messages: [{ role: "user", content: "hello" }],
-        output: "done",
-      });
-
-      // If streaks were shared, sess_b would inherit sess_a's count.
-      // The metrics don't expose streak directly, but we can verify
-      // that sess_b's droppedMalformedCount is independent (only 1 malformed).
-      expect(metrics?.droppedUntaggedFacts).toBe(1);
-      expect(callCount).toBe(3);
     });
   });
 });

--- a/src/memory-distiller.test.ts
+++ b/src/memory-distiller.test.ts
@@ -172,7 +172,6 @@ describe("memoryDistiller", () => {
         projectPromotedFacts: 3,
         userPromotedFacts: 1,
         sessionScopedFacts: 1,
-        droppedUntaggedFacts: 0,
       });
     });
 
@@ -218,7 +217,6 @@ describe("memoryDistiller", () => {
             projectPromotedFacts: 1,
             userPromotedFacts: 1,
             sessionScopedFacts: 3,
-            droppedUntaggedFacts: 0,
           },
           expectedWriteCount: 5,
         },
@@ -229,7 +227,6 @@ describe("memoryDistiller", () => {
             projectPromotedFacts: 1,
             userPromotedFacts: 0,
             sessionScopedFacts: 0,
-            droppedUntaggedFacts: 0,
           },
           expectedWriteCount: 1,
         },

--- a/src/memory-distiller.ts
+++ b/src/memory-distiller.ts
@@ -1,7 +1,8 @@
+import type { LanguageModelV3FunctionTool, LanguageModelV3ToolCall } from "@ai-sdk/provider";
 import { estimateTokens } from "./agent-input";
 import { appConfig } from "./app-config";
 import { nowIso } from "./datetime";
-import { clampToTokenEstimate, type DistillScope, normalizeMemoryText, splitScopedObservation } from "./distill-ops";
+import { clampToTokenEstimate, type DistillScope, normalizeMemoryText } from "./distill-ops";
 import { log } from "./log";
 import {
   defaultMemoryPolicy,
@@ -22,21 +23,42 @@ import { createId } from "./short-id";
 
 export const DISTILLER_PROMPT = `Extract concrete facts from this conversation.
 
-Preserve specifics: file paths, function names, error messages, config values, decisions with reasoning.
+For each fact, call memory_observe with:
+- scope: "project" for project-specific durable facts (architecture, tooling, conventions, decisions)
+         "user" for personal preferences that carry across projects
+         "session" for in-progress state, temporary constraints, working assumptions
+- content: the fact — preserve specifics: file paths, function names, error messages, config values, decisions with reasoning
+- topic: optional single-word topic label (e.g. testing, auth, config, tooling)
 
-Tag each fact with an observe directive on its own line, optionally followed by a topic tag, then the fact on the next line:
+If a preference is project-scoped, use "project" not "user". If unsure, default to "session".`;
 
-@observe project — project-specific durable facts (architecture, tooling, conventions, decisions)
-@observe user — personal preferences that carry across projects
-@observe session — in-progress state, temporary constraints, working assumptions
-@topic <word> — optional topic tag for the preceding observe (e.g. testing, auth, config, tooling)
+const MEMORY_OBSERVE_TOOL: LanguageModelV3FunctionTool = {
+  type: "function",
+  name: "memory_observe",
+  description: "Record a fact extracted from the conversation into memory.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      scope: {
+        type: "string",
+        enum: ["session", "project", "user"],
+        description:
+          "Memory scope: session (in-progress), project (durable project facts), user (cross-project preferences)",
+      },
+      content: {
+        type: "string",
+        description: "The fact to store. Be specific and concrete.",
+      },
+      topic: {
+        type: "string",
+        description: "Optional single-word topic label (e.g. testing, auth, config).",
+      },
+    },
+    required: ["scope", "content"],
+  },
+};
 
-Example:
-@observe project
-@topic testing
-Project uses Vitest for unit tests
-
-If a preference is project-scoped, use @observe project not @observe user. If unsure, default to @observe session.`;
+export type DistillObservation = { scope: DistillScope; content: string; topic: string | null };
 
 export function createDistillInput(messages: readonly { role: string; content: string }[], output: string): string {
   return [...messages, { role: "assistant", content: output }].map((m) => `${m.role}: ${m.content}`).join("\n\n");
@@ -67,9 +89,22 @@ async function embedAndStore(ds: MemoryStore, id: string, scope: string, content
   }
 }
 
-export type DistillRunner = (systemPrompt: string, userContent: string) => Promise<string>;
+export type DistillRunner = (systemPrompt: string, userContent: string) => Promise<DistillObservation[]>;
 
-async function defaultRunner(systemPrompt: string, userContent: string): Promise<string> {
+function parseToolCall(call: LanguageModelV3ToolCall): DistillObservation | null {
+  try {
+    const args = JSON.parse(call.input) as { scope?: unknown; content?: unknown; topic?: unknown };
+    if (typeof args.content !== "string" || !args.content.trim()) return null;
+    const scope = args.scope as DistillScope;
+    if (scope !== "session" && scope !== "project" && scope !== "user") return null;
+    const topic = typeof args.topic === "string" && args.topic.trim() ? args.topic.trim().toLowerCase() : null;
+    return { scope, content: args.content, topic };
+  } catch {
+    return null;
+  }
+}
+
+async function defaultRunner(systemPrompt: string, userContent: string): Promise<DistillObservation[]> {
   const qualifiedModel = normalizeModel(appConfig.distillModel);
   const model = createModel(qualifiedModel, sharedRateLimiter(providerFromModel(qualifiedModel)));
   const result = await model.doGenerate({
@@ -77,13 +112,14 @@ async function defaultRunner(systemPrompt: string, userContent: string): Promise
       { role: "system", content: systemPrompt },
       { role: "user", content: [{ type: "text", text: userContent }] },
     ],
+    tools: [MEMORY_OBSERVE_TOOL],
+    toolChoice: { type: "auto" },
     temperature: 0,
   });
-  const text = result.content
-    .filter((part): part is { type: "text"; text: string } => part.type === "text")
-    .map((part) => part.text)
-    .join("");
-  return text.trim();
+  return result.content
+    .filter((part): part is LanguageModelV3ToolCall => part.type === "tool-call" && part.toolName === "memory_observe")
+    .map(parseToolCall)
+    .filter((obs): obs is DistillObservation => obs !== null);
 }
 
 const DISTILL_SCOPE_KEY_RESOLVERS: Record<
@@ -147,64 +183,48 @@ export function createMemoryDistiller(deps: Partial<DistillerDeps> = {}): Memory
   const runner = deps.runner ?? defaultRunner;
   const policy = deps.policy ?? defaultMemoryPolicy;
   const commitScope = deps.commitScope ?? "session";
-  const malformedStreaks = new Map<string, number>();
   return {
     async commit(ctx): Promise<MemoryCommitMetrics | undefined> {
       if (commitScope === "none") return;
-      const ds = deps.store ?? (await getCachedStore());
-      const key = resolveDistillScopeKey(commitScope, ctx);
-      if (!key) return;
+      if (commitScope === "session" && !ctx.sessionId) return;
       if (ctx.messages.length < policy.messageThreshold) return;
 
+      const ds = deps.store ?? (await getCachedStore());
       const recentMessages = ctx.messages.slice(-policy.contextMessageWindow);
       const distillInput = createDistillInput(recentMessages, ctx.output);
-      const observedRaw = await runner(DISTILLER_PROMPT, distillInput);
-      const observed = clampToTokenEstimate(observedRaw, policy.maxOutputTokens);
-      if (!observed.trim()) return;
-      const promptTokens = estimateDistillPromptTokens(recentMessages, ctx.output) + estimateTokens(observed);
-      if (commitScope !== "session") {
-        const usage = await commitFact(ds, key, observed, null);
-        const observedFactCount = observed.split(/\r?\n/).filter((line) => line.trim()).length;
-        return {
-          projectPromotedFacts: commitScope === "project" ? observedFactCount : 0,
-          userPromotedFacts: commitScope === "user" ? observedFactCount : 0,
-          sessionScopedFacts: 0,
-          droppedUntaggedFacts: 0,
-          distillTokens: promptTokens + usage,
-        };
+      const observations = await runner(DISTILLER_PROMPT, distillInput);
+
+      const filtered =
+        commitScope === "session" ? observations : observations.filter((obs) => obs.scope === commitScope);
+
+      const promptTokens = estimateDistillPromptTokens(recentMessages, ctx.output);
+      let totalTokens = promptTokens;
+      let projectCount = 0;
+      let userCount = 0;
+      let sessionCount = 0;
+
+      for (const obs of filtered) {
+        const factKey = resolveDistillScopeKey(obs.scope, obs.scope === "session" ? { sessionId: ctx.sessionId } : ctx);
+        if (!factKey) continue;
+        const clamped = clampToTokenEstimate(normalizeMemoryText(obs.content), policy.maxOutputTokens);
+        if (!clamped) continue;
+        totalTokens += await commitFact(ds, factKey, clamped, obs.topic);
+        if (obs.scope === "project") projectCount++;
+        else if (obs.scope === "user") userCount++;
+        else sessionCount++;
       }
 
-      const scoped = splitScopedObservation(observed);
-      if (scoped.droppedUntaggedCount > 0) {
-        log.debug("memory.distill.dropped_untagged", { key, count: scoped.droppedUntaggedCount });
-      }
-      if (scoped.droppedMalformedCount > 0) {
-        const streak = (malformedStreaks.get(key) ?? 0) + 1;
-        malformedStreaks.set(key, streak);
-        log.debug("memory.distill.dropped_malformed", { key, count: scoped.droppedMalformedCount });
-        if (streak >= policy.malformedStreakWarningThreshold) {
-          log.warn("lifecycle.memory.quality_warning", { key, malformed_reject_streak: streak });
-        }
-      } else {
-        malformedStreaks.delete(key);
-      }
-      let totalTokens = promptTokens;
-      for (const fact of scoped.facts) {
-        const factKey = resolveDistillScopeKey(fact.scope, fact.scope === "session" ? { sessionId: key } : ctx);
-        if (factKey) totalTokens += await commitFact(ds, factKey, fact.content, fact.topic);
-      }
       log.debug("memory.distill.commit_done", {
-        key,
-        session: scoped.sessionCount,
-        project: scoped.projectCount,
-        user: scoped.userCount,
-        dropped: scoped.droppedUntaggedCount,
+        session: sessionCount,
+        project: projectCount,
+        user: userCount,
       });
+
       return {
-        projectPromotedFacts: scoped.projectCount,
-        userPromotedFacts: scoped.userCount,
-        sessionScopedFacts: scoped.sessionCount,
-        droppedUntaggedFacts: scoped.droppedUntaggedCount,
+        projectPromotedFacts: projectCount,
+        userPromotedFacts: userCount,
+        sessionScopedFacts: sessionCount,
+        droppedUntaggedFacts: 0,
         distillTokens: totalTokens,
       };
     },

--- a/src/memory-distiller.ts
+++ b/src/memory-distiller.ts
@@ -1,7 +1,6 @@
 import type { LanguageModelV3ToolCall } from "@ai-sdk/provider";
 import { estimateTokens } from "./agent-input";
 import { appConfig } from "./app-config";
-import { nowIso } from "./datetime";
 import { clampToTokenEstimate, type DistillScope, normalizeMemoryText } from "./distill-ops";
 import { log } from "./log";
 import {
@@ -10,17 +9,15 @@ import {
   type MemoryCommitMetrics,
   type MemoryDistiller,
   type MemoryPolicy,
-  type MemoryRecord,
   type MemoryStore,
 } from "./memory-contract";
-import { embeddingToBuffer, embedText } from "./memory-embedding";
+import { addObservation } from "./memory-ops";
 import { getMemoryStore } from "./memory-store";
 import { MEMORY_OBSERVE_TOOL } from "./memory-toolkit";
 import { createModel } from "./model-factory";
 import { normalizeModel, providerFromModel } from "./provider-config";
 import { sharedRateLimiter } from "./rate-limiter";
 import { defaultUserResourceId, parseResourceId, projectResourceIdFromWorkspace, type ResourceId } from "./resource-id";
-import { createId } from "./short-id";
 
 export const DISTILLER_PROMPT = `Extract concrete facts from this conversation.
 
@@ -53,15 +50,6 @@ async function getCachedStore(): Promise<MemoryStore> {
     cachedStore = await getMemoryStore();
   }
   return cachedStore;
-}
-
-async function embedAndStore(ds: MemoryStore, id: string, scope: string, content: string): Promise<void> {
-  try {
-    const vec = await embedText(content);
-    if (vec) await ds.writeEmbedding(id, scope, embeddingToBuffer(vec));
-  } catch (error) {
-    log.warn("memory.distill.embed_failed", { id, error: String(error) });
-  }
 }
 
 export type DistillRunner = (systemPrompt: string, userContent: string) => Promise<DistillObservation[]>;
@@ -123,28 +111,8 @@ function resolveDistillScopeKey(
 }
 
 async function commitFact(ds: MemoryStore, key: string, content: string, topic: string | null): Promise<number> {
-  const existingEntries = await ds.list({ scopeKey: key });
-  const latestObservation = existingEntries.filter((e) => e.kind === "observation").slice(-1)[0];
-  if (latestObservation && normalizeMemoryText(latestObservation.content) === normalizeMemoryText(content)) return 0;
-
-  const observation: MemoryRecord = {
-    id: `mem_${createId()}`,
-    scopeKey: key,
-    kind: "observation",
-    content,
-    createdAt: nowIso(),
-    tokenEstimate: estimateTokens(content),
-    topic,
-  };
-  await ds.write(observation);
-  await embedAndStore(ds, observation.id, key, content);
-  log.debug("memory.distill.observation_written", {
-    key,
-    id: observation.id,
-    topic,
-    tokens: observation.tokenEstimate,
-  });
-  return observation.tokenEstimate;
+  const record = await addObservation(key, content, { topic, store: ds });
+  return record?.tokenEstimate ?? 0;
 }
 
 export type DistillerDeps = {

--- a/src/memory-distiller.ts
+++ b/src/memory-distiller.ts
@@ -196,6 +196,7 @@ export function createMemoryDistiller(deps: Partial<DistillerDeps> = {}): Memory
 
       const filtered =
         commitScope === "session" ? observations : observations.filter((obs) => obs.scope === commitScope);
+      if (filtered.length === 0) return;
 
       const promptTokens = estimateDistillPromptTokens(recentMessages, ctx.output);
       let totalTokens = promptTokens;
@@ -224,7 +225,6 @@ export function createMemoryDistiller(deps: Partial<DistillerDeps> = {}): Memory
         projectPromotedFacts: projectCount,
         userPromotedFacts: userCount,
         sessionScopedFacts: sessionCount,
-        droppedUntaggedFacts: 0,
         distillTokens: totalTokens,
       };
     },

--- a/src/memory-distiller.ts
+++ b/src/memory-distiller.ts
@@ -1,4 +1,5 @@
 import type { LanguageModelV3ToolCall } from "@ai-sdk/provider";
+import { z } from "zod";
 import { estimateTokens } from "./agent-input";
 import { appConfig } from "./app-config";
 import { clampToTokenEstimate, type DistillScope, normalizeMemoryText } from "./distill-ops";
@@ -10,14 +11,27 @@ import {
   type MemoryDistiller,
   type MemoryPolicy,
   type MemoryStore,
+  memoryScopeSchema,
 } from "./memory-contract";
 import { addObservation } from "./memory-ops";
 import { getMemoryStore } from "./memory-store";
-import { MEMORY_OBSERVE_TOOL } from "./memory-toolkit";
 import { createModel } from "./model-factory";
 import { normalizeModel, providerFromModel } from "./provider-config";
 import { sharedRateLimiter } from "./rate-limiter";
 import { defaultUserResourceId, parseResourceId, projectResourceIdFromWorkspace, type ResourceId } from "./resource-id";
+import { toFunctionTool } from "./tool-contract";
+
+const MEMORY_OBSERVE_TOOL = toFunctionTool({
+  id: "memory_observe",
+  description: "Record a fact extracted from the conversation into memory.",
+  inputSchema: z.toJSONSchema(
+    z.object({
+      scope: memoryScopeSchema,
+      content: z.string().min(1),
+      topic: z.string().optional(),
+    }),
+  ) as Record<string, unknown>,
+});
 
 export const DISTILLER_PROMPT = `Extract concrete facts from this conversation.
 

--- a/src/memory-distiller.ts
+++ b/src/memory-distiller.ts
@@ -1,4 +1,4 @@
-import type { LanguageModelV3FunctionTool, LanguageModelV3ToolCall } from "@ai-sdk/provider";
+import type { LanguageModelV3ToolCall } from "@ai-sdk/provider";
 import { estimateTokens } from "./agent-input";
 import { appConfig } from "./app-config";
 import { nowIso } from "./datetime";
@@ -15,6 +15,7 @@ import {
 } from "./memory-contract";
 import { embeddingToBuffer, embedText } from "./memory-embedding";
 import { getMemoryStore } from "./memory-store";
+import { MEMORY_OBSERVE_TOOL } from "./memory-toolkit";
 import { createModel } from "./model-factory";
 import { normalizeModel, providerFromModel } from "./provider-config";
 import { sharedRateLimiter } from "./rate-limiter";
@@ -31,32 +32,6 @@ For each fact, call memory_observe with:
 - topic: optional single-word topic label (e.g. testing, auth, config, tooling)
 
 If a preference is project-scoped, use "project" not "user". If unsure, default to "session".`;
-
-const MEMORY_OBSERVE_TOOL: LanguageModelV3FunctionTool = {
-  type: "function",
-  name: "memory_observe",
-  description: "Record a fact extracted from the conversation into memory.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      scope: {
-        type: "string",
-        enum: ["session", "project", "user"],
-        description:
-          "Memory scope: session (in-progress), project (durable project facts), user (cross-project preferences)",
-      },
-      content: {
-        type: "string",
-        description: "The fact to store. Be specific and concrete.",
-      },
-      topic: {
-        type: "string",
-        description: "Optional single-word topic label (e.g. testing, auth, config).",
-      },
-    },
-    required: ["scope", "content"],
-  },
-};
 
 export type DistillObservation = { scope: DistillScope; content: string; topic: string | null };
 

--- a/src/memory-ops.ts
+++ b/src/memory-ops.ts
@@ -1,7 +1,9 @@
 import { estimateTokens } from "./agent-input";
+import { normalizeMemoryText } from "./distill-ops";
 import { log } from "./log";
 import {
   type MemoryEntry,
+  type MemoryRecord,
   type MemoryScope,
   type MemoryStore,
   type RemoveMemoryResult,
@@ -90,6 +92,51 @@ export async function addMemory(
   }
 
   return toMemoryEntry(record);
+}
+
+export interface AddObservationOptions {
+  topic?: string | null;
+  store?: MemoryStore;
+}
+
+export async function addObservation(
+  scopeKey: string,
+  content: string,
+  options: AddObservationOptions = {},
+): Promise<MemoryRecord | null> {
+  const trimmed = content.trim();
+  if (!trimmed) return null;
+
+  const store = options.store ?? (await getMemoryStore());
+  const existing = await store.list({ scopeKey });
+  const latest = existing.filter((e) => e.kind === "observation").slice(-1)[0];
+  if (latest && normalizeMemoryText(latest.content) === normalizeMemoryText(trimmed)) return null;
+
+  const record: MemoryRecord = {
+    id: `mem_${createId()}`,
+    scopeKey,
+    kind: "observation",
+    content: trimmed,
+    createdAt: new Date().toISOString(),
+    tokenEstimate: estimateTokens(trimmed),
+    topic: options.topic ?? null,
+  };
+  await store.write(record);
+  log.debug("memory.observation.written", { id: record.id, scopeKey, topic: record.topic });
+
+  try {
+    const vec = await embedText(trimmed);
+    if (vec) await store.writeEmbedding(record.id, scopeKey, embeddingToBuffer(vec));
+  } catch (error) {
+    log.warn("memory.observation.embed_failed", { id: record.id, error: String(error) });
+  }
+  return record;
+}
+
+export function resolveScopeKey(scope: MemoryScope, ctx: { sessionId?: string; workspace?: string }): string | null {
+  if (scope === "session") return ctx.sessionId ?? null;
+  if (scope === "project") return projectResourceIdFromWorkspace(ctx.workspace ?? process.cwd());
+  return defaultUserResourceId();
 }
 
 export async function removeMemory(id: string, options: MemoryOptions = {}): Promise<RemoveMemoryResult> {

--- a/src/memory-toolkit.int.test.ts
+++ b/src/memory-toolkit.int.test.ts
@@ -8,23 +8,28 @@ import { tempDb } from "./test-utils";
 const { create: createStore, cleanup: cleanupStores } = tempDb("acolyte-toolkit-", createSqliteMemoryStore);
 afterEach(cleanupStores);
 
-function makeRecord(id: string, scopeKey: string, content: string): MemoryRecord {
-  return { id, scopeKey, kind: "stored", content, createdAt: "2026-01-01T00:00:00.000Z", tokenEstimate: 4 };
+function createRecord(
+  id: string,
+  scopeKey: string,
+  content: string,
+  kind: MemoryRecord["kind"] = "stored",
+): MemoryRecord {
+  return { id, scopeKey, kind, content, createdAt: "2026-01-01T00:00:00.000Z", tokenEstimate: 4 };
 }
 
 describe("searchMemories", () => {
   test("returns entries up to the limit", async () => {
     const store = createStore();
-    await store.write(makeRecord("mem_a", "user_test", "alpha fact"));
-    await store.write(makeRecord("mem_b", "user_test", "beta fact"));
-    await store.write(makeRecord("mem_c", "user_test", "gamma fact"));
+    await store.write(createRecord("mem_a", "user_test", "alpha fact"));
+    await store.write(createRecord("mem_b", "user_test", "beta fact"));
+    await store.write(createRecord("mem_c", "user_test", "gamma fact"));
     const result = await searchMemories("anything", { limit: 2, store });
     expect(result).toHaveLength(2);
   });
 
   test("returns all entries when limit exceeds count", async () => {
     const store = createStore();
-    await store.write(makeRecord("mem_a", "user_test", "only fact"));
+    await store.write(createRecord("mem_a", "user_test", "only fact"));
     const result = await searchMemories("only", { limit: 10, store });
     expect(result).toHaveLength(1);
   });
@@ -37,8 +42,8 @@ describe("searchMemories", () => {
 
   test("filters by scope", async () => {
     const store = createStore();
-    await store.write(makeRecord("mem_u", "user_test", "user preference"));
-    await store.write(makeRecord("mem_p", "proj_test", "project convention"));
+    await store.write(createRecord("mem_u", "user_test", "user preference"));
+    await store.write(createRecord("mem_p", "proj_test", "project convention"));
     const userOnly = await searchMemories("anything", { scope: "user", store });
     expect(userOnly).toHaveLength(1);
     expect(userOnly[0]?.content).toBe("user preference");
@@ -49,9 +54,9 @@ describe("searchMemories", () => {
 
   test("scope filter applies before limit", async () => {
     const store = createStore();
-    await store.write(makeRecord("mem_u1", "user_test", "user a"));
-    await store.write(makeRecord("mem_u2", "user_test", "user b"));
-    await store.write(makeRecord("mem_p1", "proj_test", "project a"));
+    await store.write(createRecord("mem_u1", "user_test", "user a"));
+    await store.write(createRecord("mem_u2", "user_test", "user b"));
+    await store.write(createRecord("mem_p1", "proj_test", "project a"));
     const result = await searchMemories("anything", { scope: "user", limit: 5, store });
     expect(result).toHaveLength(2);
     for (const r of result) {
@@ -59,10 +64,30 @@ describe("searchMemories", () => {
     }
   });
 
+  test("includes project and user observations in results", async () => {
+    const store = createStore();
+    await store.write(createRecord("mem_s", "user_test", "explicit stored memory"));
+    await store.write(createRecord("mem_o", "proj_test", "distilled observation", "observation"));
+    const result = await searchMemories("anything", { store });
+    const ids = result.map((r) => r.id);
+    expect(ids).toContain("mem_s");
+    expect(ids).toContain("mem_o");
+  });
+
+  test("excludes session-scoped observations", async () => {
+    const store = createStore();
+    await store.write(createRecord("mem_p", "proj_test", "project fact", "observation"));
+    await store.write(createRecord("mem_sess", "sess_dead1234", "temporary session state", "observation"));
+    const result = await searchMemories("anything", { store });
+    const ids = result.map((r) => r.id);
+    expect(ids).toContain("mem_p");
+    expect(ids).not.toContain("mem_sess");
+  });
+
   test("stores and retrieves pre-computed embeddings", async () => {
     const store = createStore();
-    await store.write(makeRecord("mem_a", "user_test", "tool execution uses runTool"));
-    await store.write(makeRecord("mem_b", "user_test", "unrelated weather fact"));
+    await store.write(createRecord("mem_a", "user_test", "tool execution uses runTool"));
+    await store.write(createRecord("mem_b", "user_test", "unrelated weather fact"));
     const closeVec = new Float32Array([0.9, 0.1, 0]);
     const farVec = new Float32Array([0, 0, 1]);
     await store.writeEmbedding("mem_a", "user_test", embeddingToBuffer(closeVec));

--- a/src/memory-toolkit.ts
+++ b/src/memory-toolkit.ts
@@ -19,16 +19,8 @@ import {
 import { addMemory, addObservation, removeMemory, resolveScopeKey } from "./memory-ops";
 import { getMemoryStore } from "./memory-store";
 import type { ToolkitInput } from "./tool-contract";
-import { createTool, toFunctionTool } from "./tool-contract";
+import { createTool } from "./tool-contract";
 import { runTool } from "./tool-execution";
-
-const memoryObserveInputSchema = z.object({
-  scope: memoryScopeSchema.describe(
-    "Memory scope: session (in-progress), project (durable project facts), user (cross-project preferences)",
-  ),
-  content: z.string().min(1).describe("The fact to store. Be specific and concrete."),
-  topic: z.string().optional().describe("Optional single-word topic label (e.g. testing, auth, config)."),
-});
 
 function createMemoryObserveTool(input: ToolkitInput) {
   return createTool({
@@ -37,7 +29,11 @@ function createMemoryObserveTool(input: ToolkitInput) {
     category: "meta",
     description: "Record a fact extracted from the conversation into memory.",
     instruction: "Use `memory_observe` to persist facts extracted from the conversation into the memory store.",
-    inputSchema: memoryObserveInputSchema,
+    inputSchema: z.object({
+      scope: memoryScopeSchema,
+      content: z.string().min(1),
+      topic: z.string().optional(),
+    }),
     outputSchema: z.object({ kind: z.literal("memory-observe"), id: z.string().nullable() }),
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "memory_observe", toolCallId, toolInput, async () => {
@@ -52,12 +48,6 @@ function createMemoryObserveTool(input: ToolkitInput) {
     },
   });
 }
-
-export const MEMORY_OBSERVE_TOOL = toFunctionTool({
-  id: "memory_observe",
-  description: "Record a fact extracted from the conversation into memory.",
-  inputSchema: z.toJSONSchema(memoryObserveInputSchema) as Record<string, unknown>,
-});
 
 async function embedTopics(records: readonly MemoryRecord[]): Promise<Map<string, Float32Array>> {
   const topics = new Set<string>();

--- a/src/memory-toolkit.ts
+++ b/src/memory-toolkit.ts
@@ -42,8 +42,9 @@ export async function searchMemories(
   const store = options?.store ?? (await getMemoryStore());
   const limit = options?.limit ?? 10;
   const policy = options?.policy ?? createMemoryPolicy();
-  const all = await store.list({ kind: "stored" });
-  const filtered = options?.scope ? all.filter((r) => scopeFromKey(r.scopeKey) === options.scope) : all;
+  const all = await store.list();
+  const durable = all.filter((r) => r.kind === "stored" || !r.scopeKey.startsWith("sess_"));
+  const filtered = options?.scope ? durable.filter((r) => scopeFromKey(r.scopeKey) === options.scope) : durable;
   if (filtered.length === 0) return [];
 
   const queryEmbedding = await embedText(query);
@@ -55,8 +56,9 @@ export async function searchMemories(
 
   if (store.searchByEmbedding) {
     const oversample = (options?.scope ? limit * 2 : limit) * 2;
-    const raw = await store.searchByEmbedding(queryEmbedding, { kind: "stored", limit: oversample });
-    const scoped = options?.scope ? raw.filter((r) => scopeFromKey(r.scopeKey) === options.scope) : raw;
+    const raw = await store.searchByEmbedding(queryEmbedding, { limit: oversample });
+    const durableRaw = raw.filter((r) => r.kind === "stored" || !r.scopeKey.startsWith("sess_"));
+    const scoped = options?.scope ? durableRaw.filter((r) => scopeFromKey(r.scopeKey) === options.scope) : durableRaw;
     const pgTopicEmbeddings = await embedTopics(scoped);
     const pgMatchedTopics = matchTopicsByEmbedding(queryEmbedding, pgTopicEmbeddings, policy.topicThreshold);
     const pgTopicFiltered = filterByTopicEmbedding(scoped, pgMatchedTopics, policy.minTopicFilterSize);

--- a/src/memory-toolkit.ts
+++ b/src/memory-toolkit.ts
@@ -16,32 +16,48 @@ import {
   matchTopicsByEmbedding,
   tokenOverlap,
 } from "./memory-embedding";
-import { addMemory, removeMemory } from "./memory-ops";
+import { addMemory, addObservation, removeMemory, resolveScopeKey } from "./memory-ops";
 import { getMemoryStore } from "./memory-store";
 import type { ToolkitInput } from "./tool-contract";
 import { createTool, toFunctionTool } from "./tool-contract";
 import { runTool } from "./tool-execution";
 
-const memoryObserveDef = createTool({
-  id: "memory_observe",
-  toolkit: "memory",
-  category: "meta",
-  description: "Record a fact extracted from the conversation into memory.",
-  instruction: "Use `memory_observe` to persist facts extracted from the conversation into the memory store.",
-  inputSchema: z.object({
-    scope: z
-      .enum(["session", "project", "user"])
-      .describe(
-        "Memory scope: session (in-progress), project (durable project facts), user (cross-project preferences)",
-      ),
-    content: z.string().min(1).describe("The fact to store. Be specific and concrete."),
-    topic: z.string().optional().describe("Optional single-word topic label (e.g. testing, auth, config)."),
-  }),
-  outputSchema: z.object({ kind: z.literal("memory-observe") }),
-  execute: async () => ({ result: { kind: "memory-observe" as const } }),
+const memoryObserveInputSchema = z.object({
+  scope: memoryScopeSchema.describe(
+    "Memory scope: session (in-progress), project (durable project facts), user (cross-project preferences)",
+  ),
+  content: z.string().min(1).describe("The fact to store. Be specific and concrete."),
+  topic: z.string().optional().describe("Optional single-word topic label (e.g. testing, auth, config)."),
 });
 
-export const MEMORY_OBSERVE_TOOL = toFunctionTool(memoryObserveDef);
+function createMemoryObserveTool(input: ToolkitInput) {
+  return createTool({
+    id: "memory_observe",
+    toolkit: "memory",
+    category: "meta",
+    description: "Record a fact extracted from the conversation into memory.",
+    instruction: "Use `memory_observe` to persist facts extracted from the conversation into the memory store.",
+    inputSchema: memoryObserveInputSchema,
+    outputSchema: z.object({ kind: z.literal("memory-observe"), id: z.string().nullable() }),
+    execute: async (toolInput, toolCallId) => {
+      return runTool(input.session, "memory_observe", toolCallId, toolInput, async () => {
+        const scopeKey = resolveScopeKey(toolInput.scope, {
+          sessionId: input.sessionId,
+          workspace: input.workspace,
+        });
+        if (!scopeKey) return { kind: "memory-observe" as const, id: null };
+        const record = await addObservation(scopeKey, toolInput.content, { topic: toolInput.topic ?? null });
+        return { kind: "memory-observe" as const, id: record?.id ?? null };
+      });
+    },
+  });
+}
+
+export const MEMORY_OBSERVE_TOOL = toFunctionTool({
+  id: "memory_observe",
+  description: "Record a fact extracted from the conversation into memory.",
+  inputSchema: z.toJSONSchema(memoryObserveInputSchema) as Record<string, unknown>,
+});
 
 async function embedTopics(records: readonly MemoryRecord[]): Promise<Map<string, Float32Array>> {
   const topics = new Set<string>();
@@ -223,5 +239,6 @@ export function createMemoryToolkit(input: ToolkitInput) {
     memorySearch: createMemorySearchTool(input),
     memoryAdd: createMemoryAddTool(input),
     memoryRemove: createMemoryRemoveTool(input),
+    memoryObserve: createMemoryObserveTool(input),
   };
 }

--- a/src/memory-toolkit.ts
+++ b/src/memory-toolkit.ts
@@ -1,4 +1,3 @@
-import type { LanguageModelV3FunctionTool } from "@ai-sdk/provider";
 import { z } from "zod";
 import {
   createMemoryPolicy,
@@ -20,7 +19,7 @@ import {
 import { addMemory, removeMemory } from "./memory-ops";
 import { getMemoryStore } from "./memory-store";
 import type { ToolkitInput } from "./tool-contract";
-import { createTool } from "./tool-contract";
+import { createTool, toFunctionTool } from "./tool-contract";
 import { runTool } from "./tool-execution";
 
 const memoryObserveDef = createTool({
@@ -42,12 +41,7 @@ const memoryObserveDef = createTool({
   execute: async () => ({ result: { kind: "memory-observe" as const } }),
 });
 
-export const MEMORY_OBSERVE_TOOL: LanguageModelV3FunctionTool = {
-  type: "function",
-  name: memoryObserveDef.id,
-  description: memoryObserveDef.description,
-  inputSchema: memoryObserveDef.inputSchema as LanguageModelV3FunctionTool["inputSchema"],
-};
+export const MEMORY_OBSERVE_TOOL = toFunctionTool(memoryObserveDef);
 
 async function embedTopics(records: readonly MemoryRecord[]): Promise<Map<string, Float32Array>> {
   const topics = new Set<string>();

--- a/src/memory-toolkit.ts
+++ b/src/memory-toolkit.ts
@@ -1,3 +1,4 @@
+import type { LanguageModelV3FunctionTool } from "@ai-sdk/provider";
 import { z } from "zod";
 import {
   createMemoryPolicy,
@@ -21,6 +22,32 @@ import { getMemoryStore } from "./memory-store";
 import type { ToolkitInput } from "./tool-contract";
 import { createTool } from "./tool-contract";
 import { runTool } from "./tool-execution";
+
+const memoryObserveDef = createTool({
+  id: "memory_observe",
+  toolkit: "memory",
+  category: "meta",
+  description: "Record a fact extracted from the conversation into memory.",
+  instruction: "Use `memory_observe` to persist facts extracted from the conversation into the memory store.",
+  inputSchema: z.object({
+    scope: z
+      .enum(["session", "project", "user"])
+      .describe(
+        "Memory scope: session (in-progress), project (durable project facts), user (cross-project preferences)",
+      ),
+    content: z.string().min(1).describe("The fact to store. Be specific and concrete."),
+    topic: z.string().optional().describe("Optional single-word topic label (e.g. testing, auth, config)."),
+  }),
+  outputSchema: z.object({ kind: z.literal("memory-observe") }),
+  execute: async () => ({ result: { kind: "memory-observe" as const } }),
+});
+
+export const MEMORY_OBSERVE_TOOL: LanguageModelV3FunctionTool = {
+  type: "function",
+  name: memoryObserveDef.id,
+  description: memoryObserveDef.description,
+  inputSchema: memoryObserveDef.inputSchema as LanguageModelV3FunctionTool["inputSchema"],
+};
 
 async function embedTopics(records: readonly MemoryRecord[]): Promise<Map<string, Float32Array>> {
   const topics = new Set<string>();

--- a/src/tool-contract.ts
+++ b/src/tool-contract.ts
@@ -1,3 +1,4 @@
+import type { LanguageModelV3FunctionTool } from "@ai-sdk/provider";
 import { z } from "zod";
 import type { ChecklistItem } from "./checklist-contract";
 import { log } from "./log";
@@ -55,6 +56,21 @@ function toJsonSchema(schema: z.ZodType | Record<string, unknown>): Record<strin
   if (!isZodSchema(schema)) return schema;
   const { $schema: _, ...rest } = z.toJSONSchema(schema);
   return rest;
+}
+
+type AnyToolDefinition = Pick<ToolDefinition, "id" | "description" | "inputSchema">;
+
+export function toFunctionTool(tool: AnyToolDefinition): LanguageModelV3FunctionTool {
+  return {
+    type: "function",
+    name: tool.id,
+    description: tool.description,
+    inputSchema: tool.inputSchema as LanguageModelV3FunctionTool["inputSchema"],
+  };
+}
+
+export function toFunctionTools(tools: Record<string, AnyToolDefinition>): LanguageModelV3FunctionTool[] {
+  return Object.values(tools).map(toFunctionTool);
 }
 
 export function createTool<TInput, TOutput>(

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -24,6 +24,7 @@ describe("toolsets", () => {
       "listSkills",
       "listUndo",
       "memoryAdd",
+      "memoryObserve",
       "memoryRemove",
       "memorySearch",
       "readFile",


### PR DESCRIPTION
## Motivation

The distiller emitted `@observe scope` as free text parsed by a regex layer. A tool call is unambiguous, gives scope a proper type, and removes the fragile parse step. A second gap is also fixed: distilled observations were stored but excluded from `memory-search`, making the distiller write-only.

## Summary

- replace `@observe` / `@topic` directives with a `memory_observe(scope, content, topic?)` tool call
- fix `memory-search` to include project- and user-scoped observations; session observations remain excluded
- remove the text parsing layer (`splitScopedObservation` and friends) and `malformedStreakWarningThreshold`

Fixes #241