### PR TITLE
fix: dogfood-surfaced chat and agent fixes

### DIFF
--- a/src/agent-instructions.test.ts
+++ b/src/agent-instructions.test.ts
@@ -18,9 +18,10 @@ describe("createInstructions", () => {
       ["validation is blocked or unavailable", "skipped", "why"],
       ["concise", "outcome-first"],
       ["reasonable assumptions", "ambiguity or risk truly blocks progress"],
+      ["Questions about the codebase", "Search and read files immediately", "never ask"],
       ["signal_done"],
       ["signal_noop"],
-      ["signal_blocked"],
+      ["signal_blocked", "cannot obtain", "never for information findable in the workspace"],
     ]);
   });
 

--- a/src/agent-instructions.ts
+++ b/src/agent-instructions.ts
@@ -9,13 +9,14 @@ const CORE_INSTRUCTIONS = [
   "Skills are activated automatically when the task matches. Use `skill-list` to discover project-specific skills. Use `skill-activate` to load a skill manually when auto-activation did not trigger.",
   "Only recent turns are visible. When the user references something you cannot see — a prior decision, an earlier error, a file discussed before — use `session-search` to find it. Do not ask the user to repeat themselves.",
   "Use `memory-search` when starting new work or when the user references conventions, preferences, or decisions from past sessions. Use `memory-add` to persist what the user teaches you — do not forget it.",
+  "Questions about the codebase are answered by reading it. Search and read files immediately — never ask the user where something lives or for permission to investigate. Not knowing a location is never a blocker; it is a search away.",
   "Make the smallest root-cause change that matches local conventions.",
   "Skip unrelated or speculative detours.",
   "Avoid repeating tool calls without new information.",
   "After changing behavior, run related validation first. If validation is blocked or unavailable, say what was skipped and why.",
   "Keep responses concise and outcome-first. Format as plain text. Use `backticks` for code identifiers and **bold** for emphasis. No headings, links, or code blocks. Only use lists when absolutely necessary.",
   "Make reasonable assumptions to keep momentum; ask only when ambiguity or risk truly blocks progress.",
-  "After writing the final response text, call exactly one lifecycle signal tool: `signal_done`, `signal_noop`, or `signal_blocked`. Use `signal_blocked` only with a concise reason describing what is missing and what you will do once it is provided.",
+  "After writing the final response text, call exactly one lifecycle signal tool: `signal_done`, `signal_noop`, or `signal_blocked`. Use `signal_blocked` only for what your tools cannot obtain — a user decision, credential, or access — never for information findable in the workspace.",
 ];
 
 const TOOL_IDS = toolIds();

