### PR TITLE
refactor(tool-session): drop failure breaker

### DIFF
--- a/src/lifecycle-constants.ts
+++ b/src/lifecycle-constants.ts
@@ -6,7 +6,6 @@ export const STEP_TIMEOUT_MS = 120_000;
 export const MAX_UNKNOWN_ERRORS_PER_REQUEST = 2;
 export const TOOL_TIMEOUT_MS = 10_000;
 export const MAX_CONTEXT_TOKENS = 100_000;
-export const MAX_CONSECUTIVE_TOOL_FAILURES = 3;
 export const MAX_TOOL_RESULT_CHARS = 30_000;
 export const MAX_RECENT_TURNS = 5;
 

--- a/src/lifecycle-policy.ts
+++ b/src/lifecycle-policy.ts
@@ -1,6 +1,5 @@
 import {
   BUDGET_NUDGE_THRESHOLDS,
-  MAX_CONSECUTIVE_TOOL_FAILURES,
   MAX_CONTEXT_TOKENS,
   MAX_TOTAL_STEPS,
   MAX_TURN_STEPS,
@@ -22,7 +21,6 @@ export type LifecyclePolicy = {
   toolTimeoutMs: number;
   // Input budgets
   contextMaxTokens: number;
-  maxConsecutiveToolFailures: number;
   // Workspace commands
   installCommand?: WorkspaceCommand;
   formatCommand?: WorkspaceCommand;
@@ -40,7 +38,6 @@ export const defaultLifecyclePolicy: LifecyclePolicy = {
   maxUnknownErrorsPerRequest: MAX_UNKNOWN_ERRORS_PER_REQUEST,
   toolTimeoutMs: TOOL_TIMEOUT_MS,
   contextMaxTokens: MAX_CONTEXT_TOKENS,
-  maxConsecutiveToolFailures: MAX_CONSECUTIVE_TOOL_FAILURES,
   stuckLoopSameFileThreshold: STUCK_LOOP_SAME_FILE_THRESHOLD,
   stuckLoopTurnsBetweenReminders: STUCK_LOOP_TURNS_BETWEEN_REMINDERS,
   budgetNudgeThresholds: BUDGET_NUDGE_THRESHOLDS,

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -327,7 +327,6 @@ export async function runLifecycle(input: LifecycleInput, deps: LifecycleDeps = 
   ctxRef = ctx;
   attachToolOutputHandler(ctx);
   ctx.session.flags.totalStepLimit = policy.totalMaxSteps;
-  ctx.session.maxConsecutiveToolFailures = policy.maxConsecutiveToolFailures;
   if (profile.ecosystem) ctx.session.workspaceProfile = profile;
 
   ctx.debug("lifecycle.start", { task_id: input.taskId ?? null, model });

--- a/src/tool-contract.ts
+++ b/src/tool-contract.ts
@@ -92,8 +92,6 @@ export type SessionContext = {
   toolTimeoutMs?: number;
   cache?: ToolCache;
   featureFlags?: ResolvedFeatureFlags;
-  consecutiveFailures: Map<string, number>;
-  maxConsecutiveToolFailures?: number;
   onDebug?: (event: `lifecycle.${string}`, data: Record<string, unknown>) => void;
   onBeforeTool?: (ctx: PreToolContext) => EffectOutput | undefined;
   onAfterTool?: (ctx: PostToolContext) => EffectOutput | undefined;

--- a/src/tool-execution.ts
+++ b/src/tool-execution.ts
@@ -85,9 +85,9 @@ function debugEffectFailure(
   });
 }
 
-function assertStepBudget(input: Pick<ToolRunInput<unknown>, "session" | "toolId" | "options">): void {
+function assertStepBudget(input: Pick<ToolRunInput<unknown>, "session" | "options">): void {
   if (input.options?.skipStepBudget) return;
-  const budgetError = checkStepBudget(input.session, input.toolId);
+  const budgetError = checkStepBudget(input.session);
   if (!budgetError) return;
   const error = new Error(budgetError) as Error & { code: string; kind: string };
   error.code = LIFECYCLE_ERROR_CODES.budgetExhausted;

--- a/src/tool-session.test.ts
+++ b/src/tool-session.test.ts
@@ -46,49 +46,6 @@ describe("step budget", () => {
   });
 });
 
-describe("consecutive failures", () => {
-  test("blocks tool after 3 consecutive failures", () => {
-    const session = createSessionContext();
-    recordCall(session, "file-edit", {}, undefined, "failed");
-    recordCall(session, "file-edit", {}, undefined, "failed");
-    recordCall(session, "file-edit", {}, undefined, "failed");
-    expect(checkStepBudget(session, "file-edit")).toContain('Tool "file-edit" failed 3 times consecutively');
-  });
-
-  test("allows with fewer failures", () => {
-    const session = createSessionContext();
-    recordCall(session, "file-edit", {}, undefined, "failed");
-    recordCall(session, "file-edit", {}, undefined, "failed");
-    expect(checkStepBudget(session, "file-edit")).toBeUndefined();
-  });
-
-  test("resets on success", () => {
-    const session = createSessionContext();
-    recordCall(session, "file-edit", {}, undefined, "failed");
-    recordCall(session, "file-edit", {}, undefined, "failed");
-    recordCall(session, "file-edit", {}, undefined, "succeeded");
-    expect(checkStepBudget(session, "file-edit")).toBeUndefined();
-  });
-
-  test("tracks independently per tool", () => {
-    const session = createSessionContext();
-    recordCall(session, "file-edit", {}, undefined, "failed");
-    recordCall(session, "file-edit", {}, undefined, "failed");
-    recordCall(session, "file-edit", {}, undefined, "failed");
-    recordCall(session, "shell-exec", {}, undefined, "failed");
-    expect(checkStepBudget(session, "file-edit")).toContain("failed 3 times");
-    expect(checkStepBudget(session, "shell-exec")).toBeUndefined();
-  });
-
-  test("skips when no toolId provided", () => {
-    const session = createSessionContext();
-    recordCall(session, "file-edit", {}, undefined, "failed");
-    recordCall(session, "file-edit", {}, undefined, "failed");
-    recordCall(session, "file-edit", {}, undefined, "failed");
-    expect(checkStepBudget(session)).toBeUndefined();
-  });
-});
-
 describe("recordCall", () => {
   test("appends to callLog with active task id", () => {
     const session = createSessionContext("task_1");

--- a/src/tool-session.ts
+++ b/src/tool-session.ts
@@ -1,4 +1,4 @@
-import { MAX_CONSECUTIVE_TOOL_FAILURES, MAX_TOTAL_STEPS, MAX_TURN_STEPS, TOOL_TIMEOUT_MS } from "./lifecycle-constants";
+import { MAX_TOTAL_STEPS, MAX_TURN_STEPS, TOOL_TIMEOUT_MS } from "./lifecycle-constants";
 import type { SessionContext, ToolCallRecord, ToolCallStatus } from "./tool-contract";
 
 export function createSessionContext(taskId?: string, writeTools: ReadonlySet<string> = new Set()): SessionContext {
@@ -8,7 +8,6 @@ export function createSessionContext(taskId?: string, writeTools: ReadonlySet<st
     flags: {},
     writeTools,
     toolTimeoutMs: TOOL_TIMEOUT_MS,
-    consecutiveFailures: new Map(),
   };
 }
 
@@ -23,15 +22,7 @@ export function resetTurnStepCount(session: SessionContext, limit?: number): voi
   if (limit !== undefined) session.flags.turnStepLimit = limit;
 }
 
-export function checkStepBudget(session: SessionContext, toolId?: string): string | undefined {
-  if (toolId) {
-    const limit = session.maxConsecutiveToolFailures ?? MAX_CONSECUTIVE_TOOL_FAILURES;
-    const failures = session.consecutiveFailures.get(toolId) ?? 0;
-    if (failures >= limit) {
-      return `Tool "${toolId}" failed ${failures} times consecutively. Skipping further attempts.`;
-    }
-  }
-
+export function checkStepBudget(session: SessionContext): string | undefined {
   const turnLimit = session.flags.turnStepLimit ?? MAX_TURN_STEPS;
   const turnCount = session.flags.turnStepCount ?? 0;
   const totalLimit = session.flags.totalStepLimit ?? MAX_TOTAL_STEPS;
@@ -56,9 +47,4 @@ export function recordCall(
   meta?: { exitCode?: number },
 ): void {
   session.callLog.push({ toolName, args, taskId: session.taskId, resultHash, status, ...meta });
-  if (status === "failed") {
-    session.consecutiveFailures.set(toolName, (session.consecutiveFailures.get(toolName) ?? 0) + 1);
-  } else {
-    session.consecutiveFailures.delete(toolName);
-  }
 }


### PR DESCRIPTION
## Motivation

The per-tool consecutive-failure breaker refused a tool after 3 failures in a row, but it never fired in ~10k trace events and would refuse a legitimate red loop (e.g. a TDD red phase re-running the same failing command while the model is working correctly). Runaway cost is already bounded by `MAX_TOTAL_STEPS`.

## Summary
- remove the consecutive-failure breaker and its config knob
- turn/total step budgets and the broken-handoff completion gate are unchanged
