### PR TITLE
feat(trace): surface sink failures in the transcript

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "prepare": "bash scripts/setup-hooks.sh",
     "start": "bun run src/cli.ts",
     "dev": "ACOLYTE_SERVER_RESTART=1 ./scripts/with-server.sh serve:watch bun run src/cli.ts",
+    "dogfood": "bun run src/cli.ts stop; bun run src/cli.ts",
     "run": "bun run src/cli.ts run",
     "behavior:run": "bun run scripts/run-behavior.ts",
     "perf:run": "bun run scripts/run-perf.ts",

--- a/src/chat-message-handler-stream.test.ts
+++ b/src/chat-message-handler-stream.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { ChatRow } from "./chat-contract";
 import { isToolOutput } from "./chat-contract";
 import { createMessageStreamState } from "./chat-message-handler-stream";
+import { palette } from "./palette";
 
 function createRowsHarness(): {
   rows: ChatRow[];
@@ -302,6 +303,30 @@ describe("chat-message-handler-stream", () => {
     expect(h.rows.filter((r) => r.kind === "assistant").map((r) => r.content)).toEqual(["Tail that must not vanish."]);
     // finalize()'s returned ids must reference rows that actually committed.
     for (const id of ids) expect(h.rows.some((r) => r.id === id)).toBe(true);
+    state.dispose();
+  });
+
+  test("onProgressNotice appends a warn-styled system row", () => {
+    const { rows, setRows } = createRowsHarness();
+    const state = createMessageStreamState({ setRows });
+
+    state.onProgressNotice({ message: "Trace logging is off.", level: "warn", source: "trace-store" });
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.kind).toBe("system");
+    expect(rows[0]?.content).toBe("Trace logging is off.");
+    // warn is not the error color — a non-fatal notice must not read as a task failure.
+    expect(rows[0]?.style?.text).toBe(palette.yellow);
+    expect(rows[0]?.style?.text).not.toBe(palette.error);
+    state.dispose();
+  });
+
+  test("onProgressNotice deduplicates an identical consecutive notice", () => {
+    const { rows, setRows } = createRowsHarness();
+    const state = createMessageStreamState({ setRows });
+
+    state.onProgressNotice({ message: "same", level: "warn" });
+    state.onProgressNotice({ message: "same", level: "warn" });
+    expect(rows).toHaveLength(1);
     state.dispose();
   });
 });

--- a/src/chat-message-handler-stream.ts
+++ b/src/chat-message-handler-stream.ts
@@ -19,6 +19,7 @@ export type MessageStreamState = {
   }) => void;
   onChecklist: (entry: { groupId: string; groupTitle: string; items: ChecklistItem[] }) => void;
   onProgressError: (error: string) => void;
+  onProgressNotice: (notice: { message: string; level: "warn" | "error"; source?: string }) => void;
   streamedText: () => string;
   /** Flush remaining content and return IDs of all streaming agent rows (for replacement by final turn rows). */
   finalize: () => string[];
@@ -175,6 +176,15 @@ export function createMessageStreamState(input: {
         const last = current[current.length - 1];
         if (last?.style?.text === palette.error && last.content === error) return current;
         return [...current, createRow("system", error, { dim: true, text: palette.error })];
+      });
+    },
+
+    onProgressNotice: (notice) => {
+      const color = notice.level === "error" ? palette.error : palette.yellow;
+      input.setRows((current) => {
+        const last = current[current.length - 1];
+        if (last?.style?.text === color && last.content === notice.message) return current;
+        return [...current, createRow("system", notice.message, { dim: true, text: color })];
       });
     },
 

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -156,6 +156,9 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
             case "error":
               streamState.onProgressError(event.errorMessage);
               break;
+            case "notice":
+              streamState.onProgressNotice({ message: event.message, level: event.level, source: event.source });
+              break;
           }
         },
         pendingStartedAt,

--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -164,8 +164,7 @@ export async function handlePrompt(
             break;
           }
           case "notice":
