### PR TITLE
fix(lifecycle): reject a done with no final answer

### DIFF
--- a/src/agent-contract.ts
+++ b/src/agent-contract.ts
@@ -85,6 +85,7 @@ export type StreamOptions = {
   onBeforeFinish?: (attempt: {
     messages: readonly LanguageModelV4Message[];
     text: string;
+    answerText: string;
     signal?: LifecycleSignal;
   }) => OnBeforeFinishResult;
 };

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -165,6 +165,7 @@ export function createAgentStream(
             options.onBeforeFinish?.({
               messages,
               text: stepText,
+              answerText,
               ...(lifecycleSignal ? { signal: lifecycleSignal } : {}),
             }) ?? [];
           const extras = Array.isArray(finishResult) ? finishResult : finishResult.messages;
@@ -274,6 +275,7 @@ export function createAgentStream(
             options.onBeforeFinish?.({
               messages,
               text: stepText,
+              answerText,
               signal: lifecycleSignal,
             }) ?? [];
           const extras = Array.isArray(finishResult) ? finishResult : finishResult.messages;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -2,7 +2,6 @@ export const EN_MESSAGES = {
   "agent.output.no_output": "No output from model. Check /status and server logs, then retry or switch model/provider.",
   "agent.output.no_response_after_tools":
     "No final response after tool execution. Retry, or check server logs if this repeats.",
-  "agent.output.done": "Done.",
   "agent.output.no_changes_needed": "No changes needed.",
   "agent.output.blocked": "Blocked. More input is needed.",
   "agent.status.working": "Working…",

--- a/src/lifecycle-completion.test.ts
+++ b/src/lifecycle-completion.test.ts
@@ -14,6 +14,7 @@ describe("findCompletionBlock — broken-handoff (G1)", () => {
     const block = findCompletionBlock({
       signal: "done",
       callLog: [{ ...record("test-run", { command: "bun test src/app.test.ts" }), exitCode: 1 }],
+      finalText: "answer",
       writeToolSet,
       runnerToolSet,
     });
@@ -27,6 +28,7 @@ describe("findCompletionBlock — broken-handoff (G1)", () => {
     const block = findCompletionBlock({
       signal: "done",
       callLog: [{ ...record("shell-run", {}), exitCode: 2 }],
+      finalText: "answer",
       writeToolSet,
       runnerToolSet,
     });
@@ -43,6 +45,7 @@ describe("findCompletionBlock — broken-handoff (G1)", () => {
         { ...record("test-run", { command: "bun test" }), exitCode: 1 },
         { ...record("test-run", { command: "bun test" }), exitCode: 0 },
       ],
+      finalText: "answer",
       writeToolSet,
       runnerToolSet,
     });
@@ -57,6 +60,7 @@ describe("findCompletionBlock — broken-handoff (G1)", () => {
         record("file-edit", { path: "src/app.ts" }),
         { ...record("test-run", { command: "bun test" }), exitCode: 1 },
       ],
+      finalText: "answer",
       writeToolSet,
       runnerToolSet,
     });
@@ -68,6 +72,7 @@ describe("findCompletionBlock — broken-handoff (G1)", () => {
     const block = findCompletionBlock({
       signal: "blocked",
       callLog: [{ ...record("test-run", { command: "bun test" }), exitCode: 1 }],
+      finalText: "answer",
       writeToolSet,
       runnerToolSet,
     });
@@ -79,6 +84,7 @@ describe("findCompletionBlock — broken-handoff (G1)", () => {
     const block = findCompletionBlock({
       signal: "done",
       callLog: [record("file-read", { path: "src/app.ts" })],
+      finalText: "answer",
       writeToolSet,
       runnerToolSet,
     });
@@ -92,6 +98,7 @@ describe("findCompletionBlock", () => {
     const block = findCompletionBlock({
       signal: "done",
       callLog: [record("file-edit", { path: "src/app.ts" })],
+      finalText: "answer",
       writeToolSet,
       runnerToolSet,
     });
@@ -111,6 +118,7 @@ describe("findCompletionBlock", () => {
         record("file-edit", { path: "src/app.ts" }),
         { ...record("test-run", { files: ["src/app.test.ts"] }), exitCode: 0 },
       ],
+      finalText: "answer",
       writeToolSet,
       runnerToolSet,
     });
@@ -125,6 +133,7 @@ describe("findCompletionBlock", () => {
         record("file-edit", { path: "src/app.test.ts" }),
         { ...record("test-run", { files: ["src/app.ts"] }), exitCode: 0 },
       ],
+      finalText: "answer",
       writeToolSet,
       runnerToolSet,
     });
@@ -139,6 +148,7 @@ describe("findCompletionBlock", () => {
         record("file-edit", { path: "src/app.ts" }),
         { ...record("shell-run", { cmd: "bun", args: ["test", "src/app.test.ts"] }), exitCode: 0 },
       ],
+      finalText: "answer",
       writeToolSet,
       runnerToolSet,
     });
@@ -153,6 +163,7 @@ describe("findCompletionBlock", () => {
         record("file-edit", { path: "src/app.ts" }),
         { ...record("test-run", { files: ["src/other.test.ts"] }), exitCode: 0 },
       ],
+      finalText: "answer",
       writeToolSet,
       runnerToolSet,
     });
@@ -168,6 +179,7 @@ describe("findCompletionBlock", () => {
         { ...record("test-run", { command: "bun test src/app.test.ts" }), exitCode: 0 },
         record("file-edit", { path: "src/app.ts" }),
       ],
+      finalText: "answer",
       writeToolSet,
       runnerToolSet,
     });
@@ -179,6 +191,7 @@ describe("findCompletionBlock", () => {
     expect(
       findCompletionBlock({
         signal: "done",
+        finalText: "answer",
         callLog: [record("file-edit", { path: "docs/readme.md" })],
         writeToolSet,
         runnerToolSet,
@@ -188,10 +201,53 @@ describe("findCompletionBlock", () => {
     expect(
       findCompletionBlock({
         signal: "blocked",
+        finalText: "answer",
         callLog: [record("file-edit", { path: "src/app.ts" })],
         writeToolSet,
         runnerToolSet,
       }),
     ).toBeUndefined();
+  });
+});
+
+describe("findCompletionBlock — empty-answer", () => {
+  test("blocks a done that wrote no final response", () => {
+    const block = findCompletionBlock({
+      signal: "done",
+      finalText: "   ",
+      callLog: [record("file-read", { path: "src/app.ts" })],
+      writeToolSet,
+      runnerToolSet,
+    });
+
+    expect(block?.reason).toBe("empty-answer");
+    expect(block?.message).toContain("signal_done");
+  });
+
+  test("does not fire when the done wrote a final response", () => {
+    const block = findCompletionBlock({
+      signal: "done",
+      finalText: "Here is the answer.",
+      callLog: [record("file-read", { path: "src/app.ts" })],
+      writeToolSet,
+      runnerToolSet,
+    });
+
+    expect(block).toBeUndefined();
+  });
+
+  test("a green run does not excuse an empty answer", () => {
+    const block = findCompletionBlock({
+      signal: "done",
+      finalText: "",
+      callLog: [
+        record("file-edit", { path: "src/app.ts" }),
+        { ...record("test-run", { files: ["src/app.test.ts"] }), exitCode: 0 },
+      ],
+      writeToolSet,
+      runnerToolSet,
+    });
+
+    expect(block?.reason).toBe("empty-answer");
   });
 });

--- a/src/lifecycle-completion.ts
+++ b/src/lifecycle-completion.ts
@@ -1,7 +1,7 @@
 import type { LifecycleSignal } from "./agent-contract";
 import type { ToolCallRecord } from "./tool-contract";
 
-export type CompletionBlockReason = "broken-handoff" | "missing-validation-after-write";
+export type CompletionBlockReason = "broken-handoff" | "missing-validation-after-write" | "empty-answer";
 
 export type CompletionBlock = {
   reason: CompletionBlockReason;
@@ -13,6 +13,7 @@ const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mts", ".cts"]
 
 export function findCompletionBlock(input: {
   signal?: LifecycleSignal;
+  finalText: string;
   callLog: readonly ToolCallRecord[];
   writeToolSet: ReadonlySet<string>;
   runnerToolSet: ReadonlySet<string>;
@@ -30,19 +31,31 @@ export function findCompletionBlock(input: {
   }
 
   const lastWrite = findLastSourceWrite(input.callLog, input.writeToolSet);
-  if (!lastWrite) return undefined;
-
-  const laterCalls = input.callLog.slice(lastWrite.index + 1);
-  const relatedPaths = relatedValidationPaths(lastWrite.path);
-  if (laterCalls.some((entry) => isGreenRunner(entry, input.runnerToolSet) && runnerTargets(entry, relatedPaths))) {
-    return undefined;
+  if (lastWrite) {
+    const laterCalls = input.callLog.slice(lastWrite.index + 1);
+    const relatedPaths = relatedValidationPaths(lastWrite.path);
+    const validated = laterCalls.some(
+      (entry) => isGreenRunner(entry, input.runnerToolSet) && runnerTargets(entry, relatedPaths),
+    );
+    if (!validated) {
+      return {
+        reason: "missing-validation-after-write",
+        path: lastWrite.path,
+        message: `Cannot finish yet: \`${lastWrite.path}\` changed and no later validation targeted it. Run a related test or command, or say why validation is blocked.`,
+      };
+    }
   }
 
-  return {
-    reason: "missing-validation-after-write",
-    path: lastWrite.path,
-    message: `Cannot finish yet: \`${lastWrite.path}\` changed and no later validation targeted it. Run a related test or command, or say why validation is blocked.`,
-  };
+  // A `done` carries the final response; an empty answer is not a completion.
+  if (input.finalText.trim().length === 0) {
+    return {
+      reason: "empty-answer",
+      path: "",
+      message: "Cannot finish yet: you called `signal_done` without writing a final response to the user.",
+    };
+  }
+
+  return undefined;
 }
 
 function findBrokenHandoff(

--- a/src/lifecycle-finalize.test.ts
+++ b/src/lifecycle-finalize.test.ts
@@ -186,14 +186,24 @@ describe("phaseFinalize", () => {
     expect(summary.fields.budget_exhausted_count).toBe(2);
   });
 
-  test("uses signal-aware fallback output when final text is empty", () => {
+  test("an empty done is blocked and surfaces no fabricated Done.", () => {
+    // Real path: acceptResult rejects an empty done, clearing acceptedSignal and
+    // setting a blocking error, so finalize emits no output — the error row carries it.
     const done = phaseFinalize(
-      createRunContext({ result: { text: "", toolCalls: [], signal: "done" }, acceptedSignal: "done" }),
+      createRunContext({
+        result: { text: "", toolCalls: [], signal: "done" },
+        currentError: {
+          message: "Cannot finish yet: you called `signal_done` without writing a final response to the user.",
+          blocksCompletion: true,
+        },
+      }),
     );
+    expect(done.output).toBe("");
+
+    // noop is not blocked: it keeps its terse completion.
     const noop = phaseFinalize(
       createRunContext({ result: { text: "", toolCalls: [], signal: "noop" }, acceptedSignal: "noop" }),
     );
-    expect(done.output).toBe("Done.");
     expect(noop.output).toBe("No changes needed.");
   });
 

--- a/src/lifecycle-finalize.ts
+++ b/src/lifecycle-finalize.ts
@@ -5,18 +5,16 @@ import { promptUsageTotalTokens, type RunContext } from "./lifecycle-contract";
 import { DISCOVERY_TOOL_SET, READ_TOOL_SET, SEARCH_TOOL_SET, WRITE_TOOL_SET } from "./tool-registry";
 import { scopedCallLog } from "./tool-session";
 
-const SIGNAL_OUTPUT_KEYS = {
-  done: "agent.output.done",
-  noop: "agent.output.no_changes_needed",
-} as const;
-
 function signalOutput(ctx: RunContext): string {
   if (ctx.acceptedSignal === "blocked") {
     return ctx.result?.signalReason?.trim() ?? "";
   }
 
-  if (ctx.acceptedSignal === "done" || ctx.acceptedSignal === "noop") {
-    return t(SIGNAL_OUTPUT_KEYS[ctx.acceptedSignal]);
+  // `done` has no fallback text: a done carries the model's own final response,
+  // and the completion block rejects an empty one — so an empty done must surface
+  // honestly (no_response_after_tools / no_output), never a fabricated "Done.".
+  if (ctx.acceptedSignal === "noop") {
+    return t("agent.output.no_changes_needed");
   }
 
   return "";

--- a/src/lifecycle-generate-policy.test.ts
+++ b/src/lifecycle-generate-policy.test.ts
@@ -63,6 +63,21 @@ describe("generate finish policy", () => {
     expect(second).toEqual({ kind: "none" });
   });
 
+  test("empty-answer rejection asks for a final response, not validation", () => {
+    const rendered = renderFinishPolicyMessages({
+      kind: "completion-rejected-continue",
+      block: {
+        reason: "empty-answer",
+        message: "Cannot finish yet: you called `signal_done` without writing a final response to the user.",
+        path: "",
+      },
+    });
+    const text = JSON.stringify(rendered);
+
+    expect(text).toContain("Write your final response");
+    expect(text).not.toContain("run focused validation");
+  });
+
   test("re-opening the loop restores the spent missing-signal retry", () => {
     // Regression (dogfood): a missing-signal retry consumed before a completion-rejected
     // re-entry must not carry over, or a prose reply to the reminder blocks with

--- a/src/lifecycle-generate-policy.ts
+++ b/src/lifecycle-generate-policy.ts
@@ -68,24 +68,23 @@ export function renderFinishPolicyMessages(decision: FinishPolicyDecision): Lang
           ],
         },
       ];
-    case "completion-rejected-continue":
+    case "completion-rejected-continue": {
+      const followUp =
+        decision.block.reason === "empty-answer"
+          ? "Write your final response to the user now, then call `signal_done` again to finish."
+          : "Continue autonomously: run focused validation now, then call `signal_done` again to finish — or call `signal_blocked` only if validation is genuinely impossible.";
       return [
         {
           role: "user",
           content: [
             {
               type: "text",
-              text: wrapInSystemReminder(
-                "completion-rejected",
-                [
-                  decision.block.message,
-                  "Continue autonomously: run focused validation now, then call `signal_done` again to finish — or call `signal_blocked` only if validation is genuinely impossible.",
-                ].join(" "),
-              ),
+              text: wrapInSystemReminder("completion-rejected", [decision.block.message, followUp].join(" ")),
             },
           ],
         },
       ];
+    }
     case "missing-signal-block":
     case "none":
       return [];

--- a/src/lifecycle-generate.test.ts
+++ b/src/lifecycle-generate.test.ts
@@ -327,7 +327,8 @@ describe("phaseGenerate", () => {
             }),
             async getFullOutput() {
               await new Promise((resolve) => setTimeout(resolve, 0));
-              const finishResult = options.onBeforeFinish?.({ messages: [], text: "Done.", signal: "done" }) ?? [];
+              const finishResult =
+                options.onBeforeFinish?.({ messages: [], text: "Done.", answerText: "Done.", signal: "done" }) ?? [];
               const extras = Array.isArray(finishResult) ? finishResult : finishResult.messages;
               const textPart = extras[0]?.content[0];
               if (typeof textPart === "object" && textPart?.type === "text") recoveryPrompt = textPart.text;

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -275,13 +275,14 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
         }
         return reminders.map(renderReminder);
       },
-      onBeforeFinish: ({ signal }) => {
+      onBeforeFinish: ({ signal, answerText }) => {
         const toolError = unresolvedToolError(ctx);
         if (toolError) return toolErrorRecoveryMessages(toolError);
 
         const taskLog = scopedCallLog(ctx.session, ctx.taskId);
         const completionBlock = findCompletionBlock({
           signal,
+          finalText: answerText,
           callLog: taskLog,
           writeToolSet: WRITE_TOOL_SET,
           runnerToolSet: RUNNER_TOOL_SET,

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -167,6 +167,38 @@ describe("runLifecycle", () => {
     expect(response.error).toContain("bun test src/app.test.ts");
     expect(events.find((e) => e.event === "lifecycle.signal.rejected")?.fields?.reason).toBe("broken-handoff");
   });
+
+  test("rejects a done that wrote no final answer (empty-answer gate)", async () => {
+    const events: Array<{ event: string; fields?: Record<string, unknown> }> = [];
+    const deps = createLifecycleDeps({
+      phaseGenerate: mock(async (ctx) => {
+        ctx.result = { text: "", toolCalls: [], signal: "done" };
+      }),
+      phaseFinalize: mock((ctx): ChatResponse => {
+        const error = ctx.currentError?.message;
+        return {
+          state: ctx.currentError?.blocksCompletion ? "awaiting-input" : "done",
+          model: ctx.model,
+          output: error ?? ctx.result?.text ?? "",
+          ...(error ? { error } : {}),
+        };
+      }),
+    });
+
+    const response = await runLifecycle(
+      createLifecycleInput({
+        soulPrompt: "SOUL",
+        workspace: process.cwd(),
+        taskId: "task_test",
+        onDebug: (entry) => events.push(entry),
+      }),
+      deps,
+    );
+
+    expect(response.state).toBe("awaiting-input");
+    expect(response.error).toContain("without writing a final response");
+    expect(events.find((e) => e.event === "lifecycle.signal.rejected")?.fields?.reason).toBe("empty-answer");
+  });
 });
 
 describe("scheduleMemoryCommit", () => {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -181,6 +181,7 @@ function commitMemory(ctx: RunContext, input: LifecycleInput): void {
 function acceptResult(ctx: RunContext): void {
   const completionBlock = findCompletionBlock({
     signal: ctx.result?.signal,
+    finalText: ctx.result?.text ?? "",
     callLog: scopedCallLog(ctx.session, ctx.taskId),
     writeToolSet: WRITE_TOOL_SET,
     runnerToolSet: RUNNER_TOOL_SET,


### PR DESCRIPTION
## Summary

- reject a `signal_done` that carries no final response and reprompt once for the answer
- retire the fabricated "Done." fallback so an empty completion surfaces as a real answer or a visible error