### PR TITLE
fix(tui): always install the client log sink

### DIFF
--- a/src/chat-app.int.test.ts
+++ b/src/chat-app.int.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, readFileSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { installClientLogSink } from "./chat-app";
 import { getCachedRepoPathCandidates, invalidateRepoPathCandidates } from "./chat-file-ref";
+import { log, setLogSink } from "./log";
+import { stateDir } from "./paths";
 import { tempDir } from "./test-utils";
 
 const dirs = tempDir();
@@ -22,5 +26,67 @@ describe("chat-ui integration helpers", () => {
     invalidateRepoPathCandidates(root);
     const refreshed = await getCachedRepoPathCandidates(root);
     expect(refreshed).toContain("sum.rs");
+  });
+});
+
+function withLogSinkEnv(
+  fn: (ctx: { home: string; stdout: string[] }) => void,
+  options: { debug?: boolean } = {},
+): void {
+  const home = dirs.createDir("acolyte-logsink-");
+  const saved = {
+    home: process.env.HOME,
+    xdgState: process.env.XDG_STATE_HOME,
+    debug: process.env.ACOLYTE_DEBUG,
+    write: process.stdout.write,
+  };
+  const stdout: string[] = [];
+  process.env.HOME = home;
+  delete process.env.XDG_STATE_HOME;
+  if (options.debug) process.env.ACOLYTE_DEBUG = "1";
+  else delete process.env.ACOLYTE_DEBUG;
+  mkdirSync(stateDir(), { recursive: true });
+  process.stdout.write = ((data: string) => {
+    stdout.push(data);
+    return true;
+  }) as typeof process.stdout.write;
+  try {
+    // Reset to the real startup state (the test preload installs a no-op sink;
+    // production has none) so a missing sink would leak to stdout.
+    setLogSink(null);
+    fn({ home, stdout });
+  } finally {
+    setLogSink(() => {});
+    process.stdout.write = saved.write;
+    if (saved.home === undefined) delete process.env.HOME;
+    else process.env.HOME = saved.home;
+    if (saved.xdgState === undefined) delete process.env.XDG_STATE_HOME;
+    else process.env.XDG_STATE_HOME = saved.xdgState;
+    if (saved.debug === undefined) delete process.env.ACOLYTE_DEBUG;
+    else process.env.ACOLYTE_DEBUG = saved.debug;
+  }
+}
+
+describe("client log sink", () => {
+  test("keeps logs off stdout when ACOLYTE_DEBUG is unset", () => {
+    withLogSinkEnv(({ stdout }) => {
+      installClientLogSink();
+      log.debug("chat.submit", { value: "hello", resolved: "submit" });
+      expect(stdout.join("")).not.toMatch(/level=debug/);
+    });
+  });
+
+  test("diverts logs to client.log under ACOLYTE_DEBUG, never stdout", () => {
+    withLogSinkEnv(
+      ({ stdout }) => {
+        installClientLogSink();
+        log.debug("chat.submit", { value: "hello", resolved: "submit" });
+        expect(stdout.join("")).not.toMatch(/level=debug/);
+        const logged = readFileSync(join(stateDir(), "client.log"), "utf8");
+        expect(logged).toMatch(/level=debug/);
+        expect(logged).toContain("chat.submit");
+      },
+      { debug: true },
+    );
   });
 });

--- a/src/chat-app.tsx
+++ b/src/chat-app.tsx
@@ -86,17 +86,25 @@ function ChatApp(props: ChatAppProps) {
   );
 }
 
-export async function runChat(props: ChatAppProps): Promise<void> {
-  if (process.env.ACOLYTE_DEBUG) {
-    const logPath = join(stateDir(), "client.log");
-    setLogSink((line) => {
-      try {
-        appendFileSync(logPath, line);
-      } catch {
-        // best-effort
-      }
-    });
+export function installClientLogSink(): void {
+  // The TUI owns stdout exclusively, so a sink is always installed to keep logs
+  // off the frame; it writes to client.log under ACOLYTE_DEBUG, else swallows.
+  if (!process.env.ACOLYTE_DEBUG) {
+    setLogSink(() => {});
+    return;
   }
+  const logPath = join(stateDir(), "client.log");
+  setLogSink((line) => {
+    try {
+      appendFileSync(logPath, line);
+    } catch {
+      // best-effort
+    }
+  });
+}
+
+export async function runChat(props: ChatAppProps): Promise<void> {
+  installClientLogSink();
   const app = render(<ChatApp {...props} />);
   try {
     await app.waitUntilExit();


### PR DESCRIPTION
## Motivation

Since #250 the sink was only installed under `ACOLYTE_DEBUG`, so normal runs wrote `log.debug` to `process.stdout` — into the frames the custom TUI renderer owns, corrupting the display.

## Summary

- always install the log sink while the TUI is mounted, so debug logs never reach stdout; `ACOLYTE_DEBUG` now only picks the destination (`client.log` vs discard)
- add regression tests asserting no debug output leaks to stdout in either mode
