### PR TITLE
fix(lifecycle): user-facing completion errors

### DIFF
--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -204,6 +204,12 @@ export const EN_MESSAGES = {
   "error.prompt.request_failed": "Request failed. Retry and check server logs if it keeps failing.",
   "error.prompt.server_timed_out": "Server request timed out. Retry or reduce request scope.",
   "error.prompt.server_unavailable": "Server unavailable. Start the server and retry.",
+  "lifecycle.completion.empty_answer": "The agent finished without writing a response. Retry or rephrase the request.",
+  "lifecycle.completion.broken_handoff":
+    "The agent stopped while its last command was still failing (`{command}`, exit {exitCode}).",
+  "lifecycle.completion.missing_validation": "The agent finished without validating its changes to `{path}`.",
+  "lifecycle.completion.missing_signal":
+    "The agent finished without confirming completion. Retry or rephrase the request.",
   "lifecycle.stopped_unknown_errors":
     "Stopped after repeated unknown errors. Narrow the task scope or inspect lifecycle traces and retry.",
   "rpc.status.accepted": "Accepted by server…",

--- a/src/lifecycle-completion.test.ts
+++ b/src/lifecycle-completion.test.ts
@@ -19,12 +19,15 @@ describe("findCompletionBlock — broken-handoff (G1)", () => {
       runnerToolSet,
     });
 
-    expect(block?.reason).toBe("broken-handoff");
-    expect(block?.message).toContain("exit code 1");
-    expect(block?.message).toContain("bun test src/app.test.ts");
+    expect(block).toEqual({
+      reason: "broken-handoff",
+      path: "bun test src/app.test.ts",
+      command: "bun test src/app.test.ts",
+      exitCode: 1,
+    });
   });
 
