### PR TITLE
fix(chat): stop dropping the final answer

### DIFF
--- a/src/chat-message-handler-stream.test.ts
+++ b/src/chat-message-handler-stream.test.ts
@@ -256,4 +256,52 @@ describe("chat-message-handler-stream", () => {
     expect(assistantRow).toBeDefined();
     expect(assistantRow?.content).toBe("Tell me what to build.");
   });
+
+  // React 19 + StrictMode may invoke a setRows updater more than once, or defer
+  // it past a closure reset. This harness models both: every queued updater is
+  // invoked once with its result DISCARDED (the StrictMode extra call) and then
+  // again for real. The stream state's updaters must be pure or the streamed
+  // assistant row desyncs from its tracked id and silently vanishes.
+  function createStrictHarness(): {
+    rows: ChatRow[];
+    setRows: (updater: (current: ChatRow[]) => ChatRow[]) => void;
+    render: () => void;
+  } {
+    const rows: ChatRow[] = [];
+    const queue: Array<(current: ChatRow[]) => ChatRow[]> = [];
+    const setRows = (updater: (current: ChatRow[]) => ChatRow[]): void => {
+      queue.push(updater);
+    };
+    const render = (): void => {
+      while (queue.length > 0) {
+        const updater = queue.shift();
+        if (!updater) continue;
+        updater([...rows]); // StrictMode extra invocation — result discarded
+        rows.splice(0, rows.length, ...updater(rows)); // real invocation — committed
+      }
+    };
+    return { rows, setRows, render };
+  }
+
+  test("streamed answer survives StrictMode double-invocation of the flush updater", async () => {
+    const h = createStrictHarness();
+    const state = createMessageStreamState({ setRows: h.setRows });
+    state.onDelta("The final answer.");
+    await new Promise((resolve) => setTimeout(resolve, 60)); // flush timer enqueues the updater
+    h.render();
+    expect(h.rows.filter((r) => r.kind === "assistant").map((r) => r.content)).toEqual(["The final answer."]);
+    state.dispose();
+  });
+
+  test("streamed content survives a flush deferred past finalize's closure reset", () => {
+    const h = createStrictHarness();
+    const state = createMessageStreamState({ setRows: h.setRows });
+    state.onDelta("Tail that must not vanish.");
+    const ids = state.finalize(); // enqueues flush, then resets the closure — before render
+    h.render();
+    expect(h.rows.filter((r) => r.kind === "assistant").map((r) => r.content)).toEqual(["Tail that must not vanish."]);
+    // finalize()'s returned ids must reference rows that actually committed.
+    for (const id of ids) expect(h.rows.some((r) => r.id === id)).toBe(true);
+    state.dispose();
+  });
 });

