### PR TITLE
fix(lifecycle): noop carries model text

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -2,7 +2,6 @@ export const EN_MESSAGES = {
   "agent.output.no_output": "No output from model. Check /status and server logs, then retry or switch model/provider.",
   "agent.output.no_response_after_tools":
     "No final response after tool execution. Retry, or check server logs if this repeats.",
-  "agent.output.no_changes_needed": "No changes needed.",
   "agent.output.blocked": "Blocked. More input is needed.",
   "agent.status.working": "Working…",
   "chat.at_ref.attach_file": "attach file",

--- a/src/lifecycle-completion.test.ts
+++ b/src/lifecycle-completion.test.ts
@@ -251,3 +251,44 @@ describe("findCompletionBlock — empty-answer", () => {
     expect(block?.reason).toBe("empty-answer");
   });
 });
+
+describe("findCompletionBlock — empty-answer (noop)", () => {
+  test("blocks an empty noop", () => {
+    const block = findCompletionBlock({
+      signal: "noop",
+      finalText: "   ",
+      callLog: [record("file-read", { path: "src/app.ts" })],
+      writeToolSet,
+      runnerToolSet,
+    });
+
+    expect(block?.reason).toBe("empty-answer");
+    expect(block?.message).toContain("signal_noop");
+  });
+
+  test("allows a noop that carries the model's own words", () => {
+    const block = findCompletionBlock({
+      signal: "noop",
+      finalText: "Already consistent; nothing to change.",
+      callLog: [record("file-read", { path: "src/app.ts" })],
+      writeToolSet,
+      runnerToolSet,
+    });
+
+    expect(block).toBeUndefined();
+  });
+
+  test("does not apply the missing-validation gate to a noop with a source write", () => {
+    // Work-quality gates are done-only; a noop with text passes even with an
+    // unvalidated source write in the log (noop-with-writes is vetoed elsewhere).
+    const block = findCompletionBlock({
+      signal: "noop",
+      finalText: "No change was needed after inspection.",
+      callLog: [record("file-edit", { path: "src/app.ts" })],
+      writeToolSet,
+      runnerToolSet,
+    });
+
+    expect(block).toBeUndefined();
+  });
+});

