### PR TITLE
fix(trace): fix budget_exhausted_count field name

### DIFF
--- a/src/lifecycle-finalize.test.ts
+++ b/src/lifecycle-finalize.test.ts
@@ -3,6 +3,7 @@ import { parseChatResponse } from "./client-contract";
 import { phaseFinalize } from "./lifecycle-finalize";
 import { createRunContext } from "./test-utils";
 import { createSessionContext } from "./tool-session";
+import { missingCatalogDisplayFields } from "./trace-event-catalog";
 
 describe("ChatResponse error field", () => {
   test("parseChatResponse preserves error field", () => {
@@ -163,6 +164,26 @@ describe("phaseFinalize", () => {
     // "search" category, and neither recall probe inflates pre-write discovery.
     expect(summary?.search_calls).toBe(1);
     expect(summary?.pre_write_discovery_calls).toBe(2);
+  });
+
+  test("lifecycle.summary debug event has all catalog display fields", () => {
+    const debugEvents: Array<{ event: string; fields: Record<string, unknown> }> = [];
+    const ctx = createRunContext({
+      result: { text: "done", toolCalls: [] },
+      errorStats: { timeout: 0, "file-not-found": 0, "budget-exhausted": 2, other: 0 },
+      debug: (event, fields) => debugEvents.push({ event, fields: fields as Record<string, unknown> }),
+    });
+
+    phaseFinalize(ctx);
+
+    const summary = debugEvents.find((e) => e.event === "lifecycle.summary");
+    if (!summary) throw new Error("lifecycle.summary debug event not emitted");
+    const missing = missingCatalogDisplayFields(
+      "lifecycle.summary",
+      summary.fields as Record<string, string | number | boolean | null | undefined>,
+    );
+    expect(missing).toEqual([]);
+    expect(summary.fields.budget_exhausted_count).toBe(2);
   });
 
   test("uses signal-aware fallback output when final text is empty", () => {

--- a/src/lifecycle-finalize.ts
+++ b/src/lifecycle-finalize.ts
@@ -88,7 +88,7 @@ export function phaseFinalize(ctx: RunContext): ChatResponse {
     last_error_category: ctx.currentError?.category ?? null,
     timeout_error_count: ctx.errorStats.timeout,
     file_not_found_error_count: ctx.errorStats["file-not-found"],
-    budget_blocked_count: ctx.errorStats["budget-exhausted"],
+    budget_exhausted_count: ctx.errorStats["budget-exhausted"],
     other_error_count: ctx.errorStats.other,
   });
 

--- a/src/trace-event-catalog.ts
+++ b/src/trace-event-catalog.ts
@@ -175,3 +175,18 @@ export function parseTraceFields(event: string | undefined, fields: TraceFields)
   if (isCatalogTraceEvent(event)) return TRACE_EVENT_CATALOG[event].fields.parse(fields);
   return traceFieldsSchema.parse(fields);
 }
+
+/**
+ * Returns the displayField keys that are missing from `fields`.
+ * An empty result means all catalog display keys are present — use in tests to catch
+ * mismatches between what a debug() call site emits and what the catalog expects to read.
+ */
+export function missingCatalogDisplayFields(event: string | undefined, fields: TraceFields): string[] {
+  if (!isCatalogTraceEvent(event)) return [];
+  const missing: string[] = [];
+  for (const spec of TRACE_EVENT_CATALOG[event].displayFields) {
+    const key = typeof spec === "string" ? spec : spec.key;
+    if (!(key in fields)) missing.push(key);
+  }
+  return missing;
+}


### PR DESCRIPTION
## Motivation
`lifecycle.summary` emitted `budget_blocked_count` but the catalog and CLI reader both expected `budget_exhausted_count`, so budget exhaustion never appeared in `acolyte trace task` output.

## Summary
- rename emitted field in `phaseFinalize` to match catalog and `compactSummary` reader
- add `missingCatalogDisplayFields` helper to `trace-event-catalog` for conformance testing
- add regression test asserting all catalog display keys are present in the `lifecycle.summary` debug event