--- a/src/chat-message-handler-stream.ts
+++ b/src/chat-message-handler-stream.ts
@@ -53,18 +53,25 @@ export function createMessageStreamState(input: {
 
   function flush(): void {
     cancelFlushTimer();
-    if (agentContent.trim().length === 0) return;
-    input.setRows((current) => {
-      if (!activeRowId) {
-        const trimmed = agentContent.trim();
-        if (trimmed.length === 0) return current;
-        agentContent = trimmed;
-        activeRowId = `row_${createId()}`;
-        agentRowIds.push(activeRowId);
-        return [...current, { id: activeRowId, kind: "assistant", content: agentContent }];
-      }
-      return current.map((row) => (row.id === activeRowId ? { ...row, content: agentContent } : row));
-    });
+    // Leading whitespace stripped every call so `content` is a pure function of
+    // agentContent (no mutation), keeping the updater idempotent.
+    const content = agentContent.replace(/^\s+/, "");
+    if (content.length === 0) return;
+    // Row identity is assigned OUTSIDE the updater: React may invoke a setRows
+    // updater more than once (StrictMode) or after sealAgentRow/finalize reset
+    // the closure, so the updater must be a pure function of `current` only —
+    // any id creation / tracking mutation inside it desyncs agentRowIds from the
+    // committed rows and silently drops the answer.
+    if (!activeRowId) {
+      activeRowId = `row_${createId()}`;
+      agentRowIds.push(activeRowId);
+    }
+    const id = activeRowId;
+    input.setRows((current) =>
+      current.some((row) => row.id === id)
+        ? current.map((row) => (row.id === id ? { ...row, content } : row))
+        : [...current, { id, kind: "assistant" as const, content }],
+    );
   }
 
   /** Flush pending content and detach from the current agent row. */
@@ -100,14 +107,19 @@ export function createMessageStreamState(input: {
         agentContent = "";
         const rowId = `row_${createId()}`;
         toolRowIdByCallId.set(entry.toolCallId, rowId);
+        // Decide (and track) any fallback assistant row OUTSIDE the updater, for
+        // the same pure-updater reason as flush().
+        const fallbackAssistantId =
+          !(pendingContent && pendingRowId) && pendingContent.trim().length > 0 ? `row_${createId()}` : null;
+        if (fallbackAssistantId) agentRowIds.push(fallbackAssistantId);
         input.setRows((current) => {
           let rows = current;
           if (pendingContent && pendingRowId) {
             rows = rows.map((row) => (row.id === pendingRowId ? { ...row, content: pendingContent } : row));
-          } else if (pendingContent && pendingContent.trim().length > 0) {
-            const id = `row_${createId()}`;
-            agentRowIds.push(id);
-            rows = [...rows, { id, kind: "assistant" as const, content: pendingContent }];
+          } else if (fallbackAssistantId) {
+            rows = current.some((row) => row.id === fallbackAssistantId)
+              ? rows.map((row) => (row.id === fallbackAssistantId ? { ...row, content: pendingContent } : row))
+              : [...rows, { id: fallbackAssistantId, kind: "assistant" as const, content: pendingContent }];
           }
           return [...rows, { id: rowId, kind: "tool" as const, content: { parts: update.items } }];
         });

--- a/src/chat-message-handler.int.test.ts
+++ b/src/chat-message-handler.int.test.ts
@@ -253,6 +253,52 @@ describe("chat message handler", () => {
     expect(promoted.some((row) => row.kind === "assistant" && row.content === "Removed sum.rs.")).toBe(true);
   });
 
+  test("commits the authoritative reply.output, not the streamed partial", async () => {
+    const { handleMessage, calls } = createMessageHandlerHarness({
+      client: createClient({
+        status: async () => ({}),
+        replyStream: async (input) => {
+          input.onEvent({ type: "text-delta", text: "partial " });
+          return {
+            state: "done" as const,
+            model: "gpt-5-mini",
+            output: "partial plus the complete authoritative answer.",
+          };
+        },
+      }),
+    });
+
+    await handleMessage("tell me about this project");
+
+    const assistantRows = calls.promotedSnapshots.flat().filter((row) => row.kind === "assistant");
+    expect(assistantRows).toHaveLength(1);
+    expect(assistantRows[0]?.content).toBe("partial plus the complete authoritative answer.");
+  });
+
+  test("signal turn: streamed answer is not duplicated by the authoritative commit", async () => {
+    const { handleMessage, calls } = createMessageHandlerHarness({
+      client: createClient({
+        status: async () => ({}),
+        replyStream: async (input) => {
+          input.onEvent({ type: "text-delta", text: "The complete answer." });
+          input.onEvent({ type: "tool-call", toolCallId: "sig_1", toolName: "signal_done", args: {} });
+          return {
+            state: "done" as const,
+            model: "gpt-5-mini",
+            output: "The complete answer.",
+            toolCalls: ["signal_done"],
+          };
+        },
+      }),
+    });
+
+    await handleMessage("say the complete answer");
+
+    const assistantRows = calls.promotedSnapshots.flat().filter((row) => row.kind === "assistant");
+    expect(assistantRows).toHaveLength(1);
+    expect(assistantRows[0]?.content).toBe("The complete answer.");
+  });
+
   test("toggles shortcuts on ? input", async () => {
     const { handleMessage, calls } = createMessageHandlerHarness();
     await handleMessage("?");

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -162,8 +162,7 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
         createMessage: input.createMessage,
       });
       const assistantMessage = turn.assistantMessage;
-      const streamingRowIds = streamState.finalize();
-      const hasStreamingAssistantRow = streamingRowIds.length > 0;
+      const streamedRowIds = new Set(streamState.finalize());
 
       if (turn.activeSkills?.length) {
         input.currentSession.activeSkills = turn.activeSkills;
@@ -188,11 +187,12 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
       } else {
         input.setPendingState(null);
       }
+      // Honor finalize()'s replacement contract: drop the transient streamed
+      // rows and commit the authoritative answer (reply.output) exactly once, so
+      // the transcript never depends on a streamed row surviving a re-render.
       const finalRows =
-        !hasStreamingAssistantRow && assistantMessage.content.trim().length > 0
-          ? [createRow("assistant", assistantMessage.content)]
-          : [];
-      input.setRows((current) => [...current, ...finalRows, ...turn.rows]);
+        assistantMessage.content.trim().length > 0 ? [createRow("assistant", assistantMessage.content)] : [];
+      input.setRows((current) => [...current.filter((row) => !streamedRowIds.has(row.id)), ...finalRows, ...turn.rows]);
       if (!turn.awaitingInput) input.promote?.();
       invalidateRepoPathCandidates();
       input.currentSession.tokenUsage.push(turn.tokenEntry);


### PR DESCRIPTION
## Motivation

The agent's answer was sometimes generated but never shown — a React state-purity race in the stream→row mirror, amplified by StrictMode's double-invocation.

## Summary

- make the streamed-text setRows updaters pure so React re-invoking or deferring them can't desync a streamed row from its id
- always commit the authoritative reply.output and drop the transient streamed rows, so the transcript never depends on a streamed row surviving
