### PR TITLE
feat(trace): count recall probes, show memory observations

### DIFF
--- a/src/chat-commands-memory.ts
+++ b/src/chat-commands-memory.ts
@@ -84,7 +84,9 @@ async function handleMemoryList(
     ctx.setRows((current) => [...current, createRow("system", t("chat.memory.none", { scope: emptyLabel }))]);
     return { stop: true, userText: text };
   }
-  const list = memories.slice(0, 10).map((entry) => `${entry.scope}:${entry.id} ${entry.content}`);
+  const list = memories
+    .slice(0, 10)
+    .map((entry) => `${entry.scope}:${entry.id}${entry.kind === "observation" ? " (obs)" : ""} ${entry.content}`);
   const header =
     scope === "all"
       ? t("chat.memory.header.all", { count: memories.length })

--- a/src/chat-commands.test.ts
+++ b/src/chat-commands.test.ts
@@ -21,6 +21,7 @@ function createMemoryApi(overrides?: {
       overrides?.addMemory ??
       (async () => ({
         id: "mem_unused",
+        kind: "stored" as const,
         scope: "user" as const,
         content: "unused",
         createdAt: "2026-02-21T00:00:00.000Z",
@@ -139,6 +140,7 @@ describe("chat-commands", () => {
       listMemories: async () => [
         {
           id: "mem_1",
+          kind: "stored" as const,
           scope: "user" as const,
           content: "prefer concise output",
           createdAt: "2026-02-21T00:00:00.000Z",
@@ -146,6 +148,7 @@ describe("chat-commands", () => {
         },
         {
           id: "mem_2",
+          kind: "stored" as const,
           scope: "project" as const,
           content: "use bun scripts",
           createdAt: "2026-02-21T00:00:01.000Z",
@@ -166,6 +169,7 @@ describe("chat-commands", () => {
       listMemories: async () => [
         {
           id: "mem_1",
+          kind: "stored" as const,
           scope: "user" as const,
           content: "prefer concise output",
           createdAt: "2026-02-21T00:00:00.000Z",
@@ -173,6 +177,7 @@ describe("chat-commands", () => {
         },
         {
           id: "mem_2",
+          kind: "stored" as const,
           scope: "project" as const,
           content: "use bun scripts",
           createdAt: "2026-02-21T00:00:01.000Z",
@@ -194,6 +199,7 @@ describe("chat-commands", () => {
         kind: "removed" as const,
         entry: {
           id: "mem_deadbeef",
+          kind: "stored" as const,
           scope: "project" as const,
           content: "x",
           createdAt: "2026-02-21T00:00:00.000Z",
@@ -224,6 +230,7 @@ describe("chat-commands", () => {
       listMemories: async () => [
         {
           id: "mem_1",
+          kind: "stored" as const,
           scope: "user" as const,
           content: "prefer concise output",
           createdAt: "2026-02-21T00:00:00.000Z",
@@ -241,6 +248,7 @@ describe("chat-commands", () => {
       listMemories: async () => [
         {
           id: "mem_1",
+          kind: "stored" as const,
           scope: "project" as const,
           content: "use bun scripts",
           createdAt: "2026-02-21T00:00:00.000Z",
@@ -275,6 +283,7 @@ describe("chat-commands", () => {
         savedScope = scope;
         return {
           id: "mem_3",
+          kind: "stored" as const,
           scope,
           content,
           createdAt: "2026-02-21T00:00:02.000Z",

--- a/src/cli-memory.test.ts
+++ b/src/cli-memory.test.ts
@@ -12,6 +12,7 @@ function createOps(overrides?: Partial<MemoryOps>): MemoryOps {
     list: async () => [
       {
         id: "mem_abc",
+        kind: "stored" as const,
         content: "remember this",
         scope: "user" as const,
         createdAt: "9999-01-01T00:00:00.000Z",
@@ -20,6 +21,7 @@ function createOps(overrides?: Partial<MemoryOps>): MemoryOps {
     ],
     add: async (content, scope) => ({
       id: "mem_test123",
+      kind: "stored" as const,
       content,
       scope: scope ?? "user",
       createdAt: "9999-01-01T00:00:00.000Z",
@@ -106,6 +108,7 @@ describe("cli-memory", () => {
           savedScope = scope;
           return {
             id: "mem_test123",
+            kind: "stored" as const,
             content,
             scope: scope ?? "user",
             createdAt: "9999-01-01T00:00:00.000Z",

--- a/src/cli-memory.ts
+++ b/src/cli-memory.ts
@@ -49,6 +49,7 @@ export async function memoryMode(args: string[], deps: MemoryModeDeps): Promise<
     out.addTable(
       rows.slice(0, 50).map((row) => ({
         id: row.id,
+        kind: row.kind,
         content: truncateText(row.content, 80),
         created: formatRelativeTime(row.createdAt),
         recalled: row.lastRecalledAt ? formatRelativeTime(row.lastRecalledAt) : "never",

--- a/src/cli-stdout-projector.ts
+++ b/src/cli-stdout-projector.ts
@@ -59,8 +59,7 @@ export function createStdoutRowProjector(): {
   function renderTool(row: ChatRow): void {
     if (!isToolOutput(row.content)) return;
     const parts = row.content.parts;
-    // A lone header with no detail carries nothing to show yet — wait for real content,
-    // matching the old run-mode guard.
+    // A lone header with no detail carries nothing to show yet — wait for real content.
     if (parts.length === 1 && parts[0]?.kind === "tool-header" && !parts[0].detail) return;
     const rendered = renderToolOutput(parts);
     const previous = emittedTool.get(row.id);
@@ -116,8 +115,8 @@ export function createStdoutRowProjector(): {
             break;
           case "system":
             if (!emittedRowIds.has(row.id) && typeof row.content === "string") {
-              // Honor the notice/error level carried on the row style (warn→yellow,
-              // error→red), the unified colouring run mode previously lacked.
+              // Color by the notice/error level carried on the row style: warn→yellow,
+              // error→red.
               if (row.style?.text === palette.error) printError(row.content);
               else printWarning(row.content);
               hasPrintedProgress = true;
@@ -133,14 +132,11 @@ export function createStdoutRowProjector(): {
       if (!atLineStart) output.write("\n");
       printOutput("");
       if (hasPrintedProgress) printOutput("");
-      // reply.output is authoritative and must appear in full exactly once. The streamed
-      // deltas are a non-authoritative preview: if they already equal the answer, it is
-      // shown (no-op); if the answer extends them, print only the tail; otherwise the
-      // preview diverged (or nothing streamed) and the full answer is printed — the old
-      // path silently dropped a divergent answer.
-      // reply.output is trimmed upstream while the streamed preview keeps trailing
-      // whitespace, so compare on the trimmed preview or a lone trailing newline reads
-      // as divergence and reprints the whole answer.
+      // reply.output is the authoritative answer, printed in full exactly once; the
+      // streamed deltas are a preview, reused only when they equal it (no-op) or prefix
+      // it (print the tail). reply.output is trimmed upstream while the preview keeps
+      // trailing whitespace, so compare trimmed — else a lone trailing newline reads as
+      // divergence and reprints the whole answer.
       const streamed = agentStreamText.trimEnd();
       if (replyOutput === streamed) return;
       if (streamed.length > 0 && replyOutput.startsWith(streamed)) {

--- a/src/lifecycle-finalize.test.ts
+++ b/src/lifecycle-finalize.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { parseChatResponse } from "./client-contract";
 import { phaseFinalize } from "./lifecycle-finalize";
 import { createRunContext } from "./test-utils";
+import { createSessionContext } from "./tool-session";
 
 describe("ChatResponse error field", () => {
   test("parseChatResponse preserves error field", () => {
@@ -131,6 +132,37 @@ describe("phaseFinalize", () => {
     });
     const response = phaseFinalize(ctx);
     expect(response.state).toBe("done");
+  });
+
+  test("counts recall probes separately and keeps them out of search/discovery", () => {
+    const session = createSessionContext("task_1");
+    session.callLog.push(
+      { toolName: "memory-search", args: {}, taskId: "task_1", status: "succeeded" },
+      { toolName: "session-search", args: {}, taskId: "task_1", status: "succeeded" },
+      { toolName: "session-search", args: {}, taskId: "task_1", status: "succeeded" },
+      { toolName: "file-search", args: {}, taskId: "task_1", status: "succeeded" },
+      { toolName: "file-read", args: {}, taskId: "task_1", status: "succeeded" },
+      // A call from a different task must not be counted.
+      { toolName: "session-search", args: {}, taskId: "task_other", status: "succeeded" },
+    );
+    let summary: Record<string, unknown> | undefined;
+    const ctx = createRunContext({
+      taskId: "task_1",
+      session,
+      result: { text: "done", toolCalls: [] },
+      debug: (event, fields) => {
+        if (event === "lifecycle.summary") summary = fields;
+      },
+    });
+
+    phaseFinalize(ctx);
+
+    expect(summary?.memory_search_calls).toBe(1);
+    expect(summary?.session_search_calls).toBe(2);
+    // Only file-search counts as code search; session-search is excluded despite its
+    // "search" category, and neither recall probe inflates pre-write discovery.
+    expect(summary?.search_calls).toBe(1);
+    expect(summary?.pre_write_discovery_calls).toBe(2);
   });
 
   test("uses signal-aware fallback output when final text is empty", () => {

--- a/src/lifecycle-finalize.ts
+++ b/src/lifecycle-finalize.ts
@@ -46,14 +46,24 @@ export function phaseFinalize(ctx: RunContext): ChatResponse {
 
   const callLog = scopedCallLog(ctx.session, ctx.taskId);
   const totalToolCalls = callLog.length;
+  // Recall probes search memory/history, not the codebase (session-search is category
+  // "search", so it would otherwise land in the code-search and discovery tallies);
+  // keep them off those axes so read/search/discovery stay a clean over-exploration signal.
+  const isRecallProbe = (toolName: string) => toolName === "memory-search" || toolName === "session-search";
+  const isCodeDiscovery = (entry: { toolName: string }) =>
+    DISCOVERY_TOOL_SET.has(entry.toolName) && !isRecallProbe(entry.toolName);
   const readCalls = callLog.filter((entry) => READ_TOOL_SET.has(entry.toolName)).length;
-  const searchCalls = callLog.filter((entry) => SEARCH_TOOL_SET.has(entry.toolName)).length;
+  const searchCalls = callLog.filter(
+    (entry) => SEARCH_TOOL_SET.has(entry.toolName) && !isRecallProbe(entry.toolName),
+  ).length;
   const writeCalls = callLog.filter((entry) => WRITE_TOOL_SET.has(entry.toolName)).length;
+  const memorySearchCalls = callLog.filter((entry) => entry.toolName === "memory-search").length;
+  const sessionSearchCalls = callLog.filter((entry) => entry.toolName === "session-search").length;
   const firstWriteIndex = callLog.findIndex((entry) => WRITE_TOOL_SET.has(entry.toolName));
   const preWriteDiscoveryCalls =
     firstWriteIndex >= 0
-      ? callLog.slice(0, firstWriteIndex).filter((entry) => DISCOVERY_TOOL_SET.has(entry.toolName)).length
-      : callLog.filter((entry) => DISCOVERY_TOOL_SET.has(entry.toolName)).length;
+      ? callLog.slice(0, firstWriteIndex).filter(isCodeDiscovery).length
+      : callLog.filter(isCodeDiscovery).length;
 
   ctx.debug("lifecycle.summary", {
     task_id: ctx.taskId ?? null,
@@ -68,6 +78,8 @@ export function phaseFinalize(ctx: RunContext): ChatResponse {
     read_calls: readCalls,
     search_calls: searchCalls,
     write_calls: writeCalls,
+    memory_search_calls: memorySearchCalls,
+    session_search_calls: sessionSearchCalls,
     pre_write_discovery_calls: preWriteDiscoveryCalls,
     lifecycle_signal: ctx.acceptedSignal ?? null,
     budget_blocked: ctx.errorStats["budget-exhausted"] > 0,

--- a/src/memory-contract.ts
+++ b/src/memory-contract.ts
@@ -11,6 +11,7 @@ export type MemoryId = z.infer<typeof memoryIdSchema>;
 
 export interface MemoryEntry {
   readonly id: MemoryId;
+  readonly kind: MemoryKind;
   readonly content: string;
   readonly createdAt: IsoDateTimeString;
   readonly lastRecalledAt: IsoDateTimeString | null;

--- a/src/memory-ops.test.ts
+++ b/src/memory-ops.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { resolveScopeKey, visibleScopeKeys } from "./memory-ops";
+import type { MemoryRecord } from "./memory-contract";
+import { listMemories, resolveScopeKey, visibleScopeKeys } from "./memory-ops";
+import { createSqliteMemoryStore } from "./memory-store";
 import { defaultUserResourceId, projectResourceIdFromWorkspace } from "./resource-id";
 
 describe("resolveScopeKey", () => {
@@ -55,5 +57,25 @@ describe("visibleScopeKeys", () => {
     const keys = visibleScopeKeys({ sessionId: "sess_alpha" });
     expect(keys.has(projectResourceIdFromWorkspace(process.cwd()))).toBe(false);
     expect(keys).toEqual(new Set(["sess_alpha", defaultUserResourceId()]));
+  });
+});
+
+describe("listMemories", () => {
+  // Regression: the list used to filter kind:"stored", hiding distilled observations.
+  test("returns both stored memories and observations", async () => {
+    const store = createSqliteMemoryStore(":memory:");
+    const scopeKey = defaultUserResourceId();
+    const base = { scopeKey, createdAt: "2026-03-05T10:00:00.000Z", tokenEstimate: 1 };
+    const records: MemoryRecord[] = [
+      { ...base, id: "mem_stored01", kind: "stored", content: "a stored fact" },
+      { ...base, id: "mem_obs01", kind: "observation", content: "a distilled observation" },
+    ];
+    for (const record of records) await store.write(record);
+
+    const entries = await listMemories({ scope: "user", store });
+    const contents = entries.map((entry) => entry.content);
+    expect(contents).toContain("a stored fact");
+    expect(contents).toContain("a distilled observation");
+    store.close();
   });
 });

--- a/src/memory-ops.test.ts
+++ b/src/memory-ops.test.ts
@@ -73,9 +73,9 @@ describe("listMemories", () => {
     for (const record of records) await store.write(record);
 
     const entries = await listMemories({ scope: "user", store });
-    const contents = entries.map((entry) => entry.content);
-    expect(contents).toContain("a stored fact");
-    expect(contents).toContain("a distilled observation");
+    const byContent = new Map(entries.map((entry) => [entry.content, entry.kind]));
+    expect(byContent.get("a stored fact")).toBe("stored");
+    expect(byContent.get("a distilled observation")).toBe("observation");
     store.close();
   });
 });

--- a/src/memory-ops.ts
+++ b/src/memory-ops.ts
@@ -54,7 +54,8 @@ export async function listMemories(options: MemoryOptions = {}): Promise<MemoryE
   const keys = scopeKeysForScope(scope, workspace);
   const entries = [];
   for (const key of keys) {
-    const records = await store.list({ scopeKey: key, kind: "stored" });
+    // List all kinds so distilled observations appear, not only stored memories.
+    const records = await store.list({ scopeKey: key });
     entries.push(...records.map(toMemoryEntry));
   }
   entries.sort((a, b) => b.createdAt.localeCompare(a.createdAt));

--- a/src/memory-ops.ts
+++ b/src/memory-ops.ts
@@ -3,6 +3,7 @@ import { normalizeMemoryText } from "./distill-ops";
 import { log } from "./log";
 import {
   type MemoryEntry,
+  type MemoryKind,
   type MemoryRecord,
   type MemoryScope,
   type MemoryStore,
@@ -34,6 +35,7 @@ function scopeKeysForScope(scope: MemoryScope | undefined, workspace?: string): 
 
 function toMemoryEntry(record: {
   id: string;
+  kind: MemoryKind;
   scopeKey: string;
   content: string;
   createdAt: string;
@@ -41,6 +43,7 @@ function toMemoryEntry(record: {
 }): MemoryEntry {
   return {
     id: record.id,
+    kind: record.kind,
     content: record.content,
     createdAt: record.createdAt,
     lastRecalledAt: record.lastRecalledAt ?? null,

--- a/src/memory-ops.ts
+++ b/src/memory-ops.ts
@@ -182,12 +182,13 @@ export async function removeMemory(id: string, options: MemoryOptions = {}): Pro
   const store = options.store ?? (await getMemoryStore());
   const keys = scopeKeysForScope(scope, workspace);
   for (const key of keys) {
-    const records = await store.list({ scopeKey: key, kind: "stored" });
+    // Match all kinds so distilled observations are removable, not only stored memories.
+    const records = await store.list({ scopeKey: key });
     const record = records.find((r) => r.id === trimmed);
     if (record) {
       const entry = toMemoryEntry(record);
       await store.remove(entry.id);
-      log.debug("memory.stored.removed", { id: entry.id, scope: entry.scope });
+      log.debug("memory.removed", { id: entry.id, kind: entry.kind, scope: entry.scope });
       return { kind: "removed", entry };
     }
   }

--- a/src/memory.int.test.ts
+++ b/src/memory.int.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { addMemory, listMemories, removeMemory } from "./memory-ops";
+import { addMemory, addObservation, listMemories, removeMemory } from "./memory-ops";
 import { createSqliteMemoryStore } from "./memory-store";
+import { defaultUserResourceId } from "./resource-id";
 import { tempDb } from "./test-utils";
 
 const { create: createDb, cleanup } = tempDb("acolyte-memory-", createSqliteMemoryStore);
@@ -47,5 +48,21 @@ describe("sqlite memory store", () => {
     const db = createDb();
     const result = await removeMemory("mem_missing", { store: db });
     expect(result).toEqual({ kind: "not_found", id: "mem_missing" });
+  });
+
+  test("removeMemory removes a distilled observation and its embedding", async () => {
+    const db = createDb();
+    const record = await addObservation(defaultUserResourceId(), "Prefers tabs over spaces", { store: db });
+    expect(record).not.toBeNull();
+    const id = record?.id ?? "";
+    await db.writeEmbedding(id, defaultUserResourceId(), Buffer.from([1, 2, 3, 4]));
+
+    const result = await removeMemory(id, { store: db });
+    expect(result.kind).toBe("removed");
+    if (result.kind === "removed") expect(result.entry.kind).toBe("observation");
+
+    const all = await listMemories({ store: db });
+    expect(all.some((item) => item.id === id)).toBe(false);
+    expect(await db.getEmbedding(id)).toBeNull();
   });
 });

--- a/src/trace-event-catalog.ts
+++ b/src/trace-event-catalog.ts
@@ -152,6 +152,8 @@ export const TRACE_EVENT_CATALOG: Record<TraceEventName, TraceEventDefinition> =
     { key: "read_calls", label: "read" },
     { key: "search_calls", label: "search" },
     { key: "write_calls", label: "write" },
+    { key: "memory_search_calls", label: "memory_search" },
+    { key: "session_search_calls", label: "session_search" },
     { key: "pre_write_discovery_calls", label: "pre_write_discovery" },
     { key: "budget_exhausted_count", label: "budget_exhausted" },
     "has_error",


### PR DESCRIPTION
## Motivation

The I3+I6 instrumentation rider — make recall behavior and distilled memory visible ahead of dogfooding.

## Summary

- add per-task `memory-search` / `session-search` counts to the `lifecycle.summary` trace event
- exclude those recall probes from the `search` and `pre-write-discovery` tallies so those stay a clean code-exploration signal
- `acolyte memory list` and `/memory` now show distilled observations, labeled by kind — previously hidden behind a stored-only filter
- trim leftover narration comments from the run-mode projector, carried over from #278