### PR TITLE
fix(memory): scope-aware recall isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,14 +34,15 @@ Format: `type(scope): description` — types: `feat`, `fix`, `refactor`, `docs`,
 
 - No transitional architecture: land the canonical owner, normalized contract, and single source of truth.
 - When defining a string union or shared type: define it as a Zod schema first and infer the TS type from it.
-- No banner or separator comments. Import from the canonical source module directly — no re-export layers.
+- Comments: code documents itself. Don't comment *what* code does and don't write banner/separator comments; add one only for a *why* that can't be encoded in a name, type, or test (e.g. a non-obvious external constraint).
+- Import from the canonical source module directly — no re-export layers.
 - No direct `useEffect` in chat-layer code. Use the approved effect helpers from `src/tui/effects.ts`.
 
 ## Style
 
 - Factory naming: `create*` for factories. Avoid `build*` / `make*` unless established locally.
 - Export shape: prefer direct `export const` over local alias + `export { ... }`.
-- Module layout: flat `src/`, `*-contract` for type/schema modules. No re-export layers.
+- Module layout: flat `src/`, `*-contract` for type/schema modules.
 - Error classification: prefer `kind` field contracts over message string matching.
 - Switch exhaustiveness: `default` + `unreachable` when applicable.
 

--- a/docs/memory.md
+++ b/docs/memory.md
@@ -24,7 +24,7 @@ The model uses the memory toolkit to search for relevant context when it determi
 
 ## Sources
 
-The observer runs after each request and promotes facts to the appropriate scope via `memory_observe` tool calls.
+The observer runs after each request and promotes facts to the appropriate scope via `memory-observe` tool calls.
 
 Memory kinds in storage: `stored` (explicit user/tool-created), `observation` (distill-extracted facts).
 
