### PR TITLE
fix(tui): truncate tool preview lines at width

### DIFF
--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -10,6 +10,7 @@ import { t } from "./i18n";
 import { palette } from "./palette";
 import type { ToolOutputPart } from "./tool-output-contract";
 import { renderToolOutput as renderToolOutputText, resolveHeader } from "./tool-output-render";
+import { truncateToWidth } from "./truncate-text";
 import { Box, Text } from "./tui";
 import { DEFAULT_COLUMNS } from "./tui/constants";
 
@@ -61,6 +62,10 @@ function renderCommandOutput(output: CommandOutput): React.ReactNode {
   );
 }
 
+// Columns of the leading "\n  " indent every tool body line renders with; width budgets
+// subtract it so a truncated line plus its indent still fits toolContentWidth.
+const TOOL_LINE_INDENT = 2;
+
 function renderToolPart(
   part: ToolOutputPart,
   index: number,
@@ -71,8 +76,11 @@ function renderToolPart(
     const num = String(part.lineNumber).padStart(lineNumWidth);
     const prefix = ` ${num} `;
     const marker = part.marker === "add" ? "+" : part.marker === "remove" ? "-" : " ";
-    const content = part.text;
-    const padWidth = Math.max(0, toolContentWidth - 2 - prefix.length - 1 - content.length);
+    // Cut the content to the display budget (indent + gutter prefix + 1-col marker) before
+    // padding, so the colored bar still fills the width but the line never overflows and wraps.
+    const budget = Math.max(0, toolContentWidth - TOOL_LINE_INDENT - prefix.length - 1);
+    const content = truncateToWidth(part.text, budget);
+    const padWidth = Math.max(0, budget - Bun.stringWidth(content));
     const padded = content + " ".repeat(padWidth);
     if (part.marker === "add" || part.marker === "remove") {
       const bg = part.marker === "add" ? palette.diffAdd : palette.diffRemove;
@@ -103,7 +111,7 @@ function renderToolPart(
       <Text key={`tool-${index}`}>
         {"\n  "}
         <Text dimColor color={part.stream === "stderr" ? palette.red : undefined}>
-          {part.text}
+          {truncateToWidth(part.text, toolContentWidth - TOOL_LINE_INDENT)}
         </Text>
       </Text>
     );
@@ -114,7 +122,7 @@ function renderToolPart(
       return (
         <Text key={`tool-${index}`}>
           {"\n  "}
-          <Text dimColor>{text}</Text>
+          <Text dimColor>{truncateToWidth(text, toolContentWidth - TOOL_LINE_INDENT)}</Text>
         </Text>
       );
     }
@@ -125,14 +133,14 @@ function renderToolPart(
     return (
       <Text key={`tool-${index}`}>
         {"\n  "}
-        <Text dimColor>{` ${display}`}</Text>
+        <Text dimColor>{truncateToWidth(` ${display}`, toolContentWidth - TOOL_LINE_INDENT)}</Text>
       </Text>
     );
   }
   return (
     <Text key={`tool-${index}`}>
       {"\n  "}
-      <Text dimColor>{text}</Text>
+      <Text dimColor>{truncateToWidth(text, toolContentWidth - TOOL_LINE_INDENT)}</Text>
     </Text>
   );
 }

--- a/src/cli-format.ts
+++ b/src/cli-format.ts
@@ -14,9 +14,12 @@ export function displayPath(pathInput: string): string {
   return rel;
 }
 
+/** Columns every tool-output body line is indented under its header in run mode. */
+export const TOOL_BODY_INDENT = 2;
+
 export function printIndentedDim(content: string): void {
   for (const line of content.split("\n")) {
-    printDim(line.length > 0 ? `  ${line}` : "");
+    printDim(line.length > 0 ? `${" ".repeat(TOOL_BODY_INDENT)}${line}` : "");
   }
 }
 
@@ -32,7 +35,7 @@ export function printToolResult(toolId: string, raw: string, detail?: string): v
       if (trimmed.length > 0) items.push({ kind: "text", text: trimmed });
     }
   }
