### PR TITLE
test(tui): transcript-integrity VT harness

### DIFF
--- a/src/tui/render.test.tsx
+++ b/src/tui/render.test.tsx
@@ -4,6 +4,7 @@ import { createElement as h, useEffect, useState } from "react";
 import { physicalRowCount } from "./render";
 import { ansi } from "./styles";
 import { renderCapture } from "./test-utils";
+import { replayTerminal } from "./vt";
 
 function withMockedStdout(
   fn: (writes: string[]) => void | Promise<void>,
@@ -42,81 +43,10 @@ function withMockedStdout(
   );
 }
 
+// Screen-only view for the visible-region assertions below; transcript-integrity
+// (scrollback) assertions live in vt.test.tsx.
 function replayVisibleScreen(writes: string[], rows: number, columns: number): string[] {
-  const screen = Array.from({ length: rows }, () => Array.from({ length: columns }, () => " "));
-  let row = 0;
-  let col = 0;
-
-  const scroll = (): void => {
-    screen.shift();
-    screen.push(Array.from({ length: columns }, () => " "));
-    row = rows - 1;
-  };
-
-  const eraseDown = (): void => {
-    const currentRow = screen[row];
-    if (currentRow) {
-      for (let c = col; c < columns; c++) currentRow[c] = " ";
-    }
-    for (let r = row + 1; r < rows; r++) {
-      const nextRow = screen[r];
-      if (!nextRow) continue;
-      for (let c = 0; c < columns; c++) nextRow[c] = " ";
-    }
-  };
-
-  const applyWrite = (data: string): void => {
-    let index = 0;
-    while (index < data.length) {
-      const char = data[index];
-      if (char === "\x1b" && data[index + 1] === "[") {
-        let end = index + 2;
-        while (end < data.length) {
-          const code = data.charCodeAt(end);
-          if (code >= 0x40 && code <= 0x7e) break;
-          end += 1;
-        }
-        if (end >= data.length) break;
-        const sequence = data.slice(index + 2, end);
-        const finalByte = data[end];
-        const paramText = sequence.replace(/^\?/, "");
-        const param = paramText.length > 0 ? Number.parseInt(paramText, 10) : 1;
-        if (finalByte === "A") {
-          row = Math.max(0, row - (Number.isFinite(param) ? param : 1));
-        } else if (finalByte === "J") {
-          eraseDown();
-        }
-        index = end + 1;
-        continue;
-      }
-      if (char === "\r") {
-        col = 0;
-        index += 1;
-        continue;
-      }
-      if (char === "\n") {
-        row += 1;
-        col = 0;
-        if (row >= rows) scroll();
-        index += 1;
-        continue;
-      }
-      if (col >= columns) {
-        row += 1;
-        col = 0;
-        if (row >= rows) scroll();
-      }
-      if (row >= 0 && row < rows && col >= 0 && col < columns) {
-        const currentRow = screen[row];
-        if (currentRow) currentRow[col] = char;
-      }
-      col += 1;
-      index += 1;
-    }
-  };
-
-  for (const write of writes) applyWrite(write);
-  return screen.map((line) => line.join("").trimEnd());
+  return replayTerminal(writes, rows, columns).screen;
 }
 
 function extractFrameWrites(writes: string[]): string[] {

--- a/src/tui/vt.test.tsx
+++ b/src/tui/vt.test.tsx
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import type React from "react";
+import { useEffect, useState } from "react";
+import { ansi } from "./styles";
+import { renderCapture } from "./test-utils";
+import { assertTranscriptIntegrity, replayTerminal, TranscriptIntegrityError, transcriptLines } from "./vt";
+
+/** Drop the unmount-cleanup writes (cursor-show onward) so only frames remain. */
+function frameWrites(writes: string[]): string[] {
+  const cleanup = writes.findIndex((write) => write.includes(ansi.cursorShow));
+  return cleanup >= 0 ? writes.slice(0, cleanup) : writes;
+}
+
+describe("replayTerminal", () => {
+  test("keeps lines that scroll off the top in scrollback", () => {
+    const vt = replayTerminal(["a\r\nb\r\nc\r\nd\r\ne"], 3, 20);
+    expect(vt.scrollback).toEqual(["a", "b"]);
+    expect(vt.screen).toEqual(["c", "d", "e"]);
+    expect(transcriptLines(vt)).toEqual(["a", "b", "c", "d", "e"]);
+  });
+
+  test("wraps at the right margin", () => {
+    const vt = replayTerminal(["abcdef"], 3, 3);
+    expect(transcriptLines(vt)).toEqual(["abc", "def"]);
+  });
+
+  test("erase-down clears from the cursor to the end of the screen", () => {
+    const vt = replayTerminal(["one\r\ntwo\r\nthree", `${ansi.cursorUp(1)}\r${ansi.eraseDown}`], 4, 10);
+    expect(transcriptLines(vt)).toEqual(["one"]);
+  });
+});
+
+describe("assertTranscriptIntegrity", () => {
+  test("passes when the committed+visible transcript matches", () => {
+    const vt = replayTerminal(["a\r\nb\r\nc"], 5, 20);
+    expect(() => assertTranscriptIntegrity(vt, ["a", "b", "c"])).not.toThrow();
+  });
+
+  test("catches a dropped line", () => {
+    const vt = replayTerminal(["a\r\nc"], 5, 20);
+    expect(() => assertTranscriptIntegrity(vt, ["a", "b", "c"])).toThrow(TranscriptIntegrityError);
+  });
+
+  test("catches a duplicated line", () => {
+    const vt = replayTerminal(["a\r\nb\r\nb"], 5, 20);
+    expect(() => assertTranscriptIntegrity(vt, ["a", "b"])).toThrow(TranscriptIntegrityError);
+  });
+
+  test("catches a tool-result fragment interleaved into a prose line", () => {
+    // The reported corruption shape: prose is written, the cursor returns to
+    // column 0 of the same row, and a diff fragment overwrites it — the two
+    // logical lines collapse onto one row.
+    const vt = replayTerminal(["That is the answer\r124 -# allowed_mime_types"], 5, 40);
+    expect(transcriptLines(vt)).toEqual(["124 -# allowed_mime_types"]);
+    expect(() => assertTranscriptIntegrity(vt, ["That is the answer", "124 -# allowed_mime_types"])).toThrow(
+      TranscriptIntegrityError,
+    );
+  });
+
+  test("catches a bare-LF foreign write that column-splices the next line", () => {
+    // A stray `\n` with no `\r` (e.g. a foreign console.log) leaves the column
+    // where it was, offsetting the next line — the corruption render.ts avoids by
+    // normalizing its own newlines to `\r\n`.
+    const vt = replayTerminal(["hello\nworld"], 5, 20);
+    expect(transcriptLines(vt)).toEqual(["hello", "     world"]);
+    expect(() => assertTranscriptIntegrity(vt, ["hello", "world"])).toThrow(TranscriptIntegrityError);
+  });
+});
+
+function LinesApp(props: { unmount: () => void; lines: string[] }): React.JSX.Element {
+  useEffect(() => {
+    const timer = setTimeout(props.unmount, 40);
+    return () => clearTimeout(timer);
+  }, [props.unmount]);
+  return (
+    <tui-box flexDirection="column">
+      {props.lines.map((line) => (
+        <tui-text key={line}>{line}</tui-text>
+      ))}
+    </tui-box>
+  );
+}
+
+const ALL = Array.from({ length: 11 }, (_, i) => `L${i + 1}`);
+
+/** Appends lines across several frames so the overflow frozen-prefix grows
+ *  incrementally (render.ts:199-205) — the path that produced the corruption. */
+function GrowingLinesApp(props: { unmount: () => void }): React.JSX.Element {
+  const [count, setCount] = useState(7);
+  useEffect(() => {
+    const t1 = setTimeout(() => setCount(9), 20);
+    const t2 = setTimeout(() => setCount(11), 40);
+    const t3 = setTimeout(props.unmount, 60);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+      clearTimeout(t3);
+    };
+  }, [props.unmount]);
+  return (
+    <tui-box flexDirection="column">
+      {ALL.slice(0, count).map((line) => (
+        <tui-text key={line}>{line}</tui-text>
+      ))}
+    </tui-box>
+  );
+}
+
+describe("renderer transcript integrity", () => {
+  test("every overflowing line survives in the transcript exactly once", async () => {
+    const lines = ["L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8"];
+    const writes = await renderCapture(({ unmount }) => <LinesApp unmount={unmount} lines={lines} />, {
+      columns: 20,
+      rows: 6,
+    });
+    const vt = replayTerminal(frameWrites(writes), 6, 20);
+    // L1-L3 scroll into scrollback, L4-L8 stay on screen — none lost, none duplicated.
+    assertTranscriptIntegrity(vt, lines);
+  });
+
+  test("lines committed across incremental overflow frames survive in order", async () => {
+    const writes = await renderCapture(({ unmount }) => <GrowingLinesApp unmount={unmount} />, {
+      columns: 20,
+      rows: 6,
+    });
+    const vt = replayTerminal(frameWrites(writes), 6, 20);
+    // Overflow grows 7 → 9 → 11 lines across frames; every committed line stays,
+    // exactly once, in order — no loss or duplication as the frozen prefix extends.
+    assertTranscriptIntegrity(vt, ALL);
+  });
+});