--- a/src/lifecycle-completion.ts
+++ b/src/lifecycle-completion.ts
@@ -18,40 +18,47 @@ export function findCompletionBlock(input: {
   writeToolSet: ReadonlySet<string>;
   runnerToolSet: ReadonlySet<string>;
 }): CompletionBlock | undefined {
-  if (input.signal !== "done") return undefined;
+  if (input.signal !== "done" && input.signal !== "noop") return undefined;
 
-  const brokenHandoff = findBrokenHandoff(input.callLog, input.runnerToolSet);
-  if (brokenHandoff) {
-    const label = brokenHandoff.command ? `\`${brokenHandoff.command}\`` : `\`${brokenHandoff.toolName}\``;
-    return {
-      reason: "broken-handoff",
-      path: brokenHandoff.command ?? brokenHandoff.toolName,
-      message: `Cannot finish yet: the last ${label} run failed (exit code ${brokenHandoff.exitCode}). Diagnose the failure and fix it, or call \`signal_blocked\` if recovery is genuinely impossible.`,
-    };
-  }
-
-  const lastWrite = findLastSourceWrite(input.callLog, input.writeToolSet);
-  if (lastWrite) {
-    const laterCalls = input.callLog.slice(lastWrite.index + 1);
-    const relatedPaths = relatedValidationPaths(lastWrite.path);
-    const validated = laterCalls.some(
-      (entry) => isGreenRunner(entry, input.runnerToolSet) && runnerTargets(entry, relatedPaths),
-    );
-    if (!validated) {
+  // Work-quality gates apply only to `done` — a `noop` asserts no work was done.
+  if (input.signal === "done") {
+    const brokenHandoff = findBrokenHandoff(input.callLog, input.runnerToolSet);
+    if (brokenHandoff) {
+      const label = brokenHandoff.command ? `\`${brokenHandoff.command}\`` : `\`${brokenHandoff.toolName}\``;
       return {
-        reason: "missing-validation-after-write",
-        path: lastWrite.path,
-        message: `Cannot finish yet: \`${lastWrite.path}\` changed and no later validation targeted it. Run a related test or command, or say why validation is blocked.`,
+        reason: "broken-handoff",
+        path: brokenHandoff.command ?? brokenHandoff.toolName,
+        message: `Cannot finish yet: the last ${label} run failed (exit code ${brokenHandoff.exitCode}). Diagnose the failure and fix it, or call \`signal_blocked\` if recovery is genuinely impossible.`,
       };
+    }
+
+    const lastWrite = findLastSourceWrite(input.callLog, input.writeToolSet);
+    if (lastWrite) {
+      const laterCalls = input.callLog.slice(lastWrite.index + 1);
+      const relatedPaths = relatedValidationPaths(lastWrite.path);
+      const validated = laterCalls.some(
+        (entry) => isGreenRunner(entry, input.runnerToolSet) && runnerTargets(entry, relatedPaths),
+      );
+      if (!validated) {
+        return {
+          reason: "missing-validation-after-write",
+          path: lastWrite.path,
+          message: `Cannot finish yet: \`${lastWrite.path}\` changed and no later validation targeted it. Run a related test or command, or say why validation is blocked.`,
+        };
+      }
     }
   }
 
-  // A `done` carries the final response; an empty answer is not a completion.
+  // Both signals carry the model's own words — a `done` is the final response,
+  // a `noop` is why no changes were needed. An empty answer is not a completion.
   if (input.finalText.trim().length === 0) {
     return {
       reason: "empty-answer",
       path: "",
-      message: "Cannot finish yet: you called `signal_done` without writing a final response to the user.",
+      message:
+        input.signal === "noop"
+          ? "Cannot finish yet: you called `signal_noop` without telling the user why no changes were needed."
+          : "Cannot finish yet: you called `signal_done` without writing a final response to the user.",
     };
   }
 

--- a/src/lifecycle-finalize.test.ts
+++ b/src/lifecycle-finalize.test.ts
@@ -186,7 +186,7 @@ describe("phaseFinalize", () => {
     expect(summary.fields.budget_exhausted_count).toBe(2);
   });
 
-  test("an empty done is blocked and surfaces no fabricated Done.", () => {
+  test("an empty done or noop is blocked and surfaces no fabricated text", () => {
     // Real path: acceptResult rejects an empty done, clearing acceptedSignal and
     // setting a blocking error, so finalize emits no output — the error row carries it.
     const done = phaseFinalize(
@@ -200,11 +200,26 @@ describe("phaseFinalize", () => {
     );
     expect(done.output).toBe("");
 
-    // noop is not blocked: it keeps its terse completion.
+    // An empty noop is blocked the same way — no canned "No changes needed.".
     const noop = phaseFinalize(
-      createRunContext({ result: { text: "", toolCalls: [], signal: "noop" }, acceptedSignal: "noop" }),
+      createRunContext({
+        result: { text: "", toolCalls: [], signal: "noop" },
+        currentError: {
+          message: "Cannot finish yet: you called `signal_noop` without telling the user why no changes were needed.",
+          blocksCompletion: true,
+        },
+      }),
     );
-    expect(noop.output).toBe("No changes needed.");
+    expect(noop.output).toBe("");
+
+    // A noop that carries the model's own words keeps them as the output.
+    const noopWithText = phaseFinalize(
+      createRunContext({
+        result: { text: "Already consistent; nothing to change.", toolCalls: [], signal: "noop" },
+        acceptedSignal: "noop",
+      }),
+    );
+    expect(noopWithText.output).toBe("Already consistent; nothing to change.");
   });
 
   test("a tool error alone does not block a done at finalize", () => {

--- a/src/lifecycle-finalize.ts
+++ b/src/lifecycle-finalize.ts
@@ -10,13 +10,10 @@ function signalOutput(ctx: RunContext): string {
     return ctx.result?.signalReason?.trim() ?? "";
   }
 
-  // `done` has no fallback text: a done carries the model's own final response,
-  // and the completion block rejects an empty one — so an empty done must surface
-  // honestly (no_response_after_tools / no_output), never a fabricated "Done.".
-  if (ctx.acceptedSignal === "noop") {
-    return t("agent.output.no_changes_needed");
-  }
-
+  // `done` and `noop` both carry the model's own final text, and the completion
+  // block rejects an empty one — so an empty finish surfaces honestly
+  // (no_response_after_tools / no_output), never a fabricated "Done." or canned
+  // "No changes needed.".
   return "";
 }
 

--- a/src/lifecycle-generate-policy.test.ts
+++ b/src/lifecycle-generate-policy.test.ts
@@ -78,6 +78,22 @@ describe("generate finish policy", () => {
     expect(text).not.toContain("run focused validation");
   });
 
+  test("empty-answer follow-up is signal-agnostic (does not hardcode signal_done for a noop)", () => {
+    const rendered = renderFinishPolicyMessages({
+      kind: "completion-rejected-continue",
+      block: {
+        reason: "empty-answer",
+        message: "Cannot finish yet: you called `signal_noop` without telling the user why no changes were needed.",
+        path: "",
+      },
+    });
+    const text = JSON.stringify(rendered);
+
+    expect(text).toContain("Write your final response");
+    // The follow-up must not reintroduce a `signal_done`-specific instruction for a noop block.
+    expect(text).not.toContain("signal_done");
+  });
+
   test("re-opening the loop restores the spent missing-signal retry", () => {
     // Regression (dogfood): a missing-signal retry consumed before a completion-rejected
     // re-entry must not carry over, or a prose reply to the reminder blocks with

--- a/src/lifecycle-generate-policy.ts
+++ b/src/lifecycle-generate-policy.ts
@@ -71,7 +71,7 @@ export function renderFinishPolicyMessages(decision: FinishPolicyDecision): Lang
     case "completion-rejected-continue": {
       const followUp =
         decision.block.reason === "empty-answer"
-          ? "Write your final response to the user now, then call `signal_done` again to finish."
+          ? "Write your final response to the user now, then call the same signal tool again to finish."
           : "Continue autonomously: run focused validation now, then call `signal_done` again to finish — or call `signal_blocked` only if validation is genuinely impossible.";
       return [
         {

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -199,6 +199,38 @@ describe("runLifecycle", () => {
     expect(response.error).toContain("without writing a final response");
     expect(events.find((e) => e.event === "lifecycle.signal.rejected")?.fields?.reason).toBe("empty-answer");
   });
+
+  test("rejects a noop that gave no reason (empty-answer gate)", async () => {
+    const events: Array<{ event: string; fields?: Record<string, unknown> }> = [];
+    const deps = createLifecycleDeps({
+      phaseGenerate: mock(async (ctx) => {
+        ctx.result = { text: "", toolCalls: [], signal: "noop" };
+      }),
+      phaseFinalize: mock((ctx): ChatResponse => {
+        const error = ctx.currentError?.message;
+        return {
+          state: ctx.currentError?.blocksCompletion ? "awaiting-input" : "done",
+          model: ctx.model,
+          output: error ?? ctx.result?.text ?? "",
+          ...(error ? { error } : {}),
+        };
+      }),
+    });
+
+    const response = await runLifecycle(
+      createLifecycleInput({
+        soulPrompt: "SOUL",
+        workspace: process.cwd(),
+        taskId: "task_test",
+        onDebug: (entry) => events.push(entry),
+      }),
+      deps,
+    );
+
+    expect(response.state).toBe("awaiting-input");
+    expect(response.error).toContain("without telling the user why no changes were needed");
+    expect(events.find((e) => e.event === "lifecycle.signal.rejected")?.fields?.reason).toBe("empty-answer");
+  });
 });
 
 describe("scheduleMemoryCommit", () => {


### PR DESCRIPTION
## Summary
- block an empty noop like an empty done; the model must say why no changes were needed
- delete the canned "No changes needed." fallback and its i18n key
- work-quality gates (broken-handoff, missing-validation) stay done-only
