### PR TITLE
test(tui): width-aware VT with deferred wrap

### DIFF
--- a/src/tui/vt.test.tsx
+++ b/src/tui/vt.test.tsx
@@ -30,6 +30,68 @@ describe("replayTerminal", () => {
   });
 });
 
+describe("replayTerminal — width & deferred wrap", () => {
+  test("a wide grapheme exactly filling the row stays one line", () => {
+    // あ(2) + あ(2) + a(1) = 5 columns exactly.
+    expect(transcriptLines(replayTerminal(["ああa"], 4, 5))).toEqual(["ああa"]);
+  });
+
+  test("a wide grapheme with one cell left wraps whole, never split", () => {
+    // x(1) leaves col at 3; the second あ can't fit in the single last cell.
+    expect(transcriptLines(replayTerminal(["xああ"], 4, 4))).toEqual(["xあ", "あ"]);
+  });
+
+  test("an exactly-full row followed by \\r\\n produces no blank row", () => {
+    expect(transcriptLines(replayTerminal(["abcde\r\nnext"], 4, 5))).toEqual(["abcde", "next"]);
+  });
+
+  test("a pending wrap commits on the next printable char", () => {
+    expect(transcriptLines(replayTerminal(["abcdef"], 4, 5))).toEqual(["abcde", "f"]);
+  });
+
+  test("a bare line feed while a wrap is pending advances one row, preserving the column", () => {
+    // LF advances one row (not two) and clears the last-column flag, but does NOT
+    // carriage-return — so a foreign \n after a full row shows the column splice
+    // (X on the last column), never a clean col-0 write that would hide corruption.
+    expect(transcriptLines(replayTerminal(["abcde\nX"], 4, 5))).toEqual(["abcde", "    X"]);
+  });
+
+  test("erase-down landing on a wide char's continuation blanks the orphaned head", () => {
+    // CUU preserves the column onto the あ continuation at col 2; erase-down must
+    // blank the あ head at col 1 so no half-erased double-width char survives.
+    const vt = replayTerminal(["xあ\r\nab", `${ansi.cursorUp(1)}${ansi.eraseDown}`], 4, 5);
+    expect(transcriptLines(vt)).toEqual(["x"]);
+  });
+
+  test("cursor-up commits a pending wrap; a preceding \\r cancels it", () => {
+    // Without the \r, the full row parks a pending wrap that cursor-up commits, so
+    // CUU(1) lands on the "abcde" row and erase-down leaves "one".
+    const committed = replayTerminal(["one\r\nabcde", `${ansi.cursorUp(1)}\r${ansi.eraseDown}`], 5, 5);
+    expect(transcriptLines(committed)).toEqual(["one"]);
+    // With the \r, the pending wrap is cancelled, CUU(1) lands one row higher, and
+    // erase-down wipes everything — this is exactly render.ts's trailing-\r defusal.
+    const cancelled = replayTerminal(["one\r\nabcde\r", `${ansi.cursorUp(1)}\r${ansi.eraseDown}`], 5, 5);
+    expect(transcriptLines(cancelled)).toEqual([]);
+  });
+
+  test("SGR (color reset) does not commit a pending wrap", () => {
+    // If ESC[0m committed the wrap, \r+X would land on a new row → ["abcde","X"].
+    expect(transcriptLines(replayTerminal(["abcde\x1b[0m\rX"], 5, 5))).toEqual(["Xbcde"]);
+  });
+
+  test("overwriting a wide head blanks its orphaned continuation cell", () => {
+    // あ occupies col0-1; writing x over col0 must blank col1 so it does not merge
+    // with the following b as "xb".
+    expect(transcriptLines(replayTerminal(["あb\rx"], 4, 5))).toEqual(["x b"]);
+  });
+
+  test("a wide grapheme cluster survives scroll into scrollback intact", () => {
+    const vt = replayTerminal(["👩‍👩‍👧\r\nL2\r\nL3"], 2, 10);
+    expect(vt.scrollback).toEqual(["👩‍👩‍👧"]);
+    expect(transcriptLines(vt)).toEqual(["👩‍👩‍👧", "L2", "L3"]);
+  });
+});
+
 describe("assertTranscriptIntegrity", () => {
   test("passes when the committed+visible transcript matches", () => {
     const vt = replayTerminal(["a\r\nb\r\nc"], 5, 20);
@@ -106,7 +168,38 @@ function GrowingLinesApp(props: { unmount: () => void }): React.JSX.Element {
   );
 }
 
+function ExactWidthApp(props: { unmount: () => void }): React.JSX.Element {
+  const [withC, setWithC] = useState(false);
+  useEffect(() => {
+    const t1 = setTimeout(() => setWithC(true), 20);
+    const t2 = setTimeout(props.unmount, 40);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+  }, [props.unmount]);
+  return (
+    <tui-box flexDirection="column">
+      <tui-text>a</tui-text>
+      <tui-text>{"B".repeat(10)}</tui-text>
+      {withC ? <tui-text>c</tui-text> : null}
+    </tui-box>
+  );
+}
+
 describe("renderer transcript integrity", () => {
+  test("an exactly-full-width line does not desync the erase math across frames", async () => {
+    // The "BBBBBBBBBB" line is exactly `columns`, so it parks a pending wrap. render.ts's
+    // trailing `\r` cancels it before the next frame's cursor-up; deleting that `\r`
+    // (render.ts:132) makes cursor-up land one row low and duplicate "a" — caught here.
+    const writes = await renderCapture(({ unmount }) => <ExactWidthApp unmount={unmount} />, {
+      columns: 10,
+      rows: 6,
+    });
+    const vt = replayTerminal(frameWrites(writes), 6, 10);
+    assertTranscriptIntegrity(vt, ["a", "BBBBBBBBBB", "c"]);
+  });
+
   test("every overflowing line survives in the transcript exactly once", async () => {
     const lines = ["L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8"];
     const writes = await renderCapture(({ unmount }) => <LinesApp unmount={unmount} lines={lines} />, {

--- a/src/tui/vt.ts
+++ b/src/tui/vt.ts
@@ -7,15 +7,21 @@
  * ignores the rest (SGR color, sync markers, cursor visibility) since they don't
  * move transcript content between cells.
  *
- * Scope limits (don't assume coverage — each needs its own guard):
- * - Wrap is EAGER (wrap on writing the last column), not the deferred/pending-wrap
- *   of real terminals, so this does NOT cover the pending-wrap overshoot that
- *   `render.ts:127` defuses with a trailing `\r` — deleting that `\r` stays green.
- * - Cells advance one per UTF-16 code unit; `render.ts` measures with
- *   `Bun.stringWidth`, so wide (CJK/emoji) content diverges — don't write an
- *   emoji integrity test against this.
- * - A CSI sequence split across two writes is dropped mid-parse; unreachable
- *   today since `render.ts` always writes complete sequences.
+ * Cells are graphemes measured by `Bun.stringWidth`: a width-2 grapheme (CJK,
+ * emoji) occupies a head cell plus an empty continuation cell, so row text
+ * round-trips through `join("")`. Wrap is DEFERRED (pending-wrap): after a write
+ * fills the last column the cursor parks at the margin and only wraps on the next
+ * printable char — a `\r` cancels the pending wrap, a cursor-up commits it. This
+ * is exactly the behavior `render.ts` defuses with a trailing `\r`; deleting that
+ * `\r` makes an integrity test go red.
+ *
+ * Scope limits (don't assume coverage):
+ * - A CSI sequence (or a grapheme cluster) split across two writes is parsed
+ *   per-write; unreachable today since `render.ts` writes complete sequences and
+ *   whole clusters.
+ * - Erase-down while a wrap is pending does not clear the parked last cell
+ *   (`render.ts` always emits `\r` before an erase, resetting the column first).
+ * - Terminal resize is not modeled (fixed rows/columns per replay).
  *
  * Unlike a visible-only emulator, lines that scroll off the top are kept in
  * `scrollback` — the committed transcript. That is the invariant the custom
@@ -25,11 +31,19 @@
  * can.
  */
 
+const segmenter = new Intl.Segmenter();
+
 export interface VirtualTerminal {
   /** Visible grid rows, right-trimmed. */
   screen: string[];
   /** Rows evicted off the top, in commit order — the permanent transcript. */
   scrollback: string[];
+  /** Final cursor row after replay, 0-based in the current screen. */
+  row: number;
+  /** Final cursor column after replay; equals `columns` when a wrap is pending. */
+  col: number;
+  /** Replay ended with an uncommitted deferred (pending) wrap. */
+  pendingWrap: boolean;
 }
 
 export function replayTerminal(writes: string[], rows: number, columns: number): VirtualTerminal {
@@ -37,6 +51,7 @@ export function replayTerminal(writes: string[], rows: number, columns: number):
   const screen = Array.from({ length: rows }, () => Array.from({ length: columns }, () => " "));
   let row = 0;
   let col = 0;
+  let pendingWrap = false;
 
   const scroll = (): void => {
     const evicted = screen.shift();
@@ -45,9 +60,24 @@ export function replayTerminal(writes: string[], rows: number, columns: number):
     row = rows - 1;
   };
 
+  // A pending wrap counts as "the cursor is on the next row" for anything that
+  // prints or moves vertically; `\r` cancels it (that is render.ts's defusal).
+  const commitPendingWrap = (): void => {
+    if (!pendingWrap) return;
+    pendingWrap = false;
+    row += 1;
+    col = 0;
+    if (row >= rows) scroll();
+  };
+
   const eraseDown = (): void => {
     const currentRow = screen[row];
     if (currentRow) {
+      // CUU and bare LF preserve the column, so an erase can land on a wide char's
+      // continuation cell — blank the head to its left so a half-erased double-width
+      // char can't survive (matches xterm). Reachable from the foreign/adversarial
+      // writes this harness models, though not from render.ts's own output.
+      if (col < columns && currentRow[col] === "" && col - 1 >= 0) currentRow[col - 1] = " ";
       for (let c = col; c < columns; c++) currentRow[c] = " ";
     }
     for (let r = row + 1; r < rows; r++) {
@@ -57,59 +87,112 @@ export function replayTerminal(writes: string[], rows: number, columns: number):
     }
   };
 
+  // Before writing a grapheme spanning [start, start+width), blank any wide-char
+  // partner cell we would orphan: a continuation whose head we overwrite, or a
+  // head whose continuation we overwrite.
+  const clearSpan = (cells: string[], start: number, width: number): void => {
+    if (cells[start] === "" && start - 1 >= 0) cells[start - 1] = " ";
+    const last = start + width - 1;
+    if (last + 1 < columns && cells[last + 1] === "") cells[last + 1] = " ";
+  };
+
+  const placeGrapheme = (g: string): void => {
+    let width = Bun.stringWidth(g);
+    if (width <= 0) return; // zero-width (stray combining mark) — no cell, no advance
+    if (width > 2) width = 2;
+    if (pendingWrap) commitPendingWrap();
+    // A width-2 grapheme with a single cell left can't be split — wrap it whole.
+    if (width === 2 && col === columns - 1) {
+      row += 1;
+      col = 0;
+      if (row >= rows) scroll();
+    }
+    const target = screen[row];
+    if (target && col < columns) {
+      clearSpan(target, col, width);
+      target[col] = g;
+      for (let k = 1; k < width; k++) {
+        if (col + k < columns) target[col + k] = "";
+      }
+    }
+    col += width;
+    if (col >= columns) {
+      col = columns;
+      pendingWrap = true;
+    }
+  };
+
   const applyWrite = (data: string): void => {
     let index = 0;
     while (index < data.length) {
       const char = data[index];
-      if (char === "\x1b" && data[index + 1] === "[") {
-        let end = index + 2;
-        while (end < data.length) {
-          const code = data.charCodeAt(end);
-          if (code >= 0x40 && code <= 0x7e) break;
-          end += 1;
+      if (char === "\x1b") {
+        if (data[index + 1] === "[") {
+          let end = index + 2;
+          while (end < data.length) {
+            const code = data.charCodeAt(end);
+            if (code >= 0x40 && code <= 0x7e) break;
+            end += 1;
+          }
+          if (end >= data.length) break; // split CSI — out of scope
+          const sequence = data.slice(index + 2, end);
+          const finalByte = data[end];
+          const paramText = sequence.replace(/^\?/, "");
+          const param = paramText.length > 0 ? Number.parseInt(paramText, 10) : 1;
+          if (finalByte === "A") {
+            commitPendingWrap();
+            row = Math.max(0, row - (Number.isFinite(param) ? param : 1));
+          } else if (finalByte === "J") {
+            eraseDown();
+          }
+          // Other CSI (SGR color, sync markers, cursor visibility) is ignored and
+          // must NOT resolve a pending wrap — a styled full-width line ends with
+          // `ESC[0m`, which would otherwise false-commit the wrap.
+          index = end + 1;
+          continue;
         }
-        if (end >= data.length) break;
-        const sequence = data.slice(index + 2, end);
-        const finalByte = data[end];
-        const paramText = sequence.replace(/^\?/, "");
-        const param = paramText.length > 0 ? Number.parseInt(paramText, 10) : 1;
-        if (finalByte === "A") {
-          row = Math.max(0, row - (Number.isFinite(param) ? param : 1));
-        } else if (finalByte === "J") {
-          eraseDown();
-        }
-        index = end + 1;
+        // Lone/unrecognized ESC — skip one char to guarantee progress.
+        index += 1;
         continue;
       }
       if (char === "\r") {
         col = 0;
+        pendingWrap = false;
         index += 1;
         continue;
       }
       if (char === "\n") {
-        // Pure line feed: advance the row, keep the column. A bare `\n` from a
-        // foreign write (e.g. a stray console.log) column-splices content — the
+        // Pure line feed: advance exactly one row, keep the column. A bare `\n` from
+        // a foreign write (e.g. a stray console.log) column-splices content — the
         // confirmed weakest-link corruption this harness must catch. render.ts
         // normalizes its own newlines to `\r\n`, so the `\r` resets the column.
+        if (pendingWrap) {
+          // The cursor is parked at the last column with the last-column flag set.
+          // LF clears the flag and advances one row but does NOT carriage-return
+          // (raw-mode tty has OPOST off — the reason render.ts normalizes \n to
+          // \r\n), so the column is preserved at the last column. Resetting to 0
+          // here would hide a foreign-\n splice after a full row — a false green.
+          pendingWrap = false;
+          col = columns - 1;
+        }
         row += 1;
         if (row >= rows) scroll();
         index += 1;
         continue;
       }
-      if (col >= columns) {
-        row += 1;
-        col = 0;
-        if (row >= rows) scroll();
+      // Printable run: everything up to the next control char, placed grapheme by
+      // grapheme so wide chars occupy the right number of cells.
+      let runEnd = index + 1;
+      while (runEnd < data.length && data[runEnd] !== "\x1b" && data[runEnd] !== "\r" && data[runEnd] !== "\n") {
+        runEnd += 1;
       }
-      const target = screen[row];
-      if (target && col >= 0 && col < columns) target[col] = char ?? " ";
-      col += 1;
-      index += 1;
+      for (const { segment } of segmenter.segment(data.slice(index, runEnd))) placeGrapheme(segment);
+      index = runEnd;
     }
   };
 
   for (const write of writes) applyWrite(write);
-  return { screen: screen.map((line) => line.join("").replace(/\s+$/, "")), scrollback };
+  return { screen: screen.map((line) => line.join("").replace(/\s+$/, "")), scrollback, row, col, pendingWrap };
 }
 
 /** Committed (scrollback) + visible (screen) transcript, trailing blanks dropped. */


### PR DESCRIPTION
## Summary
- make the transcript-integrity VT harness width-aware (grapheme cells) with deferred/pending-wrap, catching wide-char and pending-wrap regressions the old harness missed
- mutation-verified: removing render.ts's pending-wrap `\r` now fails an integrity test
