### PR TITLE
refactor(trace): add typed event catalog

### DIFF
--- a/src/cli-trace.ts
+++ b/src/cli-trace.ts
@@ -1,10 +1,10 @@
-import { z } from "zod";
 import { hasBoolFlag, parseFlag, parsePositional, parseTailCount } from "./cli-args";
 import { type CliOutput, createJsonOutput, createTextOutput } from "./cli-output";
 import { elapsedMs, formatDuration, formatRelativeTime } from "./datetime";
 import { t } from "./i18n";
 import { VERBOSE_ONLY_EVENTS } from "./lifecycle-constants";
 import type { LogLine } from "./log-parser";
+import { traceEventDisplayFields } from "./trace-event-catalog";
 import type { TraceStore } from "./trace-store";
 
 type TraceModeDeps = {
@@ -16,103 +16,7 @@ type TraceModeDeps = {
   commandHelp: (name: string) => void;
 };
 
-const traceEventSchema = z.enum([
-  "task.state_updated",
-  "rpc.task.accepted",
-  "rpc.task.queued",
-  "rpc.task.dequeued",
-  "rpc.worker.scheduled",
-  "rpc.task.started",
-  "chat.request.started",
-  "chat.request.completed",
-  "lifecycle.workspace.profile",
-  "lifecycle.start",
-  "lifecycle.prepare",
-  "lifecycle.generate.start",
-  "lifecycle.generate.done",
-  "lifecycle.generate.error",
-  "lifecycle.error",
-  "lifecycle.yield",
-  "lifecycle.tool.call",
-  "lifecycle.tool.cache",
-  "lifecycle.tool.result",
-  "lifecycle.tool.error",
-  "lifecycle.tool.output",
-  "lifecycle.budget",
-  "lifecycle.signal.accepted",
-  "lifecycle.signal.rejected",
-  "lifecycle.skill.context",
-  "lifecycle.effect.format",
-  "lifecycle.effect.lint",
-  "lifecycle.effect.lint.output",
-  "lifecycle.eval.decision",
-  "lifecycle.eval.skipped",
-  "lifecycle.reminders.injected",
-  "lifecycle.summary",
-]);
-
-type TraceEvent = z.infer<typeof traceEventSchema>;
 type FieldSpec = string | { key: string; label: string };
-
-const EVENT_FIELDS: Record<TraceEvent, FieldSpec[]> = {
-  "task.state_updated": [{ key: "from_state", label: "from" }, { key: "to_state", label: "to" }, "reason", "transport"],
-  "rpc.task.accepted": [
-    { key: "session_id", label: "session" },
-    { key: "queued_task_count", label: "queued" },
-    { key: "has_running_task", label: "has_running" },
-  ],
-  "rpc.task.queued": [{ key: "queue_position", label: "position" }, "running_task_id"],
-  "rpc.task.dequeued": [],
-  "rpc.worker.scheduled": [
-    { key: "session_id", label: "session" },
-    { key: "queued_task_count", label: "queued" },
-  ],
-  "rpc.task.started": [{ key: "session_id", label: "session" }],
-  "chat.request.started": ["model", "workspace_mode", "message_chars"],
-  "chat.request.completed": ["duration_ms", "model_calls", "tool_count"],
-  "lifecycle.workspace.profile": [
-    "ecosystem",
-    "package_manager",
-    "lint_command",
-    "format_command",
-    "test_command",
-    "line_width",
-  ],
-  "lifecycle.start": ["model"],
-  "lifecycle.prepare": ["model", "history_messages"],
-  "lifecycle.generate.start": ["model"],
-  "lifecycle.generate.done": ["model", "tool_calls", "text_chars"],
-  "lifecycle.generate.error": ["model", "error"],
-  "lifecycle.error": ["source", "kind", "code", "category", "tool"],
-  "lifecycle.yield": [],
-  "lifecycle.tool.call": ["tool", "path", "paths", "pattern", "command"],
-  "lifecycle.tool.cache": ["tool", "hit", "hits", "misses", "size"],
-  "lifecycle.tool.result": ["tool", "duration_ms", "is_error"],
-  "lifecycle.tool.error": ["tool", "error"],
-  "lifecycle.tool.output": ["tool"],
-  "lifecycle.budget": ["tool", "action", "detail"],
-  "lifecycle.signal.accepted": ["signal"],
-  "lifecycle.signal.rejected": ["signal", "reason", "path", "action"],
-  "lifecycle.skill.context": ["skill_name", "instruction_chars"],
-  "lifecycle.effect.format": ["files"],
-  "lifecycle.effect.lint": ["files"],
-  "lifecycle.eval.decision": ["effect", "action"],
-  "lifecycle.eval.skipped": ["reason"],
-  "lifecycle.reminders.injected": ["count", "tags"],
-  "lifecycle.effect.lint.output": ["output"],
-  "lifecycle.summary": [
-    "model_calls",
-    { key: "tool_calls", label: "total_tool_calls" },
-    { key: "read_calls", label: "read" },
-    { key: "search_calls", label: "search" },
-    { key: "write_calls", label: "write" },
-    { key: "pre_write_discovery_calls", label: "pre_write_discovery" },
-    { key: "budget_exhausted_count", label: "budget_exhausted" },
-    "has_error",
-  ],
-};
-
-const KNOWN_EVENTS = new Set<string>(traceEventSchema.options);
 
 function verboseRowData(line: LogLine): Record<string, string | undefined> {
   const event = line.fields.event;
@@ -128,15 +32,10 @@ function verboseRowData(line: LogLine): Record<string, string | undefined> {
 
   data.event = event;
 
-  if (KNOWN_EVENTS.has(event)) {
-    const specs = EVENT_FIELDS[event as TraceEvent];
-    for (const spec of specs) {
-      const key = typeof spec === "string" ? spec : spec.key;
-      const label = typeof spec === "string" ? spec : spec.label;
-      data[label] = line.fields[key];
-    }
-  } else if (event.startsWith("lifecycle.memory.")) {
-    data.reason = line.fields.reason;
+  for (const spec of traceEventDisplayFields(event) as FieldSpec[]) {
+    const key = typeof spec === "string" ? spec : spec.key;
+    const label = typeof spec === "string" ? spec : spec.label;
+    data[label] = line.fields[key];
   }
 
   return data;

--- a/src/trace-event-catalog.test.ts
+++ b/src/trace-event-catalog.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isCatalogTraceEvent,
+  parseTraceFields,
+  traceEventDisplayFields,
+  traceEventNameSchema,
+} from "./trace-event-catalog";
+
+describe("trace event catalog", () => {
+  test("defines event names and display fields in one catalog", () => {
+    expect(traceEventNameSchema.options).toContain("lifecycle.start");
+    expect(isCatalogTraceEvent("lifecycle.start")).toBe(true);
+    expect(traceEventDisplayFields("lifecycle.summary")).toContain("model_calls");
+    expect(traceEventDisplayFields("lifecycle.signal.rejected")).toContain("reason");
+  });
+
+  test("validates known event fields and preserves additional scalar fields", () => {
+    const fields = parseTraceFields("lifecycle.start", {
+      model: "gpt-5.4",
+      task_id: "task_123",
+    });
+
+    expect(fields).toEqual({ model: "gpt-5.4", task_id: "task_123" });
+  });
+
+  test("rejects non-scalar field values before trace persistence", () => {
+    expect(() =>
+      parseTraceFields("lifecycle.start", {
+        model: "gpt-5.4",
+        invalid: { nested: true },
+      } as never),
+    ).toThrow();
+  });
+});

--- a/src/trace-event-catalog.ts
+++ b/src/trace-event-catalog.ts
@@ -1,0 +1,171 @@
+import { z } from "zod";
+
+export type TraceFieldSpec = string | { key: string; label: string };
+
+export const traceFieldValueSchema = z.union([z.string(), z.number(), z.boolean(), z.null(), z.undefined()]);
+export const traceFieldsSchema = z.record(z.string(), traceFieldValueSchema);
+export type TraceFields = z.infer<typeof traceFieldsSchema>;
+
+export const traceEventNameSchema = z.enum([
+  "task.state_updated",
+  "rpc.task.accepted",
+  "rpc.task.queued",
+  "rpc.task.dequeued",
+  "rpc.worker.scheduled",
+  "rpc.task.started",
+  "chat.request.started",
+  "chat.request.completed",
+  "lifecycle.workspace.profile",
+  "lifecycle.workspace.sandbox",
+  "lifecycle.start",
+  "lifecycle.prepare",
+  "lifecycle.generate.start",
+  "lifecycle.generate.done",
+  "lifecycle.generate.error",
+  "lifecycle.error",
+  "lifecycle.yield",
+  "lifecycle.tool.call",
+  "lifecycle.tool.cache",
+  "lifecycle.tool.result",
+  "lifecycle.tool.error",
+  "lifecycle.tool.output",
+  "lifecycle.tool.hook_failed",
+  "lifecycle.tool_error.recovery",
+  "lifecycle.budget",
+  "lifecycle.signal.accepted",
+  "lifecycle.signal.rejected",
+  "lifecycle.signal.missing",
+  "lifecycle.self_review.injected",
+  "lifecycle.self_review.skipped",
+  "lifecycle.skill.context",
+  "lifecycle.effect.format",
+  "lifecycle.effect.lint",
+  "lifecycle.effect.lint.output",
+  "lifecycle.effect.install",
+  "lifecycle.eval.decision",
+  "lifecycle.eval.skipped",
+  "lifecycle.reminders.injected",
+  "lifecycle.memory.commit_scheduled",
+  "lifecycle.memory.commit_done",
+  "lifecycle.memory.commit_failed",
+  "lifecycle.summary",
+]);
+
+export type TraceEventName = z.infer<typeof traceEventNameSchema>;
+
+type TraceEventDefinition = {
+  fields: z.ZodType<TraceFields>;
+  displayFields: TraceFieldSpec[];
+};
+
+function fieldSchema(keys: readonly TraceFieldSpec[]): z.ZodType<TraceFields> {
+  const shape: Record<string, z.ZodOptional<typeof traceFieldValueSchema>> = {};
+  for (const spec of keys) {
+    const key = typeof spec === "string" ? spec : spec.key;
+    shape[key] = traceFieldValueSchema.optional();
+  }
+  return z.object(shape).catchall(traceFieldValueSchema);
+}
+
+function defineEvent(displayFields: readonly TraceFieldSpec[]): TraceEventDefinition {
+  return {
+    fields: fieldSchema(displayFields),
+    displayFields: [...displayFields],
+  };
+}
+
+export const TRACE_EVENT_CATALOG: Record<TraceEventName, TraceEventDefinition> = {
+  "task.state_updated": defineEvent([
+    { key: "from_state", label: "from" },
+    { key: "to_state", label: "to" },
+    "reason",
+    "transport",
+  ]),
+  "rpc.task.accepted": defineEvent([
+    { key: "session_id", label: "session" },
+    { key: "queued_task_count", label: "queued" },
+    { key: "has_running_task", label: "has_running" },
+  ]),
+  "rpc.task.queued": defineEvent([{ key: "queue_position", label: "position" }, "running_task_id"]),
+  "rpc.task.dequeued": defineEvent([]),
+  "rpc.worker.scheduled": defineEvent([
+    { key: "session_id", label: "session" },
+    { key: "queued_task_count", label: "queued" },
+  ]),
+  "rpc.task.started": defineEvent([{ key: "session_id", label: "session" }]),
+  "chat.request.started": defineEvent(["model", "workspace_mode", "message_chars"]),
+  "chat.request.completed": defineEvent(["duration_ms", "model_calls", "tool_count"]),
+  "lifecycle.workspace.profile": defineEvent([
+    "ecosystem",
+    "package_manager",
+    "lint_command",
+    "format_command",
+    "test_command",
+    "line_width",
+  ]),
+  "lifecycle.workspace.sandbox": defineEvent(["workspace", "sandbox_root"]),
+  "lifecycle.start": defineEvent(["model"]),
+  "lifecycle.prepare": defineEvent(["model", "history_messages"]),
+  "lifecycle.generate.start": defineEvent(["model"]),
+  "lifecycle.generate.done": defineEvent(["model", "tool_calls", "text_chars"]),
+  "lifecycle.generate.error": defineEvent(["model", "error"]),
+  "lifecycle.error": defineEvent(["source", "kind", "code", "category", "tool"]),
+  "lifecycle.yield": defineEvent([]),
+  "lifecycle.tool.call": defineEvent(["tool", "path", "paths", "pattern", "command"]),
+  "lifecycle.tool.cache": defineEvent(["tool", "hit", "hits", "misses", "size"]),
+  "lifecycle.tool.result": defineEvent(["tool", "duration_ms", "is_error"]),
+  "lifecycle.tool.error": defineEvent(["tool", "error"]),
+  "lifecycle.tool.output": defineEvent(["tool"]),
+  "lifecycle.tool.hook_failed": defineEvent(["tool", "hook", "error"]),
+  "lifecycle.tool_error.recovery": defineEvent(["tool", "code", "action"]),
+  "lifecycle.budget": defineEvent(["tool", "action", "detail"]),
+  "lifecycle.signal.accepted": defineEvent(["signal"]),
+  "lifecycle.signal.rejected": defineEvent(["signal", "reason", "path", "action"]),
+  "lifecycle.signal.missing": defineEvent(["action"]),
+  "lifecycle.self_review.injected": defineEvent(["action"]),
+  "lifecycle.self_review.skipped": defineEvent(["reason"]),
+  "lifecycle.skill.context": defineEvent(["skill_name", "instruction_chars"]),
+  "lifecycle.effect.format": defineEvent(["files"]),
+  "lifecycle.effect.lint": defineEvent(["files"]),
+  "lifecycle.effect.lint.output": defineEvent(["output"]),
+  "lifecycle.effect.install": defineEvent(["package_manager", "command", "status"]),
+  "lifecycle.eval.decision": defineEvent(["effect", "action"]),
+  "lifecycle.eval.skipped": defineEvent(["reason"]),
+  "lifecycle.reminders.injected": defineEvent(["count", "tags"]),
+  "lifecycle.memory.commit_scheduled": defineEvent(["queue_key", "session_id", "message_count", "output_chars"]),
+  "lifecycle.memory.commit_done": defineEvent([
+    "queue_key",
+    "project_promoted_facts",
+    "user_promoted_facts",
+    "session_scoped_facts",
+    "dropped_untagged_facts",
+    "distill_tokens",
+  ]),
+  "lifecycle.memory.commit_failed": defineEvent(["queue_key", "message"]),
+  "lifecycle.summary": defineEvent([
+    "model_calls",
+    { key: "tool_calls", label: "total_tool_calls" },
+    { key: "read_calls", label: "read" },
+    { key: "search_calls", label: "search" },
+    { key: "write_calls", label: "write" },
+    { key: "pre_write_discovery_calls", label: "pre_write_discovery" },
+    { key: "budget_exhausted_count", label: "budget_exhausted" },
+    "has_error",
+  ]),
+};
+
+export function isCatalogTraceEvent(event: string | undefined): event is TraceEventName {
+  return Boolean(event && event in TRACE_EVENT_CATALOG);
+}
+
+export function traceEventDisplayFields(event: string | undefined): TraceFieldSpec[] {
+  if (!event) return [];
+  if (isCatalogTraceEvent(event)) return TRACE_EVENT_CATALOG[event].displayFields;
+  if (event.startsWith("lifecycle.memory.")) return ["reason"];
+  return [];
+}
+
+export function parseTraceFields(event: string | undefined, fields: TraceFields): TraceFields {
+  if (isCatalogTraceEvent(event)) return TRACE_EVENT_CATALOG[event].fields.parse(fields);
+  return traceFieldsSchema.parse(fields);
+}

--- a/src/trace-store.int.test.ts
+++ b/src/trace-store.int.test.ts
@@ -101,6 +101,21 @@ describe("createTraceStore", () => {
     expect(tasks[0]?.hasError).toBe(true);
   });
 
+  test("listTasks detects boolean hasError from lifecycle.summary", () => {
+    const store = createStore();
+    store.write(entry({ taskId: "task_err", event: "lifecycle.start" }));
+    store.write(
+      entry({
+        taskId: "task_err",
+        event: "lifecycle.summary",
+        timestamp: "2026-03-20T10:00:01.000Z",
+        fields: { has_error: true, model_calls: 3 },
+      }),
+    );
+    const tasks = store.listTasks(10);
+    expect(tasks[0]?.hasError).toBe(true);
+  });
+
   test("listTasks returns hasError false when no error", () => {
     const store = createStore();
     store.write(entry({ taskId: "task_ok", event: "lifecycle.start" }));
@@ -121,5 +136,16 @@ describe("createTraceStore", () => {
     store.write(entry());
     const lines = store.listByTaskId("task_1");
     expect(lines[0]?.raw).toBe("");
+  });
+
+  test("write validates fields through the trace event catalog", () => {
+    const store = createStore();
+    expect(() =>
+      store.write(
+        entry({
+          fields: { model: "gpt-5", invalid: { nested: true } } as never,
+        }),
+      ),
+    ).toThrow();
   });
 });

--- a/src/trace-store.ts
+++ b/src/trace-store.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { type Migration, migrateUp } from "./db-migrate";
 import type { LogLine, TaskSummary } from "./log-parser";
 import { dataDir } from "./paths";
+import { parseTraceFields, type TraceFields } from "./trace-event-catalog";
 
 const PROMOTED_COLUMNS = new Set(["event", "task_id", "request_id", "session_id", "sequence"]);
 
@@ -14,7 +15,7 @@ export type TraceEntry = {
   sessionId?: string;
   event?: string;
   sequence?: number;
-  fields: Record<string, string | number | boolean | null | undefined>;
+  fields: TraceFields;
 };
 
 export interface TraceStore {
@@ -98,7 +99,7 @@ function taskRowToSummary(row: TaskRow): TaskSummary {
   };
 }
 
-function fieldsToJson(fields: Record<string, string | number | boolean | null | undefined>): string {
+function fieldsToJson(fields: TraceFields): string {
   const clean: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(fields)) {
     if (value !== undefined && !PROMOTED_COLUMNS.has(key)) clean[key] = value;
@@ -115,7 +116,7 @@ const LIST_TASKS_SQL = `
     e.task_id,
     MIN(e.timestamp) AS timestamp,
     (SELECT json_extract(e2.fields_json, '$.model') FROM trace_events e2 WHERE e2.task_id = e.task_id AND e2.event = 'lifecycle.start' LIMIT 1) AS model,
-    MAX(CASE WHEN e.event = 'lifecycle.summary' AND json_extract(e.fields_json, '$.has_error') = 'true' THEN 1 ELSE 0 END) AS has_error,
+    MAX(CASE WHEN e.event = 'lifecycle.summary' AND json_extract(e.fields_json, '$.has_error') IN ('true', 1) THEN 1 ELSE 0 END) AS has_error,
     (SELECT json_extract(e3.fields_json, '$.lifecycle_signal') FROM trace_events e3 WHERE e3.task_id = e.task_id AND e3.event = 'lifecycle.summary' LIMIT 1) AS lifecycle_signal
   FROM trace_events e
   WHERE e.task_id IS NOT NULL
@@ -149,6 +150,7 @@ export function createTraceStore(dbPath?: string): TraceStore {
 
   return {
     write(entry) {
+      const fields = parseTraceFields(entry.event, entry.fields);
       writeStmt.run(
         entry.timestamp,
         entry.taskId ?? null,
@@ -156,7 +158,7 @@ export function createTraceStore(dbPath?: string): TraceStore {
         entry.sessionId ?? null,
         entry.event ?? null,
         entry.sequence ?? null,
-        fieldsToJson(entry.fields),
+        fieldsToJson(fields),
       );
     },
     listTasks(limit) {


### PR DESCRIPTION
## Motivation

Trace event names and display fields were embedded in `cli-trace.ts` while trace storage accepted raw scalar maps. A shared catalog keeps trace rendering and persistence aligned as observability events evolve.

## Summary

- add Zod-backed trace event catalog with event names, field schemas, and display metadata
- move verbose trace rendering metadata out of `cli-trace.ts`
- validate trace store writes through the catalog
- preserve boolean `has_error` summaries when listing traced tasks

Fixes #258