### PR TITLE
fix(agent): preserve answers on signal turns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 Acolyte is a terminal-first AI coding agent: local-first, observable, extensible. Read `docs/architecture.md` before working on unfamiliar subsystems.
 
 Extension points:
-- New lifecycle effect → `Effect` in `lifecycle-effects.ts`, add to `EFFECTS`
+- New lifecycle effect → `Effect` in `lifecycle-effects.ts`, add to `POST_EFFECTS` or `PRE_EFFECTS`
 - New tool → appropriate `*-toolkit.ts`; all tools flow through `runTool`
 - New ecosystem → `EcosystemDetector` in `workspace-detectors.ts`, add to `ECOSYSTEM_DETECTORS`
 
@@ -15,7 +15,7 @@ These must always hold. Break them and the system breaks.
 
 1. All tools go through `runTool` in `tool-execution.ts` — never call a tool function directly.
 2. Every RPC payload, model response, and config value is validated through Zod before entering the type system.
-3. `@signal` is a suffix — model output must end with exactly one `@signal` line. Strip the signal line and everything after it.
+3. Completion is signaled with a lifecycle signal tool (`signal_done` / `signal_noop` / `signal_blocked`), not inline text. A signal tool must be the only tool call in its response, and only one may appear. Signal tools are exempt from the step budget.
 4. TUI state updaters must use functional form (`setState(prev => ...)`) when reading current state — stale closure reads cause race conditions.
 5. Error handling must follow `docs/errors.md`.
 6. Run `bun run verify` before every commit.

--- a/src/agent-contract.ts
+++ b/src/agent-contract.ts
@@ -28,7 +28,6 @@ const signalToolToSignal: Record<LifecycleSignalToolName, LifecycleSignal> = {
   signal_blocked: "blocked",
 };
 