-            // Internal diagnostic (e.g. trace logging is off) — surface it here too, not just
-            // in the interactive TUI, or headless runs stay silent about a dark trace sink.
+            // Surface diagnostics in headless runs too, not only the interactive TUI.
             printError(event.message);
             break;
         }

--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -163,6 +163,11 @@ export async function handlePrompt(
             if (budgetExhausted) toolOutput.delete(event.toolCallId);
             break;
           }
+          case "notice":
+            // Internal diagnostic (e.g. trace logging is off) — surface it here too, not just
+            // in the interactive TUI, or headless runs stay silent about a dark trace sink.
+            printError(event.message);
+            break;
         }
       },
     });

--- a/src/cli-trace.ts
+++ b/src/cli-trace.ts
@@ -5,11 +5,11 @@ import { t } from "./i18n";
 import { VERBOSE_ONLY_EVENTS } from "./lifecycle-constants";
 import type { LogLine } from "./log-parser";
 import { traceEventDisplayFields } from "./trace-event-catalog";
-import type { TraceStore } from "./trace-store";
+import type { TraceReader } from "./trace-store";
 
 type TraceModeDeps = {
   hasHelpFlag: (args: string[]) => boolean;
-  traceStore?: TraceStore;
+  traceStore?: TraceReader;
   printDim: (message: string) => void;
   printError: (message: string) => void;
   commandError: (name: string, message?: string) => void;

--- a/src/client-contract.ts
+++ b/src/client-contract.ts
@@ -68,8 +68,7 @@ const errorEventSchema = z.object({
   errorCode: z.string().optional(),
   error: streamErrorSchema.optional(),
 });
-// Non-fatal internal-diagnostic surfaced in the transcript (e.g. trace logging is off).
-// Distinct from `error`, which reports a task failure.
+// Non-fatal diagnostic surfaced in the transcript; distinct from `error` (a task failure).
 const noticeEventSchema = z.object({
   type: z.literal("notice"),
   level: z.enum(["warn", "error"]),

--- a/src/client-contract.ts
+++ b/src/client-contract.ts
@@ -68,6 +68,14 @@ const errorEventSchema = z.object({
   errorCode: z.string().optional(),
   error: streamErrorSchema.optional(),
 });
+// Non-fatal internal-diagnostic surfaced in the transcript (e.g. trace logging is off).
+// Distinct from `error`, which reports a task failure.
+const noticeEventSchema = z.object({
+  type: z.literal("notice"),
+  level: z.enum(["warn", "error"]),
+  message: z.string(),
+  source: z.string().optional(),
+});
 
 export const streamEventSchema = z.discriminatedUnion("type", [
   textDeltaEventSchema,
@@ -79,6 +87,7 @@ export const streamEventSchema = z.discriminatedUnion("type", [
   statusEventSchema,
   checklistEventSchema,
   errorEventSchema,
+  noticeEventSchema,
 ]);
 export type StreamEvent = z.infer<typeof streamEventSchema>;
 

--- a/src/server-chat-runtime.test.ts
+++ b/src/server-chat-runtime.test.ts
@@ -1,7 +1,25 @@
 import { describe, expect, test } from "bun:test";
 import { appConfig } from "./app-config";
-import { isChatRequest, logLifecycleDebugEntry, runChatRequest } from "./server-chat-runtime";
+import {
+  claimTraceSinkNotice,
+  isChatRequest,
+  logLifecycleDebugEntry,
+  resetTraceSinkNoticeLatch,
+  runChatRequest,
+  traceSinkNoticeMessage,
+} from "./server-chat-runtime";
 import type { StreamErrorPayload } from "./server-contract";
+import type { TraceStore } from "./trace-store";
+
+const debugEntry = {
+  requestId: "err_abc123",
+  taskId: "task_1",
+  sessionId: "sess_1",
+  event: "lifecycle.summary",
+  sequence: 1,
+  eventTs: "2026-03-06T10:00:00.000Z",
+  logInfo: () => {},
+};
 
 describe("server chat runtime", () => {
   test("logLifecycleDebugEntry logs agent debug entry", () => {
@@ -69,6 +87,47 @@ describe("server chat runtime", () => {
     expect(debugLogs).toHaveLength(2);
     expect(infoLogs).toHaveLength(1);
     expect(infoLogs[0]).toBe("agent debug");
+  });
+
+  test("logLifecycleDebugEntry reports 'written' when the store accepts the write", () => {
+    const writes: unknown[] = [];
+    const store = { write: (e: unknown) => writes.push(e) } as unknown as TraceStore;
+    const health = logLifecycleDebugEntry({ ...debugEntry, traceStore: store });
+    expect(health).toBe("written");
+    expect(writes).toHaveLength(1);
+  });
+
+  test("logLifecycleDebugEntry reports 'store-unavailable' when there is no store", () => {
+    expect(logLifecycleDebugEntry({ ...debugEntry, traceStore: null })).toBe("store-unavailable");
+  });
+
+  test("a failing trace write is reported, never propagated to the request hot path", () => {
+    const store = {
+      write: () => {
+        throw new Error("disk full");
+      },
+    } as unknown as TraceStore;
+    // Regression: store acquisition/write used to sit outside a guard and could crash the
+    // request it only observes. It must degrade to a health signal, not throw.
+    expect(() => logLifecycleDebugEntry({ ...debugEntry, traceStore: store })).not.toThrow();
+    expect(logLifecycleDebugEntry({ ...debugEntry, traceStore: store })).toBe("write-failed");
+  });
+
+  test("trace-sink notice latches once per failure kind per process", () => {
+    resetTraceSinkNoticeLatch();
+    expect(claimTraceSinkNotice("store-unavailable")).toBe(true);
+    expect(claimTraceSinkNotice("store-unavailable")).toBe(false);
+    // A distinct failure kind still gets its own first report.
+    expect(claimTraceSinkNotice("write-failed")).toBe(true);
+    resetTraceSinkNoticeLatch();
+    expect(claimTraceSinkNotice("store-unavailable")).toBe(true);
+  });
+
+  test("trace-sink notice message names the cause and pluralizes the count", () => {
+    expect(traceSinkNoticeMessage("store-unavailable", 1)).toContain("could not be opened");
+    expect(traceSinkNoticeMessage("store-unavailable", 1)).toContain("1 diagnostic event was not recorded");
+    expect(traceSinkNoticeMessage("write-failed", 3)).toContain("writes are failing");
+    expect(traceSinkNoticeMessage("write-failed", 3)).toContain("3 diagnostic events were not recorded");
   });
 
   test("isChatRequest rejects malformed activeSkills entries", () => {

--- a/src/server-chat-runtime.test.ts
+++ b/src/server-chat-runtime.test.ts
@@ -4,6 +4,7 @@ import {
   claimTraceSinkNotice,
   isChatRequest,
   logLifecycleDebugEntry,
+  maybeTraceSinkNotice,
   resetTraceSinkNoticeLatch,
   runChatRequest,
   traceSinkNoticeMessage,
@@ -113,14 +114,55 @@ describe("server chat runtime", () => {
     expect(logLifecycleDebugEntry({ ...debugEntry, traceStore: store })).toBe("write-failed");
   });
 
-  test("trace-sink notice latches once per failure kind per process", () => {
+  test("trace-sink notice latches once per session per failure kind", () => {
     resetTraceSinkNoticeLatch();
-    expect(claimTraceSinkNotice("store-unavailable")).toBe(true);
-    expect(claimTraceSinkNotice("store-unavailable")).toBe(false);
-    // A distinct failure kind still gets its own first report.
-    expect(claimTraceSinkNotice("write-failed")).toBe(true);
+    expect(claimTraceSinkNotice("sess_1", "store-unavailable")).toBe(true);
+    expect(claimTraceSinkNotice("sess_1", "store-unavailable")).toBe(false);
+    // A distinct kind, and a distinct session, each get their own first report — the latter
+    // is why a long-lived daemon still warns every session, not just the first.
+    expect(claimTraceSinkNotice("sess_1", "write-failed")).toBe(true);
+    expect(claimTraceSinkNotice("sess_2", "store-unavailable")).toBe(true);
     resetTraceSinkNoticeLatch();
-    expect(claimTraceSinkNotice("store-unavailable")).toBe(true);
+    expect(claimTraceSinkNotice("sess_1", "store-unavailable")).toBe(true);
+  });
+
+  test("maybeTraceSinkNotice emits only on the summary event, and only when the sink failed", () => {
+    resetTraceSinkNoticeLatch();
+    // Non-summary events never emit, even mid-failure.
+    expect(
+      maybeTraceSinkNotice({
+        event: "lifecycle.tool.call",
+        sessionId: "s",
+        failureKind: "write-failed",
+        droppedEvents: 2,
+      }),
+    ).toBeNull();
+    // Summary with a healthy sink emits nothing.
+    expect(
+      maybeTraceSinkNotice({ event: "lifecycle.summary", sessionId: "s", failureKind: null, droppedEvents: 0 }),
+    ).toBeNull();
+    // Summary after a failure emits one warn notice carrying the drop count...
+    const notice = maybeTraceSinkNotice({
+      event: "lifecycle.summary",
+      sessionId: "s",
+      failureKind: "write-failed",
+      droppedEvents: 2,
+    });
+    expect(notice).toEqual({
+      type: "notice",
+      level: "warn",
+      message: traceSinkNoticeMessage("write-failed", 2),
+      source: "trace-store",
+    });
+    // ...but never twice for the same session+kind (the latch).
+    expect(
+      maybeTraceSinkNotice({
+        event: "lifecycle.summary",
+        sessionId: "s",
+        failureKind: "write-failed",
+        droppedEvents: 2,
+      }),
+    ).toBeNull();
   });
 
   test("trace-sink notice message names the cause and pluralizes the count", () => {

--- a/src/server-chat-runtime.ts
+++ b/src/server-chat-runtime.ts
@@ -100,23 +100,47 @@ export function logLifecycleDebugEntry(params: {
   }
 }
 
-// Latch so an unwritable trace DB surfaces once per process per failure kind — not a
-// warning row on every turn, which would retrain the user to ignore it.
-const reportedTraceSinkFailures = new Set<Exclude<TraceSinkHealth, "written">>();
+type TraceSinkFailure = Exclude<TraceSinkHealth, "written">;
 
-/** Test-only: clear the process-level trace-sink notice latch. */
+// Latch so an unwritable trace DB surfaces once per session per failure kind — not a
+// warning row on every turn (which retrains the user to ignore it), but not once-per-
+// process either: on a long-lived daemon that would leave every session after the first
+// silent, recreating the very blackout this warns about.
+const reportedTraceSinkFailures = new Set<string>();
+
+const latchKey = (sessionId: string | undefined, kind: TraceSinkFailure): string => `${sessionId ?? "-"}:${kind}`;
+
+/** Test-only: clear the trace-sink notice latch. */
 export function resetTraceSinkNoticeLatch(): void {
   reportedTraceSinkFailures.clear();
 }
 
-/** Claim the first-per-process report for a failure kind; returns false once latched. */
-export function claimTraceSinkNotice(kind: Exclude<TraceSinkHealth, "written">): boolean {
-  if (reportedTraceSinkFailures.has(kind)) return false;
-  reportedTraceSinkFailures.add(kind);
+/** Claim the first report for a (session, failure kind); returns false once latched. */
+export function claimTraceSinkNotice(sessionId: string | undefined, kind: TraceSinkFailure): boolean {
+  const key = latchKey(sessionId, kind);
+  if (reportedTraceSinkFailures.has(key)) return false;
+  reportedTraceSinkFailures.add(key);
   return true;
 }
 
-export function traceSinkNoticeMessage(kind: Exclude<TraceSinkHealth, "written">, droppedEvents: number): string {
+/** Trace-sink notice to surface on the summary event, or null if nothing to report / already latched. */
+export function maybeTraceSinkNotice(params: {
+  event: string;
+  sessionId: string | undefined;
+  failureKind: TraceSinkFailure | null;
+  droppedEvents: number;
+}): { type: "notice"; level: "warn"; message: string; source: string } | null {
+  if (params.event !== "lifecycle.summary" || !params.failureKind) return null;
+  if (!claimTraceSinkNotice(params.sessionId, params.failureKind)) return null;
+  return {
+    type: "notice",
+    level: "warn",
+    message: traceSinkNoticeMessage(params.failureKind, params.droppedEvents),
+    source: "trace-store",
+  };
+}
+
+export function traceSinkNoticeMessage(kind: TraceSinkFailure, droppedEvents: number): string {
   const reason = kind === "store-unavailable" ? "the trace database could not be opened" : "writes are failing";
   const events = droppedEvents === 1 ? "1 diagnostic event was" : `${droppedEvents} diagnostic events were`;
   return `Trace logging is off for this session — ${reason}, so ${events} not recorded.`;
@@ -278,20 +302,24 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
         }
         // Surface the blackout in the transcript once the summary is in (its own write is
         // counted above). log.warn is the durable record; the notice is for the human.
-        if (entry.event === "lifecycle.summary" && traceSinkFailureKind && claimTraceSinkNotice(traceSinkFailureKind)) {
-          log.warn("trace sink dark", {
-            event: "trace.sink.dark",
-            kind: traceSinkFailureKind,
-            dropped_events: traceSinkDropped,
-            request_id: requestId,
-          });
-          if (!runControl?.isCancelled()) {
-            handlers.onEvent({
-              type: "notice",
-              level: "warn",
-              message: traceSinkNoticeMessage(traceSinkFailureKind, traceSinkDropped),
-              source: "trace-store",
+        const notice = maybeTraceSinkNotice({
+          event: entry.event,
+          sessionId: chatRequest.sessionId,
+          failureKind: traceSinkFailureKind,
+          droppedEvents: traceSinkDropped,
+        });
+        if (notice) {
+          // This is a diagnostic about the request — it must never itself crash the request.
+          try {
+            log.warn("trace sink dark", {
+              event: "trace.sink.dark",
+              kind: traceSinkFailureKind,
+              dropped_events: traceSinkDropped,
+              request_id: requestId,
             });
+            if (!runControl?.isCancelled()) handlers.onEvent(notice);
+          } catch {
+            // The trace sink is already dark; a failed notice must not take the request with it.
           }
         }
       },

--- a/src/server-chat-runtime.ts
+++ b/src/server-chat-runtime.ts
@@ -102,10 +102,8 @@ export function logLifecycleDebugEntry(params: {
 
 type TraceSinkFailure = Exclude<TraceSinkHealth, "written">;
 
-// Latch so an unwritable trace DB surfaces once per session per failure kind — not a
-// warning row on every turn (which retrains the user to ignore it), but not once-per-
-// process either: on a long-lived daemon that would leave every session after the first
-// silent, recreating the very blackout this warns about.
+// Once per session per failure kind — not per turn (spam), and not per process (a
+// long-lived daemon would then warn only the first session, recreating the blackout).
 const reportedTraceSinkFailures = new Set<string>();
 
 const latchKey = (sessionId: string | undefined, kind: TraceSinkFailure): string => `${sessionId ?? "-"}:${kind}`;
@@ -300,8 +298,6 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
           traceSinkFailureKind = health;
           traceSinkDropped += 1;
         }
-        // Surface the blackout in the transcript once the summary is in (its own write is
-        // counted above). log.warn is the durable record; the notice is for the human.
         const notice = maybeTraceSinkNotice({
           event: entry.event,
           sessionId: chatRequest.sessionId,
@@ -309,7 +305,6 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
           droppedEvents: traceSinkDropped,
         });
         if (notice) {
-          // This is a diagnostic about the request — it must never itself crash the request.
           try {
             log.warn("trace sink dark", {
               event: "trace.sink.dark",
@@ -319,7 +314,7 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
             });
             if (!runControl?.isCancelled()) handlers.onEvent(notice);
           } catch {
-            // The trace sink is already dark; a failed notice must not take the request with it.
+            // A failed notice must not crash the request the sink only observes.
           }
         }
       },

--- a/src/server-chat-runtime.ts
+++ b/src/server-chat-runtime.ts
@@ -48,6 +48,9 @@ function toLogFieldMap(fields?: Record<string, unknown>): Record<string, string 
   return out;
 }
 
+/** Outcome of trying to persist one trace event — the signal for the self-check. */
+export type TraceSinkHealth = "written" | "store-unavailable" | "write-failed";
+
 export function logLifecycleDebugEntry(params: {
   requestId: string;
   taskId?: string;
@@ -59,7 +62,7 @@ export function logLifecycleDebugEntry(params: {
   logInfo?: (message: string, fields?: Record<string, string | number | boolean | null | undefined>) => void;
   logDebug?: (message: string, fields?: Record<string, string | number | boolean | null | undefined>) => void;
   traceStore?: TraceStore | null;
-}): void {
+}): TraceSinkHealth {
   const logFn = VERBOSE_ONLY_EVENTS.has(params.event) ? (params.logDebug ?? log.debug) : (params.logInfo ?? log.info);
   const logFields = toLogFieldMap(params.fields);
   logFn("agent debug", {
@@ -72,22 +75,51 @@ export function logLifecycleDebugEntry(params: {
     ...logFields,
   });
 
-  const store = params.traceStore !== undefined ? params.traceStore : getDefaultTraceStore();
-  if (store) {
-    try {
-      store.write({
-        timestamp: params.eventTs,
-        taskId: params.taskId,
-        requestId: params.requestId,
-        sessionId: params.sessionId,
-        event: params.event,
-        sequence: params.sequence,
-        fields: logFields,
-      });
-    } catch {
-      // Don't let trace store failures affect the hot path.
-    }
+  // Store acquisition can throw (createTraceStore: mkdir/open/migrate) — guard it here
+  // so a trace-DB failure never crashes the request it is only meant to observe.
+  let store: TraceStore | null;
+  try {
+    store = params.traceStore !== undefined ? params.traceStore : getDefaultTraceStore();
+  } catch {
+    return "store-unavailable";
   }
+  if (!store) return "store-unavailable";
+  try {
+    store.write({
+      timestamp: params.eventTs,
+      taskId: params.taskId,
+      requestId: params.requestId,
+      sessionId: params.sessionId,
+      event: params.event,
+      sequence: params.sequence,
+      fields: logFields,
+    });
+    return "written";
+  } catch {
+    return "write-failed";
+  }
+}
+
+// Latch so an unwritable trace DB surfaces once per process per failure kind — not a
+// warning row on every turn, which would retrain the user to ignore it.
+const reportedTraceSinkFailures = new Set<Exclude<TraceSinkHealth, "written">>();
+
+/** Test-only: clear the process-level trace-sink notice latch. */
+export function resetTraceSinkNoticeLatch(): void {
+  reportedTraceSinkFailures.clear();
+}
+
+/** Claim the first-per-process report for a failure kind; returns false once latched. */
+export function claimTraceSinkNotice(kind: Exclude<TraceSinkHealth, "written">): boolean {
+  if (reportedTraceSinkFailures.has(kind)) return false;
+  reportedTraceSinkFailures.add(kind);
+  return true;
+}
+
+export function traceSinkNoticeMessage(kind: Exclude<TraceSinkHealth, "written">, droppedEvents: number): string {
+  const reason = kind === "store-unavailable" ? "the trace database could not be opened" : "writes are failing";
+  const events = droppedEvents === 1 ? "1 diagnostic event was" : `${droppedEvents} diagnostic events were`;
+  return `Trace logging is off for this session — ${reason}, so ${events} not recorded.`;
 }
 
 function nextErrorId(): string {
@@ -208,6 +240,8 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
     const projectRulesPrompt = config.features.syncAgents
       ? "Project rules are available via project memory. Use memory-search to retrieve them when needed."
       : loadProjectRulesPrompt(workspaceResolution.workspacePath);
+    let traceSinkFailureKind: Exclude<TraceSinkHealth, "written"> | null = null;
+    let traceSinkDropped = 0;
     const reply = await runLifecycle({
       request: lifecycleRequest,
       soulPrompt,
@@ -229,7 +263,7 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
       },
       onMemoryCommit: handlers.onMemoryCommit,
       onDebug: (entry) => {
-        logLifecycleDebugEntry({
+        const health = logLifecycleDebugEntry({
           requestId,
           taskId: handlers.taskId,
           sessionId: chatRequest.sessionId,
@@ -238,6 +272,28 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
           eventTs: entry.ts,
           fields: entry.fields,
         });
+        if (health !== "written") {
+          traceSinkFailureKind = health;
+          traceSinkDropped += 1;
+        }
+        // Surface the blackout in the transcript once the summary is in (its own write is
+        // counted above). log.warn is the durable record; the notice is for the human.
+        if (entry.event === "lifecycle.summary" && traceSinkFailureKind && claimTraceSinkNotice(traceSinkFailureKind)) {
+          log.warn("trace sink dark", {
+            event: "trace.sink.dark",
+            kind: traceSinkFailureKind,
+            dropped_events: traceSinkDropped,
+            request_id: requestId,
+          });
+          if (!runControl?.isCancelled()) {
+            handlers.onEvent({
+              type: "notice",
+              level: "warn",
+              message: traceSinkNoticeMessage(traceSinkFailureKind, traceSinkDropped),
+              source: "trace-store",
+            });
+          }
+        }
       },
     });
     if (runControl?.isCancelled()) {

--- a/src/trace-store.ts
+++ b/src/trace-store.ts
@@ -18,11 +18,14 @@ export type TraceEntry = {
   fields: TraceFields;
 };
 
-export interface TraceStore {
-  write(entry: TraceEntry): void;
+export interface TraceReader {
   listTasks(limit: number): TaskSummary[];
   listByTaskId(taskId: string): LogLine[];
   close(): void;
+}
+
+export interface TraceStore extends TraceReader {
+  write(entry: TraceEntry): void;
 }
 
 const MIGRATIONS: Migration[] = [
@@ -174,13 +177,10 @@ export function createTraceStore(dbPath?: string): TraceStore {
   };
 }
 
-function openReadOnly(dbPath: string): TraceStore {
+function openReadOnly(dbPath: string): TraceReader {
   const db = new Database(dbPath, { readonly: true });
   const queries = prepareReadQueries(db);
   return {
-    write() {
-      // Read-only store — writes are silently dropped.
-    },
     listTasks(limit) {
       return queries.listTasks.all(limit).map(taskRowToSummary);
     },
@@ -213,7 +213,7 @@ export function defaultTraceDbPath(): string {
   return join(dataDir(), "trace.db");
 }
 
-export function openTraceStore(dbPath?: string): TraceStore | null {
+export function openTraceStore(dbPath?: string): TraceReader | null {
   const resolvedPath = dbPath ?? defaultTraceDbPath();
   try {
     return openReadOnly(resolvedPath);


### PR DESCRIPTION
## Motivation

The trace DB can fail silently — it can go dark unnoticed. This surfaces a blackout in the transcript instead of losing it.

## Summary

- add a non-fatal `notice` StreamEvent (distinct from fatal `error`), shown in both the TUI and headless run mode
- report three-state trace-sink health; warn once per session when the sink is dark, backed by a durable log.warn
- move trace-store acquisition inside the guard so a trace-DB failure can't crash the request it observes
- split TraceReader from TraceStore so the read-only path can't silently drop writes
- add a `bun run dogfood` script (evict stale daemon, relaunch on fresh code)