-  const rendered = renderToolOutput(items);
+  const rendered = renderToolOutput(items, Math.max(24, process.stdout.columns ?? 120));
   const lines = rendered.split("\n");
   if (lines[0]) printToolHeader(tDynamic(labelKey), detail);
   for (const line of lines.slice(1)) {

--- a/src/cli-stdout-projector.ts
+++ b/src/cli-stdout-projector.ts
@@ -1,7 +1,7 @@
 import { stdout as output } from "node:process";
 import { type ChatRow, isChecklistOutput, isToolOutput } from "./chat-contract";
 import { formatChecklist } from "./checklist-format";
-import { formatAgentReplyOutput, printIndentedDim } from "./cli-format";
+import { formatAgentReplyOutput, printIndentedDim, TOOL_BODY_INDENT } from "./cli-format";
 import { palette } from "./palette";
 import { renderToolOutput } from "./tool-output-render";
 import { printDim, printError, printOutput, printWarning, streamText } from "./ui";
@@ -61,7 +61,7 @@ export function createStdoutRowProjector(): {
     const parts = row.content.parts;
     // A lone header with no detail carries nothing to show yet — wait for real content.
     if (parts.length === 1 && parts[0]?.kind === "tool-header" && !parts[0].detail) return;
-    const rendered = renderToolOutput(parts);
+    const rendered = renderToolOutput(parts, Math.max(24, (output.columns ?? 120) - TOOL_BODY_INDENT));
     const previous = emittedTool.get(row.id);
     emittedTool.set(row.id, rendered);
     if (previous !== undefined) {

--- a/src/tool-output-render.ts
+++ b/src/tool-output-render.ts
@@ -1,5 +1,6 @@
 import { t, tDynamic } from "./i18n";
 import type { ToolOutputPart } from "./tool-output-contract";
+import { truncateToWidth } from "./truncate-text";
 
 export type ResolvedHeader = { label: string; detail?: string; meta?: Record<string, unknown> };
 
@@ -87,7 +88,7 @@ function renderDiffLine(item: Extract<ToolOutputPart, { kind: "diff" }>, numWidt
   return `${num} ${prefix}${item.text}`;
 }
 
-function renderList(items: ToolOutputPart[]): string {
+function renderList(items: ToolOutputPart[], width?: number): string {
   const first = items[0];
   if (!first) return "";
   const header = renderPart(first);
@@ -107,11 +108,15 @@ function renderList(items: ToolOutputPart[]): string {
     }
     return renderPart(item);
   });
-  return `${header}\n${lines.map((line) => `  ${line}`).join("\n")}`;
+  // Truncate each assembled body line (indent + gutter + content) at the display width so
+  // preview lines never wrap; the gutter sits at line start, so alignment is preserved.
+  // The header is left intact (long paths want middle-truncation, a separate concern).
+  const bodyLines = lines.map((line) => (width === undefined ? `  ${line}` : truncateToWidth(`  ${line}`, width)));
+  return `${header}\n${bodyLines.join("\n")}`;
 }
 
-export function renderToolOutput(content: ToolOutputPart | ToolOutputPart[]): string {
-  return Array.isArray(content) ? renderList(content) : renderPart(content);
+export function renderToolOutput(content: ToolOutputPart | ToolOutputPart[], width?: number): string {
+  return Array.isArray(content) ? renderList(content, width) : renderPart(content);
 }
 
 export type ToolOutputUpdate = {

--- a/src/tool-output.tui.test.tsx
+++ b/src/tool-output.tui.test.tsx
@@ -6,9 +6,9 @@ import type { ToolOutputPart } from "./tool-output-contract";
 import { renderToolOutput } from "./tool-output-render";
 import { renderPlain } from "./tui/test-utils";
 
-function renderChat(toolOutput: ToolOutputPart[]): string {
+function renderChat(toolOutput: ToolOutputPart[], columns = 96): string {
   const row: ChatRow = { id: "r1", kind: "tool", content: { parts: toolOutput } };
-  return renderPlain(<ChatTranscript rows={[row]} pendingFrame={0} />, 96);
+  return renderPlain(<ChatTranscript rows={[row]} pendingFrame={0} />, columns);
 }
 
 describe("tool output TUI — CLI (renderToolOutput)", () => {
@@ -423,6 +423,25 @@ describe("tool output TUI — CLI (renderToolOutput)", () => {
       `),
     );
   });
+
+  test("truncates a long body line to the given width, leaving the header intact", () => {
+    const items: ToolOutputPart[] = [
+      { kind: "edit-header", labelKey: "tool.label.file_edit", path: "notes.ts", files: 1, added: 1, removed: 0 },
+      { kind: "diff", lineNumber: 1, marker: "add", text: "X".repeat(60) },
+    ];
+    const [header, body] = renderToolOutput(items, 20).split("\n");
+    expect(header).toBe("Edit notes.ts (+1 -0)"); // header is never truncated
+    expect(body).toBe(`  1 +${"X".repeat(14)}…`);
+    expect(Bun.stringWidth(body)).toBe(20);
+  });
+
+  test("omitting the width leaves long lines unwrapped (default path unchanged)", () => {
+    const items: ToolOutputPart[] = [
+      { kind: "edit-header", labelKey: "tool.label.file_edit", path: "notes.ts", files: 1, added: 1, removed: 0 },
+      { kind: "diff", lineNumber: 1, marker: "add", text: "X".repeat(60) },
+    ];
+    expect(renderToolOutput(items)).toBe(`Edit notes.ts (+1 -0)\n  1 +${"X".repeat(60)}`);
+  });
 });
 
 describe("tool output TUI — chat (Ink rendering)", () => {
@@ -676,5 +695,17 @@ describe("tool output TUI — chat (Ink rendering)", () => {
 
   test("skill-activate with name", () => {
     expect(renderChat([{ kind: "tool-header", labelKey: "tool.label.skill", detail: "build" }])).toBe("• Skill build");
+  });
+
+  test("truncates a long diff line to the terminal width instead of wrapping", () => {
+    const items: ToolOutputPart[] = [
+      { kind: "edit-header", labelKey: "tool.label.file_edit", path: "notes.ts", files: 1, added: 1, removed: 0 },
+      { kind: "diff", lineNumber: 1, marker: "add", text: "X".repeat(80) },
+    ];
+    const out = renderChat(items, 40); // terminal width 40 → line must fit, not wrap
+    const diffLine = out.split("\n").find((line) => line.includes("X")) ?? "";
+    expect(diffLine.endsWith("…")).toBe(true); // content was cut, not wrapped
+    expect(Bun.stringWidth(diffLine)).toBeLessThanOrEqual(40);
+    expect(out).toContain("• Edit notes.ts (+1 -0)");
   });
 });

--- a/src/truncate-text.test.ts
+++ b/src/truncate-text.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { truncateMiddle, truncateText } from "./truncate-text";
+import { truncateMiddle, truncateText, truncateToWidth } from "./truncate-text";
 
 describe("truncateText", () => {
   test("returns input unchanged when within limit", () => {
@@ -70,5 +70,45 @@ describe("truncateMiddle", () => {
 
   test("handles empty string", () => {
     expect(truncateMiddle("", 100)).toBe("");
+  });
+});
+
+describe("truncateToWidth", () => {
+  test("returns input unchanged when within width", () => {
+    expect(truncateToWidth("hello", 10)).toBe("hello");
+    expect(truncateToWidth("hello", 5)).toBe("hello");
+  });
+
+  test("cuts with a trailing ellipsis when over width", () => {
+    expect(truncateToWidth("abcdef", 4)).toBe("abc…");
+  });
+
+  test("result never exceeds the target width", () => {
+    const out = truncateToWidth("x".repeat(100), 20);
+    expect(out).toBe(`${"x".repeat(19)}…`);
+    expect(Bun.stringWidth(out)).toBe(20);
+  });
+
+  test("returns empty string for non-positive width", () => {
+    expect(truncateToWidth("abc", 0)).toBe("");
+    expect(truncateToWidth("abc", -5)).toBe("");
+  });
+
+  test("counts wide (CJK) characters by display width, not code points", () => {
+    const wide = "一二三四"; // 4 code points, 8 display columns
+    expect(truncateToWidth(wide, 8)).toBe(wide);
+    // budget 5 reserves 1 column for the ellipsis, leaving 4 columns = 2 wide chars
+    expect(truncateToWidth(wide, 5)).toBe("一二…");
+  });
+
+  test("never splits a surrogate-pair grapheme mid-character", () => {
+    const out = truncateToWidth("🙂".repeat(5), 5);
+    expect(out.endsWith("…")).toBe(true);
+    expect(out).not.toContain("�");
+    expect(Bun.stringWidth(out)).toBeLessThanOrEqual(5);
+  });
+
+  test("handles empty string", () => {
+    expect(truncateToWidth("", 10)).toBe("");
   });
 });

--- a/src/truncate-text.ts
+++ b/src/truncate-text.ts
@@ -15,3 +15,25 @@ export function truncateMiddle(text: string, maxChars: number): string {
   const tail = budget - head;
   return text.slice(0, head) + marker + text.slice(-tail);
 }
+
+const graphemeSegmenter = new Intl.Segmenter();
+
+/**
+ * Width-aware truncation: cuts by grapheme so the result (including the `…`) never
+ * exceeds `maxWidth` terminal columns per `Bun.stringWidth`. Plain text only — ANSI is
+ * applied downstream by the renderers, so don't pass styled strings.
+ */
+export function truncateToWidth(text: string, maxWidth: number): string {
+  if (maxWidth <= 0) return "";
+  if (Bun.stringWidth(text) <= maxWidth) return text;
+  const budget = maxWidth - 1; // reserve one column for the ellipsis
+  let out = "";
+  let used = 0;
+  for (const { segment } of graphemeSegmenter.segment(text)) {
+    const width = Bun.stringWidth(segment);
+    if (used + width > budget) break;
+    out += segment;
+    used += width;
+  }
+  return `${out}…`;
+}


### PR DESCRIPTION
## Summary
- truncate tool-output preview lines at the display width instead of letting them wrap and break gutter alignment — in both the TUI and run mode
- add a shared `truncateToWidth` primitive (grapheme-cut by `Bun.stringWidth`, trailing `…`) so both interpreters apply one truncation policy
- name the previously-magic indent widths (`TOOL_BODY_INDENT`, `TOOL_LINE_INDENT`)
- headers are left intact (long paths are a separate middle-truncation concern)