-/** Map a tool name to its lifecycle signal, or undefined if it is not a signal tool. */
 export function signalForToolName(toolName: string): LifecycleSignal | undefined {
   const parsed = lifecycleSignalToolNameSchema.safeParse(toolName);
   if (!parsed.success) return undefined;

--- a/src/agent-contract.ts
+++ b/src/agent-contract.ts
@@ -9,6 +9,7 @@ export type ToolCallEntry = {
 };
 
 export type GenerateResult = {
+  /** The model's latest non-blank assistant text; later steps supersede earlier ones. */
   text: string;
   toolCalls: ToolCallEntry[];
   signal?: LifecycleSignal;

--- a/src/agent-contract.ts
+++ b/src/agent-contract.ts
@@ -19,6 +19,22 @@ export type GenerateResult = {
 const lifecycleSignalSchema = z.enum(["done", "noop", "blocked"]);
 export type LifecycleSignal = z.infer<typeof lifecycleSignalSchema>;
 
+export const lifecycleSignalToolNameSchema = z.enum(["signal_done", "signal_noop", "signal_blocked"]);
+export type LifecycleSignalToolName = z.infer<typeof lifecycleSignalToolNameSchema>;
+
+const signalToolToSignal: Record<LifecycleSignalToolName, LifecycleSignal> = {
+  signal_done: "done",
+  signal_noop: "noop",
+  signal_blocked: "blocked",
+};
+
+/** Map a tool name to its lifecycle signal, or undefined if it is not a signal tool. */
+export function signalForToolName(toolName: string): LifecycleSignal | undefined {
+  const parsed = lifecycleSignalToolNameSchema.safeParse(toolName);
+  if (!parsed.success) return undefined;
+  return signalToolToSignal[parsed.data];
+}
+
 export type TextDeltaPayload = { text?: string };
 export type ToolCallPayload = { toolCallId?: string; toolName?: string; args?: Record<string, unknown> };
 export type ToolResultPayload = { toolCallId?: string; toolName?: string; result?: unknown };

--- a/src/agent-stream.test.ts
+++ b/src/agent-stream.test.ts
@@ -277,4 +277,83 @@ describe("onBeforeNextCall hook", () => {
     });
     expect(secondPrompt).toContainEqual({ role: "user", content: [{ type: "text", text: "<<finish-rejected>>" }] });
   });
+
+  test("returns the answer when a nudged text step is followed by a bare signal", async () => {
+    const promptCapture: LanguageModelV4Message[][] = [];
+    const turns: LanguageModelV4StreamPart[][] = [
+      [
+        { type: "text-start", id: "t_1" },
+        { type: "text-delta", id: "t_1", delta: "The answer is 42." },
+        { type: "text-end", id: "t_1" },
+        finishPart("stop"),
+      ],
+      [
+        { type: "tool-call", toolCallId: "tc_signal_1", toolName: "signal_done", input: "{}" },
+        finishPart("tool-calls"),
+      ],
+    ];
+    const model = scriptedModel(turns, promptCapture);
+    const stream = createAgentStream(model, "sys", { signal_done: signalDoneTool() }, noopRateLimiter);
+
+    let nudged = false;
+    const { getFullOutput } = await stream("hi", {
+      onBeforeFinish: () => {
+        if (nudged) return [];
+        nudged = true;
+        return [{ role: "user", content: [{ type: "text", text: "<<signal to finish>>" }] }];
+      },
+    });
+    const output = await getFullOutput();
+
+    expect(output.text).toBe("The answer is 42.");
+    expect(output.signal).toBe("done");
+  });
+
+  test("the final answer supersedes earlier tool-step narration", async () => {
+    const promptCapture: LanguageModelV4Message[][] = [];
+    const turns: LanguageModelV4StreamPart[][] = [
+      [
+        { type: "text-start", id: "t_1" },
+        { type: "text-delta", id: "t_1", delta: "Checking file." },
+        { type: "text-end", id: "t_1" },
+        { type: "tool-call", toolCallId: "tc_1", toolName: "noop", input: "{}" },
+        finishPart("tool-calls"),
+      ],
+      [
+        { type: "text-start", id: "t_2" },
+        { type: "text-delta", id: "t_2", delta: "x is 2." },
+        { type: "text-end", id: "t_2" },
+        { type: "tool-call", toolCallId: "tc_signal_1", toolName: "signal_done", input: "{}" },
+        finishPart("tool-calls"),
+      ],
+    ];
+    const model = scriptedModel(turns, promptCapture);
+    const stream = createAgentStream(
+      model,
+      "sys",
+      { noop: echoTool(), signal_done: signalDoneTool() },
+      noopRateLimiter,
+    );
+    const { getFullOutput } = await stream("hi", {});
+    const output = await getFullOutput();
+
+    expect(output.text).toBe("x is 2.");
+  });
+
+  test("a bare signal with no text yields empty result text", async () => {
+    const promptCapture: LanguageModelV4Message[][] = [];
+    const turns: LanguageModelV4StreamPart[][] = [
+      [
+        { type: "tool-call", toolCallId: "tc_signal_1", toolName: "signal_done", input: "{}" },
+        finishPart("tool-calls"),
+      ],
+    ];
+    const model = scriptedModel(turns, promptCapture);
+    const stream = createAgentStream(model, "sys", { signal_done: signalDoneTool() }, noopRateLimiter);
+    const { getFullOutput } = await stream("hi", {});
+    const output = await getFullOutput();
+
+    expect(output.text).toBe("");
+    expect(output.signal).toBe("done");
+  });
 });

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -16,6 +16,7 @@ import type {
   StreamOutput,
   ToolCallEntry,
 } from "./agent-contract";
+import { signalForToolName } from "./agent-contract";
 import { ERROR_KINDS, LIFECYCLE_ERROR_CODES } from "./error-contract";
 import { serializeToolError } from "./error-handling";
 import { MAX_TOOL_RESULT_CHARS } from "./lifecycle-constants";
@@ -25,7 +26,6 @@ import { applyPromptCacheMarkers } from "./prompt-cache";
 import { estimatePromptSize, promptBudgetError } from "./prompt-size";
 import { normalizeModel, providerFromModel } from "./provider-config";
 import { type RateLimiter, sharedRateLimiter } from "./rate-limiter";
-import { signalForToolName } from "./signal-toolkit";
 import { type ToolDefinition, toFunctionTools } from "./tool-contract";
 import { truncateMiddle } from "./truncate-text";
 

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -55,7 +55,10 @@ export function createAgentStream(
     ];
     applyPromptCacheMarkers(provider, messages, functionTools);
 
-    let fullText = "";
+    // The model's answer: the text of the latest step that said anything non-blank. Each step's
+    // text supersedes the previous candidate; an empty step supersedes nothing. There is no
+    // "commit on stop" rule, so a nudge/rejection continue can never lose the answer.
+    let answerText = "";
     const allToolCalls: ToolCallEntry[] = [];
     let loopIteration = 0;
     let streamController!: ReadableStreamDefaultController<StreamChunk>;
