### PR TITLE
refactor(lifecycle): extract generate policy

### DIFF
--- a/src/lifecycle-generate-policy.test.ts
+++ b/src/lifecycle-generate-policy.test.ts
@@ -1,34 +1,28 @@
 import { describe, expect, test } from "bun:test";
 import { LIFECYCLE_ERROR_CODES } from "./error-contract";
-import {
-  createGenerateFinishPolicyState,
-  createGeneratePromptCacheKey,
-  decideGenerateFinish,
-  renderGenerateFinishPolicyMessages,
-} from "./lifecycle-generate-policy";
+import { createFinishPolicyState, decideFinish, renderFinishPolicyMessages } from "./lifecycle-generate-policy";
+import { createPromptCacheKey } from "./prompt-cache";
 
 describe("generate finish policy", () => {
   test("creates a stable prompt cache key for generate calls", () => {
-    const key = createGeneratePromptCacheKey({
+    const key = createPromptCacheKey({
       model: "gpt-5.4",
       sessionId: "session-123",
       workspace: "/repo",
     });
 
-    expect(key).toBe(createGeneratePromptCacheKey({ model: "gpt-5.4", sessionId: "session-123", workspace: "/repo" }));
-    expect(key).not.toBe(
-      createGeneratePromptCacheKey({ model: "gpt-5.4", sessionId: "session-456", workspace: "/repo" }),
-    );
+    expect(key).toBe(createPromptCacheKey({ model: "gpt-5.4", sessionId: "session-123", workspace: "/repo" }));
+    expect(key).not.toBe(createPromptCacheKey({ model: "gpt-5.4", sessionId: "session-456", workspace: "/repo" }));
   });
 
   test("missing signal gets one retry before blocking completion", () => {
-    const state = createGenerateFinishPolicyState();
+    const state = createFinishPolicyState();
 
-    const retry = decideGenerateFinish({ state, hasWrites: false });
-    const block = decideGenerateFinish({ state, hasWrites: false });
+    const retry = decideFinish({ state, hasWrites: false });
+    const block = decideFinish({ state, hasWrites: false });
 
     expect(retry).toMatchObject({ kind: "missing-signal-continue" });
-    expect(renderGenerateFinishPolicyMessages(retry)[0]).toMatchObject({
+    expect(renderFinishPolicyMessages(retry)[0]).toMatchObject({
       role: "user",
       content: [{ type: "text", text: expect.stringContaining('type="missing-signal"') }],
     });
@@ -38,17 +32,17 @@ describe("generate finish policy", () => {
         "Cannot finish yet: final responses must call exactly one lifecycle signal tool (`signal_done`, `signal_noop`, or `signal_blocked`).",
       code: LIFECYCLE_ERROR_CODES.unknown,
     });
-    expect(renderGenerateFinishPolicyMessages(block)).toEqual([]);
+    expect(renderFinishPolicyMessages(block)).toEqual([]);
   });
 
   test("done with writes injects self-review once", () => {
-    const state = createGenerateFinishPolicyState();
+    const state = createFinishPolicyState();
 
-    const first = decideGenerateFinish({ state, signal: "done", hasWrites: true });
-    const second = decideGenerateFinish({ state, signal: "done", hasWrites: true });
+    const first = decideFinish({ state, signal: "done", hasWrites: true });
+    const second = decideFinish({ state, signal: "done", hasWrites: true });
 
     expect(first).toEqual({ kind: "self-review-inject" });
-    expect(renderGenerateFinishPolicyMessages(first)[0]).toMatchObject({
+    expect(renderFinishPolicyMessages(first)[0]).toMatchObject({
       role: "user",
       content: [{ type: "text", text: expect.stringContaining('type="task-self-review"') }],
     });
@@ -56,29 +50,29 @@ describe("generate finish policy", () => {
   });
 
   test("done without writes consumes self-review and records skip reason", () => {
-    const state = createGenerateFinishPolicyState();
+    const state = createFinishPolicyState();
 
-    const first = decideGenerateFinish({ state, signal: "done", hasWrites: false });
-    const second = decideGenerateFinish({ state, signal: "done", hasWrites: true });
+    const first = decideFinish({ state, signal: "done", hasWrites: false });
+    const second = decideFinish({ state, signal: "done", hasWrites: true });
 
     expect(first).toEqual({ kind: "self-review-skip", reason: "no-writes" });
-    expect(renderGenerateFinishPolicyMessages(first)).toEqual([]);
+    expect(renderFinishPolicyMessages(first)).toEqual([]);
     expect(second).toEqual({ kind: "none" });
   });
 
   test("completion rejection gets one retry after self-review is exhausted", () => {
-    const state = createGenerateFinishPolicyState(0);
+    const state = createFinishPolicyState(0);
     const completionBlock = {
       reason: "missing-validation-after-write" as const,
       message: "Cannot finish yet.",
       path: "src/app.ts",
     };
 
-    const first = decideGenerateFinish({ state, signal: "done", hasWrites: true, completionBlock });
-    const second = decideGenerateFinish({ state, signal: "done", hasWrites: true, completionBlock });
+    const first = decideFinish({ state, signal: "done", hasWrites: true, completionBlock });
+    const second = decideFinish({ state, signal: "done", hasWrites: true, completionBlock });
 
     expect(first).toEqual({ kind: "completion-rejected-continue", block: completionBlock });
-    expect(renderGenerateFinishPolicyMessages(first)[0]).toMatchObject({
+    expect(renderFinishPolicyMessages(first)[0]).toMatchObject({
       role: "user",
       content: [{ type: "text", text: expect.stringContaining('type="completion-rejected"') }],
     });

--- a/src/lifecycle-generate-policy.test.ts
+++ b/src/lifecycle-generate-policy.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import { LIFECYCLE_ERROR_CODES } from "./error-contract";
+import {
+  createGenerateFinishPolicyState,
+  createGeneratePromptCacheKey,
+  decideGenerateFinish,
+  renderGenerateFinishPolicyMessages,
+} from "./lifecycle-generate-policy";
+
+describe("generate finish policy", () => {
+  test("creates a stable prompt cache key for generate calls", () => {
+    const key = createGeneratePromptCacheKey({
+      model: "gpt-5.4",
+      sessionId: "session-123",
+      workspace: "/repo",
+    });
+
+    expect(key).toBe(createGeneratePromptCacheKey({ model: "gpt-5.4", sessionId: "session-123", workspace: "/repo" }));
+    expect(key).not.toBe(
+      createGeneratePromptCacheKey({ model: "gpt-5.4", sessionId: "session-456", workspace: "/repo" }),
+    );
+  });
+
+  test("missing signal gets one retry before blocking completion", () => {
+    const state = createGenerateFinishPolicyState();
+
+    const retry = decideGenerateFinish({ state, hasWrites: false });
+    const block = decideGenerateFinish({ state, hasWrites: false });
+
+    expect(retry).toMatchObject({ kind: "missing-signal-continue" });
+    expect(renderGenerateFinishPolicyMessages(retry)[0]).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: expect.stringContaining('type="missing-signal"') }],
+    });
+    expect(block).toEqual({
+      kind: "missing-signal-block",
+      message:
+        "Cannot finish yet: final responses must call exactly one lifecycle signal tool (`signal_done`, `signal_noop`, or `signal_blocked`).",
+      code: LIFECYCLE_ERROR_CODES.unknown,
+    });
+    expect(renderGenerateFinishPolicyMessages(block)).toEqual([]);
+  });
+
+  test("done with writes injects self-review once", () => {
+    const state = createGenerateFinishPolicyState();
+
+    const first = decideGenerateFinish({ state, signal: "done", hasWrites: true });
+    const second = decideGenerateFinish({ state, signal: "done", hasWrites: true });
+
+    expect(first).toEqual({ kind: "self-review-inject" });
+    expect(renderGenerateFinishPolicyMessages(first)[0]).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: expect.stringContaining('type="task-self-review"') }],
+    });
+    expect(second).toEqual({ kind: "none" });
+  });
+
+  test("done without writes consumes self-review and records skip reason", () => {
+    const state = createGenerateFinishPolicyState();
+
+    const first = decideGenerateFinish({ state, signal: "done", hasWrites: false });
+    const second = decideGenerateFinish({ state, signal: "done", hasWrites: true });
+
+    expect(first).toEqual({ kind: "self-review-skip", reason: "no-writes" });
+    expect(renderGenerateFinishPolicyMessages(first)).toEqual([]);
+    expect(second).toEqual({ kind: "none" });
+  });
+
+  test("completion rejection gets one retry after self-review is exhausted", () => {
+    const state = createGenerateFinishPolicyState(0);
+    const completionBlock = {
+      reason: "missing-validation-after-write" as const,
+      message: "Cannot finish yet.",
+      path: "src/app.ts",
+    };
+
+    const first = decideGenerateFinish({ state, signal: "done", hasWrites: true, completionBlock });
+    const second = decideGenerateFinish({ state, signal: "done", hasWrites: true, completionBlock });
+
+    expect(first).toEqual({ kind: "completion-rejected-continue", block: completionBlock });
+    expect(renderGenerateFinishPolicyMessages(first)[0]).toMatchObject({
+      role: "user",
+      content: [{ type: "text", text: expect.stringContaining('type="completion-rejected"') }],
+    });
+    expect(second).toEqual({ kind: "none" });
+  });
+});

--- a/src/lifecycle-generate-policy.ts
+++ b/src/lifecycle-generate-policy.ts
@@ -1,0 +1,128 @@
+import type { LanguageModelV3Message } from "@ai-sdk/provider";
+import type { LifecycleSignal } from "./agent-contract";
+import { wrapInSystemReminder } from "./agent-reminders-render";
+import { unreachable } from "./assert";
+import { LIFECYCLE_ERROR_CODES } from "./error-contract";
+import type { CompletionBlock } from "./lifecycle-completion";
+import { SELF_REVIEW_TURNS_COOLDOWN } from "./lifecycle-constants";
+import { createPromptCacheKey } from "./prompt-cache";
+
+const MISSING_SIGNAL_MESSAGE =
+  "Cannot finish yet: final responses must call exactly one lifecycle signal tool (`signal_done`, `signal_noop`, or `signal_blocked`).";
+
+const SELF_REVIEW_MESSAGE = [
+  "Before finishing, review the original task you were given.",
+  "In one sentence, confirm what you completed.",
+  "If anything requested is still outstanding — files not updated, tests not added, steps skipped — address it now rather than handing off silently.",
+].join(" ");
+
+export type GenerateFinishPolicyState = {
+  completionRetryUsed: boolean;
+  missingSignalRetryUsed: boolean;
+  selfReviewTurnsRemaining: number;
+};
+
+export type GenerateFinishPolicyDecision =
+  | { kind: "none" }
+  | { kind: "missing-signal-continue"; message: string }
+  | { kind: "missing-signal-block"; message: string; code: typeof LIFECYCLE_ERROR_CODES.unknown }
+  | { kind: "self-review-inject" }
+  | { kind: "self-review-skip"; reason: "no-writes" }
+  | { kind: "completion-rejected-continue"; block: CompletionBlock };
+
+export function createGeneratePromptCacheKey(input: {
+  model: string;
+  sessionId: string | undefined;
+  workspace: string | undefined;
+}): string {
+  return createPromptCacheKey(input);
+}
+
+export function createGenerateFinishPolicyState(
+  selfReviewTurnsRemaining = SELF_REVIEW_TURNS_COOLDOWN,
+): GenerateFinishPolicyState {
+  return {
+    completionRetryUsed: false,
+    missingSignalRetryUsed: false,
+    selfReviewTurnsRemaining,
+  };
+}
+
+export function decideGenerateFinish(input: {
+  state: GenerateFinishPolicyState;
+  signal?: LifecycleSignal;
+  hasWrites: boolean;
+  completionBlock?: CompletionBlock;
+}): GenerateFinishPolicyDecision {
+  if (!input.signal) {
+    if (!input.state.missingSignalRetryUsed) {
+      input.state.missingSignalRetryUsed = true;
+      return { kind: "missing-signal-continue", message: MISSING_SIGNAL_MESSAGE };
+    }
+    return { kind: "missing-signal-block", message: MISSING_SIGNAL_MESSAGE, code: LIFECYCLE_ERROR_CODES.unknown };
+  }
+
+  if (input.signal === "done" && input.state.selfReviewTurnsRemaining > 0) {
+    input.state.selfReviewTurnsRemaining = 0;
+    if (!input.hasWrites) return { kind: "self-review-skip", reason: "no-writes" };
+    return { kind: "self-review-inject" };
+  }
+
+  if (input.completionBlock && !input.state.completionRetryUsed) {
+    input.state.completionRetryUsed = true;
+    return { kind: "completion-rejected-continue", block: input.completionBlock };
+  }
+
+  return { kind: "none" };
+}
+
+export function renderGenerateFinishPolicyMessages(decision: GenerateFinishPolicyDecision): LanguageModelV3Message[] {
+  switch (decision.kind) {
+    case "missing-signal-continue":
+      return [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: wrapInSystemReminder(
+                "missing-signal",
+                `${decision.message} Continue by calling the correct signal tool now.`,
+              ),
+            },
+          ],
+        },
+      ];
+    case "self-review-inject":
+      return [
+        {
+          role: "user",
+          content: [{ type: "text", text: wrapInSystemReminder("task-self-review", SELF_REVIEW_MESSAGE) }],
+        },
+      ];
+    case "completion-rejected-continue":
+      return [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: wrapInSystemReminder(
+                "completion-rejected",
+                [
+                  decision.block.message,
+                  "Continue autonomously: run focused validation now, or call `signal_blocked` only if validation is genuinely impossible.",
+                ].join(" "),
+              ),
+            },
+          ],
+        },
+      ];
+    case "missing-signal-block":
+    case "self-review-skip":
+    case "none":
+      return [];
+    default:
+      return unreachable(decision);
+  }
+}