-  test("includes tool name in message when no command arg", () => {
+  test("carries the tool name as command when no command arg", () => {
     const block = findCompletionBlock({
       signal: "done",
       callLog: [{ ...record("shell-run", {}), exitCode: 2 }],
@@ -33,9 +36,7 @@ describe("findCompletionBlock — broken-handoff (G1)", () => {
       runnerToolSet,
     });
 
-    expect(block?.reason).toBe("broken-handoff");
-    expect(block?.message).toContain("shell-run");
-    expect(block?.message).toContain("exit code 2");
+    expect(block).toEqual({ reason: "broken-handoff", path: "shell-run", command: "shell-run", exitCode: 2 });
   });
 
   test("allows done when the most recent runner succeeded", () => {
@@ -103,12 +104,7 @@ describe("findCompletionBlock", () => {
       runnerToolSet,
     });
 
-    expect(block).toEqual({
-      reason: "missing-validation-after-write",
-      path: "src/app.ts",
-      message:
-        "Cannot finish yet: `src/app.ts` changed and no later validation targeted it. Run a related test or command, or say why validation is blocked.",
-    });
+    expect(block).toEqual({ reason: "missing-validation-after-write", path: "src/app.ts" });
   });
 
   test("allows done when a successful runner targets the test companion", () => {
@@ -220,8 +216,7 @@ describe("findCompletionBlock — empty-answer", () => {
       runnerToolSet,
     });
 
-    expect(block?.reason).toBe("empty-answer");
-    expect(block?.message).toContain("signal_done");
+    expect(block).toEqual({ reason: "empty-answer", path: "", signal: "done" });
   });
 
   test("does not fire when the done wrote a final response", () => {
@@ -262,8 +257,7 @@ describe("findCompletionBlock — empty-answer (noop)", () => {
       runnerToolSet,
     });
 
-    expect(block?.reason).toBe("empty-answer");
-    expect(block?.message).toContain("signal_noop");
+    expect(block).toEqual({ reason: "empty-answer", path: "", signal: "noop" });
   });
 
   test("allows a noop that carries the model's own words", () => {

--- a/src/lifecycle-completion.ts
+++ b/src/lifecycle-completion.ts
@@ -1,13 +1,12 @@
 import type { LifecycleSignal } from "./agent-contract";
 import type { ToolCallRecord } from "./tool-contract";
 
-export type CompletionBlockReason = "broken-handoff" | "missing-validation-after-write" | "empty-answer";
-
-export type CompletionBlock = {
-  reason: CompletionBlockReason;
-  message: string;
-  path: string;
-};
+// Facts only — never prose. Each audience (model retry-nudge, user error row) renders
+// its own text from these facts, so `currentError.message` stays user-audience by contract.
+export type CompletionBlock =
+  | { reason: "broken-handoff"; path: string; command: string; exitCode: number }
+  | { reason: "missing-validation-after-write"; path: string }
+  | { reason: "empty-answer"; path: string; signal: "done" | "noop" };
 
 const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx", ".mts", ".cts"]);
 
@@ -24,12 +23,8 @@ export function findCompletionBlock(input: {
   if (input.signal === "done") {
     const brokenHandoff = findBrokenHandoff(input.callLog, input.runnerToolSet);
     if (brokenHandoff) {
-      const label = brokenHandoff.command ? `\`${brokenHandoff.command}\`` : `\`${brokenHandoff.toolName}\``;
-      return {
-        reason: "broken-handoff",
-        path: brokenHandoff.command ?? brokenHandoff.toolName,
-        message: `Cannot finish yet: the last ${label} run failed (exit code ${brokenHandoff.exitCode}). Diagnose the failure and fix it, or call \`signal_blocked\` if recovery is genuinely impossible.`,
-      };
+      const command = brokenHandoff.command ?? brokenHandoff.toolName;
+      return { reason: "broken-handoff", path: command, command, exitCode: brokenHandoff.exitCode };
     }
 
     const lastWrite = findLastSourceWrite(input.callLog, input.writeToolSet);
@@ -40,11 +35,7 @@ export function findCompletionBlock(input: {
         (entry) => isGreenRunner(entry, input.runnerToolSet) && runnerTargets(entry, relatedPaths),
       );
       if (!validated) {
-        return {
-          reason: "missing-validation-after-write",
-          path: lastWrite.path,
-          message: `Cannot finish yet: \`${lastWrite.path}\` changed and no later validation targeted it. Run a related test or command, or say why validation is blocked.`,
-        };
+        return { reason: "missing-validation-after-write", path: lastWrite.path };
       }
     }
   }
@@ -52,14 +43,7 @@ export function findCompletionBlock(input: {
   // Both signals carry the model's own words — a `done` is the final response,
   // a `noop` is why no changes were needed. An empty answer is not a completion.
   if (input.finalText.trim().length === 0) {
-    return {
-      reason: "empty-answer",
-      path: "",
-      message:
-        input.signal === "noop"
-          ? "Cannot finish yet: you called `signal_noop` without telling the user why no changes were needed."
-          : "Cannot finish yet: you called `signal_done` without writing a final response to the user.",
-    };
+    return { reason: "empty-answer", path: "", signal: input.signal };
   }
 
   return undefined;

--- a/src/lifecycle-finalize.test.ts
+++ b/src/lifecycle-finalize.test.ts
@@ -193,7 +193,7 @@ describe("phaseFinalize", () => {
       createRunContext({
         result: { text: "", toolCalls: [], signal: "done" },
         currentError: {
-          message: "Cannot finish yet: you called `signal_done` without writing a final response to the user.",
+          message: "The agent finished without writing a response. Retry or rephrase the request.",
           blocksCompletion: true,
         },
       }),
@@ -205,7 +205,7 @@ describe("phaseFinalize", () => {
       createRunContext({
         result: { text: "", toolCalls: [], signal: "noop" },
         currentError: {
-          message: "Cannot finish yet: you called `signal_noop` without telling the user why no changes were needed.",
+          message: "The agent finished without writing a response. Retry or rephrase the request.",
           blocksCompletion: true,
         },
       }),

--- a/src/lifecycle-generate-policy.test.ts
+++ b/src/lifecycle-generate-policy.test.ts
@@ -26,12 +26,7 @@ describe("generate finish policy", () => {
       role: "user",
       content: [{ type: "text", text: expect.stringContaining('type="missing-signal"') }],
     });
-    expect(block).toEqual({
-      kind: "missing-signal-block",
-      message:
-        "Cannot finish yet: final responses must call exactly one lifecycle signal tool (`signal_done`, `signal_noop`, or `signal_blocked`).",
-      code: LIFECYCLE_ERROR_CODES.unknown,
-    });
+    expect(block).toEqual({ kind: "missing-signal-block", code: LIFECYCLE_ERROR_CODES.unknown });
     expect(renderFinishPolicyMessages(block)).toEqual([]);
   });
 
@@ -45,7 +40,6 @@ describe("generate finish policy", () => {
     const state = createFinishPolicyState();
     const completionBlock = {
       reason: "missing-validation-after-write" as const,
-      message: "Cannot finish yet.",
       path: "src/app.ts",
     };
 
@@ -66,11 +60,7 @@ describe("generate finish policy", () => {
   test("empty-answer rejection asks for a final response, not validation", () => {
     const rendered = renderFinishPolicyMessages({
       kind: "completion-rejected-continue",
-      block: {
-        reason: "empty-answer",
-        message: "Cannot finish yet: you called `signal_done` without writing a final response to the user.",
-        path: "",
-      },
+      block: { reason: "empty-answer", path: "", signal: "done" },
     });
     const text = JSON.stringify(rendered);
 
@@ -81,16 +71,13 @@ describe("generate finish policy", () => {
   test("empty-answer follow-up is signal-agnostic (does not hardcode signal_done for a noop)", () => {
     const rendered = renderFinishPolicyMessages({
       kind: "completion-rejected-continue",
-      block: {
-        reason: "empty-answer",
-        message: "Cannot finish yet: you called `signal_noop` without telling the user why no changes were needed.",
-        path: "",
-      },
+      block: { reason: "empty-answer", path: "", signal: "noop" },
     });
     const text = JSON.stringify(rendered);
 
     expect(text).toContain("Write your final response");
-    // The follow-up must not reintroduce a `signal_done`-specific instruction for a noop block.
+    // The model-facing text must be the noop variant and must not name `signal_done`.
+    expect(text).toContain("signal_noop");
     expect(text).not.toContain("signal_done");
   });
 
@@ -101,7 +88,6 @@ describe("generate finish policy", () => {
     const state = createFinishPolicyState();
     const completionBlock = {
       reason: "missing-validation-after-write" as const,
-      message: "Cannot finish yet.",
       path: "src/app.ts",
     };
 

--- a/src/lifecycle-generate-policy.ts
+++ b/src/lifecycle-generate-policy.ts
@@ -8,6 +8,23 @@ import type { CompletionBlock } from "./lifecycle-completion";
 const MISSING_SIGNAL_MESSAGE =
   "Cannot finish yet: final responses must call exactly one lifecycle signal tool (`signal_done`, `signal_noop`, or `signal_blocked`).";
 
+// Model-audience prose composed from block facts. The prompt-injection layer is the only
+// legitimate home for second-person "you called…" text — it never reaches the user.
+function modelFacingBlockText(block: CompletionBlock): string {
+  switch (block.reason) {
+    case "empty-answer":
+      return block.signal === "noop"
+        ? "Cannot finish yet: you called `signal_noop` without telling the user why no changes were needed."
+        : "Cannot finish yet: you called `signal_done` without writing a final response to the user.";
+    case "broken-handoff":
+      return `Cannot finish yet: the last \`${block.command}\` run failed (exit code ${block.exitCode}). Diagnose the failure and fix it, or call \`signal_blocked\` if recovery is genuinely impossible.`;
+    case "missing-validation-after-write":
+      return `Cannot finish yet: \`${block.path}\` changed and no later validation targeted it. Run a related test or command, or say why validation is blocked.`;
+    default:
+      return unreachable(block);
+  }
+}
+
 export type FinishPolicyState = {
   completionRetryUsed: boolean;
   missingSignalRetryUsed: boolean;
@@ -16,7 +33,7 @@ export type FinishPolicyState = {
 export type FinishPolicyDecision =
   | { kind: "none" }
   | { kind: "missing-signal-continue"; message: string }
-  | { kind: "missing-signal-block"; message: string; code: typeof LIFECYCLE_ERROR_CODES.unknown }
+  | { kind: "missing-signal-block"; code: typeof LIFECYCLE_ERROR_CODES.unknown }
   | { kind: "completion-rejected-continue"; block: CompletionBlock };
 
 export function createFinishPolicyState(): FinishPolicyState {
@@ -36,7 +53,7 @@ export function decideFinish(input: {
       input.state.missingSignalRetryUsed = true;
       return { kind: "missing-signal-continue", message: MISSING_SIGNAL_MESSAGE };
     }
-    return { kind: "missing-signal-block", message: MISSING_SIGNAL_MESSAGE, code: LIFECYCLE_ERROR_CODES.unknown };
+    return { kind: "missing-signal-block", code: LIFECYCLE_ERROR_CODES.unknown };
   }
 
   if (input.completionBlock && !input.state.completionRetryUsed) {
@@ -69,8 +86,9 @@ export function renderFinishPolicyMessages(decision: FinishPolicyDecision): Lang
         },
       ];
     case "completion-rejected-continue": {
+      const block = decision.block;
       const followUp =
-        decision.block.reason === "empty-answer"
+        block.reason === "empty-answer"
           ? "Write your final response to the user now, then call the same signal tool again to finish."
           : "Continue autonomously: run focused validation now, then call `signal_done` again to finish — or call `signal_blocked` only if validation is genuinely impossible.";
       return [
@@ -79,7 +97,7 @@ export function renderFinishPolicyMessages(decision: FinishPolicyDecision): Lang
           content: [
             {
               type: "text",
-              text: wrapInSystemReminder("completion-rejected", [decision.block.message, followUp].join(" ")),
+              text: wrapInSystemReminder("completion-rejected", [modelFacingBlockText(block), followUp].join(" ")),
             },
           ],
         },

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -15,6 +15,7 @@ import {
   errorKindFromCategory,
   parseError,
 } from "./error-handling";
+import { t } from "./i18n";
 import { findCompletionBlock } from "./lifecycle-completion";
 import {
   type GenerateOptions,
@@ -227,7 +228,7 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
             return { messages: renderFinishPolicyMessages(decision), toolChoice: "required" };
           case "missing-signal-block":
             ctx.currentError = {
-              message: decision.message,
+              message: t("lifecycle.completion.missing_signal"),
               code: decision.code,
               category: "other",
               blocksCompletion: true,

--- a/src/lifecycle.int.test.ts
+++ b/src/lifecycle.int.test.ts
@@ -403,7 +403,9 @@ exit 1
 
     expect(turnCount).toBe(3);
     expect(reply.state).toBe("awaiting-input");
-    expect(reply.error).toContain("changed and no later validation targeted it");
+    // User-audience terminal error — never the model-facing "Run a related test…" nudge.
+    expect(reply.error).toContain("finished without validating its changes");
+    expect(reply.error).not.toContain("Run a related test");
   });
 
   test("runControl yield skips result acceptance", async () => {

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -121,7 +121,8 @@ describe("runLifecycle", () => {
 
     expect(WRITE_TOOL_SET.has("file-edit")).toBe(true);
     expect(response.state).toBe("awaiting-input");
-    expect(response.error).toContain("changed and no later validation targeted it");
+    expect(response.error).toBe("The agent finished without validating its changes to `src/app.ts`.");
+    expect(response.error).not.toContain("Run a related test");
     expect(events.find((entry) => entry.event === "lifecycle.signal.rejected")?.fields?.reason).toBe(
       "missing-validation-after-write",
     );
@@ -163,8 +164,10 @@ describe("runLifecycle", () => {
 
     expect(RUNNER_TOOL_SET.has("test-run")).toBe(true);
     expect(response.state).toBe("awaiting-input");
-    expect(response.error).toContain("exit code 1");
+    expect(response.error).toContain("exit 1");
     expect(response.error).toContain("bun test src/app.test.ts");
+    // The terminal error is user-audience: never the model-facing retry nudge.
+    expect(response.error).not.toContain("Diagnose the failure");
     expect(events.find((e) => e.event === "lifecycle.signal.rejected")?.fields?.reason).toBe("broken-handoff");
   });
 
@@ -196,7 +199,10 @@ describe("runLifecycle", () => {
     );
 
     expect(response.state).toBe("awaiting-input");
-    expect(response.error).toContain("without writing a final response");
+    // Regression (dogfood 2026-07-10): the terminal error must be user-audience, never the
+    // model-facing "you called `signal_done`…" retry nudge that used to leak into the transcript.
+    expect(response.error).toBe("The agent finished without writing a response. Retry or rephrase the request.");
+    expect(response.error).not.toContain("you called");
     expect(events.find((e) => e.event === "lifecycle.signal.rejected")?.fields?.reason).toBe("empty-answer");
   });
 
@@ -228,7 +234,10 @@ describe("runLifecycle", () => {
     );
 
     expect(response.state).toBe("awaiting-input");
-    expect(response.error).toContain("without telling the user why no changes were needed");
+    // Same user-audience message as the empty done — the done/noop split lives only in the
+    // model-facing nudge, never in the user's error row.
+    expect(response.error).toBe("The agent finished without writing a response. Retry or rephrase the request.");
+    expect(response.error).not.toContain("you called");
     expect(events.find((e) => e.event === "lifecycle.signal.rejected")?.fields?.reason).toBe("empty-answer");
   });
 });

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,9 +1,10 @@
 import type { LifecycleSignal } from "./agent-contract";
 import { ensureRealTokenEncoder } from "./agent-input";
+import { unreachable } from "./assert";
 import { errorMessage, LIFECYCLE_ERROR_CODES } from "./error-contract";
 import { createErrorStats } from "./error-handling";
 import { t } from "./i18n";
-import { findCompletionBlock } from "./lifecycle-completion";
+import { type CompletionBlock, findCompletionBlock } from "./lifecycle-completion";
 import type { LifecycleEventName, LifecycleInput, RunContext, ToolOutputEvent } from "./lifecycle-contract";
 import { attachLifecycleEffectHandlers } from "./lifecycle-effects";
 import { phaseFinalize } from "./lifecycle-finalize";
@@ -178,6 +179,21 @@ function commitMemory(ctx: RunContext, input: LifecycleInput): void {
   );
 }
 
+// User-audience prose rendered from block facts. Kept out of lifecycle-completion (facts
+// only) and distinct from the model-facing retry nudge — the two audiences never share text.
+function userFacingCompletionMessage(block: CompletionBlock): string {
+  switch (block.reason) {
+    case "empty-answer":
+      return t("lifecycle.completion.empty_answer");
+    case "broken-handoff":
+      return t("lifecycle.completion.broken_handoff", { command: block.command, exitCode: block.exitCode });
+    case "missing-validation-after-write":
+      return t("lifecycle.completion.missing_validation", { path: block.path });
+    default:
+      return unreachable(block);
+  }
+}
+
 function acceptResult(ctx: RunContext): void {
   const completionBlock = findCompletionBlock({
     signal: ctx.result?.signal,
@@ -189,7 +205,7 @@ function acceptResult(ctx: RunContext): void {
   if (completionBlock) {
     ctx.acceptedSignal = undefined;
     ctx.currentError = {
-      message: completionBlock.message,
+      message: userFacingCompletionMessage(completionBlock),
       code: LIFECYCLE_ERROR_CODES.unknown,
       category: "other",
       blocksCompletion: true,


### PR DESCRIPTION
## Summary
- stop model-facing completion-block text ("you called `signal_done`…") from leaking into the user transcript
- make `CompletionBlock` carry facts only; render model-facing and user-facing text per audience
- show honest user-audience error rows for empty-answer, broken-handoff, and unvalidated-write finishes
- fix the same leak on the missing-signal terminal path
- add regression tests asserting terminal errors are never the model nudge
