### PR TITLE
feat(tools): add bounded file-read windows

### DIFF
--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -50,7 +50,7 @@ Entries in `IGNORED_DIRS` take precedence and cannot be re-included by gitignore
 
 ## Tool result cache
 
-Read-only and search tools (`file-read`, `file-find`, `file-search`, `code-scan`) are cached. Identical calls return the cached result without re-executing.
+Read-only and search tools (`file-read`, `file-find`, `file-search`, `code-scan`) are cached. Identical calls return the cached result without re-executing. Bounded `file-read` windows are keyed by `aroundLine` and `contextLines`, so full reads and windowed reads cache independently while still invalidating together by path.
 
 - **Key**: deterministic `toolName:stableJSON(args)` — object keys sorted for stability
 - **Invalidation**: write tools (`file-edit`, `file-create`, `file-delete`) evict entries with overlapping paths; `shell-run` clears the entire cache

--- a/src/file-ops.int.test.ts
+++ b/src/file-ops.int.test.ts
@@ -19,12 +19,52 @@ describe("path validation — fs", () => {
     expect(result.result.output).toContain("hello from workspace");
   });
 
+  test("readFile supports bounded windows", async () => {
+    const workspace = dirs.createDir("acolyte-read-tool-window-");
+    const filePath = join(workspace, `test-read-tool-window-${testUuid()}.txt`);
+    const lines = Array.from({ length: 6 }, (_, i) => `line ${i + 1}`).join("\n");
+    await writeFile(filePath, lines, "utf8");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.readFile.execute({ path: filePath, aroundLine: 3, contextLines: 1 }, "call_read_window");
+    expect(result.result.aroundLine).toBe(3);
+    expect(result.result.contextLines).toBe(1);
+    expect(result.result.output).toContain("Lines: 2-4 of 6");
+    expect(result.result.output).toContain("2: line 2");
+    expect(result.result.output).not.toContain("5: line 5");
+  });
+
+  test("readFile defaults bounded window context to 20 lines", async () => {
+    const workspace = dirs.createDir("acolyte-read-tool-default-window-");
+    const filePath = join(workspace, `test-read-tool-default-window-${testUuid()}.txt`);
+    const lines = Array.from({ length: 100 }, (_, i) => `line ${i + 1}`).join("\n");
+    await writeFile(filePath, lines, "utf8");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.readFile.execute({ path: filePath, aroundLine: 50 }, "call_read_default_window");
+    expect(result.result.contextLines).toBe(20);
+    expect(result.result.output).toContain("Lines: 30-70 of 100");
+    expect(result.result.output).toContain("50: line 50");
+    expect(result.result.output).not.toContain("29: line 29");
+    expect(result.result.output).not.toContain("71: line 71");
+  });
+
+  test("readFile ignores contextLines without aroundLine", async () => {
+    const workspace = dirs.createDir("acolyte-read-tool-context-only-");
+    const filePath = join(workspace, `test-read-tool-context-only-${testUuid()}.txt`);
+    await writeFile(filePath, "line 1\nline 2\nline 3", "utf8");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.readFile.execute({ path: filePath, contextLines: 1 }, "call_read_context_only");
+    expect(result.result.contextLines).toBeUndefined();
+    expect(result.result.output).not.toContain("Lines:");
+    expect(result.result.output).toContain("1: line 1");
+    expect(result.result.output).toContain("3: line 3");
+  });
+
   test("readFileContent rejects files exceeding maxLines", async () => {
     const workspace = dirs.createDir("acolyte-read-maxlines-");
     const filePath = join(workspace, `test-large-${testUuid()}.txt`);
     const lines = Array.from({ length: 11 }, (_, i) => `line ${i + 1}`).join("\n");
     await writeFile(filePath, lines, "utf8");
-    await expect(readFileContent(workspace, filePath, 10)).rejects.toThrow(/too large/);
+    await expect(readFileContent(workspace, filePath, { maxLines: 10 })).rejects.toThrow(/too large/);
   });
 
   test("readFileContent allows files at exactly maxLines", async () => {
@@ -32,8 +72,54 @@ describe("path validation — fs", () => {
     const filePath = join(workspace, `test-exact-${testUuid()}.txt`);
     const lines = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join("\n");
     await writeFile(filePath, lines, "utf8");
-    const output = await readFileContent(workspace, filePath, 10);
+    const output = await readFileContent(workspace, filePath, { maxLines: 10 });
     expect(output).toContain("line 1");
+  });
+
+  test("readFileContent returns a bounded line window", async () => {
+    const workspace = dirs.createDir("acolyte-read-window-");
+    const filePath = join(workspace, `test-window-${testUuid()}.txt`);
+    const lines = Array.from({ length: 6 }, (_, i) => `line ${i + 1}`).join("\n");
+    await writeFile(filePath, lines, "utf8");
+    const output = await readFileContent(workspace, filePath, { aroundLine: 4, contextLines: 1, maxLines: 10 });
+    expect(output).toContain("Lines: 3-5 of 6");
+    expect(output).toContain("3: line 3");
+    expect(output).toContain("5: line 5");
+    expect(output).not.toContain("2: line 2");
+    expect(output).not.toContain("6: line 6");
+  });
+
+  test("readFileContent clamps window end to file length", async () => {
+    const workspace = dirs.createDir("acolyte-read-window-clamp-");
+    const filePath = join(workspace, `test-window-clamp-${testUuid()}.txt`);
+    await writeFile(filePath, "line 1\nline 2\nline 3", "utf8");
+    const output = await readFileContent(workspace, filePath, { aroundLine: 3, contextLines: 1, maxLines: 10 });
+    expect(output).toContain("Lines: 2-3 of 3");
+    expect(output).toContain("2: line 2");
+    expect(output).toContain("3: line 3");
+  });
+
+  test("readFileContent rejects invalid windows", async () => {
+    const workspace = dirs.createDir("acolyte-read-window-invalid-");
+    const filePath = join(workspace, `test-window-invalid-${testUuid()}.txt`);
+    await writeFile(filePath, "line 1\nline 2\nline 3", "utf8");
+    await expect(readFileContent(workspace, filePath, { aroundLine: 0 })).rejects.toThrow("aroundLine must be >= 1");
+    await expect(readFileContent(workspace, filePath, { aroundLine: 2, contextLines: -1 })).rejects.toThrow(
+      "contextLines must be >= 0",
+    );
+    await expect(readFileContent(workspace, filePath, { aroundLine: 4 })).rejects.toThrow(
+      "aroundLine (4) exceeds file length (3)",
+    );
+  });
+
+  test("readFileContent enforces maxLines on bounded windows", async () => {
+    const workspace = dirs.createDir("acolyte-read-window-maxlines-");
+    const filePath = join(workspace, `test-window-maxlines-${testUuid()}.txt`);
+    const lines = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`).join("\n");
+    await writeFile(filePath, lines, "utf8");
+    await expect(
+      readFileContent(workspace, filePath, { aroundLine: 10, contextLines: 6, maxLines: 10 }),
+    ).rejects.toThrow("Read window");
   });
 
   test("editFile allows workspace files", async () => {

--- a/src/file-ops.ts
+++ b/src/file-ops.ts
@@ -32,7 +32,7 @@ const MAX_FIND_REPLACE_LINES = 24;
 const MAX_FIND_REPLACE_CHARS = 1600;
 const MAX_BATCH_EDIT_LINES = 32;
 const MAX_BATCH_EDIT_CHARS = 2400;
-const DEFAULT_READ_CONTEXT_LINES = 20;
+export const DEFAULT_READ_CONTEXT_LINES = 20;
 
 export async function findFiles(workspace: string, patterns: string[], maxResults = 40): Promise<string> {
   if (patterns.length === 0) throw new Error("At least one pattern is required");

--- a/src/file-ops.ts
+++ b/src/file-ops.ts
@@ -20,12 +20,19 @@ export type FindReplaceEdit = { find: string; replace: string };
 export type LineRangeEdit = { startLine: number; endLine: number; replace: string };
 export type FileEdit = FindReplaceEdit | LineRangeEdit;
 
+export type FileReadOptions = {
+  maxLines?: number;
+  aroundLine?: number;
+  contextLines?: number;
+};
+
 const MAX_FIND_SNIPPET_LINES = 8;
 const MAX_FIND_SNIPPET_CHARS = 500;
 const MAX_FIND_REPLACE_LINES = 24;
 const MAX_FIND_REPLACE_CHARS = 1600;
 const MAX_BATCH_EDIT_LINES = 32;
 const MAX_BATCH_EDIT_CHARS = 2400;
+const DEFAULT_READ_CONTEXT_LINES = 20;
 
 export async function findFiles(workspace: string, patterns: string[], maxResults = 40): Promise<string> {
   if (patterns.length === 0) throw new Error("At least one pattern is required");
@@ -118,17 +125,43 @@ export async function searchFiles(
   return "No matches.";
 }
 
-export async function readFileContent(workspace: string, path: string, maxLines?: number): Promise<string> {
+export async function readFileContent(workspace: string, path: string, options: FileReadOptions = {}): Promise<string> {
   const absPath = ensurePathWithinSandbox(path, workspace);
   const raw = await readFile(absPath, "utf8");
   const lines = raw.split("\n");
-  if (maxLines !== undefined && lines.length > maxLines) {
+  const { maxLines, aroundLine } = options;
+  const contextLines = aroundLine === undefined ? 0 : (options.contextLines ?? DEFAULT_READ_CONTEXT_LINES);
+  if (maxLines !== undefined && (!Number.isInteger(maxLines) || maxLines < 1)) {
+    throw new Error("maxLines must be >= 1");
+  }
+  if (aroundLine !== undefined && (!Number.isInteger(aroundLine) || aroundLine < 1)) {
+    throw new Error("aroundLine must be >= 1");
+  }
+  if (!Number.isInteger(contextLines) || contextLines < 0) {
+    throw new Error("contextLines must be >= 0");
+  }
+  const hasWindow = aroundLine !== undefined;
+  if (maxLines !== undefined && !hasWindow && lines.length > maxLines) {
     throw new Error(
       `File "${path}" is too large (${lines.length} lines). Use \`file-search\` or \`code-scan\` to find the relevant sections.`,
     );
   }
-  const numbered = lines.map((line, idx) => `${idx + 1}: ${line}`);
-  return [`File: ${absPath}`, ...numbered].join("\n");
+  if (aroundLine !== undefined && aroundLine > lines.length) {
+    throw new Error(`aroundLine (${aroundLine}) exceeds file length (${lines.length})`);
+  }
+  const startLine = aroundLine === undefined ? 1 : Math.max(1, aroundLine - contextLines);
+  const endLine = aroundLine === undefined ? lines.length : aroundLine + contextLines;
+  const clampedEndLine = Math.min(endLine, lines.length);
+  const selectedLines = lines.slice(startLine - 1, clampedEndLine);
+  if (maxLines !== undefined && selectedLines.length > maxLines) {
+    throw new Error(
+      `Read window for "${path}" is too large (${selectedLines.length} lines). Use a smaller contextLines value.`,
+    );
+  }
+  const numbered = selectedLines.map((line, idx) => `${startLine + idx}: ${line}`);
+  const header = [`File: ${absPath}`];
+  if (hasWindow) header.push(`Lines: ${startLine}-${clampedEndLine} of ${lines.length}`);
+  return [...header, ...numbered].join("\n");
 }
 
 export async function editFile(input: {

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -99,37 +99,63 @@ function createSearchFilesTool(input: ToolkitInput) {
 }
 
 const FILE_READ_MAX_LINES = 10_000;
+const FILE_READ_DEFAULT_CONTEXT_LINES = 20;
 
 function createReadFileTool(input: ToolkitInput) {
   return createTool({
     id: "file-read",
     toolkit: "file",
     category: "read",
-    description: "Read a text file. Never re-read a file you already have.",
-    instruction:
-      "Use `file-read` before `file-edit` or `code-edit`. For named edits, re-read the target file immediately before editing.",
+    description:
+      "Read a text file. Prefer bounded windows with aroundLine after file-search; full-read only when broad context is necessary.",
+    instruction: [
+      "Use `file-read` before `file-edit` or `code-edit`.",
+      "After `file-search`, pass aroundLine from the matching line instead of reading the whole file.",
+      "Default contextLines is 20; widen contextLines incrementally up to 60 when local context is insufficient.",
+      "For named edits, re-read the target file immediately before editing.",
+    ].join(" "),
     inputSchema: z.object({
       path: z.string().min(1),
+      aroundLine: z.number().int().min(1).optional(),
+      contextLines: z.number().int().min(0).max(60).optional(),
     }),
     outputSchema: z.object({
       kind: z.literal("file-read"),
       path: z.string().min(1),
+      aroundLine: z.number().int().min(1).optional(),
+      contextLines: z.number().int().min(0).max(60).optional(),
       output: z.string(),
     }),
     execute: async (toolInput, toolCallId) => {
-      return runTool(input.session, "file-read", toolCallId, toolInput, async (callId) => {
+      const contextLines =
+        toolInput.aroundLine === undefined ? undefined : (toolInput.contextLines ?? FILE_READ_DEFAULT_CONTEXT_LINES);
+      const readInput =
+        toolInput.aroundLine === undefined
+          ? { path: toolInput.path }
+          : { path: toolInput.path, aroundLine: toolInput.aroundLine, contextLines };
+      return runTool(input.session, "file-read", toolCallId, readInput, async (callId) => {
         input.onOutput({
           toolName: "file-read",
           content: {
             kind: "file-header",
             labelKey: "tool.label.file_read",
             count: 1,
-            targets: [toDisplayPath(toolInput.path, input.workspace)],
+            targets: [toDisplayPath(readInput.path, input.workspace)],
           },
           toolCallId: callId,
         });
-        const output = await readFileContent(input.workspace, toolInput.path, FILE_READ_MAX_LINES);
-        return { kind: "file-read" as const, path: toolInput.path, output };
+        const output = await readFileContent(input.workspace, toolInput.path, {
+          maxLines: FILE_READ_MAX_LINES,
+          aroundLine: toolInput.aroundLine,
+          contextLines,
+        });
+        return {
+          kind: "file-read" as const,
+          path: toolInput.path,
+          aroundLine: toolInput.aroundLine,
+          contextLines,
+          output,
+        };
       });
     },
   });

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -1,6 +1,14 @@
 import { isAbsolute, relative } from "node:path";
 import { z } from "zod";
-import { deleteTextFile, editFile, findFiles, readFileContent, searchFiles, writeTextFile } from "./file-ops";
+import {
+  DEFAULT_READ_CONTEXT_LINES,
+  deleteTextFile,
+  editFile,
+  findFiles,
+  readFileContent,
+  searchFiles,
+  writeTextFile,
+} from "./file-ops";
 import { createTool, type ToolkitInput } from "./tool-contract";
 import { runTool } from "./tool-execution";
 import { diffSummaryParts, emitParts, findSummaryParts, searchSummaryParts } from "./tool-output-format";
@@ -99,7 +107,6 @@ function createSearchFilesTool(input: ToolkitInput) {
 }
 
 const FILE_READ_MAX_LINES = 10_000;
-const FILE_READ_DEFAULT_CONTEXT_LINES = 20;
 
 function createReadFileTool(input: ToolkitInput) {
   return createTool({
@@ -128,7 +135,7 @@ function createReadFileTool(input: ToolkitInput) {
     }),
     execute: async (toolInput, toolCallId) => {
       const contextLines =
-        toolInput.aroundLine === undefined ? undefined : (toolInput.contextLines ?? FILE_READ_DEFAULT_CONTEXT_LINES);
+        toolInput.aroundLine === undefined ? undefined : (toolInput.contextLines ?? DEFAULT_READ_CONTEXT_LINES);
       const readInput =
         toolInput.aroundLine === undefined
           ? { path: toolInput.path }

--- a/src/tool-cache.int.test.ts
+++ b/src/tool-cache.int.test.ts
@@ -20,6 +20,19 @@ describe("L2 SQLite integration", () => {
     expect(entry?.result).toBe("content-a");
   });
 
+  test("file-read windows persist and invalidate by path in L2", () => {
+    const store = createStore();
+    const cache1 = createToolCache(CACHEABLE, 256, store);
+    cache1.set("file-read", { path: "/a.ts", aroundLine: 10, contextLines: 20 }, { result: "window-a" });
+    cache1.set("file-read", { path: "/b.ts", aroundLine: 10, contextLines: 20 }, { result: "window-b" });
+
+    cache1.invalidateForWrite("file-edit", { path: "/a.ts" });
+
+    const cache2 = createToolCache(CACHEABLE, 256, store);
+    expect(cache2.get("file-read", { path: "/a.ts", aroundLine: 10, contextLines: 20 })).toBeUndefined();
+    expect(cache2.get("file-read", { path: "/b.ts", aroundLine: 10, contextLines: 20 })?.result).toBe("window-b");
+  });
+
   test("pathless entries are not persisted to L2", () => {
     const store = createStore();
     const cache1 = createToolCache(CACHEABLE, 256, store);

--- a/src/tool-cache.test.ts
+++ b/src/tool-cache.test.ts
@@ -43,6 +43,14 @@ describe("tool-cache", () => {
     expect(cache.stats().misses).toBe(1);
   });
 
+  test("file-read windows are cached separately from full reads", () => {
+    const cache = createToolCache(CACHEABLE);
+    cache.set("file-read", { path: "src/foo.ts" }, { result: "full" });
+    cache.set("file-read", { path: "src/foo.ts", aroundLine: 10, contextLines: 20 }, { result: "window" });
+    expect(cache.get("file-read", { path: "src/foo.ts" })?.result).toBe("full");
+    expect(cache.get("file-read", { path: "src/foo.ts", aroundLine: 10, contextLines: 20 })?.result).toBe("window");
+  });
+
   test("stable key ignores object key order", () => {
     const cache = createToolCache(CACHEABLE);
     cache.set("file-read", { path: "a.ts", extra: 1 }, { result: "ok" });
@@ -66,6 +74,17 @@ describe("tool-cache", () => {
     expect(cache.get("file-read", { path: "src/foo.ts" })).toBeUndefined();
     expect(cache.get("file-read", { path: "src/bar.ts" })).toBeDefined();
     expect(cache.stats().invalidations).toBeGreaterThan(0);
+  });
+
+  test("invalidateForWrite evicts all file-read windows for an overlapping path", () => {
+    const cache = createToolCache(CACHEABLE);
+    cache.set("file-read", { path: "src/foo.ts" }, { result: "full" });
+    cache.set("file-read", { path: "src/foo.ts", aroundLine: 10, contextLines: 20 }, { result: "window" });
+    cache.set("file-read", { path: "src/bar.ts", aroundLine: 10, contextLines: 20 }, { result: "unrelated" });
+    cache.invalidateForWrite("file-edit", { path: "src/foo.ts" });
+    expect(cache.get("file-read", { path: "src/foo.ts" })).toBeUndefined();
+    expect(cache.get("file-read", { path: "src/foo.ts", aroundLine: 10, contextLines: 20 })).toBeUndefined();
+    expect(cache.get("file-read", { path: "src/bar.ts", aroundLine: 10, contextLines: 20 })).toBeDefined();
   });
 
   test("invalidateForWrite clears search/find entries on any write", () => {

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -125,6 +125,10 @@ describe("localization baseline", () => {
 
     expectIntent(readInstruction, [
       ["file-read", "before", "file-edit", "code-edit"],
+      ["file-search", "aroundLine"],
+      ["Default", "contextLines", "20"],
+      ["up to", "60"],
+      ["widen", "incrementally"],
       ["re-read", "target file", "before editing"],
     ]);
     expectIntent(findInstruction, [["file-find", "locate files"]]);


### PR DESCRIPTION
## Motivation

Full-file reads make common search-read-edit flows burn unnecessary tokens and preserve too much context across turns.

## Summary

- add bounded file-read windows around matched lines
- keep full-file reads available when broad context is needed
- cache bounded read windows separately while invalidating by path
- cover bounded reads, cache behavior, and tool guidance in tests

Fixes #262