--- a/src/lifecycle-generate-policy.ts
+++ b/src/lifecycle-generate-policy.ts
@@ -5,7 +5,6 @@ import { unreachable } from "./assert";
 import { LIFECYCLE_ERROR_CODES } from "./error-contract";
 import type { CompletionBlock } from "./lifecycle-completion";
 import { SELF_REVIEW_TURNS_COOLDOWN } from "./lifecycle-constants";
-import { createPromptCacheKey } from "./prompt-cache";
 
 const MISSING_SIGNAL_MESSAGE =
   "Cannot finish yet: final responses must call exactly one lifecycle signal tool (`signal_done`, `signal_noop`, or `signal_blocked`).";
@@ -30,15 +29,7 @@ export type GenerateFinishPolicyDecision =
   | { kind: "self-review-skip"; reason: "no-writes" }
   | { kind: "completion-rejected-continue"; block: CompletionBlock };
 
-export function createGeneratePromptCacheKey(input: {
-  model: string;
-  sessionId: string | undefined;
-  workspace: string | undefined;
-}): string {
-  return createPromptCacheKey(input);
-}
-
-export function createGenerateFinishPolicyState(
+export function createFinishPolicyState(
   selfReviewTurnsRemaining = SELF_REVIEW_TURNS_COOLDOWN,
 ): GenerateFinishPolicyState {
   return {
@@ -48,7 +39,7 @@ export function createGenerateFinishPolicyState(
   };
 }
 
-export function decideGenerateFinish(input: {
+export function decideFinish(input: {
   state: GenerateFinishPolicyState;
   signal?: LifecycleSignal;
   hasWrites: boolean;
@@ -76,7 +67,7 @@ export function decideGenerateFinish(input: {
   return { kind: "none" };
 }
 
-export function renderGenerateFinishPolicyMessages(decision: GenerateFinishPolicyDecision): LanguageModelV3Message[] {
+export function renderFinishPolicyMessages(decision: GenerateFinishPolicyDecision): LanguageModelV3Message[] {
   switch (decision.kind) {
     case "missing-signal-continue":
       return [

--- a/src/lifecycle-generate-policy.ts
+++ b/src/lifecycle-generate-policy.ts
@@ -15,13 +15,13 @@ const SELF_REVIEW_MESSAGE = [
   "If anything requested is still outstanding — files not updated, tests not added, steps skipped — address it now rather than handing off silently.",
 ].join(" ");
 
-export type GenerateFinishPolicyState = {
+export type FinishPolicyState = {
   completionRetryUsed: boolean;
   missingSignalRetryUsed: boolean;
   selfReviewTurnsRemaining: number;
 };
 
-export type GenerateFinishPolicyDecision =
+export type FinishPolicyDecision =
   | { kind: "none" }
   | { kind: "missing-signal-continue"; message: string }
   | { kind: "missing-signal-block"; message: string; code: typeof LIFECYCLE_ERROR_CODES.unknown }
@@ -29,9 +29,7 @@ export type GenerateFinishPolicyDecision =
   | { kind: "self-review-skip"; reason: "no-writes" }
   | { kind: "completion-rejected-continue"; block: CompletionBlock };
 
-export function createFinishPolicyState(
-  selfReviewTurnsRemaining = SELF_REVIEW_TURNS_COOLDOWN,
-): GenerateFinishPolicyState {
+export function createFinishPolicyState(selfReviewTurnsRemaining = SELF_REVIEW_TURNS_COOLDOWN): FinishPolicyState {
   return {
     completionRetryUsed: false,
     missingSignalRetryUsed: false,
@@ -40,11 +38,11 @@ export function createFinishPolicyState(
 }
 
 export function decideFinish(input: {
-  state: GenerateFinishPolicyState;
+  state: FinishPolicyState;
   signal?: LifecycleSignal;
   hasWrites: boolean;
   completionBlock?: CompletionBlock;
-}): GenerateFinishPolicyDecision {
+}): FinishPolicyDecision {
   if (!input.signal) {
     if (!input.state.missingSignalRetryUsed) {
       input.state.missingSignalRetryUsed = true;
@@ -67,7 +65,7 @@ export function decideFinish(input: {
   return { kind: "none" };
 }
 
-export function renderFinishPolicyMessages(decision: GenerateFinishPolicyDecision): LanguageModelV3Message[] {
+export function renderFinishPolicyMessages(decision: FinishPolicyDecision): LanguageModelV3Message[] {
   switch (decision.kind) {
     case "missing-signal-continue":
       return [

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -6,6 +6,7 @@ import { collectReminders, reminderTag } from "./agent-reminders";
 import { renderReminder, wrapInSystemReminder } from "./agent-reminders-render";
 import { createAgent } from "./agent-stream";
 import { appConfig } from "./app-config";
+import { unreachable } from "./assert";
 import { errorCode, errorMessage, LIFECYCLE_ERROR_CODES, TOOL_ERROR_CODES } from "./error-contract";
 import {
   categoryFromErrorCode,
@@ -17,9 +18,14 @@ import {
   parseError,
 } from "./error-handling";
 import { findCompletionBlock } from "./lifecycle-completion";
-import { SELF_REVIEW_TURNS_COOLDOWN } from "./lifecycle-constants";
 import { type GenerateOptions, promptUsageTotalTokens, type RunContext } from "./lifecycle-contract";
-import { createPromptCacheKey, mergeProviderOptions, promptCacheProviderOptions } from "./prompt-cache";
+import {
+  createGenerateFinishPolicyState,
+  createGeneratePromptCacheKey,
+  decideGenerateFinish,
+  renderGenerateFinishPolicyMessages,
+} from "./lifecycle-generate-policy";
+import { mergeProviderOptions, promptCacheProviderOptions } from "./prompt-cache";
 import { providerFromModel, reasoningProviderOptions } from "./provider-config";
 import type { StreamError } from "./stream-error";
 import type { ToolDefinition } from "./tool-contract";
@@ -209,13 +215,8 @@ export async function phaseGenerate(ctx: RunContext, opts: GenerateOptions): Pro
 async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: number): Promise<GenerateResult> {
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
   const controller = new AbortController();
-  let completionRetryUsed = false;
   let toolErrorRecoveryUsed = false;
-  let missingSignalRetryUsed = false;
-  // Number of turns remaining during which the self-review injection is allowed.
-  // Initialized from lifecycle constants so behavior can be tuned centrally.
-  // When set to 1 this behaves like the prior boolean `selfReviewDone` flag.
-  let selfReviewTurnsRemaining = SELF_REVIEW_TURNS_COOLDOWN;
+  const finishPolicyState = createGenerateFinishPolicyState();
 
   const toolErrorRecoveryMessages = (toolError: { tool: string; message: string; code?: string }) => {
     if (toolErrorRecoveryUsed) return [];
@@ -245,7 +246,7 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
   try {
     resetTimeout();
     const provider = providerFromModel(ctx.model);
-    const cacheKey = createPromptCacheKey({
+    const cacheKey = createGeneratePromptCacheKey({
       model: ctx.model,
       sessionId: ctx.request.sessionId,
       workspace: ctx.workspace,
@@ -284,97 +285,52 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
         const toolError = unresolvedToolError(ctx);
         if (toolError) return toolErrorRecoveryMessages(toolError);
 
-        if (!signal) {
-          const message =
-            "Cannot finish yet: final responses must call exactly one lifecycle signal tool (`signal_done`, `signal_noop`, or `signal_blocked`).";
-          if (!missingSignalRetryUsed) {
-            missingSignalRetryUsed = true;
-            ctx.debug("lifecycle.signal.missing", { action: "continue" });
-            return [
-              {
-                role: "user" as const,
-                content: [
-                  {
-                    type: "text" as const,
-                    text: wrapInSystemReminder(
-                      "missing-signal",
-                      `${message} Continue by calling the correct signal tool now.`,
-                    ),
-                  },
-                ],
-              },
-            ];
-          }
-          ctx.currentError = {
-            message,
-            code: LIFECYCLE_ERROR_CODES.unknown,
-            category: "other",
-            blocksCompletion: true,
-          };
-          ctx.debug("lifecycle.signal.missing", { action: "block" });
-          return [];
-        }
-
-        if (signal === "done" && selfReviewTurnsRemaining > 0) {
-          selfReviewTurnsRemaining = 0;
-          const taskLog = scopedCallLog(ctx.session, ctx.taskId);
-          const hasWrites = taskLog.some((e) => ctx.session.writeTools.has(e.toolName));
-          if (!hasWrites) {
-            ctx.debug("lifecycle.self_review.skipped", { reason: "no-writes" });
-            return [];
-          }
-          ctx.debug("lifecycle.self_review.injected", { action: "continue" });
-          return [
-            {
-              role: "user" as const,
-              content: [
-                {
-                  type: "text" as const,
-                  text: wrapInSystemReminder(
-                    "task-self-review",
-                    [
-                      "Before finishing, review the original task you were given.",
-                      "In one sentence, confirm what you completed.",
-                      "If anything requested is still outstanding — files not updated, tests not added, steps skipped — address it now rather than handing off silently.",
-                    ].join(" "),
-                  ),
-                },
-              ],
-            },
-          ];
-        }
-
+        const taskLog = scopedCallLog(ctx.session, ctx.taskId);
         const completionBlock = findCompletionBlock({
           signal,
-          callLog: scopedCallLog(ctx.session, ctx.taskId),
+          callLog: taskLog,
           writeToolSet: WRITE_TOOL_SET,
           runnerToolSet: RUNNER_TOOL_SET,
         });
-        if (!completionBlock || completionRetryUsed) return [];
-        completionRetryUsed = true;
-        ctx.debug("lifecycle.signal.rejected", {
-          signal: signal ?? null,
-          reason: completionBlock.reason,
-          path: completionBlock.path,
-          action: "continue",
+        const decision = decideGenerateFinish({
+          state: finishPolicyState,
+          signal,
+          hasWrites: taskLog.some((e) => ctx.session.writeTools.has(e.toolName)),
+          completionBlock,
         });
-        return [
-          {
-            role: "user",
-            content: [
-              {
-                type: "text",
-                text: wrapInSystemReminder(
-                  "completion-rejected",
-                  [
-                    completionBlock.message,
-                    "Continue autonomously: run focused validation now, or call `signal_blocked` only if validation is genuinely impossible.",
-                  ].join(" "),
-                ),
-              },
-            ],
-          },
-        ];
+        switch (decision.kind) {
+          case "missing-signal-continue":
+            ctx.debug("lifecycle.signal.missing", { action: "continue" });
+            break;
+          case "missing-signal-block":
+            ctx.currentError = {
+              message: decision.message,
+              code: decision.code,
+              category: "other",
+              blocksCompletion: true,
+            };
+            ctx.debug("lifecycle.signal.missing", { action: "block" });
+            break;
+          case "self-review-inject":
+            ctx.debug("lifecycle.self_review.injected", { action: "continue" });
+            break;
+          case "self-review-skip":
+            ctx.debug("lifecycle.self_review.skipped", { reason: decision.reason });
+            break;
+          case "completion-rejected-continue":
+            ctx.debug("lifecycle.signal.rejected", {
+              signal: signal ?? null,
+              reason: decision.block.reason,
+              path: decision.block.path,
+              action: "continue",
+            });
+            break;
+          case "none":
+            break;
+          default:
+            unreachable(decision);
+        }
+        return renderGenerateFinishPolicyMessages(decision);
       },
       ...(typeof temperature === "number" ? { temperature } : {}),
       ...(providerOptions ? { providerOptions } : {}),

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -19,13 +19,8 @@ import {
 } from "./error-handling";
 import { findCompletionBlock } from "./lifecycle-completion";
 import { type GenerateOptions, promptUsageTotalTokens, type RunContext } from "./lifecycle-contract";
-import {
-  createGenerateFinishPolicyState,
-  createGeneratePromptCacheKey,
-  decideGenerateFinish,
-  renderGenerateFinishPolicyMessages,
-} from "./lifecycle-generate-policy";
-import { mergeProviderOptions, promptCacheProviderOptions } from "./prompt-cache";
+import { createFinishPolicyState, decideFinish, renderFinishPolicyMessages } from "./lifecycle-generate-policy";
+import { createPromptCacheKey, mergeProviderOptions, promptCacheProviderOptions } from "./prompt-cache";
 import { providerFromModel, reasoningProviderOptions } from "./provider-config";
 import type { StreamError } from "./stream-error";
 import type { ToolDefinition } from "./tool-contract";
@@ -216,7 +211,7 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
   const controller = new AbortController();
   let toolErrorRecoveryUsed = false;
-  const finishPolicyState = createGenerateFinishPolicyState();
+  const finishPolicyState = createFinishPolicyState();
 
   const toolErrorRecoveryMessages = (toolError: { tool: string; message: string; code?: string }) => {
     if (toolErrorRecoveryUsed) return [];
@@ -246,7 +241,7 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
   try {
     resetTimeout();
     const provider = providerFromModel(ctx.model);
-    const cacheKey = createGeneratePromptCacheKey({
+    const cacheKey = createPromptCacheKey({
       model: ctx.model,
       sessionId: ctx.request.sessionId,
       workspace: ctx.workspace,
@@ -292,7 +287,7 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
           writeToolSet: WRITE_TOOL_SET,
           runnerToolSet: RUNNER_TOOL_SET,
         });
-        const decision = decideGenerateFinish({
+        const decision = decideFinish({
           state: finishPolicyState,
           signal,
           hasWrites: taskLog.some((e) => ctx.session.writeTools.has(e.toolName)),
@@ -330,7 +325,7 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
           default:
             unreachable(decision);
         }
-        return renderGenerateFinishPolicyMessages(decision);
+        return renderFinishPolicyMessages(decision);
       },
       ...(typeof temperature === "number" ? { temperature } : {}),
       ...(providerOptions ? { providerOptions } : {}),


### PR DESCRIPTION
## Motivation

`lifecycle-generate.ts` had retry, self-review, completion rejection, and cache-key decisions embedded in the streaming hook, which made those policies hard to test without a full generate pass.

## Summary

- extract generate finish decisions into `lifecycle-generate-policy`
- route prompt cache key creation through the generate policy module
- add direct policy tests for cache keys, missing signals, self-review, and completion rejection

Fixes #253