@@ -35,11 +35,11 @@ Memory kinds in storage: `stored` (explicit user/tool-created), `observation` (d
 
 ## Inspiration
 
-The observation model is inspired by [Mastra's Observational Memory](https://mastra.ai/docs/memory/observational-memory). Acolyte adapts this idea with explicit scope promotion via `memory_observe` tool calls and on-demand retrieval via the memory toolkit.
+The observation model is inspired by [Mastra's Observational Memory](https://mastra.ai/docs/memory/observational-memory). Acolyte adapts this idea with explicit scope promotion via `memory-observe` tool calls and on-demand retrieval via the memory toolkit.
 
 ## Distill behavior
 
-- the observer extracts facts from conversations via `memory_observe(scope, content, topic?)` tool calls
+- the observer extracts facts from conversations via `memory-observe(scope, content, topic?)` tool calls
 - each call produces one observation record with its own embedding
 - scope via the `scope` parameter:
   - `"project"` — project-scoped facts (architecture, tooling, conventions)
@@ -60,6 +60,14 @@ The observation model is inspired by [Mastra's Observational Memory](https://mas
 - hybrid recall: entries scored by cosine similarity + TF-IDF weighted token overlap (see below). Falls back to recency when embeddings are unavailable
 
 ## Recall
+
+Recall is scoped to the caller's context before ranking — a record is returned only if the caller could have written to its scope:
+
+- `"session"` — the current session's own facts (when a session id is known); other sessions are never returned
+- `"project"` — facts for the current project, derived from the workspace; other projects are never returned
+- `"user"` — always visible
+
+An explicit `scope` argument narrows recall to that single scope.
 
 Memory records are embedded at write time using the provider embedding API. At query time, entries are scored by a weighted blend of two signals:
 

--- a/src/memory-distiller.int.test.ts
+++ b/src/memory-distiller.int.test.ts
@@ -30,19 +30,19 @@ beforeAll(() => {
         {
           id: `fc_proj_${ctx.responseCounter}`,
           callId: `call_proj_${ctx.responseCounter}`,
-          name: "memory_observe",
+          name: "memory-observe",
           args: JSON.stringify({ scope: "project", content: "project uses Bun as runtime", topic: "tooling" }),
         },
         {
           id: `fc_user_${ctx.responseCounter}`,
           callId: `call_user_${ctx.responseCounter}`,
-          name: "memory_observe",
+          name: "memory-observe",
           args: JSON.stringify({ scope: "user", content: "prefers concise responses" }),
         },
         {
           id: `fc_sess_${ctx.responseCounter}`,
           callId: `call_sess_${ctx.responseCounter}`,
-          name: "memory_observe",
+          name: "memory-observe",
           args: JSON.stringify({ scope: "session", content: "fixing memory search bug" }),
         },
       ]),
@@ -62,7 +62,7 @@ afterAll(() => {
 afterEach(cleanupStores);
 
 describe("memoryDistiller integration", () => {
-  test("defaultRunner emits memory_observe tool calls and stores all scopes", async () => {
+  test("defaultRunner emits memory-observe tool calls and stores all scopes", async () => {
     const store = createStore();
     const distiller = createMemoryDistiller({ store, policy: testPolicy });
 
@@ -107,7 +107,7 @@ describe("memoryDistiller integration", () => {
       output: "hi",
     });
 
-    const results = await searchMemories("Bun runtime tooling", { store });
+    const results = await searchMemories("Bun runtime tooling", { resourceId: "proj_inttest002" }, { store });
     const contents = results.map((r) => r.content);
     expect(contents).toContain("project uses Bun as runtime");
     expect(contents).toContain("prefers concise responses");

--- a/src/memory-distiller.ts
+++ b/src/memory-distiller.ts
@@ -13,16 +13,15 @@ import {
   type MemoryStore,
   memoryScopeSchema,
 } from "./memory-contract";
-import { addObservation } from "./memory-ops";
+import { addObservation, resolveScopeKey } from "./memory-ops";
 import { getMemoryStore } from "./memory-store";
 import { createModel } from "./model-factory";
 import { normalizeModel, providerFromModel } from "./provider-config";
 import { sharedRateLimiter } from "./rate-limiter";
-import { defaultUserResourceId, parseResourceId, projectResourceIdFromWorkspace, type ResourceId } from "./resource-id";
 import { toFunctionTool } from "./tool-contract";
 
 const MEMORY_OBSERVE_TOOL = toFunctionTool({
-  id: "memory_observe",
+  id: "memory-observe",
   description: "Record a fact extracted from the conversation into memory.",
   inputSchema: z.toJSONSchema(
     z.object({
@@ -35,7 +34,7 @@ const MEMORY_OBSERVE_TOOL = toFunctionTool({
 
 export const DISTILLER_PROMPT = `Extract concrete facts from this conversation.
 
-For each fact, call memory_observe with:
+For each fact, call memory-observe with:
 - scope: "project" for project-specific durable facts (architecture, tooling, conventions, decisions)
          "user" for personal preferences that carry across projects
          "session" for in-progress state, temporary constraints, working assumptions
@@ -94,34 +93,9 @@ async function defaultRunner(systemPrompt: string, userContent: string): Promise
     temperature: 0,
   });
   return result.content
-    .filter((part): part is LanguageModelV4ToolCall => part.type === "tool-call" && part.toolName === "memory_observe")
+    .filter((part): part is LanguageModelV4ToolCall => part.type === "tool-call" && part.toolName === "memory-observe")
     .map(parseToolCall)
     .filter((obs): obs is DistillObservation => obs !== null);
-}
-
-const DISTILL_SCOPE_KEY_RESOLVERS: Record<
-  DistillScope,
-  (ctx: { sessionId?: string; workspace?: string; resourceId?: ResourceId }) => string | null
-> = {
-  session: (ctx) => ctx.sessionId ?? null,
-  project: (ctx) => {
-    const parsed = parseResourceId(ctx.resourceId);
-    if (parsed?.startsWith("proj_")) return parsed;
-    if (!ctx.workspace) return null;
-    return projectResourceIdFromWorkspace(ctx.workspace);
-  },
-  user: (ctx) => {
-    const parsed = parseResourceId(ctx.resourceId);
-    if (parsed?.startsWith("user_")) return parsed;
-    return defaultUserResourceId();
-  },
-};
-
-function resolveDistillScopeKey(
-  scope: DistillScope,
-  ctx: { sessionId?: string; workspace?: string; resourceId?: ResourceId },
-): string | null {
-  return DISTILL_SCOPE_KEY_RESOLVERS[scope](ctx);
 }
 
 async function commitFact(ds: MemoryStore, key: string, content: string, topic: string | null): Promise<number> {
@@ -162,7 +136,7 @@ export function createMemoryDistiller(deps: Partial<DistillerDeps> = {}): Memory
       let sessionCount = 0;
 
       for (const obs of filtered) {
-        const factKey = resolveDistillScopeKey(obs.scope, obs.scope === "session" ? { sessionId: ctx.sessionId } : ctx);
+        const factKey = resolveScopeKey(obs.scope, ctx, { strict: true });
         if (!factKey) continue;
         const clamped = clampToTokenEstimate(normalizeMemoryText(obs.content), policy.maxOutputTokens);
         if (!clamped) continue;

--- a/src/memory-ops.test.ts
+++ b/src/memory-ops.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { resolveScopeKey, visibleScopeKeys } from "./memory-ops";
+import { defaultUserResourceId, projectResourceIdFromWorkspace } from "./resource-id";
+
+describe("resolveScopeKey", () => {
+  test("session resolves to the session id, or null when absent", () => {
+    expect(resolveScopeKey("session", { sessionId: "sess_alpha" })).toBe("sess_alpha");
+    expect(resolveScopeKey("session", {})).toBeNull();
+    expect(resolveScopeKey("session", {}, { strict: true })).toBeNull();
+  });
+
+  test("user always resolves, honoring a user_ resourceId override", () => {
+    expect(resolveScopeKey("user", {})).toBe(defaultUserResourceId());
+    expect(resolveScopeKey("user", { resourceId: "user_override1" })).toBe("user_override1");
+  });
+
+  test("project derives from workspace path", () => {
+    expect(resolveScopeKey("project", { workspace: "/ws/one" })).toBe(projectResourceIdFromWorkspace("/ws/one"));
+  });
+
+  test("project prefers a proj_ resourceId over workspace", () => {
+    const key = resolveScopeKey("project", { workspace: "/ws/one", resourceId: "proj_explicit1" });
+    expect(key).toBe("proj_explicit1");
+  });
+
+  test("project is strict: no workspace/resourceId yields no key, never a cwd fallback", () => {
+    expect(resolveScopeKey("project", {}, { strict: true })).toBeNull();
+    expect(resolveScopeKey("project", {})).toBe(projectResourceIdFromWorkspace(process.cwd()));
+  });
+
+  test("distinct workspaces resolve to distinct project keys", () => {
+    const one = resolveScopeKey("project", { workspace: "/ws/one" });
+    const two = resolveScopeKey("project", { workspace: "/ws/two" });
+    expect(one).not.toBe(two);
+  });
+});
+
+describe("visibleScopeKeys", () => {
+  test("full context exposes session, project, and user keys", () => {
+    const keys = visibleScopeKeys({ sessionId: "sess_alpha", workspace: "/ws/one" });
+    expect(keys).toEqual(new Set(["sess_alpha", projectResourceIdFromWorkspace("/ws/one"), defaultUserResourceId()]));
+  });
+
+  test("user scope is always visible", () => {
+    expect(visibleScopeKeys({}).has(defaultUserResourceId())).toBe(true);
+  });
+
+  test("sessionless context hides the session key", () => {
+    const keys = visibleScopeKeys({ workspace: "/ws/one" });
+    expect(keys.has("sess_alpha")).toBe(false);
+    expect(keys.has(projectResourceIdFromWorkspace("/ws/one"))).toBe(true);
+  });
+
+  test("workspaceless context hides the project key (no cwd fallback)", () => {
+    const keys = visibleScopeKeys({ sessionId: "sess_alpha" });
+    expect(keys.has(projectResourceIdFromWorkspace(process.cwd()))).toBe(false);
+    expect(keys).toEqual(new Set(["sess_alpha", defaultUserResourceId()]));
+  });
+});

--- a/src/memory-ops.ts
+++ b/src/memory-ops.ts
@@ -11,7 +11,7 @@ import {
 } from "./memory-contract";
 import { embeddingToBuffer, embedText } from "./memory-embedding";
 import { getMemoryStore } from "./memory-store";
-import { defaultUserResourceId, projectResourceIdFromWorkspace } from "./resource-id";
+import { defaultUserResourceId, parseResourceId, projectResourceIdFromWorkspace, type ResourceId } from "./resource-id";
 import { createId } from "./short-id";
 
 export type { MemoryEntry, MemoryScope, RemoveMemoryResult } from "./memory-contract";
@@ -61,17 +61,22 @@ export async function listMemories(options: MemoryOptions = {}): Promise<MemoryE
   return entries;
 }
 
-export async function addMemory(
-  content: string,
-  options: Omit<MemoryOptions, "scope"> & { scope?: MemoryScope } = {},
-): Promise<MemoryEntry> {
+export interface AddMemoryOptions {
+  scope?: MemoryScope;
+  workspace?: string;
+  sessionId?: string;
+  resourceId?: ResourceId;
+  store?: MemoryStore;
+}
+
+export async function addMemory(content: string, options: AddMemoryOptions = {}): Promise<MemoryEntry> {
   const trimmed = content.trim();
   if (!trimmed) throw new Error("Memory content cannot be empty");
 
-  const { scope = "user", workspace } = options;
+  const { scope = "user", workspace, sessionId, resourceId } = options;
   const store = options.store ?? (await getMemoryStore());
-  const scopeKey =
-    scope === "project" ? projectResourceIdFromWorkspace(workspace ?? process.cwd()) : defaultUserResourceId();
+  const scopeKey = resolveScopeKey(scope, { sessionId, workspace, resourceId });
+  if (!scopeKey) throw new Error(`Cannot resolve scope key for scope "${scope}"`);
 
   const record = {
     id: `mem_${createId()}`,
@@ -133,10 +138,36 @@ export async function addObservation(
   return record;
 }
 
-export function resolveScopeKey(scope: MemoryScope, ctx: { sessionId?: string; workspace?: string }): string | null {
+export type ScopeContext = {
+  sessionId?: string;
+  workspace?: string;
+  resourceId?: ResourceId;
+};
+
+export function resolveScopeKey(
+  scope: MemoryScope,
+  ctx: ScopeContext,
+  options: { strict?: boolean } = {},
+): string | null {
   if (scope === "session") return ctx.sessionId ?? null;
-  if (scope === "project") return projectResourceIdFromWorkspace(ctx.workspace ?? process.cwd());
+  if (scope === "project") {
+    const fromResource = parseResourceId(ctx.resourceId);
+    if (fromResource?.startsWith("proj_")) return fromResource;
+    if (ctx.workspace) return projectResourceIdFromWorkspace(ctx.workspace);
+    return options.strict ? null : projectResourceIdFromWorkspace(process.cwd());
+  }
+  const fromResource = parseResourceId(ctx.resourceId);
+  if (fromResource?.startsWith("user_")) return fromResource;
   return defaultUserResourceId();
+}
+
+export function visibleScopeKeys(ctx: ScopeContext): Set<string> {
+  const keys = new Set<string>();
+  for (const scope of ["session", "project", "user"] as const) {
+    const key = resolveScopeKey(scope, ctx, { strict: true });
+    if (key) keys.add(key);
+  }
+  return keys;
 }
 
 export async function removeMemory(id: string, options: MemoryOptions = {}): Promise<RemoveMemoryResult> {

--- a/src/memory-toolkit-embedding.int.test.ts
+++ b/src/memory-toolkit-embedding.int.test.ts
@@ -1,0 +1,82 @@
+import { afterAll, describe, expect, mock, test } from "bun:test";
+import type { MemoryRecord, MemoryStore } from "./memory-contract";
+import * as realEmbedding from "./memory-embedding";
+import type { ScopeContext } from "./memory-ops";
+import { defaultUserResourceId, projectResourceIdFromWorkspace } from "./resource-id";
+
+// searchMemories reaches the searchByEmbedding branch only when embedText returns a
+// vector; stub it (and restore after, so it never leaks into other files' tests).
+const QUERY_VEC = new Float32Array([0.1, 0.2, 0.3]);
+mock.module("./memory-embedding", () => ({ ...realEmbedding, embedText: async () => QUERY_VEC }));
+afterAll(() => mock.module("./memory-embedding", () => realEmbedding));
+
+const { searchMemories } = await import("./memory-toolkit");
+
+const WS_ONE = "/ws/one";
+const projOne = projectResourceIdFromWorkspace(WS_ONE);
+const projTwo = projectResourceIdFromWorkspace("/ws/two");
+const userKey = defaultUserResourceId();
+const ctx: ScopeContext = { sessionId: "sess_alpha", workspace: WS_ONE };
+
+let seq = 0;
+function rec(scopeKey: string, content: string): MemoryRecord {
+  seq += 1;
+  return {
+    id: `mem_${String(seq).padStart(4, "0")}`,
+    scopeKey,
+    kind: "observation",
+    content,
+    createdAt: `2026-01-01T00:00:${String(seq).padStart(2, "0")}.000Z`,
+    tokenEstimate: 4,
+    topic: null,
+  };
+}
+
+function fakeCloudStore(records: MemoryRecord[]): MemoryStore {
+  return {
+    async list() {
+      return records;
+    },
+    async write() {},
+    async remove() {},
+    async touchRecalled() {},
+    async writeEmbedding() {},
+    async removeEmbedding() {},
+    async getEmbedding() {
+      return null;
+    },
+    async getEmbeddings() {
+      return new Map();
+    },
+    async searchByEmbedding(_vec, opts) {
+      return records.slice(0, opts.limit);
+    },
+    close() {},
+  };
+}
+
+const contents = (records: readonly MemoryRecord[]): string[] => records.map((r) => r.content);
+
+describe("searchMemories searchByEmbedding (cloud) path", () => {
+  test("filters to the visible scope set", async () => {
+    const store = fakeCloudStore([
+      rec(projOne, "project one fact"),
+      rec(projTwo, "project two secret"),
+      rec(userKey, "user pref"),
+      rec("sess_alpha", "current session note"),
+      rec("sess_beta", "other session note"),
+    ]);
+    const got = contents(await searchMemories("anything", ctx, { store }));
+    expect(got).toContain("project one fact");
+    expect(got).toContain("user pref");
+    expect(got).toContain("current session note");
+    expect(got).not.toContain("project two secret");
+    expect(got).not.toContain("other session note");
+  });
+
+  test("honors the scope option", async () => {
+    const store = fakeCloudStore([rec(projOne, "project fact"), rec(userKey, "user pref")]);
+    const got = contents(await searchMemories("anything", ctx, { scope: "user", store }));
+    expect(got).toEqual(["user pref"]);
+  });
+});

--- a/src/memory-toolkit.int.test.ts
+++ b/src/memory-toolkit.int.test.ts
@@ -1,100 +1,122 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import type { MemoryRecord } from "./memory-contract";
-import { embeddingToBuffer } from "./memory-embedding";
+import type { ScopeContext } from "./memory-ops";
 import { createSqliteMemoryStore } from "./memory-store";
 import { searchMemories } from "./memory-toolkit";
+import { defaultUserResourceId, projectResourceIdFromWorkspace } from "./resource-id";
 import { tempDb } from "./test-utils";
 
 const { create: createStore, cleanup: cleanupStores } = tempDb("acolyte-toolkit-", createSqliteMemoryStore);
 afterEach(cleanupStores);
 
-function createRecord(
-  id: string,
-  scopeKey: string,
-  content: string,
-  kind: MemoryRecord["kind"] = "stored",
-): MemoryRecord {
-  return { id, scopeKey, kind, content, createdAt: "2026-01-01T00:00:00.000Z", tokenEstimate: 4 };
+const WS_ONE = "/ws/one";
+const WS_TWO = "/ws/two";
+const projOne = projectResourceIdFromWorkspace(WS_ONE);
+const projTwo = projectResourceIdFromWorkspace(WS_TWO);
+const userKey = defaultUserResourceId();
+
+const ctx: ScopeContext = { sessionId: "sess_alpha", workspace: WS_ONE };
+
+let seq = 0;
+function createRecord(scopeKey: string, content: string, kind: MemoryRecord["kind"] = "stored"): MemoryRecord {
+  seq += 1;
+  return {
+    id: `mem_${String(seq).padStart(4, "0")}`,
+    scopeKey,
+    kind,
+    content,
+    createdAt: `2026-01-01T00:00:${String(seq).padStart(2, "0")}.000Z`,
+    tokenEstimate: 4,
+  };
 }
 
-describe("searchMemories", () => {
+const contents = (records: readonly MemoryRecord[]): string[] => records.map((r) => r.content);
+
+describe("searchMemories scope visibility", () => {
+  test("round-trips a fact written in the same context", async () => {
+    const store = createStore();
+    await store.write(createRecord(projOne, "project one convention"));
+    const results = await searchMemories("anything", ctx, { store });
+    expect(contents(results)).toContain("project one convention");
+  });
+
+  test("isolates memories from other projects", async () => {
+    const store = createStore();
+    await store.write(createRecord(projOne, "project one convention"));
+    await store.write(createRecord(projTwo, "project two secret"));
+    const results = await searchMemories("anything", ctx, { store });
+    expect(contents(results)).toContain("project one convention");
+    expect(contents(results)).not.toContain("project two secret");
+  });
+
+  test("isolates memories from other sessions but surfaces the current session", async () => {
+    const store = createStore();
+    await store.write(createRecord("sess_alpha", "current session note", "observation"));
+    await store.write(createRecord("sess_beta", "other session note", "observation"));
+    const results = await searchMemories("anything", ctx, { store });
+    expect(contents(results)).toContain("current session note");
+    expect(contents(results)).not.toContain("other session note");
+  });
+
+  test("always surfaces user-scoped memories", async () => {
+    const store = createStore();
+    await store.write(createRecord(userKey, "cross-project preference"));
+    const results = await searchMemories("anything", ctx, { store });
+    expect(contents(results)).toContain("cross-project preference");
+  });
+
+  test("a sessionless context hides session memories", async () => {
+    const store = createStore();
+    await store.write(createRecord("sess_alpha", "session note", "observation"));
+    await store.write(createRecord(userKey, "durable pref"));
+    const results = await searchMemories("anything", { workspace: WS_ONE }, { store });
+    expect(contents(results)).not.toContain("session note");
+    expect(contents(results)).toContain("durable pref");
+  });
+
+  test("a workspaceless context hides project memories, never defaulting to cwd", async () => {
+    const store = createStore();
+    await store.write(createRecord(projOne, "project fact"));
+    await store.write(createRecord(userKey, "durable pref"));
+    const results = await searchMemories("anything", { sessionId: "sess_alpha" }, { store });
+    expect(contents(results)).not.toContain("project fact");
+    expect(contents(results)).toContain("durable pref");
+  });
+});
+
+describe("searchMemories scope option", () => {
+  test("intersects to a single scope within the visible set", async () => {
+    const store = createStore();
+    await store.write(createRecord(userKey, "user pref"));
+    await store.write(createRecord(projOne, "project fact"));
+    await store.write(createRecord("sess_alpha", "session note", "observation"));
+
+    expect(contents(await searchMemories("anything", ctx, { scope: "user", store }))).toEqual(["user pref"]);
+    expect(contents(await searchMemories("anything", ctx, { scope: "project", store }))).toEqual(["project fact"]);
+    expect(contents(await searchMemories("anything", ctx, { scope: "session", store }))).toEqual(["session note"]);
+  });
+
+  test("returns nothing when the requested scope is not in the context", async () => {
+    const store = createStore();
+    await store.write(createRecord(projOne, "project fact"));
+    const results = await searchMemories("anything", { workspace: WS_ONE }, { scope: "session", store });
+    expect(results).toEqual([]);
+  });
+});
+
+describe("searchMemories basics", () => {
   test("returns entries up to the limit", async () => {
     const store = createStore();
-    await store.write(createRecord("mem_a", "user_test", "alpha fact"));
-    await store.write(createRecord("mem_b", "user_test", "beta fact"));
-    await store.write(createRecord("mem_c", "user_test", "gamma fact"));
-    const result = await searchMemories("anything", { limit: 2, store });
-    expect(result).toHaveLength(2);
+    await store.write(createRecord(userKey, "alpha fact"));
+    await store.write(createRecord(userKey, "beta fact"));
+    await store.write(createRecord(userKey, "gamma fact"));
+    const results = await searchMemories("anything", ctx, { limit: 2, store });
+    expect(results).toHaveLength(2);
   });
 
-  test("returns all entries when limit exceeds count", async () => {
+  test("returns an empty array for an empty store", async () => {
     const store = createStore();
-    await store.write(createRecord("mem_a", "user_test", "only fact"));
-    const result = await searchMemories("only", { limit: 10, store });
-    expect(result).toHaveLength(1);
-  });
-
-  test("returns empty array for empty store", async () => {
-    const store = createStore();
-    const result = await searchMemories("query", { store });
-    expect(result).toEqual([]);
-  });
-
-  test("filters by scope", async () => {
-    const store = createStore();
-    await store.write(createRecord("mem_u", "user_test", "user preference"));
-    await store.write(createRecord("mem_p", "proj_test", "project convention"));
-    const userOnly = await searchMemories("anything", { scope: "user", store });
-    expect(userOnly).toHaveLength(1);
-    expect(userOnly[0]?.content).toBe("user preference");
-    const projectOnly = await searchMemories("anything", { scope: "project", store });
-    expect(projectOnly).toHaveLength(1);
-    expect(projectOnly[0]?.content).toBe("project convention");
-  });
-
-  test("scope filter applies before limit", async () => {
-    const store = createStore();
-    await store.write(createRecord("mem_u1", "user_test", "user a"));
-    await store.write(createRecord("mem_u2", "user_test", "user b"));
-    await store.write(createRecord("mem_p1", "proj_test", "project a"));
-    const result = await searchMemories("anything", { scope: "user", limit: 5, store });
-    expect(result).toHaveLength(2);
-    for (const r of result) {
-      expect(r.scopeKey.startsWith("user_")).toBe(true);
-    }
-  });
-
-  test("includes project and user observations in results", async () => {
-    const store = createStore();
-    await store.write(createRecord("mem_s", "user_test", "explicit stored memory"));
-    await store.write(createRecord("mem_o", "proj_test", "distilled observation", "observation"));
-    const result = await searchMemories("anything", { store });
-    const ids = result.map((r) => r.id);
-    expect(ids).toContain("mem_s");
-    expect(ids).toContain("mem_o");
-  });
-
-  test("excludes session-scoped observations", async () => {
-    const store = createStore();
-    await store.write(createRecord("mem_p", "proj_test", "project fact", "observation"));
-    await store.write(createRecord("mem_sess", "sess_dead1234", "temporary session state", "observation"));
-    const result = await searchMemories("anything", { store });
-    const ids = result.map((r) => r.id);
-    expect(ids).toContain("mem_p");
-    expect(ids).not.toContain("mem_sess");
-  });
-
-  test("stores and retrieves pre-computed embeddings", async () => {
-    const store = createStore();
-    await store.write(createRecord("mem_a", "user_test", "tool execution uses runTool"));
-    await store.write(createRecord("mem_b", "user_test", "unrelated weather fact"));
-    const closeVec = new Float32Array([0.9, 0.1, 0]);
-    const farVec = new Float32Array([0, 0, 1]);
-    await store.writeEmbedding("mem_a", "user_test", embeddingToBuffer(closeVec));
-    await store.writeEmbedding("mem_b", "user_test", embeddingToBuffer(farVec));
-    const embA = await store.getEmbedding("mem_a");
-    const embB = await store.getEmbedding("mem_b");
-    expect(embA).not.toBeNull();
-    expect(embB).not.toBeNull();
+    const results = await searchMemories("anything", ctx, { store });
+    expect(results).toEqual([]);
   });
 });

--- a/src/memory-toolkit.ts
+++ b/src/memory-toolkit.ts
@@ -3,6 +3,7 @@ import {
   createMemoryPolicy,
   type MemoryPolicy,
   type MemoryRecord,
+  type MemoryScope,
   type MemoryStore,
   memoryScopeSchema,
   scopeFromKey,
@@ -16,7 +17,14 @@ import {
   matchTopicsByEmbedding,
   tokenOverlap,
 } from "./memory-embedding";
-import { addMemory, addObservation, removeMemory, resolveScopeKey } from "./memory-ops";
+import {
+  addMemory,
+  addObservation,
+  removeMemory,
+  resolveScopeKey,
+  type ScopeContext,
+  visibleScopeKeys,
+} from "./memory-ops";
 import { getMemoryStore } from "./memory-store";
 import type { ToolkitInput } from "./tool-contract";
 import { createTool } from "./tool-contract";
@@ -24,11 +32,11 @@ import { runTool } from "./tool-execution";
 
 function createMemoryObserveTool(input: ToolkitInput) {
   return createTool({
-    id: "memory_observe",
+    id: "memory-observe",
     toolkit: "memory",
     category: "meta",
     description: "Record a fact extracted from the conversation into memory.",
-    instruction: "Use `memory_observe` to persist facts extracted from the conversation into the memory store.",
+    instruction: "Use `memory-observe` to persist facts extracted from the conversation into the memory store.",
     inputSchema: z.object({
       scope: memoryScopeSchema,
       content: z.string().min(1),
@@ -36,7 +44,7 @@ function createMemoryObserveTool(input: ToolkitInput) {
     }),
     outputSchema: z.object({ kind: z.literal("memory-observe"), id: z.string().nullable() }),
     execute: async (toolInput, toolCallId) => {
-      return runTool(input.session, "memory_observe", toolCallId, toolInput, async () => {
+      return runTool(input.session, "memory-observe", toolCallId, toolInput, async () => {
         const scopeKey = resolveScopeKey(toolInput.scope, {
           sessionId: input.sessionId,
           workspace: input.workspace,
@@ -62,16 +70,25 @@ async function embedTopics(records: readonly MemoryRecord[]): Promise<Map<string
   return result;
 }
 
+function allowedScopeKeys(ctx: ScopeContext, scope?: MemoryScope): Set<string> {
+  if (!scope) return visibleScopeKeys(ctx);
+  const key = resolveScopeKey(scope, ctx, { strict: true });
+  return new Set(key ? [key] : []);
+}
+
 export async function searchMemories(
   query: string,
-  options?: { scope?: "user" | "project"; limit?: number; store?: MemoryStore; policy?: MemoryPolicy },
+  ctx: ScopeContext,
+  options?: { scope?: MemoryScope; limit?: number; store?: MemoryStore; policy?: MemoryPolicy },
 ): Promise<MemoryRecord[]> {
   const store = options?.store ?? (await getMemoryStore());
   const limit = options?.limit ?? 10;
   const policy = options?.policy ?? createMemoryPolicy();
+  const allowed = allowedScopeKeys(ctx, options?.scope);
+  if (allowed.size === 0) return [];
+
   const all = await store.list();
-  const durable = all.filter((r) => r.kind === "stored" || !r.scopeKey.startsWith("sess_"));
-  const filtered = options?.scope ? durable.filter((r) => scopeFromKey(r.scopeKey) === options.scope) : durable;
+  const filtered = all.filter((r) => allowed.has(r.scopeKey));
   if (filtered.length === 0) return [];
 
   const queryEmbedding = await embedText(query);
@@ -84,8 +101,7 @@ export async function searchMemories(
   if (store.searchByEmbedding) {
     const oversample = (options?.scope ? limit * 2 : limit) * 2;
     const raw = await store.searchByEmbedding(queryEmbedding, { limit: oversample });
-    const durableRaw = raw.filter((r) => r.kind === "stored" || !r.scopeKey.startsWith("sess_"));
-    const scoped = options?.scope ? durableRaw.filter((r) => scopeFromKey(r.scopeKey) === options.scope) : durableRaw;
+    const scoped = raw.filter((r) => allowed.has(r.scopeKey));
     const pgTopicEmbeddings = await embedTopics(scoped);
     const pgMatchedTopics = matchTopicsByEmbedding(queryEmbedding, pgTopicEmbeddings, policy.topicThreshold);
     const pgTopicFiltered = filterByTopicEmbedding(scoped, pgMatchedTopics, policy.minTopicFilterSize);
@@ -131,7 +147,7 @@ function createMemorySearchTool(input: ToolkitInput) {
       "Use `memory-search` to recall prior context, decisions, or facts before starting work that might overlap with previous sessions.",
     inputSchema: z.object({
       query: z.union([z.string().min(1), z.array(z.string().min(1)).min(1)]),
-      scope: memoryScopeSchema.extract(["user", "project"]).optional(),
+      scope: memoryScopeSchema.optional(),
       limit: z.number().int().min(1).max(20).optional(),
     }),
     outputSchema: z.object({
@@ -140,7 +156,7 @@ function createMemorySearchTool(input: ToolkitInput) {
         z.object({
           id: z.string(),
           content: z.string(),
-          scope: memoryScopeSchema.extract(["user", "project"]),
+          scope: memoryScopeSchema,
           createdAt: z.string(),
           lastRecalledAt: z.string().nullable(),
         }),
@@ -148,11 +164,12 @@ function createMemorySearchTool(input: ToolkitInput) {
     }),
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "memory-search", toolCallId, toolInput, async () => {
+        const ctx: ScopeContext = { sessionId: input.sessionId, workspace: input.workspace };
         const queries = Array.isArray(toolInput.query) ? toolInput.query : [toolInput.query];
         const seen = new Set<string>();
         const results: MemoryRecord[] = [];
         for (const q of queries) {
-          for (const r of await searchMemories(q, { scope: toolInput.scope, limit: toolInput.limit })) {
+          for (const r of await searchMemories(q, ctx, { scope: toolInput.scope, limit: toolInput.limit })) {
             if (!seen.has(r.id)) {
               seen.add(r.id);
               results.push(r);
@@ -194,7 +211,7 @@ function createMemoryAddTool(input: ToolkitInput) {
     }),
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "memory-add", toolCallId, toolInput, async () => {
-        const entry = await addMemory(toolInput.content, { scope: toolInput.scope });
+        const entry = await addMemory(toolInput.content, { scope: toolInput.scope, workspace: input.workspace });
         return { kind: "memory-add" as const, id: entry.id, scope: entry.scope };
       });
     },


### PR DESCRIPTION
## Motivation

Recall filtered by scope *type*, not *which* project — so every project's memories leaked into every other project's recall. It also excluded all session-scoped rows, so the current session could not recall its own facts.

## Summary

- filter recall to the caller's visible scope keys (current session + current project + user), replacing the scope-type filter that leaked memories across projects
- make the current session's own facts recallable while keeping other sessions and projects isolated
- add a shared strict `resolveScopeKey` + `visibleScopeKeys`; merge the distiller's separate resolver into it
- widen `memory-search` and `memory-observe` to all three scopes; keep `memory-add` to user/project
- fix `memory-add` project writes to key off the session workspace instead of the process working directory
- make project scope on the read path strict — no fallback to the process working directory
- rename the `memory_observe` tool id to `memory-observe` for kebab-case consistency
- cover cross-project, cross-session, sessionless, and workspaceless isolation on both the sqlite and cloud paths