--- a/src/chat-input-handlers.test.ts
+++ b/src/chat-input-handlers.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { processInputChange, processInputSubmit } from "./chat-input-handlers";
 
 describe("chat input handlers", () => {
-  test("processInputChange ignores leading question-mark shortcut trigger", () => {
+  test("processInputChange ignores a typed leading question-mark shortcut trigger", () => {
     expect(
       processInputChange({
         currentValue: "",
         nextValue: "?",
         applyingHistory: false,
+        paste: false,
       }),
     ).toEqual({
       ignore: true,
@@ -17,12 +18,30 @@ describe("chat input handlers", () => {
     });
   });
 
+  test("processInputChange inserts a pasted leading question-mark as text", () => {
+    // Regression: a lone pasted "?" was dropped by this second handler layer.
+    expect(
+      processInputChange({
+        currentValue: "",
+        nextValue: "?",
+        applyingHistory: false,
+        paste: true,
+      }),
+    ).toEqual({
+      ignore: false,
+      clearApplyingHistory: false,
+      resetHistoryIndex: true,
+      nextValue: "?",
+    });
+  });
+
   test("processInputChange clears applying-history without resetting history index", () => {
     expect(
       processInputChange({
         currentValue: "hello",
         nextValue: "hello!",
         applyingHistory: true,
+        paste: false,
       }),
     ).toEqual({
       ignore: false,

--- a/src/chat-input-handlers.ts
+++ b/src/chat-input-handlers.ts
@@ -4,6 +4,7 @@ type ProcessInputChangeParams = {
   currentValue: string;
   nextValue: string;
   applyingHistory: boolean;
+  paste: boolean;
 };
 
 export type InputChangeDecision = {
@@ -14,7 +15,10 @@ export type InputChangeDecision = {
 };
 
 export function processInputChange(params: ProcessInputChangeParams): InputChangeDecision {
-  if (params.currentValue.length === 0 && params.nextValue === "?") {
+  // Swallow only a *typed* "?" on an empty field — it is the help shortcut the
+  // keybinding layer consumes. A pasted "?" must insert as text (matching the
+  // keybinding layer, which already ignores paste for the same shortcut).
+  if (!params.paste && params.currentValue.length === 0 && params.nextValue === "?") {
     return {
       ignore: true,
       clearApplyingHistory: false,

--- a/src/chat-keybindings.test.ts
+++ b/src/chat-keybindings.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  resolveBareCharShortcut,
   resolveEscapeAction,
   resolveHistoryDown,
   resolveHistoryUp,
@@ -49,6 +50,22 @@ describe("chat keybindings helpers", () => {
       isTab: true,
     });
     expect(result).toBe("/status");
+  });
+
+  test("resolveBareCharShortcut ignores pasted ? and $ so they insert as text", () => {
+    // Regression: pasting text ending in "?" popped the help panel.
+    expect(resolveBareCharShortcut({ keyInput: "?", paste: true, valueLength: 0, isPending: false })).toBeNull();
+    expect(resolveBareCharShortcut({ keyInput: "$", paste: true, valueLength: 0, isPending: false })).toBeNull();
+  });
+
+  test("resolveBareCharShortcut fires only on a genuine keystroke on an empty field", () => {
+    expect(resolveBareCharShortcut({ keyInput: "?", paste: false, valueLength: 0, isPending: false })).toBe("help");
+    expect(resolveBareCharShortcut({ keyInput: "$", paste: false, valueLength: 0, isPending: false })).toBe("skills");
+    // non-empty field: a real char in the text, not a shortcut
+    expect(resolveBareCharShortcut({ keyInput: "?", paste: false, valueLength: 3, isPending: false })).toBeNull();
+    // help works while pending; skills does not
+    expect(resolveBareCharShortcut({ keyInput: "?", paste: false, valueLength: 0, isPending: true })).toBe("help");
+    expect(resolveBareCharShortcut({ keyInput: "$", paste: false, valueLength: 0, isPending: true })).toBeNull();
   });
 
   test("resolveEscapeAction prefers interrupt while thinking", () => {

--- a/src/chat-keybindings.ts
+++ b/src/chat-keybindings.ts
@@ -21,6 +21,23 @@ type ResolveTabAutocompleteInput = {
   isTab: boolean;
 };
 
+export type BareCharShortcut = "help" | "skills" | null;
+
+// `?`/`$` on an empty input are shortcuts only for a genuine keystroke — never
+// for a pasted character, which must insert literally (a paste with "?" would
+// otherwise pop the help panel).
+export function resolveBareCharShortcut(params: {
+  keyInput: string;
+  paste: boolean;
+  valueLength: number;
+  isPending: boolean;
+}): BareCharShortcut {
+  if (params.paste || params.valueLength !== 0) return null;
+  if (params.keyInput === "?") return "help";
+  if (params.keyInput === "$" && !params.isPending) return "skills";
+  return null;
+}
+
 export function resolveHistoryUp(
   inputHistory: string[],
   inputHistoryIndex: number,
@@ -241,11 +258,17 @@ export function useChatKeybindings(input: UseChatKeybindingsInput): void {
           return;
         }
       }
-      if (!input.isPending && keyInput === "$" && input.value.length === 0) {
+      const bareShortcut = resolveBareCharShortcut({
+        keyInput,
+        paste: key.paste,
+        valueLength: input.value.length,
+        isPending: input.isPending,
+      });
+      if (bareShortcut === "skills") {
         void input.openSkillsPanel();
         return;
       }
-      if (keyInput === "?" && input.value.length === 0) {
+      if (bareShortcut === "help") {
         input.setShowHelp((current) => !current);
         return;
       }

--- a/src/chat-state.ts
+++ b/src/chat-state.ts
@@ -308,11 +308,12 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
   }, [picker, handlePickerSelect]);
 
   const handleInputChange = useCallback(
-    (next: string) => {
+    (next: string, fromPaste = false) => {
       const decision = processInputChange({
         currentValue: value,
         nextValue: next,
         applyingHistory: applyingHistoryRef.current,
+        paste: fromPaste,
       });
       if (decision.ignore) return;
       if (decision.clearApplyingHistory) applyingHistoryRef.current = false;

--- a/src/chat-turn.test.ts
+++ b/src/chat-turn.test.ts
@@ -261,4 +261,39 @@ describe("chat turn helpers", () => {
 
     expect(turn.assistantMessage.kind).toBe("tool_payload");
   });
+
+  test("runAssistantTurn worked row uses the arrow token format shared with the status line", async () => {
+    const turn = await runAssistantTurn({
+      client: {
+        replyStream: async () => ({
+          state: "done" as const,
+          model: "gpt-5-mini",
+          output: "done",
+          toolCalls: ["file-read", "signal_done"],
+          usage: { inputTokens: 52000, outputTokens: 586, totalTokens: 52586 },
+        }),
+        status: async () => ({}),
+        taskStatus: async () => null,
+      },
+      userText: "read the file",
+      history: [],
+      model: "gpt-5-mini",
+      sessionId: "sess_test",
+      pendingStartedAt: Date.now() - 1000,
+      createMessage: (role, content) => ({
+        id: "msg_assistant",
+        role,
+        content,
+        timestamp: "2026-02-20T00:00:00.000Z",
+      }),
+    });
+
+    const worked = turn.rows.find(
+      (row) => row.kind === "status" && typeof row.content === "string" && row.content.includes("Worked"),
+    );
+    const content = worked?.content;
+    expect(typeof content).toBe("string");
+    expect(content as string).toContain("↑52.0k ↓586");
+    expect(content as string).not.toContain("52.0k/586");
+  });
 });

--- a/src/chat-turn.ts
+++ b/src/chat-turn.ts
@@ -160,7 +160,10 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
       if (toolCount > 0) details.push(t("unit.tool", { count: toolCount }));
       if (inputTokens + outputTokens > 0)
         details.push(
-          t("unit.token.split", { input: formatCompactNumber(inputTokens), output: formatCompactNumber(outputTokens) }),
+          t("unit.token.arrows", {
+            input: formatCompactNumber(inputTokens),
+            output: formatCompactNumber(outputTokens),
+          }),
         );
       const suffix = details.length > 0 ? ` (${details.join(" · ")})` : "";
       rows.push(createRow("status", t("chat.worked", { duration, suffix }), { marker: palette.success, dim: true }));

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -279,7 +279,6 @@ export const EN_MESSAGES = {
   "unit.result.one": "{count} result",
   "unit.token": "{count} tokens",
   "unit.token.one": "{count} token",
-  "unit.token.split": "{input}/{output} tokens",
   "unit.token.arrows": "↑{input} ↓{output}",
   "unit.tool": "{count} tools",
   "unit.tool.one": "{count} tool",

--- a/src/prompt-input.tsx
+++ b/src/prompt-input.tsx
@@ -14,7 +14,7 @@ interface PromptInputProps {
   caretVisible?: boolean;
   linePrefixFirst?: string;
   linePrefixRest?: string;
-  onChange: (next: string) => void;
+  onChange: (next: string, fromPaste?: boolean) => void;
   onSubmit: (value: string) => void;
   onCursorLine: (line: number) => void;
   wrapWidth?: number;
@@ -225,9 +225,9 @@ export function PromptInput({
   onSubmitRef.current = onSubmit;
 
   const handleInput = useCallback((input: string, key: Parameters<Parameters<typeof useInput>[0]>[1]) => {
-    const emitChange = (next: string) => {
+    const emitChange = (next: string, fromPaste = false) => {
       valueRef.current = next;
-      onChangeRef.current(next);
+      onChangeRef.current(next, fromPaste);
     };
     const moveCursor = (next: number) => {
       cursorRef.current = next;
@@ -303,7 +303,7 @@ export function PromptInput({
         return;
       case "insert":
         metaPrefixAt.current = null;
-        emitChange(`${v.slice(0, c)}${action.text}${v.slice(c)}`);
+        emitChange(`${v.slice(0, c)}${action.text}${v.slice(c)}`, key.paste);
         moveCursor(c + action.text.length);
         return;
       default:

--- a/src/tui/context.ts
+++ b/src/tui/context.ts
@@ -24,6 +24,7 @@ export type KeyEvent = {
   end: boolean;
   backspace: boolean;
   delete: boolean;
+  paste: boolean;
 };
 
 export type InputRegistration = {

--- a/src/tui/input.test.ts
+++ b/src/tui/input.test.ts
@@ -237,6 +237,13 @@ describe("parseKeyInput", () => {
       expect(results[0]?.key.return).toBe(true);
     });
 
+    test("pasted chars are flagged paste; typed chars are not", () => {
+      const pasted = parseKeyInput("\x1b[200~a?\x1b[201~");
+      expect(pasted.every((r) => r.key.paste)).toBe(true);
+      const typed = parseKeyInput("?");
+      expect(typed[0]?.key.paste).toBe(false);
+    });
+
     test("unterminated paste consumes remaining input as text", () => {
       const pasted = "\x1b[200~hello world";
       const results = parseKeyInput(pasted);

--- a/src/tui/input.ts
+++ b/src/tui/input.ts
@@ -39,6 +39,7 @@ export function emptyKey(): KeyEvent {
     end: false,
     backspace: false,
     delete: false,
+    paste: false,
   };
 }
 
@@ -280,7 +281,7 @@ function parseBracketedPaste(
   const content = raw.slice(contentStart, contentEnd).replace(/\r\n/g, "\n").replace(/\r/g, "\n");
   const events: Array<{ input: string; key: KeyEvent }> = [];
   for (const ch of content) {
-    events.push({ input: ch, key: emptyKey() });
+    events.push({ input: ch, key: { ...emptyKey(), paste: true } });
   }
   return { events, consumed };
 }


### PR DESCRIPTION
## Motivation

A dogfood session surfaced several small defects in the chat UI and agent behavior.

## Summary

- worked-row token counts now use the `↑in ↓out` arrow format, matching the status line
- pasted `?`/`$` no longer fire the help/skills shortcuts — they insert as text (fixed in both the keybinding and input-handler layers)
- agent now reads/searches the codebase to answer questions instead of asking the user where things live; `signal_blocked` reserved for what tools genuinely cannot obtain