### PR TITLE
refactor(tools): deepen runTool pipeline

### DIFF
--- a/src/tool-execution.test.ts
+++ b/src/tool-execution.test.ts
@@ -48,7 +48,7 @@ describe("per-tool timeout", () => {
     expect(result).toEqual({ result: "done" });
   });
 
-  test("returns effectOutput from lifecycle hooks", async () => {
+  test("returns effectOutput from lifecycle side effects", async () => {
     const session = createSessionContext();
     session.toolTimeoutMs = 500;
     session.onAfterTool = () => ({ append: "Lint errors:\nsrc/foo.ts:1 missing semicolon" });
@@ -57,7 +57,7 @@ describe("per-tool timeout", () => {
     expect(result.effectOutput).toBe("Lint errors:\nsrc/foo.ts:1 missing semicolon");
   });
 
-  test("omits effectOutput when lifecycle hooks return no feedback", async () => {
+  test("omits effectOutput when lifecycle side effects return no feedback", async () => {
     const session = createSessionContext();
     session.toolTimeoutMs = 500;
     session.onAfterTool = () => undefined;
@@ -144,7 +144,7 @@ describe("per-tool timeout", () => {
     expect(session.callLog[0]).toMatchObject({ toolName: "file-read", status: "succeeded" });
   });
 
-  test("reports failed executions to async hooks before recording the failed call", async () => {
+  test("reports failed executions to async side effects before recording the failed call", async () => {
     const session = createSessionContext();
     session.toolTimeoutMs = 500;
     const events: string[] = [];

--- a/src/tool-execution.test.ts
+++ b/src/tool-execution.test.ts
@@ -48,7 +48,7 @@ describe("per-tool timeout", () => {
     expect(result).toEqual({ result: "done" });
   });
 
-  test("returns effectOutput from lifecycle side effects", async () => {
+  test("returns effectOutput from lifecycle effects", async () => {
     const session = createSessionContext();
     session.toolTimeoutMs = 500;
     session.onAfterTool = () => ({ append: "Lint errors:\nsrc/foo.ts:1 missing semicolon" });
@@ -57,7 +57,7 @@ describe("per-tool timeout", () => {
     expect(result.effectOutput).toBe("Lint errors:\nsrc/foo.ts:1 missing semicolon");
   });
 
-  test("omits effectOutput when lifecycle side effects return no feedback", async () => {
+  test("omits effectOutput when lifecycle effects return no feedback", async () => {
     const session = createSessionContext();
     session.toolTimeoutMs = 500;
     session.onAfterTool = () => undefined;
@@ -144,7 +144,7 @@ describe("per-tool timeout", () => {
     expect(session.callLog[0]).toMatchObject({ toolName: "file-read", status: "succeeded" });
   });
 
-  test("reports failed executions to async side effects before recording the failed call", async () => {
+  test("reports failed executions to async effects before recording the failed call", async () => {
     const session = createSessionContext();
     session.toolTimeoutMs = 500;
     const events: string[] = [];

--- a/src/tool-execution.test.ts
+++ b/src/tool-execution.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { invariant } from "./assert";
 import { LIFECYCLE_ERROR_CODES } from "./error-contract";
+import { createToolCache } from "./tool-cache";
 import { runTool, withToolError } from "./tool-execution";
 import { createSessionContext } from "./tool-session";
 
@@ -84,5 +85,80 @@ describe("per-tool timeout", () => {
     session.toolTimeoutMs = 500;
     await runTool(session, "test-run", "call_1", {}, async () => ({ kind: "test-run", exitCode: 1 }));
     expect(session.callLog[0]).toMatchObject({ toolName: "test-run", status: "succeeded", exitCode: 1 });
+  });
+
+  test("runs success pipeline stages in order", async () => {
+    const session = createSessionContext();
+    session.toolTimeoutMs = 500;
+    const events: string[] = [];
+    session.onBeforeTool = () => {
+      events.push("before-sync");
+      return { append: "before output" };
+    };
+    session.onBeforeToolAsync = async () => {
+      events.push("before-async");
+    };
+    session.onAfterTool = () => {
+      events.push("after-sync");
+      return { append: "after output" };
+    };
+    session.onAfterToolAsync = async () => {
+      events.push(`after-async:call-log-${session.callLog.length}`);
+    };
+
+    const result = await runTool(session, "file-edit", "call_1", { path: "src/app.ts" }, async () => {
+      events.push("execute");
+      return { ok: true };
+    });
+
+    expect(result).toEqual({ result: { ok: true }, effectOutput: "before output\nafter output" });
+    expect(events).toEqual(["before-sync", "before-async", "execute", "after-sync", "after-async:call-log-0"]);
+    expect(session.callLog).toHaveLength(1);
+  });
+
+  test("uses cached result without executing and records the call", async () => {
+    const session = createSessionContext();
+    session.toolTimeoutMs = 500;
+    session.cache = createToolCache(new Set(["file-read"]));
+    session.cache.set("file-read", { path: "src/app.ts" }, { result: { output: "cached" } });
+    const events: string[] = [];
+    session.onBeforeTool = () => {
+      events.push("before-sync");
+      return { append: "before output" };
+    };
+    session.onAfterTool = () => {
+      events.push("after-sync");
+      return { append: "after output" };
+    };
+    session.onAfterToolAsync = async () => {
+      events.push("after-async");
+    };
+
+    const result = await runTool(session, "file-read", "call_1", { path: "src/app.ts" }, async () => {
+      events.push("execute");
+      return { output: "fresh" };
+    });
+
+    expect(result).toEqual({ result: { output: "cached" } });
+    expect(events).toEqual(["before-sync", "after-async"]);
+    expect(session.callLog[0]).toMatchObject({ toolName: "file-read", status: "succeeded" });
+  });
+
+  test("reports failed executions to async hooks before recording the failed call", async () => {
+    const session = createSessionContext();
+    session.toolTimeoutMs = 500;
+    const events: string[] = [];
+    session.onAfterToolAsync = async (ctx) => {
+      events.push(`${ctx.status}:call-log-${session.callLog.length}`);
+    };
+
+    await expect(
+      runTool(session, "file-read", "call_1", {}, async () => {
+        throw Object.assign(new Error("missing"), { code: "E_MISSING" });
+      }),
+    ).rejects.toThrow("file-read failed: missing");
+
+    expect(events).toEqual(["failed:call-log-0"]);
+    expect(session.callLog[0]).toMatchObject({ toolName: "file-read", status: "failed" });
   });
 });

--- a/src/tool-execution.ts
+++ b/src/tool-execution.ts
@@ -70,14 +70,14 @@ type ToolExecutionResult<T> = {
   taskError?: unknown;
 };
 
-function debugSideEffectFailure(
+function debugEffectFailure(
   session: SessionContext,
   phase: "before" | "after",
   toolId: string,
   toolCallId: string,
   error: unknown,
 ) {
-  session.onDebug?.("lifecycle.tool.side_effect_failed", {
+  session.onDebug?.("lifecycle.tool.effect_failed", {
     phase,
     tool: toolId,
     tool_call_id: toolCallId,
@@ -95,7 +95,7 @@ function assertStepBudget(input: Pick<ToolRunInput<unknown>, "session" | "toolId
   throw error;
 }
 
-async function runBeforeToolSideEffects(
+async function runBeforeToolEffects(
   input: Pick<ToolRunInput<unknown>, "session" | "toolId" | "toolCallId" | "args">,
 ): Promise<BeforeToolResult> {
   const ctx: PreToolContext = { toolId: input.toolId, toolCallId: input.toolCallId, args: input.args };
@@ -104,18 +104,18 @@ async function runBeforeToolSideEffects(
     try {
       await input.session.onBeforeToolAsync(ctx);
     } catch (error) {
-      debugSideEffectFailure(input.session, "before", input.toolId, input.toolCallId, error);
+      debugEffectFailure(input.session, "before", input.toolId, input.toolCallId, error);
     }
   }
   return { preOutput };
 }
 
-async function runAfterToolSideEffects(session: SessionContext, ctx: PostToolContext): Promise<void> {
+async function runAfterToolEffects(session: SessionContext, ctx: PostToolContext): Promise<void> {
   if (!session.onAfterToolAsync) return;
   try {
     await session.onAfterToolAsync(ctx);
   } catch (error) {
-    debugSideEffectFailure(session, "after", ctx.toolId, ctx.toolCallId, error);
+    debugEffectFailure(session, "after", ctx.toolId, ctx.toolCallId, error);
   }
 }
 
@@ -157,7 +157,7 @@ async function returnCachedResult<T>(
   input: Pick<ToolRunInput<T>, "session" | "toolId" | "toolCallId" | "args">,
   result: T,
 ): Promise<RunToolResult<T>> {
-  await runAfterToolSideEffects(input.session, {
+  await runAfterToolEffects(input.session, {
     toolId: input.toolId,
     toolCallId: input.toolCallId,
     args: input.args,
@@ -183,7 +183,7 @@ async function finalizeExecutedTool<T>(
 ): Promise<void> {
   if (execution.taskFailed) {
     const parsed = parseError(execution.taskError);
-    await runAfterToolSideEffects(input.session, {
+    await runAfterToolEffects(input.session, {
       toolId: input.toolId,
       toolCallId: input.toolCallId,
       args: input.args,
@@ -194,7 +194,7 @@ async function finalizeExecutedTool<T>(
     return;
   }
 
-  await runAfterToolSideEffects(input.session, {
+  await runAfterToolEffects(input.session, {
     toolId: input.toolId,
     toolCallId: input.toolCallId,
     args: input.args,
@@ -238,7 +238,7 @@ export async function runTool<T = unknown>(
   return withToolError(toolId, async () => {
     const input: ToolRunInput<T> = { session, toolId, toolCallId, args, execute, options };
     assertStepBudget(input);
-    const { preOutput } = await runBeforeToolSideEffects(input);
+    const { preOutput } = await runBeforeToolEffects(input);
     const cache = session.cache;
     const timeoutMs = resolveTimeoutMs(session, options);
     const cached = readCachedResult<T>(cache, input);

--- a/src/tool-execution.ts
+++ b/src/tool-execution.ts
@@ -2,7 +2,15 @@ import { invariant } from "./assert";
 import { ERROR_KINDS, errorMessage, LIFECYCLE_ERROR_CODES } from "./error-contract";
 import { parseError } from "./error-handling";
 import { field } from "./field";
-import type { RunToolResult, SessionContext } from "./tool-contract";
+import type {
+  EffectOutput,
+  PostToolContext,
+  PreToolContext,
+  RunToolResult,
+  SessionContext,
+  ToolCache,
+  ToolCacheEntry,
+} from "./tool-contract";
 import { ToolError } from "./tool-error";
 import { checkStepBudget, recordCall } from "./tool-session";
 
@@ -43,6 +51,165 @@ function extractExitCode(value: unknown): number | undefined {
   return typeof exitCode === "number" && Number.isInteger(exitCode) ? exitCode : undefined;
 }
 
+type ToolRunInput<T> = {
+  session: SessionContext;
+  toolId: string;
+  toolCallId: string;
+  args: Record<string, unknown>;
+  execute: (toolCallId: string) => Promise<T>;
+  options?: { timeoutMs?: number; skipStepBudget?: boolean };
+};
+
+type BeforeToolResult = {
+  preOutput?: EffectOutput;
+};
+
+type ToolExecutionResult<T> = {
+  result: T;
+  taskFailed: boolean;
+  taskError?: unknown;
+};
+
+function debugHookFailure(
+  session: SessionContext,
+  hook: "before" | "after",
+  toolId: string,
+  toolCallId: string,
+  error: unknown,
+) {
+  session.onDebug?.("lifecycle.tool.hook_failed", {
+    hook,
+    tool: toolId,
+    tool_call_id: toolCallId,
+    message: errorMessage(error),
+  });
+}
+
+function assertStepBudget(input: Pick<ToolRunInput<unknown>, "session" | "toolId" | "options">): void {
+  if (input.options?.skipStepBudget) return;
+  const budgetError = checkStepBudget(input.session, input.toolId);
+  if (!budgetError) return;
+  const error = new Error(budgetError) as Error & { code: string; kind: string };
+  error.code = LIFECYCLE_ERROR_CODES.budgetExhausted;
+  error.kind = ERROR_KINDS.budgetExhausted;
+  throw error;
+}
+
+async function runBeforeToolHooks(
+  input: Pick<ToolRunInput<unknown>, "session" | "toolId" | "toolCallId" | "args">,
+): Promise<BeforeToolResult> {
+  const ctx: PreToolContext = { toolId: input.toolId, toolCallId: input.toolCallId, args: input.args };
+  const preOutput = input.session.onBeforeTool?.(ctx);
+  if (input.session.onBeforeToolAsync) {
+    try {
+      await input.session.onBeforeToolAsync(ctx);
+    } catch (error) {
+      debugHookFailure(input.session, "before", input.toolId, input.toolCallId, error);
+    }
+  }
+  return { preOutput };
+}
+
+async function runAfterToolAsync(session: SessionContext, ctx: PostToolContext): Promise<void> {
+  if (!session.onAfterToolAsync) return;
+  try {
+    await session.onAfterToolAsync(ctx);
+  } catch (error) {
+    debugHookFailure(session, "after", ctx.toolId, ctx.toolCallId, error);
+  }
+}
+
+function resolveTimeoutMs(session: SessionContext, options?: ToolRunInput<unknown>["options"]): number {
+  const timeoutMs = options?.timeoutMs ?? session.toolTimeoutMs;
+  invariant(
+    typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0,
+    "timeoutMs must be a positive number",
+  );
+  return timeoutMs;
+}
+
+function readCachedResult<T>(
+  cache: ToolCache | undefined,
+  input: Pick<ToolRunInput<T>, "session" | "toolId" | "toolCallId" | "args">,
+): ToolCacheEntry | undefined {
+  if (!cache?.isCacheable(input.toolId)) return undefined;
+  const cached = cache.get(input.toolId, input.args);
+  if (!cached) {
+    input.session.onDebug?.("lifecycle.tool.cache", { tool: input.toolId, hit: false, ...cache.stats() });
+    return undefined;
+  }
+
+  input.session.onDebug?.("lifecycle.tool.cache", { tool: input.toolId, hit: true, ...cache.stats() });
+  return cached;
+}
+
+function recordToolSuccess<T>(session: SessionContext, toolId: string, args: Record<string, unknown>, result: T): void {
+  recordCall(session, toolId, args, hashResultValue(result), "succeeded", {
+    exitCode: extractExitCode(result),
+  });
+}
+
+function recordToolFailure(session: SessionContext, toolId: string, args: Record<string, unknown>): void {
+  recordCall(session, toolId, args, undefined, "failed");
+}
+
+async function returnCachedResult<T>(
+  input: Pick<ToolRunInput<T>, "session" | "toolId" | "toolCallId" | "args">,
+  result: T,
+): Promise<RunToolResult<T>> {
+  await runAfterToolAsync(input.session, {
+    toolId: input.toolId,
+    toolCallId: input.toolCallId,
+    args: input.args,
+    status: "succeeded",
+    result,
+  });
+  recordToolSuccess(input.session, input.toolId, input.args, result);
+  return { result };
+}
+
+async function executeToolTask<T>(input: ToolRunInput<T>, timeoutMs: number): Promise<ToolExecutionResult<T>> {
+  try {
+    const result = await withTimeout(() => input.execute(input.toolCallId), timeoutMs, input.toolId);
+    return { result, taskFailed: false };
+  } catch (error) {
+    return { result: undefined as T, taskFailed: true, taskError: error };
+  }
+}
+
+async function finalizeExecutedTool<T>(
+  input: Pick<ToolRunInput<T>, "session" | "toolId" | "toolCallId" | "args">,
+  execution: ToolExecutionResult<T>,
+): Promise<void> {
+  if (execution.taskFailed) {
+    const parsed = parseError(execution.taskError);
+    await runAfterToolAsync(input.session, {
+      toolId: input.toolId,
+      toolCallId: input.toolCallId,
+      args: input.args,
+      status: "failed",
+      error: parsed.ok ? parsed.value : { message: `${input.toolId} failed` },
+    });
+    recordToolFailure(input.session, input.toolId, input.args);
+    return;
+  }
+
+  await runAfterToolAsync(input.session, {
+    toolId: input.toolId,
+    toolCallId: input.toolCallId,
+    args: input.args,
+    status: "succeeded",
+    result: execution.result,
+  });
+  recordToolSuccess(input.session, input.toolId, input.args, execution.result);
+}
+
+function invalidateCacheAfterWrite(cache: ToolCache | undefined, toolId: string, args: Record<string, unknown>): void {
+  if (cache && !cache.isCacheable(toolId)) {
+    cache.invalidateForWrite(toolId, args);
+  }
+}
+
 export async function withToolError<T>(toolId: string, task: () => Promise<T>): Promise<T> {
   try {
     return await task();
@@ -69,129 +236,35 @@ export async function runTool<T = unknown>(
   options?: { timeoutMs?: number; skipStepBudget?: boolean },
 ): Promise<RunToolResult<T>> {
   return withToolError(toolId, async () => {
-    if (!options?.skipStepBudget) {
-      const budgetError = checkStepBudget(session, toolId);
-      if (budgetError) {
-        const error = new Error(budgetError) as Error & { code: string; kind: string };
-        error.code = LIFECYCLE_ERROR_CODES.budgetExhausted;
-        error.kind = ERROR_KINDS.budgetExhausted;
-        throw error;
-      }
-    }
-
-    const preOutput = session.onBeforeTool?.({ toolId, toolCallId, args });
-    if (session.onBeforeToolAsync) {
-      try {
-        await session.onBeforeToolAsync({ toolId, toolCallId, args });
-      } catch (error) {
-        session.onDebug?.("lifecycle.tool.hook_failed", {
-          hook: "before",
-          tool: toolId,
-          tool_call_id: toolCallId,
-          message: errorMessage(error),
-        });
-      }
-    }
-
+    const input: ToolRunInput<T> = { session, toolId, toolCallId, args, execute, options };
+    assertStepBudget(input);
+    const { preOutput } = await runBeforeToolHooks(input);
     const cache = session.cache;
-    const timeoutMs = options?.timeoutMs ?? session.toolTimeoutMs;
-    invariant(
-      typeof timeoutMs === "number" && Number.isFinite(timeoutMs) && timeoutMs > 0,
-      "timeoutMs must be a positive number",
-    );
+    const timeoutMs = resolveTimeoutMs(session, options);
+    const cached = readCachedResult<T>(cache, input);
+    if (cached) return returnCachedResult(input, cached.result as T);
 
-    if (cache?.isCacheable(toolId)) {
-      const cached = cache.get(toolId, args);
-      if (cached) {
-        session.onDebug?.("lifecycle.tool.cache", { tool: toolId, hit: true, ...cache.stats() });
-        if (session.onAfterToolAsync) {
-          try {
-            await session.onAfterToolAsync({
-              toolId,
-              toolCallId,
-              args: args,
-              status: "succeeded",
-              result: cached.result,
-            });
-          } catch (error) {
-            session.onDebug?.("lifecycle.tool.hook_failed", {
-              hook: "after",
-              tool: toolId,
-              tool_call_id: toolCallId,
-              message: errorMessage(error),
-            });
-          }
-        }
-        recordCall(session, toolId, args, hashResultValue(cached.result), "succeeded", {
-          exitCode: extractExitCode(cached.result),
-        });
-        return { result: cached.result as T };
-      }
-      session.onDebug?.("lifecycle.tool.cache", { tool: toolId, hit: false, ...cache.stats() });
-    }
-
-    let taskFailed = false;
-    let taskResult = undefined as T;
-    let taskError: unknown;
+    let execution = await executeToolTask(input, timeoutMs);
     try {
-      taskResult = await withTimeout(() => execute(toolCallId), timeoutMs, toolId);
+      if (execution.taskFailed) throw execution.taskError;
       if (cache?.isCacheable(toolId)) {
-        cache.set(toolId, args, { result: taskResult });
+        cache.set(toolId, args, { result: execution.result });
       }
       const postOutput = session.onAfterTool?.({
         toolId,
         toolCallId,
         args: args,
         status: "succeeded",
-        result: taskResult,
+        result: execution.result,
       });
       const append = [preOutput?.append, postOutput?.append].filter(Boolean).join("\n");
-      return { result: taskResult, effectOutput: append || undefined };
+      return { result: execution.result, effectOutput: append || undefined };
     } catch (error) {
-      taskFailed = true;
-      taskError = error;
+      execution = { result: undefined as T, taskFailed: true, taskError: error };
       throw error;
     } finally {
-      if (session.onAfterToolAsync) {
-        try {
-          if (taskFailed) {
-            const parsed = parseError(taskError);
-            await session.onAfterToolAsync({
-              toolId,
-              toolCallId,
-              args: args,
-              status: "failed",
-              error: parsed.ok ? parsed.value : { message: `${toolId} failed` },
-            });
-          } else {
-            await session.onAfterToolAsync({
-              toolId,
-              toolCallId,
-              args: args,
-              status: "succeeded",
-              result: taskResult,
-            });
-          }
-        } catch (error) {
-          session.onDebug?.("lifecycle.tool.hook_failed", {
-            hook: "after",
-            tool: toolId,
-            tool_call_id: toolCallId,
-            message: errorMessage(error),
-          });
-        }
-      }
-      recordCall(
-        session,
-        toolId,
-        args,
-        taskFailed ? undefined : hashResultValue(taskResult),
-        taskFailed ? "failed" : "succeeded",
-        taskFailed ? undefined : { exitCode: extractExitCode(taskResult) },
-      );
-      if (cache && !cache.isCacheable(toolId) && !taskFailed) {
-        cache.invalidateForWrite(toolId, args);
-      }
+      await finalizeExecutedTool(input, execution);
+      if (!execution.taskFailed) invalidateCacheAfterWrite(cache, toolId, args);
     }
   });
 }

--- a/src/tool-execution.ts
+++ b/src/tool-execution.ts
@@ -70,15 +70,15 @@ type ToolExecutionResult<T> = {
   taskError?: unknown;
 };
 
-function debugHookFailure(
+function debugSideEffectFailure(
   session: SessionContext,
-  hook: "before" | "after",
+  phase: "before" | "after",
   toolId: string,
   toolCallId: string,
   error: unknown,
 ) {
-  session.onDebug?.("lifecycle.tool.hook_failed", {
-    hook,
+  session.onDebug?.("lifecycle.tool.side_effect_failed", {
+    phase,
     tool: toolId,
     tool_call_id: toolCallId,
     message: errorMessage(error),
@@ -95,7 +95,7 @@ function assertStepBudget(input: Pick<ToolRunInput<unknown>, "session" | "toolId
   throw error;
 }
 
-async function runBeforeToolHooks(
+async function runBeforeToolSideEffects(
   input: Pick<ToolRunInput<unknown>, "session" | "toolId" | "toolCallId" | "args">,
 ): Promise<BeforeToolResult> {
   const ctx: PreToolContext = { toolId: input.toolId, toolCallId: input.toolCallId, args: input.args };
@@ -104,18 +104,18 @@ async function runBeforeToolHooks(
     try {
       await input.session.onBeforeToolAsync(ctx);
     } catch (error) {
-      debugHookFailure(input.session, "before", input.toolId, input.toolCallId, error);
+      debugSideEffectFailure(input.session, "before", input.toolId, input.toolCallId, error);
     }
   }
   return { preOutput };
 }
 
-async function runAfterToolAsync(session: SessionContext, ctx: PostToolContext): Promise<void> {
+async function runAfterToolSideEffects(session: SessionContext, ctx: PostToolContext): Promise<void> {
   if (!session.onAfterToolAsync) return;
   try {
     await session.onAfterToolAsync(ctx);
   } catch (error) {
-    debugHookFailure(session, "after", ctx.toolId, ctx.toolCallId, error);
+    debugSideEffectFailure(session, "after", ctx.toolId, ctx.toolCallId, error);
   }
 }
 
@@ -157,7 +157,7 @@ async function returnCachedResult<T>(
   input: Pick<ToolRunInput<T>, "session" | "toolId" | "toolCallId" | "args">,
   result: T,
 ): Promise<RunToolResult<T>> {
-  await runAfterToolAsync(input.session, {
+  await runAfterToolSideEffects(input.session, {
     toolId: input.toolId,
     toolCallId: input.toolCallId,
     args: input.args,
@@ -183,7 +183,7 @@ async function finalizeExecutedTool<T>(
 ): Promise<void> {
   if (execution.taskFailed) {
     const parsed = parseError(execution.taskError);
-    await runAfterToolAsync(input.session, {
+    await runAfterToolSideEffects(input.session, {
       toolId: input.toolId,
       toolCallId: input.toolCallId,
       args: input.args,
@@ -194,7 +194,7 @@ async function finalizeExecutedTool<T>(
     return;
   }
 
-  await runAfterToolAsync(input.session, {
+  await runAfterToolSideEffects(input.session, {
     toolId: input.toolId,
     toolCallId: input.toolCallId,
     args: input.args,
@@ -238,7 +238,7 @@ export async function runTool<T = unknown>(
   return withToolError(toolId, async () => {
     const input: ToolRunInput<T> = { session, toolId, toolCallId, args, execute, options };
     assertStepBudget(input);
-    const { preOutput } = await runBeforeToolHooks(input);
+    const { preOutput } = await runBeforeToolSideEffects(input);
     const cache = session.cache;
     const timeoutMs = resolveTimeoutMs(session, options);
     const cached = readCachedResult<T>(cache, input);


### PR DESCRIPTION
## Motivation

Keep tool execution policy local to runTool while making hook, cache, timeout, and recording order easier to reason about.

## Summary

- split runTool internals into explicit pipeline stages
- preserve the existing public runTool interface and tool behavior
- add tests for pipeline ordering, cache hits, and failed-call finalization

Fixes #257