### PR TITLE
refactor(chat): unify TUI and run-mode output rendering

### DIFF
--- a/src/chat-message-handler-stream.test.ts
+++ b/src/chat-message-handler-stream.test.ts
@@ -26,6 +26,33 @@ describe("chat-message-handler-stream", () => {
     state.dispose();
   });
 
+  test("onEvent routes row events to the same projection as the direct methods", () => {
+    const { rows, setRows } = createRowsHarness();
+    const state = createMessageStreamState({ setRows });
+
+    state.onEvent({ type: "text-delta", text: "answer" });
+    expect(state.streamedText()).toBe("answer");
+
+    state.onEvent({ type: "notice", level: "warn", message: "sink is dark" });
+    expect(rows.some((r) => r.content === "sink is dark" && r.style?.text === palette.yellow)).toBe(true);
+
+    state.onEvent({ type: "error", errorMessage: "boom" });
+    expect(rows.some((r) => r.content === "boom" && r.style?.text === palette.error)).toBe(true);
+    state.dispose();
+  });
+
+  test("onEvent ignores non-row events (status/usage/reasoning)", () => {
+    const { rows, setRows } = createRowsHarness();
+    const state = createMessageStreamState({ setRows });
+
+    state.onEvent({ type: "status", state: { kind: "running" } });
+    state.onEvent({ type: "usage", inputTokens: 10, outputTokens: 2 });
+    state.onEvent({ type: "reasoning", text: "thinking" });
+    expect(rows).toHaveLength(0);
+    expect(state.streamedText()).toBe("");
+    state.dispose();
+  });
+
   test("finalize returns pending row id and clears state", async () => {
     const { rows, setRows } = createRowsHarness();
     const state = createMessageStreamState({ setRows });

--- a/src/chat-message-handler-stream.ts
+++ b/src/chat-message-handler-stream.ts
@@ -1,5 +1,6 @@
 import { type ChatRow, createRow } from "./chat-contract";
 import type { ChecklistItem } from "./checklist-contract";
+import type { StreamEvent } from "./client-contract";
 import { LIFECYCLE_ERROR_CODES } from "./error-contract";
 import { palette } from "./palette";
 import { createId } from "./short-id";
@@ -7,6 +8,9 @@ import type { ToolOutputPart } from "./tool-output-contract";
 import { createToolOutputState } from "./tool-output-render";
 
 export type MessageStreamState = {
+  /** The single interpreter: translate one stream event into row mutations. Non-row
+   *  events (status/usage/reasoning) are ignored — the caller owns those. */
+  onEvent: (event: StreamEvent) => void;
   onDelta: (delta: string) => void;
   onToolCall: () => void;
   onOutput: (entry: { toolCallId: string; toolName: string; content: ToolOutputPart }) => void;
@@ -83,7 +87,33 @@ export function createMessageStreamState(input: {
     agentContent = "";
   }
 
-  return {
+  const state: MessageStreamState = {
+    onEvent: (event) => {
+      switch (event.type) {
+        case "text-delta":
+          state.onDelta(event.text);
+          break;
+        case "tool-call":
+          state.onToolCall();
+          break;
+        case "tool-output":
+          state.onOutput(event);
+          break;
+        case "tool-result":
+          state.onToolResult(event);
+          break;
+        case "checklist":
+          state.onChecklist(event);
+          break;
+        case "error":
+          state.onProgressError(event.errorMessage);
+          break;
+        case "notice":
+          state.onProgressNotice({ message: event.message, level: event.level, source: event.source });
+          break;
+      }
+    },
+
     onDelta: (delta) => {
       if (delta.length === 0) return;
       agentContent += delta;
@@ -217,4 +247,6 @@ export function createMessageStreamState(input: {
       }
     },
   };
+
+  return state;
 }

--- a/src/chat-message-handler-stream.ts
+++ b/src/chat-message-handler-stream.ts
@@ -202,6 +202,9 @@ export function createMessageStreamState(input: {
     },
 
     onProgressError: (error) => {
+      // Flush buffered prose first so it renders before the notice, not after the
+      // pending flush timer fires (which would invert their order).
+      sealAgentRow();
       input.setRows((current) => {
         const last = current[current.length - 1];
         if (last?.style?.text === palette.error && last.content === error) return current;
@@ -210,6 +213,7 @@ export function createMessageStreamState(input: {
     },
 
     onProgressNotice: (notice) => {
+      sealAgentRow();
       const color = notice.level === "error" ? palette.error : palette.yellow;
       input.setRows((current) => {
         const last = current[current.length - 1];

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -121,6 +121,9 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
         workspace: input.currentSession.workspace,
         signal: controller.signal,
         onEvent: (event) => {
+          // Row projection goes through the single interpreter; this switch owns only
+          // the TUI-local pending/usage indicators, which are not row mutations.
+          streamState.onEvent(event);
           switch (event.type) {
             case "status":
               if (event.state.kind === "running") {
@@ -137,27 +140,8 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
               input.setRunningUsage({ inputTokens: event.inputTokens, outputTokens: event.outputTokens });
               break;
             case "tool-call":
-              streamState.onToolCall();
               runningToolCallIds.add(event.toolCallId);
               input.setPendingState({ kind: "running", toolCalls: runningToolCallIds.size });
-              break;
-            case "text-delta":
-              streamState.onDelta(event.text);
-              break;
-            case "tool-output":
-              streamState.onOutput(event);
-              break;
-            case "tool-result":
-              streamState.onToolResult(event);
-              break;
-            case "checklist":
-              streamState.onChecklist(event);
-              break;
-            case "error":
-              streamState.onProgressError(event.errorMessage);
-              break;
-            case "notice":
-              streamState.onProgressNotice({ message: event.message, level: event.level, source: event.source });
               break;
           }
         },

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -154,7 +154,11 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
       if (turn.activeSkills?.length) {
         input.currentSession.activeSkills = turn.activeSkills;
       }
-      input.currentSession.messages.push(assistantMessage);
+      // A blocked turn with no model prose has empty output; don't persist a blank
+      // assistant message (the error row carries the turn, and history filtering keeps it).
+      if (assistantMessage.content.trim().length > 0) {
+        input.currentSession.messages.push(assistantMessage);
+      }
       for (const row of turn.rows) {
         if (row.kind === "status" && typeof row.content === "string") {
           const msg = input.createMessage("system", row.content);

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -155,7 +155,8 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
         input.currentSession.activeSkills = turn.activeSkills;
       }
       // A blocked turn with no model prose has empty output; don't persist a blank
-      // assistant message (the error row carries the turn, and history filtering keeps it).
+      // assistant message — a textless bubble is noise, and the block reason is already
+      // shown as the error row in the live transcript.
       if (assistantMessage.content.trim().length > 0) {
         input.currentSession.messages.push(assistantMessage);
       }

--- a/src/cli-prompt-golden.test.ts
+++ b/src/cli-prompt-golden.test.ts
@@ -73,8 +73,10 @@ describe("cli-prompt golden output (output-path fold safety net)", () => {
       { type: "notice", level: "warn", message: "trace sink is dark" },
     ];
     const out = await capture("check config", client(events, { state: "done", output: "Updated the config." }));
+    // The final answer ("Updated the config.") diverges from the streamed preview ("Let
+    // me check the config.") and now appears in full — previously it was dropped.
     expect(out).toBe(
-      "❯ check config\n• Let me check the config.• tool.file_read.header src/config.ts\n• Steps (1/2)\n  ● read\n  ○ edit\ntrace sink is dark",
+      "❯ check config\n• Let me check the config.• tool.file_read.header src/config.ts\n• Steps (1/2)\n  ● read\n  ○ edit\ntrace sink is dark\n\n\n\n• Updated the config.",
     );
   });
 

--- a/src/cli-prompt-golden.test.ts
+++ b/src/cli-prompt-golden.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { captureCliOutput } from "./cli-test-harness";
 import { handlePrompt } from "./cli-prompt";
+import { captureCliOutput } from "./cli-test-harness";
 import type { Client, StreamEvent } from "./client-contract";
 import type { Session } from "./session-contract";
 

--- a/src/cli-prompt-golden.test.ts
+++ b/src/cli-prompt-golden.test.ts
@@ -4,10 +4,13 @@ import { captureCliOutput } from "./cli-test-harness";
 import type { Client, StreamEvent } from "./client-contract";
 import type { Session } from "./session-contract";
 
-// Byte-for-byte safety net for the output-path fold: run mode's exact stdout for
-// representative event streams, frozen against the pre-fold renderer. The projector
-// that replaces cli-prompt's hand-rolled renderer must reproduce these verbatim; any
-// diff is a deliberate behavior change, not an accident. Captured output is ANSI-
+// Golden test. Freeze the exact stdout of run mode against known-good code, then assert
+// every future run reproduces it byte for byte. The purpose is change detection: refactor
+// the renderer and these pass, so the output is provably unchanged; a real diff points at
+// exactly what moved. When a change is intentional, update the frozen string in the same
+// commit, so the diff becomes the review surface.
+//
+// Each test freezes run mode's output for one event stream. Captured output is ANSI-
 // stripped and trimmed (see captureCliOutput), so this locks structure, not color.
 
 function session(): Session {

--- a/src/cli-prompt-golden.test.ts
+++ b/src/cli-prompt-golden.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { captureCliOutput } from "./cli-test-harness";
+import { handlePrompt } from "./cli-prompt";
+import type { Client, StreamEvent } from "./client-contract";
+import type { Session } from "./session-contract";
+
+// Byte-for-byte safety net for the output-path fold: run mode's exact stdout for
+// representative event streams, frozen against the pre-fold renderer. The projector
+// that replaces cli-prompt's hand-rolled renderer must reproduce these verbatim; any
+// diff is a deliberate behavior change, not an accident. Captured output is ANSI-
+// stripped and trimmed (see captureCliOutput), so this locks structure, not color.
+
+function session(): Session {
+  return {
+    id: "sess_golden",
+    createdAt: "2026-03-05T10:00:00.000Z",
+    updatedAt: "2026-03-05T10:00:00.000Z",
+    model: "gpt-5-mini",
+    title: "New Session",
+    messages: [],
+    tokenUsage: [],
+  };
+}
+
+function client(
+  events: StreamEvent[],
+  reply: { state: "done" | "awaiting-input"; output: string; error?: string },
+): Client {
+  return {
+    replyStream: async (input) => {
+      for (const event of events) input.onEvent(event);
+      return { ...reply, model: "gpt-5-mini", toolCalls: reply.state === "done" ? ["file-read"] : [] };
+    },
+    status: async () => ({}),
+    taskStatus: async () => null,
+  };
+}
+
+function capture(prompt: string, c: Client): Promise<string> {
+  return captureCliOutput(async () => {
+    await handlePrompt(prompt, session(), c);
+  });
+}
+
+describe("cli-prompt golden output (output-path fold safety net)", () => {
+  test("streamed answer", async () => {
+    const out = await capture(
+      "hi",
+      client([{ type: "text-delta", text: "Hello there." }], { state: "done", output: "Hello there." }),
+    );
+    expect(out).toBe("❯ hi\n• Hello there.");
+  });
+
+  test("tool output, checklist, and notice", async () => {
+    const events: StreamEvent[] = [
+      { type: "text-delta", text: "Let me check the config." },
+      {
+        type: "tool-output",
+        toolCallId: "c1",
+        toolName: "file-read",
+        content: { kind: "tool-header", labelKey: "tool.file_read.header", detail: "src/config.ts" },
+      },
+      { type: "tool-result", toolCallId: "c1", toolName: "file-read" },
+      {
+        type: "checklist",
+        groupId: "g1",
+        groupTitle: "Steps",
+        items: [
+          { id: "s1", label: "read", status: "done", order: 0 },
+          { id: "s2", label: "edit", status: "pending", order: 1 },
+        ],
+      },
+      { type: "notice", level: "warn", message: "trace sink is dark" },
+    ];
+    const out = await capture("check config", client(events, { state: "done", output: "Updated the config." }));
+    expect(out).toBe(
+      "❯ check config\n• Let me check the config.• tool.file_read.header src/config.ts\n• Steps (1/2)\n  ● read\n  ○ edit\ntrace sink is dark",
+    );
+  });
+
+  test("blocking error surfaces after streamed text", async () => {
+    const out = await capture(
+      "fix",
+      client([{ type: "text-delta", text: "Trying the edit." }], {
+        state: "awaiting-input",
+        output: "",
+        error: "Cannot finish yet: validation missing",
+      }),
+    );
+    expect(out).toBe("❯ fix\n• Trying the edit.Cannot finish yet: validation missing");
+  });
+});

--- a/src/cli-prompt-golden.test.ts
+++ b/src/cli-prompt-golden.test.ts
@@ -94,4 +94,40 @@ describe("cli-prompt golden output (output-path fold safety net)", () => {
     );
     expect(out).toBe("❯ fix\n• Trying the edit.Cannot finish yet: validation missing");
   });
+
+  test("a lone detail-less tool header prints nothing until it has content", async () => {
+    const out = await capture(
+      "search",
+      client(
+        [
+          {
+            type: "tool-output",
+            toolCallId: "c1",
+            toolName: "memory-search",
+            content: { kind: "tool-header", labelKey: "tool.memory_search.header" },
+          },
+        ],
+        { state: "done", output: "Done." },
+      ),
+    );
+    expect(out).toBe("❯ search\n\n• Done.");
+  });
+
+  test("checklist reprints on each progress update", async () => {
+    const items = (readDone: boolean) => [
+      { id: "s1", label: "read", status: readDone ? ("done" as const) : ("pending" as const), order: 0 },
+      { id: "s2", label: "edit", status: "pending" as const, order: 1 },
+    ];
+    const out = await capture(
+      "run",
+      client(
+        [
+          { type: "checklist", groupId: "g1", groupTitle: "Steps", items: items(false) },
+          { type: "checklist", groupId: "g1", groupTitle: "Steps", items: items(true) },
+        ],
+        { state: "done", output: "Done." },
+      ),
+    );
+    expect(out).toBe("❯ run\n• Steps (0/2)\n  ○ read\n  ○ edit\n• Steps (1/2)\n  ● read\n  ○ edit\n\n\n• Done.");
+  });
 });

--- a/src/cli-prompt.test.ts
+++ b/src/cli-prompt.test.ts
@@ -182,6 +182,18 @@ describe("cli-prompt", () => {
     expect(output).toBe("❯ hi\n• Hello there.");
   });
 
+  // Regression: a notice appended while agent prose is still buffered used to render
+  // before the prose (the flush timer had not fired yet), inverting their order.
+  test("buffered prose flushes before a notice", async () => {
+    const events: StreamEvent[] = [
+      { type: "text-delta", text: "Alpha text." },
+      { type: "notice", level: "warn", message: "trace sink is dark" },
+    ];
+
+    const { output } = await runPromptAndCapture("hi", createTestSession(), createStreamingClient(events));
+    expect(output.indexOf("Alpha text.")).toBeLessThan(output.indexOf("trace sink is dark"));
+  });
+
   // Regression: a failed turn left the flush timer armed, so buffered text wrote to
   // stdout after handlePrompt returned — a write outside any output-capture window.
   test("a failed turn writes nothing to stdout after it returns", async () => {

--- a/src/cli-prompt.test.ts
+++ b/src/cli-prompt.test.ts
@@ -164,4 +164,21 @@ describe("cli-prompt", () => {
     const headerMatches = output.match(/src\/foo\.ts/g) ?? [];
     expect(headerMatches.length).toBe(1);
   });
+
+  // Regression: reply.output is trimmed upstream while the streamed preview keeps its
+  // trailing newline, so a naive equality check saw divergence and reprinted the whole
+  // answer — the authoritative output rendered twice.
+  test("a trailing newline in the preview does not duplicate the final answer", async () => {
+    const client: Client = {
+      replyStream: async (input) => {
+        input.onEvent({ type: "text-delta", text: "Hello there.\n" });
+        return { state: "done" as const, output: "Hello there.", model: "gpt-5-mini", toolCalls: [] };
+      },
+      status: async () => ({}),
+      taskStatus: async () => null,
+    };
+
+    const { output } = await runPromptAndCapture("hi", createTestSession(), client);
+    expect(output).toBe("❯ hi\n• Hello there.");
+  });
 });

--- a/src/cli-prompt.test.ts
+++ b/src/cli-prompt.test.ts
@@ -181,4 +181,34 @@ describe("cli-prompt", () => {
     const { output } = await runPromptAndCapture("hi", createTestSession(), client);
     expect(output).toBe("❯ hi\n• Hello there.");
   });
+
+  // Regression: a failed turn left the flush timer armed, so buffered text wrote to
+  // stdout after handlePrompt returned — a write outside any output-capture window.
+  test("a failed turn writes nothing to stdout after it returns", async () => {
+    const failing: Client = {
+      replyStream: async (input) => {
+        input.onEvent({ type: "text-delta", text: "partial secret" });
+        throw new Error("network dropped");
+      },
+      status: async () => ({}),
+      taskStatus: async () => null,
+    };
+
+    const writes: string[] = [];
+    const original = process.stdout.write;
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+      return true;
+    }) as typeof process.stdout.write;
+    try {
+      const ok = await handlePrompt("hi", createTestSession(), failing);
+      expect(ok).toBe(false);
+      const countAtReturn = writes.length;
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      expect(writes.length).toBe(countAtReturn);
+      expect(writes.join("")).not.toContain("partial secret");
+    } finally {
+      process.stdout.write = original;
+    }
+  });
 });

--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -27,10 +27,11 @@ export async function handlePrompt(
   session.messages.push(userMsg);
   setSessionTitle(session, prompt);
 
+  const projector = createStdoutRowProjector();
+  const streamState = createMessageStreamState({ setRows: projector.setRows });
+
   try {
     printOutput(`❯ ${prompt}`);
-    const projector = createStdoutRowProjector();
-    const streamState = createMessageStreamState({ setRows: projector.setRows });
 
     const suggestions: string[] = [];
     const skillSuggestion = createSkillSuggestion(prompt, session.activeSkills);
@@ -68,6 +69,9 @@ export async function handlePrompt(
     session.updatedAt = nowIso();
     return true;
   } catch (error) {
+    // A failed turn may leave a flush timer armed; dispose it so buffered text can't
+    // write to stdout after we've returned (mirrors the TUI's non-abort catch).
+    streamState.dispose();
     if (!(error instanceof Error)) printError(t("error.prompt.request_failed"));
     else printError(formatPromptError(error.message));
     session.updatedAt = nowIso();

--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -1,83 +1,20 @@
-import { stdout as output } from "node:process";
 import { createWorkspaceSpecifier } from "./api";
+import { createMessageStreamState } from "./chat-message-handler-stream";
 import { createMessage } from "./chat-session";
-import { formatChecklist } from "./checklist-format";
-import { formatAgentReplyOutput, printIndentedDim } from "./cli-format";
+import { createStdoutRowProjector } from "./cli-stdout-projector";
 import type { Client } from "./client-contract";
 import { nowIso } from "./datetime";
-import { LIFECYCLE_ERROR_CODES } from "./error-contract";
 import { formatPromptError } from "./error-messages";
 import { t } from "./i18n";
 import type { ResourceId } from "./resource-id";
 import type { Session } from "./session-contract";
 import { createSkillSuggestion } from "./skill-triggers";
-import { createToolOutputState, renderToolOutput } from "./tool-output-render";
-import { printDim, printError, printOutput, streamText } from "./ui";
+import { printError, printOutput } from "./ui";
 
 function setSessionTitle(session: Session, inputText: string): void {
   if (session.title !== t("chat.session.default_title")) return;
   const title = inputText.trim().replace(/\s+/g, " ").slice(0, 60);
   if (title.length > 0) session.title = title;
-}
-
-function missingAgentStreamTail(streamed: string, finalOutput: string): string {
-  if (streamed.length === 0) return finalOutput;
-  if (finalOutput === streamed) return "";
-  if (finalOutput.startsWith(streamed)) return finalOutput.slice(streamed.length);
-  return "";
-}
-
-function createAgentStreamRenderer(): {
-  onDelta: (delta: string) => void;
-  renderReply: (replyOutput: string, hasPrintedProgress: boolean) => Promise<void>;
-  streamedText: () => string;
-} {
-  let agentStreamStarted = false;
-  let agentStreamText = "";
-  let atLineStart = true;
-
-  const writeRaw = (text: string): void => {
-    if (text.length === 0) return;
-    let remaining = text;
-    while (remaining.length > 0) {
-      if (atLineStart) {
-        const prefix = agentStreamStarted ? "  " : "• ";
-        process.stdout.write(prefix);
-        agentStreamStarted = true;
-      }
-      const newlineIndex = remaining.indexOf("\n");
-      if (newlineIndex === -1) {
-        process.stdout.write(remaining);
-        atLineStart = false;
-        break;
-      }
-      process.stdout.write(`${remaining.slice(0, newlineIndex)}\n`);
-      remaining = remaining.slice(newlineIndex + 1);
-      atLineStart = true;
-    }
-  };
-
-  return {
-    onDelta: (delta) => {
-      if (delta.length === 0) return;
-      agentStreamText += delta;
-      writeRaw(delta);
-    },
-    renderReply: async (replyOutput, hasPrintedProgress) => {
-      if (!atLineStart) process.stdout.write("\n");
-      printOutput("");
-      if (hasPrintedProgress) printOutput("");
-      const missingTail = missingAgentStreamTail(agentStreamText, replyOutput);
-      if (missingTail.length > 0) {
-        writeRaw(missingTail);
-        if (!atLineStart) process.stdout.write("\n");
-      } else if (!agentStreamStarted) {
-        const wrapWidth = Math.max(24, (output.columns ?? 120) - 4);
-        await streamText(formatAgentReplyOutput(replyOutput, wrapWidth));
-      }
-    },
-    streamedText: () => agentStreamText,
-  };
 }
 
 export async function handlePrompt(
@@ -92,10 +29,8 @@ export async function handlePrompt(
 
   try {
     printOutput(`❯ ${prompt}`);
-    const agentRenderer = createAgentStreamRenderer();
-    const toolOutput = createToolOutputState();
-    const snapshotByCallId = new Map<string, string>();
-    let hasPrintedToolProgress = false;
+    const projector = createStdoutRowProjector();
+    const streamState = createMessageStreamState({ setRows: projector.setRows });
 
     const suggestions: string[] = [];
     const skillSuggestion = createSkillSuggestion(prompt, session.activeSkills);
@@ -113,70 +48,18 @@ export async function handlePrompt(
         ...createWorkspaceSpecifier(options?.workspace),
       },
       onEvent: (event) => {
-        switch (event.type) {
-          case "text-delta":
-            agentRenderer.onDelta(event.text);
-            break;
-          case "tool-output": {
-            const update = toolOutput.push(event);
-            if (!update) break;
-            if (update.items.length === 1 && update.items[0]?.kind === "tool-header" && !update.items[0].detail) break;
-            const rendered = renderToolOutput(update.items);
-            if (!rendered) break;
-            const previous = snapshotByCallId.get(event.toolCallId);
-            snapshotByCallId.set(event.toolCallId, rendered);
-            if (previous) {
-              const current = rendered.trimEnd();
-              const before = previous.trimEnd();
-              if (current === before) break;
-              if (current.startsWith(`${before}\n`)) {
-                printIndentedDim(current.slice(before.length + 1));
-                hasPrintedToolProgress = true;
-                break;
-              }
-              const currentLines = current.split("\n");
-              const previousLines = before.split("\n");
-              if (currentLines.length > previousLines.length) {
-                printIndentedDim(currentLines.slice(previousLines.length).join("\n"));
-                hasPrintedToolProgress = true;
-                break;
-              }
-              break;
-            }
-            printDim(`• ${rendered.split("\n")[0] ?? ""}`);
-            if (rendered.includes("\n")) printIndentedDim(rendered.slice(rendered.indexOf("\n") + 1));
-            hasPrintedToolProgress = true;
-            break;
-          }
-          case "checklist": {
-            const { header, items } = formatChecklist(event);
-            printDim(`• ${header}`);
-            for (const item of items) printIndentedDim(`${item.marker} ${item.label}`);
-            hasPrintedToolProgress = true;
-            break;
-          }
-          case "tool-result": {
-            const budgetExhausted =
-              event.isError === true &&
-              (event.errorCode === LIFECYCLE_ERROR_CODES.budgetExhausted ||
-                event.error?.category === "budget-exhausted");
-            if (budgetExhausted) toolOutput.delete(event.toolCallId);
-            break;
-          }
-          case "notice":
-            // Surface diagnostics in headless runs too, not only the interactive TUI.
-            printError(event.message);
-            break;
-        }
+        streamState.onEvent(event);
       },
     });
+    // Flush any buffered agent text the stream left pending before the final answer.
+    streamState.finalize();
 
     if (reply.error) {
       printError(reply.error);
       return false;
-    } else {
-      await agentRenderer.renderReply(reply.output, hasPrintedToolProgress);
     }
+    await projector.renderReply(reply.output);
+
     const assistantMessage = createMessage("assistant", reply.output);
     session.messages.push(
       (reply.toolCalls?.length ?? 0) > 0 ? { ...assistantMessage, kind: "tool_payload" } : assistantMessage,

--- a/src/cli-stdout-projector.ts
+++ b/src/cli-stdout-projector.ts
@@ -24,6 +24,7 @@ export function createStdoutRowProjector(): {
 
   const emittedAssistant = new Map<string, string>();
   const emittedTool = new Map<string, string>();
+  const emittedChecklist = new Map<string, string>();
   const emittedRowIds = new Set<string>();
 
   function writeRaw(text: string): void {
@@ -57,7 +58,11 @@ export function createStdoutRowProjector(): {
 
   function renderTool(row: ChatRow): void {
     if (!isToolOutput(row.content)) return;
-    const rendered = renderToolOutput(row.content.parts);
+    const parts = row.content.parts;
+    // A lone header with no detail carries nothing to show yet — wait for real content,
+    // matching the old run-mode guard.
+    if (parts.length === 1 && parts[0]?.kind === "tool-header" && !parts[0].detail) return;
+    const rendered = renderToolOutput(parts);
     const previous = emittedTool.get(row.id);
     emittedTool.set(row.id, rendered);
     if (previous !== undefined) {
@@ -85,6 +90,11 @@ export function createStdoutRowProjector(): {
   function renderChecklist(row: ChatRow): void {
     if (!isChecklistOutput(row.content)) return;
     const { header, items } = formatChecklist(row.content);
+    // The stream reuses one row id per checklist group, so reprint on every content
+    // change (progress update) but not when an unrelated event re-runs the projection.
+    const rendered = `${header}\n${items.map((item) => `${item.marker} ${item.label}`).join("\n")}`;
+    if (emittedChecklist.get(row.id) === rendered) return;
+    emittedChecklist.set(row.id, rendered);
     printDim(`• ${header}`);
     for (const item of items) printIndentedDim(`${item.marker} ${item.label}`);
     hasPrintedProgress = true;
@@ -102,7 +112,7 @@ export function createStdoutRowProjector(): {
             renderTool(row);
             break;
           case "task":
-            if (!emittedRowIds.has(row.id)) renderChecklist(row);
+            renderChecklist(row);
             break;
           case "system":
             if (!emittedRowIds.has(row.id) && typeof row.content === "string") {

--- a/src/cli-stdout-projector.ts
+++ b/src/cli-stdout-projector.ts
@@ -138,7 +138,10 @@ export function createStdoutRowProjector(): {
       // shown (no-op); if the answer extends them, print only the tail; otherwise the
       // preview diverged (or nothing streamed) and the full answer is printed — the old
       // path silently dropped a divergent answer.
-      const streamed = agentStreamText;
+      // reply.output is trimmed upstream while the streamed preview keeps trailing
+      // whitespace, so compare on the trimmed preview or a lone trailing newline reads
+      // as divergence and reprints the whole answer.
+      const streamed = agentStreamText.trimEnd();
       if (replyOutput === streamed) return;
       if (streamed.length > 0 && replyOutput.startsWith(streamed)) {
         writeRaw(replyOutput.slice(streamed.length));

--- a/src/cli-stdout-projector.ts
+++ b/src/cli-stdout-projector.ts
@@ -6,16 +6,6 @@ import { palette } from "./palette";
 import { renderToolOutput } from "./tool-output-render";
 import { printDim, printError, printOutput, printWarning, streamText } from "./ui";
 
-// If the final answer extends the streamed preview, return the un-streamed tail; if it
-// equals it, return "" (already shown). Divergence returns "" too — a known run-mode gap
-// (the final answer is dropped) that the fold's follow-up commit addresses.
-function missingAgentStreamTail(streamed: string, finalOutput: string): string {
-  if (streamed.length === 0) return finalOutput;
-  if (finalOutput === streamed) return "";
-  if (finalOutput.startsWith(streamed)) return finalOutput.slice(streamed.length);
-  return "";
-}
-
 /**
  * Projects the row model (fed by MessageStreamState.onEvent) onto append-only stdout,
  * reproducing run mode's incremental rendering. Diffs each row against what it has
@@ -133,14 +123,20 @@ export function createStdoutRowProjector(): {
       if (!atLineStart) output.write("\n");
       printOutput("");
       if (hasPrintedProgress) printOutput("");
-      const missingTail = missingAgentStreamTail(agentStreamText, replyOutput);
-      if (missingTail.length > 0) {
-        writeRaw(missingTail);
+      // reply.output is authoritative and must appear in full exactly once. The streamed
+      // deltas are a non-authoritative preview: if they already equal the answer, it is
+      // shown (no-op); if the answer extends them, print only the tail; otherwise the
+      // preview diverged (or nothing streamed) and the full answer is printed — the old
+      // path silently dropped a divergent answer.
+      const streamed = agentStreamText;
+      if (replyOutput === streamed) return;
+      if (streamed.length > 0 && replyOutput.startsWith(streamed)) {
+        writeRaw(replyOutput.slice(streamed.length));
         if (!atLineStart) output.write("\n");
-      } else if (!agentStreamStarted) {
-        const wrapWidth = Math.max(24, (output.columns ?? 120) - 4);
-        await streamText(formatAgentReplyOutput(replyOutput, wrapWidth));
+        return;
       }
+      const wrapWidth = Math.max(24, (output.columns ?? 120) - 4);
+      await streamText(formatAgentReplyOutput(replyOutput, wrapWidth));
     },
   };
 }

--- a/src/cli-stdout-projector.ts
+++ b/src/cli-stdout-projector.ts
@@ -1,0 +1,146 @@
+import { stdout as output } from "node:process";
+import { type ChatRow, isChecklistOutput, isToolOutput } from "./chat-contract";
+import { formatChecklist } from "./checklist-format";
+import { formatAgentReplyOutput, printIndentedDim } from "./cli-format";
+import { palette } from "./palette";
+import { renderToolOutput } from "./tool-output-render";
+import { printDim, printError, printOutput, printWarning, streamText } from "./ui";
+
+// If the final answer extends the streamed preview, return the un-streamed tail; if it
+// equals it, return "" (already shown). Divergence returns "" too — a known run-mode gap
+// (the final answer is dropped) that the fold's follow-up commit addresses.
+function missingAgentStreamTail(streamed: string, finalOutput: string): string {
+  if (streamed.length === 0) return finalOutput;
+  if (finalOutput === streamed) return "";
+  if (finalOutput.startsWith(streamed)) return finalOutput.slice(streamed.length);
+  return "";
+}
+
+/**
+ * Projects the row model (fed by MessageStreamState.onEvent) onto append-only stdout,
+ * reproducing run mode's incremental rendering. Diffs each row against what it has
+ * already emitted so growing tool output and streamed text print only their new tail —
+ * the relocation of cli-prompt's hand-rolled `snapshotByCallId` logic.
+ */
+export function createStdoutRowProjector(): {
+  setRows: (updater: (current: ChatRow[]) => ChatRow[]) => void;
+  renderReply: (replyOutput: string) => Promise<void>;
+} {
+  let rows: ChatRow[] = [];
+  let atLineStart = true;
+  let agentStreamStarted = false;
+  let agentStreamText = "";
+  let hasPrintedProgress = false;
+
+  const emittedAssistant = new Map<string, string>();
+  const emittedTool = new Map<string, string>();
+  const emittedRowIds = new Set<string>();
+
+  function writeRaw(text: string): void {
+    if (text.length === 0) return;
+    let remaining = text;
+    while (remaining.length > 0) {
+      if (atLineStart) {
+        output.write(agentStreamStarted ? "  " : "• ");
+        agentStreamStarted = true;
+      }
+      const newlineIndex = remaining.indexOf("\n");
+      if (newlineIndex === -1) {
+        output.write(remaining);
+        atLineStart = false;
+        break;
+      }
+      output.write(`${remaining.slice(0, newlineIndex)}\n`);
+      remaining = remaining.slice(newlineIndex + 1);
+      atLineStart = true;
+    }
+  }
+
+  function renderAssistant(row: ChatRow): void {
+    const full = typeof row.content === "string" ? row.content : "";
+    const prev = emittedAssistant.get(row.id) ?? "";
+    const delta = full.startsWith(prev) ? full.slice(prev.length) : full;
+    emittedAssistant.set(row.id, full);
+    agentStreamText = full;
+    writeRaw(delta);
+  }
+
+  function renderTool(row: ChatRow): void {
+    if (!isToolOutput(row.content)) return;
+    const rendered = renderToolOutput(row.content.parts);
+    const previous = emittedTool.get(row.id);
+    emittedTool.set(row.id, rendered);
+    if (previous !== undefined) {
+      const current = rendered.trimEnd();
+      const before = previous.trimEnd();
+      if (current === before) return;
+      if (current.startsWith(`${before}\n`)) {
+        printIndentedDim(current.slice(before.length + 1));
+        hasPrintedProgress = true;
+        return;
+      }
+      const currentLines = current.split("\n");
+      const previousLines = before.split("\n");
+      if (currentLines.length > previousLines.length) {
+        printIndentedDim(currentLines.slice(previousLines.length).join("\n"));
+        hasPrintedProgress = true;
+      }
+      return;
+    }
+    printDim(`• ${rendered.split("\n")[0] ?? ""}`);
+    if (rendered.includes("\n")) printIndentedDim(rendered.slice(rendered.indexOf("\n") + 1));
+    hasPrintedProgress = true;
+  }
+
+  function renderChecklist(row: ChatRow): void {
+    if (!isChecklistOutput(row.content)) return;
+    const { header, items } = formatChecklist(row.content);
+    printDim(`• ${header}`);
+    for (const item of items) printIndentedDim(`${item.marker} ${item.label}`);
+    hasPrintedProgress = true;
+  }
+
+  return {
+    setRows: (updater) => {
+      const next = updater(rows);
+      for (const row of next) {
+        switch (row.kind) {
+          case "assistant":
+            renderAssistant(row);
+            break;
+          case "tool":
+            renderTool(row);
+            break;
+          case "task":
+            if (!emittedRowIds.has(row.id)) renderChecklist(row);
+            break;
+          case "system":
+            if (!emittedRowIds.has(row.id) && typeof row.content === "string") {
+              // Honor the notice/error level carried on the row style (warn→yellow,
+              // error→red), the unified colouring run mode previously lacked.
+              if (row.style?.text === palette.error) printError(row.content);
+              else printWarning(row.content);
+              hasPrintedProgress = true;
+            }
+            break;
+        }
+        emittedRowIds.add(row.id);
+      }
+      rows = next;
+    },
+
+    renderReply: async (replyOutput) => {
+      if (!atLineStart) output.write("\n");
+      printOutput("");
+      if (hasPrintedProgress) printOutput("");
+      const missingTail = missingAgentStreamTail(agentStreamText, replyOutput);
+      if (missingTail.length > 0) {
+        writeRaw(missingTail);
+        if (!atLineStart) output.write("\n");
+      } else if (!agentStreamStarted) {
+        const wrapWidth = Math.max(24, (output.columns ?? 120) - 4);
+        await streamText(formatAgentReplyOutput(replyOutput, wrapWidth));
+      }
+    },
+  };
+}

--- a/src/lifecycle-finalize.test.ts
+++ b/src/lifecycle-finalize.test.ts
@@ -179,6 +179,20 @@ describe("phaseFinalize", () => {
     expect(response.error).toBe("Cannot finish yet: `src/app.ts` changed after the last successful validation.");
   });
 
+  test("blocking error with no model text emits empty output, not a fallback bubble", () => {
+    const ctx = createRunContext({
+      currentError: { message: "Cannot finish yet: validation missing", category: "other", blocksCompletion: true },
+      result: { text: "", toolCalls: [], signal: "done" },
+    });
+
+    const response = phaseFinalize(ctx);
+
+    expect(response.state).toBe("awaiting-input");
+    // The error row is authoritative; no placeholder output to render beside it.
+    expect(response.output).toBe("");
+    expect(response.error).toBe("Cannot finish yet: validation missing");
+  });
+
   test("does not use an unaccepted blocked signal for response state", () => {
     const ctx = createRunContext({
       currentError: { message: "tool failed", category: "other" },

--- a/src/lifecycle-finalize.ts
+++ b/src/lifecycle-finalize.ts
@@ -31,9 +31,13 @@ export function phaseFinalize(ctx: RunContext): ChatResponse {
   const output =
     rawOutput.length > 0
       ? rawOutput
-      : ctx.observedTools.size > 0
-        ? t("agent.output.no_response_after_tools")
-        : t("agent.output.no_output");
+      : blockingError
+        ? // On a blocking error the status/error row is the authoritative output; emit
+          // no fallback so it never renders a placeholder bubble beside the reason.
+          ""
+        : ctx.observedTools.size > 0
+          ? t("agent.output.no_response_after_tools")
+          : t("agent.output.no_output");
 
   const { promptUsage } = ctx;
   const promptInputTokens = promptUsageTotalTokens(promptUsage);


### PR DESCRIPTION
## Motivation

The chat and run-mode output paths were two drifting interpreters of the same stream. Dogfooding showed the cost: an error rendered twice, and run mode silently dropping a final answer that diverged from its streamed preview.

## Summary
- route both the TUI and headless run mode through one stream-event interpreter (`MessageStreamState.onEvent`); run mode renders via a row projector instead of a bespoke switch, so the two can no longer drift
- fix: run mode prints the final answer when it diverges from the streamed preview, instead of dropping it
- fix: a blocked turn shows only its status row, no placeholder bubble
- add a golden snapshot test locking run mode's exact output