--- a/src/tui/vt.ts
+++ b/src/tui/vt.ts
@@ -1,0 +1,145 @@
+/**
+ * Minimal pure-JS virtual terminal (VT, as in VT100) for asserting renderer
+ * transcript integrity.
+ *
+ * Models the ANSI subset `render.ts` emits — cursor-up (`ESC[nA`), erase-down
+ * (`ESC[J`), carriage return, line feed with scroll, and auto-margin wrap — and
+ * ignores the rest (SGR color, sync markers, cursor visibility) since they don't
+ * move transcript content between cells.
+ *
+ * Scope limits (don't assume coverage — each needs its own guard):
+ * - Wrap is EAGER (wrap on writing the last column), not the deferred/pending-wrap
+ *   of real terminals, so this does NOT cover the pending-wrap overshoot that
+ *   `render.ts:127` defuses with a trailing `\r` — deleting that `\r` stays green.
+ * - Cells advance one per UTF-16 code unit; `render.ts` measures with
+ *   `Bun.stringWidth`, so wide (CJK/emoji) content diverges — don't write an
+ *   emoji integrity test against this.
+ * - A CSI sequence split across two writes is dropped mid-parse; unreachable
+ *   today since `render.ts` always writes complete sequences.
+ *
+ * Unlike a visible-only emulator, lines that scroll off the top are kept in
+ * `scrollback` — the committed transcript. That is the invariant the custom
+ * renderer must never break: once a line is committed to scrollback it is
+ * permanent and must never be dropped, rewritten, duplicated, or merged with
+ * another line. A render-to-string test cannot see any of those failures; this
+ * can.
+ */
+
+export interface VirtualTerminal {
+  /** Visible grid rows, right-trimmed. */
+  screen: string[];
+  /** Rows evicted off the top, in commit order — the permanent transcript. */
+  scrollback: string[];
+}
+
+export function replayTerminal(writes: string[], rows: number, columns: number): VirtualTerminal {
+  const scrollback: string[] = [];
+  const screen = Array.from({ length: rows }, () => Array.from({ length: columns }, () => " "));
+  let row = 0;
+  let col = 0;
+
+  const scroll = (): void => {
+    const evicted = screen.shift();
+    if (evicted) scrollback.push(evicted.join("").replace(/\s+$/, ""));
+    screen.push(Array.from({ length: columns }, () => " "));
+    row = rows - 1;
+  };
+
+  const eraseDown = (): void => {
+    const currentRow = screen[row];
+    if (currentRow) {
+      for (let c = col; c < columns; c++) currentRow[c] = " ";
+    }
+    for (let r = row + 1; r < rows; r++) {
+      const nextRow = screen[r];
+      if (!nextRow) continue;
+      for (let c = 0; c < columns; c++) nextRow[c] = " ";
+    }
+  };
+
+  const applyWrite = (data: string): void => {
+    let index = 0;
+    while (index < data.length) {
+      const char = data[index];
+      if (char === "\x1b" && data[index + 1] === "[") {
+        let end = index + 2;
+        while (end < data.length) {
+          const code = data.charCodeAt(end);
+          if (code >= 0x40 && code <= 0x7e) break;
+          end += 1;
+        }
+        if (end >= data.length) break;
+        const sequence = data.slice(index + 2, end);
+        const finalByte = data[end];
+        const paramText = sequence.replace(/^\?/, "");
+        const param = paramText.length > 0 ? Number.parseInt(paramText, 10) : 1;
+        if (finalByte === "A") {
+          row = Math.max(0, row - (Number.isFinite(param) ? param : 1));
+        } else if (finalByte === "J") {
+          eraseDown();
+        }
+        index = end + 1;
+        continue;
+      }
+      if (char === "\r") {
+        col = 0;
+        index += 1;
+        continue;
+      }
+      if (char === "\n") {
+        // Pure line feed: advance the row, keep the column. A bare `\n` from a
+        // foreign write (e.g. a stray console.log) column-splices content — the
+        // confirmed weakest-link corruption this harness must catch. render.ts
+        // normalizes its own newlines to `\r\n`, so the `\r` resets the column.
+        row += 1;
+        if (row >= rows) scroll();
+        index += 1;
+        continue;
+      }
+      if (col >= columns) {
+        row += 1;
+        col = 0;
+        if (row >= rows) scroll();
+      }
+      const target = screen[row];
+      if (target && col >= 0 && col < columns) target[col] = char ?? " ";
+      col += 1;
+      index += 1;
+    }
+  };
+
+  for (const write of writes) applyWrite(write);
+  return { screen: screen.map((line) => line.join("").replace(/\s+$/, "")), scrollback };
+}
+
+/** Committed (scrollback) + visible (screen) transcript, trailing blanks dropped. */
+export function transcriptLines(vt: VirtualTerminal): string[] {
+  const all = [...vt.scrollback, ...vt.screen];
+  let end = all.length;
+  while (end > 0 && all[end - 1] === "") end -= 1;
+  return all.slice(0, end);
+}
+
+export class TranscriptIntegrityError extends Error {
+  constructor(
+    readonly actual: string[],
+    readonly expected: string[],
+  ) {
+    super(
+      `transcript integrity violation\n  expected: ${JSON.stringify(expected)}\n  actual:   ${JSON.stringify(actual)}`,
+    );
+    this.name = "TranscriptIntegrityError";
+  }
+}
+
+/**
+ * Assert the committed+visible transcript exactly equals `expected`, in order.
+ * A mismatch is a dropped line (loss), a repeated line (duplication), a merged
+ * row (interleaving), or a reordering — the transcript-corruption class.
+ */
+export function assertTranscriptIntegrity(vt: VirtualTerminal, expected: string[]): void {
+  const actual = transcriptLines(vt);
+  if (actual.length !== expected.length || actual.some((line, i) => line !== expected[i])) {
+    throw new TranscriptIntegrityError(actual, expected);
+  }
+}


### PR DESCRIPTION
## Motivation

The renderer's append-only transcript invariant was coded but unverified — render-to-string tests can't see scrollback corruption.

## Summary

- add a pure-JS virtual-terminal harness (`src/tui/vt.ts`) that keeps scrolled-off lines in scrollback and asserts transcript integrity (loss, duplication, interleaving, reorder)
- cover the overflow and incremental-split paths with real-renderer tests, plus teeth tests reproducing the reported prose+diff corruption