@@ -146,6 +149,7 @@ export function createAgentStream(
         }
 
         const stepText = stepTextParts.join("");
+        if (stepText.trim().length > 0) answerText = stepText;
 
         if (pendingToolCalls.length === 0) {
           const extras =
@@ -161,7 +165,6 @@ export function createAgentStream(
             lifecycleSignalReason = undefined;
             continue;
           }
-          if (stepText.length > 0) fullText += stepText;
           break;
         }
 
@@ -172,8 +175,6 @@ export function createAgentStream(
         if (signalToolCalls.length > 0 && pendingToolCalls.length !== 1) {
           throw new Error("Lifecycle signal tool must be the only tool call in its model response.");
         }
-        if (signalToolCalls.length === 0 && stepText.length > 0) fullText += stepText;
-
         const assistantContent: Array<LanguageModelV4TextPart | LanguageModelV4ToolCallPart> = [
           ...(stepText.length > 0 ? [{ type: "text" as const, text: stepText }] : []),
           ...pendingToolCalls.map((tc) => ({
@@ -265,7 +266,6 @@ export function createAgentStream(
             lifecycleSignalReason = undefined;
             continue;
           }
-          if (stepText.length > 0) fullText += stepText;
           break;
         }
 
@@ -278,13 +278,13 @@ export function createAgentStream(
       log.debug("agent-stream.complete", {
         iterations: loopIteration,
         total_tool_calls: allToolCalls.length,
-        text_length: fullText.length,
+        text_length: answerText.length,
         finish_reason: finishReason?.unified ?? "unknown",
         signal: lifecycleSignal ?? null,
       });
       streamController.close();
       return {
-        text: fullText,
+        text: answerText,
         toolCalls: allToolCalls,
         ...(lifecycleSignal ? { signal: lifecycleSignal } : {}),
         ...(lifecycleSignalReason ? { signalReason: lifecycleSignalReason } : {}),

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -55,9 +55,7 @@ export function createAgentStream(
     ];
     applyPromptCacheMarkers(provider, messages, functionTools);
 
-    // The model's answer: the text of the latest step that said anything non-blank. Each step's
-    // text supersedes the previous candidate; an empty step supersedes nothing. There is no
-    // "commit on stop" rule, so a nudge/rejection continue can never lose the answer.
+    // No "commit on stop" rule, so a nudge/rejection continue can never lose the answer.
     let answerText = "";
     const allToolCalls: ToolCallEntry[] = [];
     let loopIteration = 0;

--- a/src/chat-turn.test.ts
+++ b/src/chat-turn.test.ts
@@ -205,4 +205,60 @@ describe("chat turn helpers", () => {
 
     expect(turn.assistantMessage.kind).toBe("tool_payload");
   });
+
+  test("runAssistantTurn does not mark a signal-only reply as tool_payload", async () => {
+    const turn = await runAssistantTurn({
+      client: {
+        replyStream: async () => ({
+          state: "done" as const,
+          model: "gpt-5-mini",
+          output: "The answer is 42.",
+          toolCalls: ["signal_done"],
+        }),
+        status: async () => ({}),
+        taskStatus: async () => null,
+      },
+      userText: "what is the answer",
+      history: [],
+      model: "gpt-5-mini",
+      sessionId: "sess_test",
+      pendingStartedAt: Date.now(),
+      createMessage: (role, content) => ({
+        id: "msg_assistant",
+        role,
+        content,
+        timestamp: "2026-02-20T00:00:00.000Z",
+      }),
+    });
+
+    expect(turn.assistantMessage.kind).toBeUndefined();
+  });
+
+  test("runAssistantTurn keeps tool_payload when a real tool is mixed with a signal", async () => {
+    const turn = await runAssistantTurn({
+      client: {
+        replyStream: async () => ({
+          state: "done" as const,
+          model: "gpt-5-mini",
+          output: "Reading the file.",
+          toolCalls: ["file-read", "signal_done"],
+        }),
+        status: async () => ({}),
+        taskStatus: async () => null,
+      },
+      userText: "read the file",
+      history: [],
+      model: "gpt-5-mini",
+      sessionId: "sess_test",
+      pendingStartedAt: Date.now(),
+      createMessage: (role, content) => ({
+        id: "msg_assistant",
+        role,
+        content,
+        timestamp: "2026-02-20T00:00:00.000Z",
+      }),
+    });
+
+    expect(turn.assistantMessage.kind).toBe("tool_payload");
+  });
 });

--- a/src/chat-turn.ts
+++ b/src/chat-turn.ts
@@ -1,5 +1,6 @@
 import { stat } from "node:fs/promises";
 import { resolve } from "node:path";
+import { signalForToolName } from "./agent-contract";
 import { createWorkspaceSpecifier } from "./api";
 import type { ChatMessage } from "./chat-contract";
 import { type ChatRow, createRow } from "./chat-contract";
@@ -133,8 +134,11 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
   });
 
   const baseAssistantMessage = params.createMessage("assistant", reply.output);
+  // Signal tools (signal_done/noop/blocked) aren't real work — a reply whose only tool calls are
+  // signals is a normal assistant answer, so don't demote it to tool_payload in the next turn's context.
+  const nonSignalToolCalls = (reply.toolCalls ?? []).filter((name) => !signalForToolName(name));
   const assistantMessage: ChatMessage =
-    (reply.toolCalls?.length ?? 0) > 0 ? { ...baseAssistantMessage, kind: "tool_payload" } : baseAssistantMessage;
+    nonSignalToolCalls.length > 0 ? { ...baseAssistantMessage, kind: "tool_payload" } : baseAssistantMessage;
   const rows: ChatRow[] = [];
   if (reply.error) {
     rows.push(createRow("system", reply.error, { text: palette.error }));

--- a/src/chat-turn.ts
+++ b/src/chat-turn.ts
@@ -134,8 +134,7 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
   });
 
   const baseAssistantMessage = params.createMessage("assistant", reply.output);
-  // Signal tools (signal_done/noop/blocked) aren't real work — a reply whose only tool calls are
-  // signals is a normal assistant answer, so don't demote it to tool_payload in the next turn's context.
+  // A signal-only reply is a normal answer, not tool work — don't demote it to tool_payload next turn.
   const nonSignalToolCalls = (reply.toolCalls ?? []).filter((name) => !signalForToolName(name));
   const assistantMessage: ChatMessage =
     nonSignalToolCalls.length > 0 ? { ...baseAssistantMessage, kind: "tool_payload" } : baseAssistantMessage;

--- a/src/signal-toolkit.test.ts
+++ b/src/signal-toolkit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { createSignalToolkit, signalForToolName } from "./signal-toolkit";
+import { signalForToolName } from "./agent-contract";
+import { createSignalToolkit } from "./signal-toolkit";
 import { createSessionContext } from "./tool-session";
 
 const noop = () => {};

--- a/src/signal-toolkit.ts
+++ b/src/signal-toolkit.ts
@@ -1,22 +1,6 @@
 import { z } from "zod";
-import type { LifecycleSignal } from "./agent-contract";
 import { createTool, type ToolkitInput } from "./tool-contract";
 import { runTool } from "./tool-execution";
-
-export const lifecycleSignalToolNameSchema = z.enum(["signal_done", "signal_noop", "signal_blocked"]);
-export type LifecycleSignalToolName = z.infer<typeof lifecycleSignalToolNameSchema>;
-
-const signalToolToSignal: Record<LifecycleSignalToolName, LifecycleSignal> = {
-  signal_done: "done",
-  signal_noop: "noop",
-  signal_blocked: "blocked",
-};
-
-export function signalForToolName(toolName: string): LifecycleSignal | undefined {
-  const parsed = lifecycleSignalToolNameSchema.safeParse(toolName);
-  if (!parsed.success) return undefined;
-  return signalToolToSignal[parsed.data];
-}
 
 function createDoneSignalTool(input: ToolkitInput) {
   return createTool({


### PR DESCRIPTION
## Motivation

Since lifecycle signal tools shipped, a task ending with the answer in one step and a bare `signal_done` in the next returned an empty `result.text` — so the user saw a canned "Done." Those signal-only replies were also demoted to `tool_payload`, deprioritizing them in the next turn.

## Summary

- preserve the answer as the latest non-blank step's text, so a trailing signal-only step can't drop it
- stop demoting signal-only replies to `tool_payload`
- correct the stale `@signal` invariant and effect names in `AGENTS.md`
