### PR TITLE
fix: prompt ordering, reasoning migration, usage telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ These must always hold. Break them and the system breaks.
 
 ## Commits
 
-Format: `type(scope): description` — types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`. Single-line subject, no body, under 72 characters. ASCII only.
+Format: `type(scope): description` — types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`. Single-line subject, no body, under 72 characters. ASCII only. No issue references or links in the subject (`(#123)`, `Fixes #123`) — issue references belong in the PR body.
 
 ## Code
 

--- a/src/agent-contract.ts
+++ b/src/agent-contract.ts
@@ -49,6 +49,9 @@ export type ToolErrorPayload = {
 export type ModelUsagePayload = {
   inputTokens?: number;
   outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  reasoningTokens?: number;
 };
 export type StreamChunk =
   | { type: "step-start" }

--- a/src/agent-contract.ts
+++ b/src/agent-contract.ts
@@ -1,5 +1,6 @@
 import type { LanguageModelV4, LanguageModelV4Message, SharedV4ProviderOptions } from "@ai-sdk/provider";
 import { z } from "zod";
+import type { ReasoningLevel } from "./config-contract";
 import type { ToolDefinition } from "./tool-contract";
 
 export type ToolCallEntry = {
@@ -70,6 +71,7 @@ export type Agent = {
 export type StreamOptions = {
   toolChoice?: "auto" | "none" | "required";
   temperature?: number;
+  reasoning?: ReasoningLevel;
   providerOptions?: SharedV4ProviderOptions;
   preCallInputTokenLimit?: number;
   onBeforeNextCall?: (messages: readonly LanguageModelV4Message[]) => LanguageModelV4Message[];

--- a/src/agent-input.test.ts
+++ b/src/agent-input.test.ts
@@ -145,6 +145,22 @@ describe("createAgentInput", () => {
     expect(input).not.toContain("TOOL_SENTINEL");
   });
 
+  test("renders history chronologically — a later tool payload never precedes earlier turns", () => {
+    // Budget is ample so all three are kept; the tool payload occurs last, so it must
+    // render last. Regression: the two-pass selection used to hoist every tool payload
+    // ahead of every conversational message, so turn-N tool output preceded the turn-1 user.
+    const { input } = createAgentInput(
+      req("continue", [
+        msg("u", "user", "FIRST_USER"),
+        msg("a", "assistant", "SECOND_ASSISTANT"),
+        msg("tool", "assistant", "THIRD_TOOL", "tool_payload"),
+      ]),
+      defaultOptions,
+    );
+    expect(input.indexOf("FIRST_USER")).toBeLessThan(input.indexOf("THIRD_TOOL"));
+    expect(input.indexOf("SECOND_ASSISTANT")).toBeLessThan(input.indexOf("THIRD_TOOL"));
+  });
+
   test("excludes turns beyond the window even when budget allows", () => {
     const count = MAX_RECENT_TURNS + 3;
     const { input, usage } = createAgentInput(req("go", exchanges(count)), defaultOptions);

--- a/src/agent-input.ts
+++ b/src/agent-input.ts
@@ -132,27 +132,37 @@ function collectLinesWithinBudget(
   usedIds: Set<string>,
   remainingTokens: number,
 ): { lines: string[]; consumedTokens: number } {
-  const lines: string[] = [];
   let consumed = 0;
-  const includeMessage = (i: number): void => {
+  // Selected lines keyed by original index, so the budget-selection priority below
+  // never dictates render order — the transcript must stay chronological.
+  const selected = new Map<number, string>();
+  const selectMessage = (i: number): void => {
     const message = messages[i];
     if (usedIds.has(message.id)) return;
     const candidate = lineForMessageWithinBudget(message, remainingTokens - consumed);
     if (!candidate || candidate.tokens === 0) return;
     usedIds.add(message.id);
-    lines.unshift(candidate.line);
+    selected.set(i, candidate.line);
     consumed += candidate.tokens;
   };
 
-  // Prefer conversational turns first and only then spend remaining budget on tool payloads.
+  // Priority: spend budget on conversational turns first, then tool payloads, so under
+  // pressure it is tool output that drops out — not user/assistant turns.
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     if (isAssistantToolPayloadMessage(messages[i])) continue;
-    includeMessage(i);
+    selectMessage(i);
   }
   for (let i = messages.length - 1; i >= 0; i -= 1) {
     if (!isAssistantToolPayloadMessage(messages[i])) continue;
-    includeMessage(i);
+    selectMessage(i);
   }
+
+  // Emit in original (chronological) order. The passes above choose *which* messages
+  // survive the budget; they must not reorder them, or a later turn's tool payload
+  // renders ahead of an earlier user/assistant message.
+  const lines = Array.from(selected.keys())
+    .sort((a, b) => a - b)
+    .map((i) => selected.get(i) as string);
   return { lines, consumedTokens: consumed };
 }
 

--- a/src/agent-stream.test.ts
+++ b/src/agent-stream.test.ts
@@ -138,6 +138,7 @@ describe("onBeforeNextCall hook", () => {
   function scriptedModel(
     turns: LanguageModelV4StreamPart[][],
     promptCapture: LanguageModelV4Message[][],
+    argsCapture?: Array<Record<string, unknown>>,
   ): LanguageModelV4 {
     let call = 0;
     return {
@@ -145,8 +146,9 @@ describe("onBeforeNextCall hook", () => {
       provider: "test",
       modelId: "test-model",
       supportedUrls: {},
-      async doStream(args: { prompt: LanguageModelV4Message[] }) {
+      async doStream(args: { prompt: LanguageModelV4Message[] } & Record<string, unknown>) {
         promptCapture.push(args.prompt.map((m) => ({ ...m })));
+        argsCapture?.push(args);
         const parts = turns[call] ?? [];
         call += 1;
         return {
@@ -355,5 +357,53 @@ describe("onBeforeNextCall hook", () => {
 
     expect(output.text).toBe("");
     expect(output.signal).toBe("done");
+  });
+
+  test("passes the reasoning level through to the model as a call option", async () => {
+    const promptCapture: LanguageModelV4Message[][] = [];
+    const argsCapture: Array<Record<string, unknown>> = [];
+    const turns: LanguageModelV4StreamPart[][] = [[finishPart("stop")]];
+    const model = scriptedModel(turns, promptCapture, argsCapture);
+    const stream = createAgentStream(model, "sys", {}, noopRateLimiter);
+    const { getFullOutput } = await stream("hi", { reasoning: "high" });
+    await getFullOutput();
+
+    expect(argsCapture).toHaveLength(1);
+    expect(argsCapture[0].reasoning).toBe("high");
+    // Reasoning must ride the unified call option, never a hand-built thinking budget.
+    expect(argsCapture[0].providerOptions).toBeUndefined();
+  });
+
+  test("replays reasoning blocks with their signature alongside the tool call", async () => {
+    const promptCapture: LanguageModelV4Message[][] = [];
+    const turns: LanguageModelV4StreamPart[][] = [
+      [
+        { type: "reasoning-start", id: "r_1" },
+        { type: "reasoning-delta", id: "r_1", delta: "Weighing options." },
+        // Anthropic delivers the thinking-block signature on a zero-length delta.
+        { type: "reasoning-delta", id: "r_1", delta: "", providerMetadata: { anthropic: { signature: "sig-abc" } } },
+        { type: "tool-call", toolCallId: "tc_1", toolName: "noop", input: "{}" },
+        finishPart("tool-calls"),
+      ],
+      [
+        { type: "text-start", id: "t_1" },
+        { type: "text-delta", id: "t_1", delta: "done" },
+        { type: "text-end", id: "t_1" },
+        finishPart("stop"),
+      ],
+    ];
+    const model = scriptedModel(turns, promptCapture);
+    const stream = createAgentStream(model, "sys", { noop: echoTool() }, noopRateLimiter);
+    const { getFullOutput } = await stream("hi", { reasoning: "high" });
+    await getFullOutput();
+
+    const secondPrompt = promptCapture[1];
+    expect(secondPrompt).toContainEqual({
+      role: "assistant",
+      content: [
+        { type: "reasoning", text: "Weighing options.", providerOptions: { anthropic: { signature: "sig-abc" } } },
+        { type: "tool-call", toolCallId: "tc_1", toolName: "noop", input: {} },
+      ],
+    });
   });
 });

--- a/src/agent-stream.test.ts
+++ b/src/agent-stream.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { LanguageModelV4, LanguageModelV4Message, LanguageModelV4StreamPart } from "@ai-sdk/provider";
+import type { StreamChunk } from "./agent-contract";
 import { COMPACTED_OUTPUT, compactPriorToolResults, createAgentStream } from "./agent-stream";
 import type { RateLimiter } from "./rate-limiter";
 import type { ToolDefinition } from "./tool-contract";
@@ -404,6 +405,47 @@ describe("onBeforeNextCall hook", () => {
         { type: "reasoning", text: "Weighing options.", providerOptions: { anthropic: { signature: "sig-abc" } } },
         { type: "tool-call", toolCallId: "tc_1", toolName: "noop", input: {} },
       ],
+    });
+  });
+
+  test("emits cache and reasoning token counts from the finish part", async () => {
+    const promptCapture: LanguageModelV4Message[][] = [];
+    const turns: LanguageModelV4StreamPart[][] = [
+      [
+        {
+          type: "finish",
+          finishReason: { unified: "stop", raw: "stop" },
+          usage: {
+            inputTokens: { total: 100, noCache: 40, cacheRead: 60, cacheWrite: 10 },
+            outputTokens: { total: 20, text: 12, reasoning: 8 },
+          },
+        },
+      ],
+    ];
+    const model = scriptedModel(turns, promptCapture);
+    const stream = createAgentStream(model, "sys", {}, noopRateLimiter);
+    const { fullStream, getFullOutput } = await stream("hi", {});
+
+    const chunks: StreamChunk[] = [];
+    const reader = fullStream.getReader();
+    const drain = (async () => {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+    })();
+    await getFullOutput();
+    await drain;
+
+    const usage = chunks.find((c) => c.type === "model-usage");
+    if (usage?.type !== "model-usage") throw new Error("no model-usage chunk emitted");
+    expect(usage.payload).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 20,
+      cacheReadTokens: 60,
+      cacheWriteTokens: 10,
+      reasoningTokens: 8,
     });
   });
 });

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -145,6 +145,9 @@ export function createAgentStream(
               payload: {
                 inputTokens: part.usage?.inputTokens?.total,
                 outputTokens: part.usage?.outputTokens?.total,
+                cacheReadTokens: part.usage?.inputTokens?.cacheRead,
+                cacheWriteTokens: part.usage?.inputTokens?.cacheWrite,
+                reasoningTokens: part.usage?.outputTokens?.reasoning,
               },
             });
           }

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -2,10 +2,12 @@ import type {
   LanguageModelV4,
   LanguageModelV4FinishReason,
   LanguageModelV4Message,
+  LanguageModelV4ReasoningPart,
   LanguageModelV4StreamPart,
   LanguageModelV4TextPart,
   LanguageModelV4ToolCallPart,
   LanguageModelV4ToolResultPart,
+  SharedV4ProviderOptions,
 } from "@ai-sdk/provider";
 import type {
   Agent,
@@ -108,6 +110,7 @@ export function createAgentStream(
               : functionTools.length > 0
                 ? { type: "auto" }
                 : undefined,
+            ...(options.reasoning ? { reasoning: options.reasoning } : {}),
             ...(options.providerOptions ? { providerOptions: options.providerOptions } : {}),
           });
           rateLimiter.reset();
@@ -128,12 +131,13 @@ export function createAgentStream(
         }> = [];
         finishReason = undefined;
         const stepTextParts: string[] = [];
+        const reasoningBlocks = new Map<string, ReasoningBlock>();
 
         const reader = streamResult.stream.getReader();
         while (true) {
           const { done, value: part } = await reader.read();
           if (done) break;
-          emitStreamPart(part, streamController, stepTextParts, pendingToolCalls);
+          emitStreamPart(part, streamController, stepTextParts, pendingToolCalls, reasoningBlocks);
           if (part.type === "finish") {
             finishReason = part.finishReason;
             streamController.enqueue({
@@ -173,7 +177,10 @@ export function createAgentStream(
         if (signalToolCalls.length > 0 && pendingToolCalls.length !== 1) {
           throw new Error("Lifecycle signal tool must be the only tool call in its model response.");
         }
-        const assistantContent: Array<LanguageModelV4TextPart | LanguageModelV4ToolCallPart> = [
+        const assistantContent: Array<
+          LanguageModelV4ReasoningPart | LanguageModelV4TextPart | LanguageModelV4ToolCallPart
+        > = [
+          ...reasoningContentParts(reasoningBlocks),
           ...(stepText.length > 0 ? [{ type: "text" as const, text: stepText }] : []),
           ...pendingToolCalls.map((tc) => ({
             type: "tool-call" as const,
@@ -306,11 +313,26 @@ function signalReasonFromResult(result: unknown): string | undefined {
   return typeof reason === "string" && reason.trim().length > 0 ? reason.trim() : undefined;
 }
 
+type ReasoningBlock = { text: string; providerOptions?: SharedV4ProviderOptions };
+
+function reasoningContentParts(blocks: Map<string, ReasoningBlock>): LanguageModelV4ReasoningPart[] {
+  const parts: LanguageModelV4ReasoningPart[] = [];
+  for (const block of blocks.values()) {
+    parts.push({
+      type: "reasoning",
+      text: block.text,
+      ...(block.providerOptions ? { providerOptions: block.providerOptions } : {}),
+    });
+  }
+  return parts;
+}
+
 function emitStreamPart(
   part: LanguageModelV4StreamPart,
   controller: ReadableStreamDefaultController<StreamChunk>,
   textParts: string[],
   pendingToolCalls: Array<{ toolCallId: string; toolName: string; input: string }>,
+  reasoningBlocks: Map<string, ReasoningBlock>,
 ): void {
   switch (part.type) {
     case "text-delta": {
@@ -320,9 +342,20 @@ function emitStreamPart(
       }
       break;
     }
-    case "reasoning-delta":
+    case "reasoning-start": {
+      const block = reasoningBlocks.get(part.id) ?? { text: "" };
+      if (part.providerMetadata) block.providerOptions = { ...block.providerOptions, ...part.providerMetadata };
+      reasoningBlocks.set(part.id, block);
+      break;
+    }
+    case "reasoning-delta": {
+      const block = reasoningBlocks.get(part.id) ?? { text: "" };
+      block.text += part.delta;
+      if (part.providerMetadata) block.providerOptions = { ...block.providerOptions, ...part.providerMetadata };
+      reasoningBlocks.set(part.id, block);
       controller.enqueue({ type: "reasoning-delta", payload: { text: part.delta } });
       break;
+    }
     case "tool-call":
       pendingToolCalls.push({
         toolCallId: part.toolCallId,

--- a/src/lifecycle-generate.test.ts
+++ b/src/lifecycle-generate.test.ts
@@ -109,6 +109,48 @@ describe("phaseGenerate", () => {
     expect(capturedOptions?.providerOptions?.openai?.promptCacheKey).toBeString();
   });
 
+  test("forwards the reasoning level as a call option and suppresses temperature", async () => {
+    const savedReasoning = appConfig.reasoning;
+    (appConfig as { reasoning: typeof appConfig.reasoning }).reasoning = "high";
+    let capturedOptions: StreamOptions | undefined;
+    const ctx = createRunContext({
+      model: "anthropic/claude-opus-4-8",
+      temperature: 0.42,
+      agent: {
+        id: "test-agent",
+        name: "test-agent",
+        instructions: "",
+        model: {} as RunContext["agent"]["model"],
+        tools: {},
+        async stream(_prompt, options) {
+          capturedOptions = options;
+          return {
+            fullStream: new ReadableStream({
+              start(controller) {
+                controller.close();
+              },
+            }),
+            async getFullOutput() {
+              return { text: "done", toolCalls: [] };
+            },
+          };
+        },
+      },
+    });
+
+    try {
+      await phaseGenerate(ctx, { timeoutMs: 1000 });
+    } finally {
+      (appConfig as { reasoning: typeof appConfig.reasoning }).reasoning = savedReasoning;
+    }
+
+    expect(capturedOptions?.reasoning).toBe("high");
+    // Reasoning models reject an explicit temperature, and the deprecated thinking
+    // budget must never be assembled by hand.
+    expect(capturedOptions?.temperature).toBeUndefined();
+    expect(capturedOptions?.providerOptions?.anthropic).toBeUndefined();
+  });
+
   test("passes Vercel AI Gateway prompt caching options", async () => {
     let capturedOptions: StreamOptions | undefined;
     const ctx = createRunContext({

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -548,6 +548,13 @@ const CHUNK_HANDLERS: Record<StreamChunk["type"], ChunkHandler> = {
     if (typeof p?.inputTokens === "number") ctx.inputTokensAccum += p.inputTokens;
     if (typeof p?.outputTokens === "number") ctx.outputTokensAccum += p.outputTokens;
     ctx.modelCallCount += 1;
+    ctx.debug("lifecycle.model_usage", {
+      inputTokens: p?.inputTokens,
+      outputTokens: p?.outputTokens,
+      cacheReadTokens: p?.cacheReadTokens,
+      cacheWriteTokens: p?.cacheWriteTokens,
+      reasoningTokens: p?.reasoningTokens,
+    });
     ctx.emit({
       type: "usage",
       inputTokens: ctx.inputTokensAccum,

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -20,8 +20,8 @@ import {
 import { findCompletionBlock } from "./lifecycle-completion";
 import { type GenerateOptions, promptUsageTotalTokens, type RunContext } from "./lifecycle-contract";
 import { createFinishPolicyState, decideFinish, renderFinishPolicyMessages } from "./lifecycle-generate-policy";
-import { createPromptCacheKey, mergeProviderOptions, promptCacheProviderOptions } from "./prompt-cache";
-import { providerFromModel, reasoningProviderOptions } from "./provider-config";
+import { createPromptCacheKey, promptCacheProviderOptions } from "./prompt-cache";
+import { providerFromModel } from "./provider-config";
 import type { StreamError } from "./stream-error";
 import type { ToolDefinition } from "./tool-contract";
 import { extractToolErrorCode } from "./tool-error";
@@ -246,9 +246,9 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
       sessionId: ctx.request.sessionId,
       workspace: ctx.workspace,
     });
-    const reasoningOptions = reasoningProviderOptions(provider, appConfig.reasoning);
-    const providerOptions = mergeProviderOptions(reasoningOptions, promptCacheProviderOptions(provider, cacheKey));
-    const temperature = reasoningOptions ? undefined : (ctx.temperature ?? appConfig.temperature);
+    const providerOptions = promptCacheProviderOptions(provider, cacheKey);
+    const reasoning = appConfig.reasoning;
+    const temperature = reasoning ? undefined : (ctx.temperature ?? appConfig.temperature);
     const streamOutput = await ctx.agent.stream(prompt, {
       toolChoice: "auto",
       preCallInputTokenLimit: ctx.policy.contextMaxTokens,
@@ -328,6 +328,7 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
         return renderFinishPolicyMessages(decision);
       },
       ...(typeof temperature === "number" ? { temperature } : {}),
+      ...(reasoning ? { reasoning } : {}),
       ...(providerOptions ? { providerOptions } : {}),
     });
     const fullOutput = streamOutput.getFullOutput();

--- a/src/model-factory.test.ts
+++ b/src/model-factory.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import type { LanguageModelV4Message } from "@ai-sdk/provider";
+import type { ProviderCredentialsMap } from "./agent-model";
+import { createModel } from "./model-factory";
+import { sharedRateLimiter } from "./rate-limiter";
+
+describe("createModel anthropic reasoning", () => {
+  function minimalStreamResponse(): Response {
+    const body =
+      "event: message_start\n" +
+      'data: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"claude-opus-4-8","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":1,"output_tokens":1}}}\n\n' +
+      "event: message_delta\n" +
+      'data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":1}}\n\n' +
+      "event: message_stop\n" +
+      'data: {"type":"message_stop"}\n\n';
+    return new Response(body, { status: 200, headers: { "content-type": "text/event-stream" } });
+  }
+
+  async function captureRequestBody(modelId: string, reasoning: "low" | "medium" | "high") {
+    const originalFetch = globalThis.fetch;
+    let captured: Record<string, unknown> | undefined;
+    globalThis.fetch = (async (_url: string | URL | Request, init?: RequestInit) => {
+      captured = JSON.parse(String(init?.body)) as Record<string, unknown>;
+      return minimalStreamResponse();
+    }) as typeof globalThis.fetch;
+
+    try {
+      const credentials: ProviderCredentialsMap = { anthropic: { apiKey: "test-key" } };
+      const model = createModel(modelId, sharedRateLimiter("anthropic"), credentials);
+      const { stream } = await model.doStream({
+        prompt: [{ role: "user", content: [{ type: "text", text: "hi" }] }] as LanguageModelV4Message[],
+        reasoning,
+      });
+      const reader = stream.getReader();
+      while (true) {
+        const { done } = await reader.read();
+        if (done) break;
+      }
+      return captured;
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }
+
+  test("maps reasoning to adaptive thinking on current models, never a budget", async () => {
+    const body = await captureRequestBody("anthropic/claude-opus-4-8", "high");
+    expect(body?.thinking).toEqual({ type: "adaptive" });
+    expect(JSON.stringify(body)).not.toContain("budget_tokens");
+    expect(body?.output_config).toMatchObject({ effort: "high" });
+  });
+
+  test("maps the reasoning level onto the effort knob", async () => {
+    const body = await captureRequestBody("anthropic/claude-opus-4-8", "low");
+    expect(body?.thinking).toEqual({ type: "adaptive" });
+    expect(body?.output_config).toMatchObject({ effort: "low" });
+  });
+});

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -1,11 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import {
-  formatModel,
-  isProviderAvailable,
-  normalizeModel,
-  providerFromModel,
-  reasoningProviderOptions,
-} from "./provider-config";
+import { formatModel, isProviderAvailable, normalizeModel, providerFromModel } from "./provider-config";
 
 describe("provider config", () => {
   test("normalizeModel prefixes unqualified model ids", () => {
@@ -41,19 +35,6 @@ describe("provider config", () => {
     expect(providerFromModel("vercel/anthropic/claude-sonnet-4")).toBe("vercel");
     expect(providerFromModel("xai/grok-4.1")).toBe("vercel");
     expect(providerFromModel("mistral/mistral-large")).toBe("vercel");
-  });
-
-  test("reasoningProviderOptions returns provider-specific options", () => {
-    expect(reasoningProviderOptions("openai", "high")).toEqual({ openai: { reasoningEffort: "high" } });
-    expect(reasoningProviderOptions("anthropic", "high")).toEqual({
-      anthropic: { thinking: { type: "enabled", budgetTokens: 20_000 } },
-    });
-    expect(reasoningProviderOptions("google", "low")).toEqual({ google: { thinkingConfig: { thinkingLevel: "low" } } });
-    expect(reasoningProviderOptions("vercel", "high")).toEqual({ openai: { reasoningEffort: "high" } });
-  });
-
-  test("reasoningProviderOptions returns undefined when level is not set", () => {
-    expect(reasoningProviderOptions("openai", undefined)).toBeUndefined();
   });
 
   test("isProviderAvailable validates credential requirements", () => {

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -1,4 +1,3 @@
-import type { SharedV4ProviderOptions } from "@ai-sdk/provider";
 import type { ReasoningLevel } from "./config-contract";
 import { type Provider, providerSchema } from "./provider-contract";
 
@@ -72,28 +71,6 @@ export function providerFromModel(model: string): Provider {
 export type ProviderCredentials = { apiKey?: string; baseUrl?: string };
 
 export const DEFAULT_REASONING = "medium";
-
-const ANTHROPIC_THINKING_BUDGET: Record<string, number> = {
-  low: 5_000,
-  medium: 10_000,
-  high: 20_000,
-};
-
-export function reasoningProviderOptions(
-  provider: Provider,
-  level: ReasoningLevel | undefined,
-): SharedV4ProviderOptions | undefined {
-  if (!level) return undefined;
-  switch (provider) {
-    case "openai":
-    case "vercel":
-      return { openai: { reasoningEffort: level } };
-    case "anthropic":
-      return { anthropic: { thinking: { type: "enabled", budgetTokens: ANTHROPIC_THINKING_BUDGET[level] ?? 10_000 } } };
-    case "google":
-      return { google: { thinkingConfig: { thinkingLevel: level } } };
-  }
-}
 
 export function isProviderAvailable(provider: Provider, credentials: ProviderCredentials): boolean {
   if (provider === "anthropic") return Boolean(credentials.apiKey) && isAnthropicBaseUrlValid(credentials.baseUrl);


### PR DESCRIPTION
## Summary

- keep prompt history in chronological order so tool_payload messages don't jump ahead of turn order
- migrate Anthropic thinking config to the unified `reasoning` call option, clearing the live 400 on Opus 4.7/4.8 and Fable 5
- replay reasoning blocks alongside tool_use so multi-turn tool use doesn't 400
- surface cache and reasoning token counts in model-usage telemetry

Fixes #267
Fixes #268
Fixes #269
