### PR TITLE
test(tui): harden renderer tests

### DIFF
--- a/src/chat-transcript.integrity.test.tsx
+++ b/src/chat-transcript.integrity.test.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import type React from "react";
+import { type ChatRow, createRow } from "./chat-contract";
+import { ChatTranscript } from "./chat-transcript";
+import { assertCursorAccounting, frameWrites, renderScript } from "./tui/test-utils";
+import { assertTranscriptIntegrity, replayTerminal, transcriptLines } from "./tui/vt";
+
+const COLUMNS = 40;
+// contentWidth = COLUMNS - 2 (marker box). A contentWidth-wide line plus its
+// 2-col marker fills the row exactly, parking a pending wrap render.ts must defuse.
+const CONTENT_WIDTH = COLUMNS - 2;
+const CJK = "日本語のテスト"; // width-2 graphemes — exercises real column arithmetic
+
+// A rich, tricky rowset: a wrapping CJK line, a line that fills the row exactly,
+// a tool part with a padded diff bar, a header that wraps at narrow width, and
+// plain prose. Each vector (wide-char erase, pending-wrap \r, diff-bar padding,
+// narrow header wrap) is present in one transcript.
+const ROWS: ChatRow[] = [
+  createRow("user", "run the analysis on the report"),
+  createRow("assistant", `解析結果: ${CJK}${CJK}${CJK}`),
+  createRow("assistant", "X".repeat(CONTENT_WIDTH)),
+  createRow("tool", {
+    parts: [
+      { kind: "tool-header", labelKey: "tool.label.file_read", detail: "src/report.ts" },
+      { kind: "diff", marker: "add", lineNumber: 1, text: "const value = computeExpensiveThing(input, options)" },
+      { kind: "diff", marker: "remove", lineNumber: 2, text: "let value = 1" },
+    ],
+  }),
+  createRow("assistant", "and that is the final summary line of the reply body"),
+];
+
+function transcriptOf(rows: ChatRow[]): React.JSX.Element {
+  return <ChatTranscript rows={rows} pendingFrame={0} />;
+}
+
+/** Render the full rowset in one frame at a viewport tall enough to hold it all;
+ *  its committed+visible transcript is the ground truth every other render must
+ *  reproduce line-for-line. */
+async function oracleTranscript(): Promise<string[]> {
+  const frames = await renderScript([transcriptOf(ROWS)], { columns: COLUMNS, rows: 200 });
+  return transcriptLines(replayTerminal(frameWrites(frames.flat()), 200, COLUMNS));
+}
+
+describe("ChatTranscript transcript integrity", () => {
+  test("the oracle transcript is non-trivial and carries every tricky vector", async () => {
+    const expected = await oracleTranscript();
+    // Guards against a vacuous pass: the transcript must actually contain the CJK
+    // line, the diff content, and a line filling the row exactly.
+    expect(expected.some((line) => line.includes(CJK))).toBe(true);
+    // The diff bar truncates its content to the width budget, so match the prefix.
+    expect(expected.some((line) => line.includes("+const value"))).toBe(true);
+    expect(expected.some((line) => Bun.stringWidth(line) === COLUMNS)).toBe(true);
+  });
+
+  test("streaming rows through an overflowing viewport loses and duplicates nothing", async () => {
+    const expected = await oracleTranscript();
+    // Grow the transcript one row per frame at a short viewport so the top rows
+    // overflow into scrollback — the frozen-prefix path that produced the loss bug.
+    const script = ROWS.map((_, i) => transcriptOf(ROWS.slice(0, i + 1)));
+    const frames = await renderScript(script, { columns: COLUMNS, rows: 6 });
+    const vt = replayTerminal(frameWrites(frames.flat()), 6, COLUMNS);
+    // Every line the tall oracle shows survives exactly once, in order, across the
+    // scrollback boundary — no drop, duplicate, or column-splice.
+    assertTranscriptIntegrity(vt, expected);
+  });
+
+  test("cursor-up distance matches the prior live region on every frame", async () => {
+    // Tall viewport → no overflow, so each frame is a pure active re-render and the
+    // emitted cursorUp(n) must equal the physical height of the previous frame's
+    // live region, measured by the width-aware VT and render's own physicalRowCount.
+    const script = ROWS.map((_, i) => transcriptOf(ROWS.slice(0, i + 1)));
+    const frames = await renderScript(script, { columns: COLUMNS, rows: 40 });
+    assertCursorAccounting(frames, COLUMNS);
+  });
+});

--- a/src/chat-transcript.integrity.test.tsx
+++ b/src/chat-transcript.integrity.test.tsx
@@ -70,6 +70,14 @@ describe("ChatTranscript transcript integrity", () => {
     // live region, measured by the width-aware VT and render's own physicalRowCount.
     const script = ROWS.map((_, i) => transcriptOf(ROWS.slice(0, i + 1)));
     const frames = await renderScript(script, { columns: COLUMNS, rows: 40 });
-    assertCursorAccounting(frames, COLUMNS);
+    assertCursorAccounting(frames, COLUMNS, 40);
+  });
+
+  test("cursor-accounting refuses to measure an overflowing viewport", async () => {
+    // The invariant only holds without scrollback; the `rows` guard must reject a
+    // viewport too short to hold the content rather than silently measure garbage.
+    const script = ROWS.map((_, i) => transcriptOf(ROWS.slice(0, i + 1)));
+    const frames = await renderScript(script, { columns: COLUMNS, rows: 6 });
+    expect(() => assertCursorAccounting(frames, COLUMNS, 6)).toThrow(/precondition violated/);
   });
 });

--- a/src/tool-output.tui.test.tsx
+++ b/src/tool-output.tui.test.tsx
@@ -11,37 +11,50 @@ function renderChat(toolOutput: ToolOutputPart[], columns = 96): string {
   return renderPlain(<ChatTranscript rows={[row]} pendingFrame={0} />, columns);
 }
 
-describe("tool output TUI — CLI (renderToolOutput)", () => {
-  test("empty content returns empty string", () => {
-    expect(renderToolOutput([])).toBe("");
-  });
+/**
+ * One case, two expected strings. The CLI (`renderToolOutput`) and chat
+ * (`ChatTranscript`) blocks are intentionally different renderers of the same
+ * `ToolOutputPart[]` — the CLI is markerless with `out |`/`err |` stream
+ * prefixes, chat prepends a `• ` marker and re-implements the gutter math. This
+ * shared table drives both from one input so a case can never be present in one
+ * block and silently missing from the other; a new case that omits `cli` or
+ * `chat` is a type error, not a coverage gap.
+ */
+interface ToolCase {
+  name: string;
+  parts: ToolOutputPart[];
+  cli: string;
+  chat: string;
+}
 
-  test("tool-header only", () => {
-    expect(renderToolOutput([{ kind: "tool-header", labelKey: "tool.label.file_read", detail: "a.ts" }])).toBe(
-      "Read a.ts",
-    );
-  });
-
-  test("tool-header without detail", () => {
-    expect(renderToolOutput([{ kind: "tool-header", labelKey: "tool.label.git_status" }])).toBe("Git Status");
-  });
-
-  test("file-header renders label and targets", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "file-header", labelKey: "tool.label.file_read", count: 2, targets: ["a.ts", "b.ts"] },
-    ];
-    expect(renderToolOutput(items)).toBe("Read 2 files");
-  });
-
-  test("file-header with single file shows path", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "file-header", labelKey: "tool.label.file_read", count: 1, targets: ["a.ts"] },
-    ];
-    expect(renderToolOutput(items)).toBe("Read a.ts");
-  });
-
-  test("scope-header for search with summary", () => {
-    const items: ToolOutputPart[] = [
+const CASES: ToolCase[] = [
+  {
+    name: "tool-header with detail",
+    parts: [{ kind: "tool-header", labelKey: "tool.label.file_read", detail: "a.ts" }],
+    cli: "Read a.ts",
+    chat: "• Read a.ts",
+  },
+  {
+    name: "tool-header without detail",
+    parts: [{ kind: "tool-header", labelKey: "tool.label.git_status" }],
+    cli: "Git Status",
+    chat: "• Git Status",
+  },
+  {
+    name: "file-header renders label and targets",
+    parts: [{ kind: "file-header", labelKey: "tool.label.file_read", count: 2, targets: ["a.ts", "b.ts"] }],
+    cli: "Read 2 files",
+    chat: "• Read 2 files",
+  },
+  {
+    name: "file-header with single file shows path",
+    parts: [{ kind: "file-header", labelKey: "tool.label.file_read", count: 1, targets: ["a.ts"] }],
+    cli: "Read a.ts",
+    chat: "• Read a.ts",
+  },
+  {
+    name: "scope-header for search with summary",
+    parts: [
       {
         kind: "scope-header",
         labelKey: "tool.label.file_search",
@@ -50,43 +63,49 @@ describe("tool output TUI — CLI (renderToolOutput)", () => {
         matches: 3,
       },
       { kind: "text", text: "3 matches in 2 files" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Search needle
+    ],
+    cli: dedent(`
+      Search needle
+        3 matches in 2 files
+    `),
+    chat: dedent(`
+      • Search needle
           3 matches in 2 files
-      `),
-    );
-  });
-
-  test("scope-header with non-workspace scope", () => {
-    const items: ToolOutputPart[] = [
+    `),
+  },
+  {
+    name: "scope-header with non-workspace scope",
+    parts: [
       { kind: "scope-header", labelKey: "tool.label.file_search", scope: "src/", patterns: ["needle"], matches: 1 },
       { kind: "text", text: "1 match in 1 file" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Search needle in src/
+    ],
+    cli: dedent(`
+      Search needle in src/
+        1 match in 1 file
+    `),
+    chat: dedent(`
+      • Search needle in src/
           1 match in 1 file
-      `),
-    );
-  });
-
-  test("scope-header for file-find", () => {
-    const items: ToolOutputPart[] = [
+    `),
+  },
+  {
+    name: "scope-header for file-find",
+    parts: [
       { kind: "scope-header", labelKey: "tool.label.file_find", scope: "workspace", patterns: ["*.ts"], matches: 2 },
       { kind: "text", text: "2 files" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Find *.ts
+    ],
+    cli: dedent(`
+      Find *.ts
+        2 files
+    `),
+    chat: dedent(`
+      • Find *.ts
           2 files
-      `),
-    );
-  });
-
-  test("scope-header with multiple patterns shows count", () => {
-    const items: ToolOutputPart[] = [
+    `),
+  },
+  {
+    name: "scope-header with multiple patterns shows count",
+    parts: [
       {
         kind: "scope-header",
         labelKey: "tool.label.file_search",
@@ -95,278 +114,67 @@ describe("tool output TUI — CLI (renderToolOutput)", () => {
         matches: 5,
       },
       { kind: "text", text: "5 matches in 3 files" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Search 3 patterns
+    ],
+    cli: dedent(`
+      Search 3 patterns
+        5 matches in 3 files
+    `),
+    chat: dedent(`
+      • Search 3 patterns
           5 matches in 3 files
-      `),
-    );
-  });
-
-  test("edit-header with diff lines", () => {
-    const items: ToolOutputPart[] = [
+    `),
+  },
+  {
+    name: "edit-header with diff lines",
+    parts: [
       { kind: "edit-header", labelKey: "tool.label.file_edit", path: "notes.ts", files: 1, added: 1, removed: 1 },
       { kind: "diff", lineNumber: 9, marker: "context", text: "const x = 1;" },
       { kind: "diff", lineNumber: 10, marker: "remove", text: "const y = 2;" },
       { kind: "diff", lineNumber: 10, marker: "add", text: "const y = 3;" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Edit notes.ts (+1 -1)
-           9  const x = 1;
-          10 -const y = 2;
-          10 +const y = 3;
-      `),
-    );
-  });
-
-  test("shell-run with text body", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "echo hello" },
-      { kind: "shell-output", stream: "stdout", text: "hello" },
-      { kind: "shell-output", stream: "stdout", text: "world" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Run echo hello
-          out | hello
-          out | world
-      `),
-    );
-  });
-
-  test("shell-run with truncated output", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "cmd" },
-      { kind: "shell-output", stream: "stdout", text: "line1" },
-      { kind: "shell-output", stream: "stdout", text: "line2" },
-      { kind: "text", text: "⋮ +3 lines" },
-      { kind: "shell-output", stream: "stdout", text: "line6" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Run cmd
-          out | line1
-          out | line2
-          ⋮ +3 lines
-          out | line6
-      `),
-    );
-  });
-
-  test("no-output marker", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "cmd" },
-      { kind: "no-output" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Run cmd
-          (No output)
-      `),
-    );
-  });
-
-  test("git-status with changes", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_status" },
-      { kind: "text", text: "M src/cli.ts" },
-      { kind: "text", text: "?? src/new.ts" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Git Status
-          M src/cli.ts
-          ?? src/new.ts
-      `),
-    );
-  });
-
-  test("git-diff with text body", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_diff", detail: "src/agent.ts" },
-      { kind: "text", text: "diff --git a/src/agent.ts b/src/agent.ts" },
-      { kind: "text", text: "+const x = 1;" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Git Diff src/agent.ts
-          diff --git a/src/agent.ts b/src/agent.ts
-          +const x = 1;
-      `),
-    );
-  });
-
-  test("git-diff with truncated output", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_diff" },
-      { kind: "text", text: "+line1" },
-      { kind: "text", text: "-line2" },
-      { kind: "text", text: "⋮ +10 lines" },
-      { kind: "text", text: "+line13" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Git Diff
-          +line1
-          -line2
-          ⋮ +10 lines
-          +line13
-      `),
-    );
-  });
-
-  test("git-log with commit lines", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_log", detail: "src/cli.ts" },
-      { kind: "text", text: "abc1234 feat: add feature" },
-      { kind: "text", text: "def5678 fix: resolve bug" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Git Log src/cli.ts
-          abc1234 feat: add feature
-          def5678 fix: resolve bug
-      `),
-    );
-  });
-
-  test("git-log with truncated output", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_log" },
-      { kind: "text", text: "abc1234 first" },
-      { kind: "text", text: "def5678 second" },
-      { kind: "truncated", count: 8, unit: "lines" },
-      { kind: "text", text: "ghi9012 last" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Git Log
-          abc1234 first
-          def5678 second
-          … +8 lines
-          ghi9012 last
-      `),
-    );
-  });
-
-  test("git-show with ref detail", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_show", detail: "abc1234" },
-      { kind: "text", text: "feat: add feature" },
-      { kind: "text", text: "+const x = 1;" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Git Show abc1234
-          feat: add feature
-          +const x = 1;
-      `),
-    );
-  });
-
-  test("git-add with file paths", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_add", detail: "3 files" },
-      { kind: "text", text: "src/a.ts" },
-      { kind: "text", text: "src/b.ts" },
-      { kind: "text", text: "src/c.ts" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Git Add 3 files
-          src/a.ts
-          src/b.ts
-          src/c.ts
-      `),
-    );
-  });
-
-  test("git-add with truncated file list", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_add", detail: "8 files" },
-      { kind: "text", text: "src/a.ts" },
-      { kind: "text", text: "src/b.ts" },
-      { kind: "truncated", count: 6, unit: "files" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Git Add 8 files
-          src/a.ts
-          src/b.ts
-          … +6 files
-      `),
-    );
-  });
-
-  test("git-add all", () => {
-    const items: ToolOutputPart[] = [{ kind: "tool-header", labelKey: "tool.label.git_add", detail: "all" }];
-    expect(renderToolOutput(items)).toBe("Git Add all");
-  });
-
-  test("git-commit with hash", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_commit", detail: "feat: add feature (abc1234)" },
-    ];
-    expect(renderToolOutput(items)).toBe("Git Commit feat: add feature (abc1234)");
-  });
-
-  test("git-commit with body lines", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_commit", detail: "feat: add feature (abc1234)" },
-      { kind: "text", text: "Added new auth module" },
-      { kind: "text", text: "Updated config schema" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Git Commit feat: add feature (abc1234)
-          Added new auth module
-          Updated config schema
-      `),
-    );
-  });
-
-  test("git-commit with truncated body", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_commit", detail: "refactor: cleanup (def5678)" },
-      { kind: "text", text: "Line 1" },
-      { kind: "text", text: "Line 2" },
-      { kind: "truncated", count: 5, unit: "lines" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Git Commit refactor: cleanup (def5678)
-          Line 1
-          Line 2
-          … +5 lines
-      `),
-    );
-  });
-
-  test("diff context gaps show ellipsis without line count", () => {
-    const items: ToolOutputPart[] = [
+    ],
+    cli: dedent(`
+      Edit notes.ts (+1 -1)
+         9  const x = 1;
+        10 -const y = 2;
+        10 +const y = 3;
+    `),
+    chat: dedent(`
+      • Edit notes.ts (+1 -1)
+            9  const x = 1;
+           10 -const y = 2;
+           10 +const y = 3;
+    `),
+  },
+  {
+    name: "diff context gaps show ellipsis without line count",
+    parts: [
       { kind: "edit-header", labelKey: "tool.label.file_edit", path: "notes.ts", files: 1, added: 1, removed: 1 },
       { kind: "diff", lineNumber: 1, marker: "context", text: "const a = 1;" },
       { kind: "truncated" },
       { kind: "diff", lineNumber: 10, marker: "remove", text: "const y = 2;" },
       { kind: "diff", lineNumber: 10, marker: "add", text: "const y = 3;" },
       { kind: "diff", lineNumber: 11, marker: "context", text: "const b = 4;" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Edit notes.ts (+1 -1)
-           1  const a = 1;
-           ⋮
-          10 -const y = 2;
-          10 +const y = 3;
-          11  const b = 4;
-      `),
-    );
-  });
-
-  test("multi-file edit-header with per-file sub-headers", () => {
-    const items: ToolOutputPart[] = [
+    ],
+    cli: dedent(`
+      Edit notes.ts (+1 -1)
+         1  const a = 1;
+         ⋮
+        10 -const y = 2;
+        10 +const y = 3;
+        11  const b = 4;
+    `),
+    chat: dedent(`
+      • Edit notes.ts (+1 -1)
+            1  const a = 1;
+            ⋮
+           10 -const y = 2;
+           10 +const y = 3;
+           11  const b = 4;
+    `),
+  },
+  {
+    name: "multi-file edit-header with per-file sub-headers",
+    parts: [
       { kind: "edit-header", labelKey: "tool.label.file_edit", path: "14 files", files: 14, added: 28, removed: 28 },
       { kind: "text", text: "src/short-id.ts (+1 -1)" },
       { kind: "diff", lineNumber: 2, marker: "remove", text: "export function generateId(size = 8): string {" },
@@ -374,54 +182,361 @@ describe("tool output TUI — CLI (renderToolOutput)", () => {
       { kind: "text", text: "src/chat-contract.ts (+2 -2)" },
       { kind: "diff", lineNumber: 4, marker: "remove", text: 'import { generateId } from "./short-id";' },
       { kind: "diff", lineNumber: 4, marker: "add", text: 'import { generateId } from "./short-id";' },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Edit 14 files (+28 -28)
+    ],
+    cli: dedent(`
+      Edit 14 files (+28 -28)
+        src/short-id.ts (+1 -1)
+          2 -export function generateId(size = 8): string {
+          2 +export function generateId(size = 8): string {
+        src/chat-contract.ts (+2 -2)
+          4 -import { generateId } from "./short-id";
+          4 +import { generateId } from "./short-id";
+    `),
+    chat: dedent(`
+      • Edit 14 files (+28 -28)
           src/short-id.ts (+1 -1)
-            2 -export function generateId(size = 8): string {
-            2 +export function generateId(size = 8): string {
+           2 -export function generateId(size = 8): string {
+           2 +export function generateId(size = 8): string {
           src/chat-contract.ts (+2 -2)
-            4 -import { generateId } from "./short-id";
-            4 +import { generateId } from "./short-id";
-      `),
-    );
-  });
-
-  test("single-file edit has no per-file sub-header", () => {
-    const items: ToolOutputPart[] = [
+           4 -import { generateId } from "./short-id";
+           4 +import { generateId } from "./short-id";
+    `),
+  },
+  {
+    name: "single-file edit has no per-file sub-header",
+    parts: [
       { kind: "edit-header", labelKey: "tool.label.file_edit", path: "notes.ts", files: 1, added: 1, removed: 1 },
       { kind: "diff", lineNumber: 2, marker: "remove", text: "old" },
       { kind: "diff", lineNumber: 2, marker: "add", text: "new" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Edit notes.ts (+1 -1)
-          2 -old
-          2 +new
-      `),
-    );
-  });
-
-  test("skill-activate with name", () => {
-    expect(renderToolOutput([{ kind: "tool-header", labelKey: "tool.label.skill", detail: "build" }])).toBe(
-      "Skill build",
-    );
-  });
-
-  test("truncated without unit", () => {
-    const items: ToolOutputPart[] = [
+    ],
+    cli: dedent(`
+      Edit notes.ts (+1 -1)
+        2 -old
+        2 +new
+    `),
+    chat: dedent(`
+      • Edit notes.ts (+1 -1)
+           2 -old
+           2 +new
+    `),
+  },
+  {
+    name: "shell-run with text body",
+    parts: [
+      { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "echo hello" },
+      { kind: "shell-output", stream: "stdout", text: "hello" },
+      { kind: "shell-output", stream: "stdout", text: "world" },
+    ],
+    cli: dedent(`
+      Run echo hello
+        out | hello
+        out | world
+    `),
+    chat: dedent(`
+      • Run echo hello
+          hello
+          world
+    `),
+  },
+  {
+    name: "shell-run with mixed stdout and stderr",
+    parts: [
+      { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "make" },
+      { kind: "shell-output", stream: "stdout", text: "compiling..." },
+      { kind: "shell-output", stream: "stderr", text: "warning: unused var" },
+      { kind: "shell-output", stream: "stdout", text: "done" },
+    ],
+    cli: dedent(`
+      Run make
+        out | compiling...
+        err | warning: unused var
+        out | done
+    `),
+    chat: dedent(`
+      • Run make
+          compiling...
+          warning: unused var
+          done
+    `),
+  },
+  {
+    name: "shell-run with truncated output",
+    parts: [
+      { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "cmd" },
+      { kind: "shell-output", stream: "stdout", text: "line1" },
+      { kind: "shell-output", stream: "stdout", text: "line2" },
+      { kind: "text", text: "⋮ +3 lines" },
+      { kind: "shell-output", stream: "stdout", text: "line6" },
+    ],
+    cli: dedent(`
+      Run cmd
+        out | line1
+        out | line2
+        ⋮ +3 lines
+        out | line6
+    `),
+    chat: dedent(`
+      • Run cmd
+          line1
+          line2
+          ⋮ +3 lines
+          line6
+    `),
+  },
+  {
+    name: "no-output marker",
+    parts: [{ kind: "tool-header", labelKey: "tool.label.shell_run", detail: "cmd" }, { kind: "no-output" }],
+    cli: dedent(`
+      Run cmd
+        (No output)
+    `),
+    chat: dedent(`
+      • Run cmd
+          (No output)
+    `),
+  },
+  {
+    name: "git-status with changes",
+    parts: [
+      { kind: "tool-header", labelKey: "tool.label.git_status" },
+      { kind: "text", text: "M src/cli.ts" },
+      { kind: "text", text: "?? src/new.ts" },
+    ],
+    cli: dedent(`
+      Git Status
+        M src/cli.ts
+        ?? src/new.ts
+    `),
+    chat: dedent(`
+      • Git Status
+          M src/cli.ts
+          ?? src/new.ts
+    `),
+  },
+  {
+    name: "git-diff with text body",
+    parts: [
+      { kind: "tool-header", labelKey: "tool.label.git_diff", detail: "src/agent.ts" },
+      { kind: "text", text: "+const x = 1;" },
+      { kind: "text", text: "-const y = 2;" },
+    ],
+    cli: dedent(`
+      Git Diff src/agent.ts
+        +const x = 1;
+        -const y = 2;
+    `),
+    chat: dedent(`
+      • Git Diff src/agent.ts
+          +const x = 1;
+          -const y = 2;
+    `),
+  },
+  {
+    name: "git-diff with truncated output",
+    parts: [
+      { kind: "tool-header", labelKey: "tool.label.git_diff" },
+      { kind: "text", text: "+line1" },
+      { kind: "text", text: "-line2" },
+      { kind: "text", text: "⋮ +10 lines" },
+      { kind: "text", text: "+line13" },
+    ],
+    cli: dedent(`
+      Git Diff
+        +line1
+        -line2
+        ⋮ +10 lines
+        +line13
+    `),
+    chat: dedent(`
+      • Git Diff
+          +line1
+          -line2
+          ⋮ +10 lines
+          +line13
+    `),
+  },
+  {
+    name: "git-log with commit lines",
+    parts: [
+      { kind: "tool-header", labelKey: "tool.label.git_log", detail: "src/cli.ts" },
+      { kind: "text", text: "abc1234 feat: add feature" },
+      { kind: "text", text: "def5678 fix: resolve bug" },
+    ],
+    cli: dedent(`
+      Git Log src/cli.ts
+        abc1234 feat: add feature
+        def5678 fix: resolve bug
+    `),
+    chat: dedent(`
+      • Git Log src/cli.ts
+          abc1234 feat: add feature
+          def5678 fix: resolve bug
+    `),
+  },
+  {
+    name: "git-log with truncated output",
+    parts: [
+      { kind: "tool-header", labelKey: "tool.label.git_log" },
+      { kind: "text", text: "abc1234 first" },
+      { kind: "text", text: "def5678 second" },
+      { kind: "truncated", count: 8, unit: "lines" },
+      { kind: "text", text: "ghi9012 last" },
+    ],
+    cli: dedent(`
+      Git Log
+        abc1234 first
+        def5678 second
+        … +8 lines
+        ghi9012 last
+    `),
+    chat: dedent(`
+      • Git Log
+          abc1234 first
+          def5678 second
+          … +8 lines
+          ghi9012 last
+    `),
+  },
+  {
+    name: "git-show with ref detail",
+    parts: [
+      { kind: "tool-header", labelKey: "tool.label.git_show", detail: "abc1234" },
+      { kind: "text", text: "feat: add feature" },
+      { kind: "text", text: "+const x = 1;" },
+    ],
+    cli: dedent(`
+      Git Show abc1234
+        feat: add feature
+        +const x = 1;
+    `),
+    chat: dedent(`
+      • Git Show abc1234
+          feat: add feature
+          +const x = 1;
+    `),
+  },
+  {
+    name: "git-add with file paths",
+    parts: [
+      { kind: "tool-header", labelKey: "tool.label.git_add", detail: "3 files" },
+      { kind: "text", text: "src/a.ts" },
+      { kind: "text", text: "src/b.ts" },
+      { kind: "text", text: "src/c.ts" },
+    ],
+    cli: dedent(`
+      Git Add 3 files
+        src/a.ts
+        src/b.ts
+        src/c.ts
+    `),
+    chat: dedent(`
+      • Git Add 3 files
+          src/a.ts
+          src/b.ts
+          src/c.ts
+    `),
+  },
+  {
+    name: "git-add with truncated file list",
+    parts: [
+      { kind: "tool-header", labelKey: "tool.label.git_add", detail: "8 files" },
+      { kind: "text", text: "src/a.ts" },
+      { kind: "text", text: "src/b.ts" },
+      { kind: "truncated", count: 6, unit: "files" },
+    ],
+    cli: dedent(`
+      Git Add 8 files
+        src/a.ts
+        src/b.ts
+        … +6 files
+    `),
+    chat: dedent(`
+      • Git Add 8 files
+          src/a.ts
+          src/b.ts
+          … +6 files
+    `),
+  },
+  {
+    name: "git-commit with hash",
+    parts: [{ kind: "tool-header", labelKey: "tool.label.git_commit", detail: "feat: add feature (abc1234)" }],
+    cli: "Git Commit feat: add feature (abc1234)",
+    chat: "• Git Commit feat: add feature (abc1234)",
+  },
+  {
+    name: "git-commit with body lines",
+    parts: [
+      { kind: "tool-header", labelKey: "tool.label.git_commit", detail: "feat: add feature (abc1234)" },
+      { kind: "text", text: "Added new auth module" },
+      { kind: "text", text: "Updated config schema" },
+    ],
+    cli: dedent(`
+      Git Commit feat: add feature (abc1234)
+        Added new auth module
+        Updated config schema
+    `),
+    chat: dedent(`
+      • Git Commit feat: add feature (abc1234)
+          Added new auth module
+          Updated config schema
+    `),
+  },
+  {
+    name: "git-commit with truncated body",
+    parts: [
+      { kind: "tool-header", labelKey: "tool.label.git_commit", detail: "refactor: cleanup (def5678)" },
+      { kind: "text", text: "Line 1" },
+      { kind: "text", text: "Line 2" },
+      { kind: "truncated", count: 5, unit: "lines" },
+    ],
+    cli: dedent(`
+      Git Commit refactor: cleanup (def5678)
+        Line 1
+        Line 2
+        … +5 lines
+    `),
+    chat: dedent(`
+      • Git Commit refactor: cleanup (def5678)
+          Line 1
+          Line 2
+          … +5 lines
+    `),
+  },
+  {
+    name: "truncated without unit",
+    parts: [
       { kind: "tool-header", labelKey: "tool.label.file_find", detail: "*.ts" },
       { kind: "text", text: "a.ts" },
       { kind: "truncated", count: 5, unit: "matches" },
-    ];
-    expect(renderToolOutput(items)).toBe(
-      dedent(`
-        Find *.ts
+    ],
+    cli: dedent(`
+      Find *.ts
+        a.ts
+        … +5 matches
+    `),
+    chat: dedent(`
+      • Find *.ts
           a.ts
           … +5 matches
-      `),
-    );
+    `),
+  },
+  {
+    name: "skill-activate with name",
+    parts: [{ kind: "tool-header", labelKey: "tool.label.skill", detail: "build" }],
+    cli: "Skill build",
+    chat: "• Skill build",
+  },
+];
+
+describe("tool output TUI — CLI (renderToolOutput)", () => {
+  for (const { name, parts, cli } of CASES) {
+    test(name, () => {
+      expect(renderToolOutput(parts)).toBe(cli);
+    });
+  }
+
+  test("empty content returns empty string", () => {
+    expect(renderToolOutput([])).toBe("");
   });
 
   test("truncates a long body line to the given width, leaving the header intact", () => {
@@ -445,257 +560,11 @@ describe("tool output TUI — CLI (renderToolOutput)", () => {
 });
 
 describe("tool output TUI — chat (Ink rendering)", () => {
-  test("tool-header only", () => {
-    expect(renderChat([{ kind: "tool-header", labelKey: "tool.label.file_read", detail: "a.ts" }])).toBe("• Read a.ts");
-  });
-
-  test("tool-header without detail", () => {
-    expect(renderChat([{ kind: "tool-header", labelKey: "tool.label.git_status" }])).toBe("• Git Status");
-  });
-
-  test("file-header renders label and targets", () => {
-    expect(
-      renderChat([{ kind: "file-header", labelKey: "tool.label.file_read", count: 2, targets: ["a.ts", "b.ts"] }]),
-    ).toBe("• Read 2 files");
-  });
-
-  test("scope-header with summary", () => {
-    const items: ToolOutputPart[] = [
-      {
-        kind: "scope-header",
-        labelKey: "tool.label.file_search",
-        scope: "workspace",
-        patterns: ["needle"],
-        matches: 3,
-      },
-      { kind: "text", text: "3 matches in 2 files" },
-    ];
-    expect(renderChat(items)).toBe(
-      dedent(`
-        • Search needle
-            3 matches in 2 files
-      `),
-    );
-  });
-
-  test("edit-header with diff lines", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "edit-header", labelKey: "tool.label.file_edit", path: "notes.ts", files: 1, added: 1, removed: 1 },
-      { kind: "diff", lineNumber: 9, marker: "context", text: "const x = 1;" },
-      { kind: "diff", lineNumber: 10, marker: "remove", text: "const y = 2;" },
-      { kind: "diff", lineNumber: 10, marker: "add", text: "const y = 3;" },
-    ];
-    expect(renderChat(items)).toBe(
-      dedent(`
-        • Edit notes.ts (+1 -1)
-              9  const x = 1;
-             10 -const y = 2;
-             10 +const y = 3;
-      `),
-    );
-  });
-
-  test("shell-run with stdout", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "echo hello" },
-      { kind: "shell-output", stream: "stdout", text: "hello" },
-      { kind: "shell-output", stream: "stdout", text: "world" },
-    ];
-    expect(renderChat(items)).toBe(
-      dedent(`
-        • Run echo hello
-            hello
-            world
-      `),
-    );
-  });
-
-  test("shell-run with mixed stdout and stderr", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "make" },
-      { kind: "shell-output", stream: "stdout", text: "compiling..." },
-      { kind: "shell-output", stream: "stderr", text: "warning: unused var" },
-      { kind: "shell-output", stream: "stdout", text: "done" },
-    ];
-    expect(renderChat(items)).toBe(
-      dedent(`
-        • Run make
-            compiling...
-            warning: unused var
-            done
-      `),
-    );
-  });
-
-  test("shell-run with truncated output", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "cmd" },
-      { kind: "shell-output", stream: "stdout", text: "line1" },
-      { kind: "shell-output", stream: "stdout", text: "line2" },
-      { kind: "text", text: "⋮ +3 lines" },
-      { kind: "shell-output", stream: "stdout", text: "line6" },
-    ];
-    expect(renderChat(items)).toBe(
-      dedent(`
-        • Run cmd
-            line1
-            line2
-            ⋮ +3 lines
-            line6
-      `),
-    );
-  });
-
-  test("no-output marker", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "cmd" },
-      { kind: "no-output" },
-    ];
-    expect(renderChat(items)).toBe(
-      dedent(`
-        • Run cmd
-            (No output)
-      `),
-    );
-  });
-
-  test("git-status with changes", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_status" },
-      { kind: "text", text: "M src/cli.ts" },
-      { kind: "text", text: "?? src/new.ts" },
-    ];
-    expect(renderChat(items)).toBe(
-      dedent(`
-        • Git Status
-            M src/cli.ts
-            ?? src/new.ts
-      `),
-    );
-  });
-
-  test("git-diff with text body", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_diff", detail: "src/agent.ts" },
-      { kind: "text", text: "+const x = 1;" },
-      { kind: "text", text: "⋮ +5 lines" },
-      { kind: "text", text: "-const y = 2;" },
-    ];
-    expect(renderChat(items)).toBe(
-      dedent(`
-        • Git Diff src/agent.ts
-            +const x = 1;
-            ⋮ +5 lines
-            -const y = 2;
-      `),
-    );
-  });
-
-  test("git-log with commit lines", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_log" },
-      { kind: "text", text: "abc1234 feat: add feature" },
-      { kind: "text", text: "def5678 fix: resolve bug" },
-    ];
-    expect(renderChat(items)).toBe(
-      dedent(`
-        • Git Log
-            abc1234 feat: add feature
-            def5678 fix: resolve bug
-      `),
-    );
-  });
-
-  test("git-show with ref detail", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_show", detail: "abc1234" },
-      { kind: "text", text: "feat: add feature" },
-      { kind: "text", text: "+const x = 1;" },
-    ];
-    expect(renderChat(items)).toBe(
-      dedent(`
-        • Git Show abc1234
-            feat: add feature
-            +const x = 1;
-      `),
-    );
-  });
-
-  test("git-add with file paths", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_add", detail: "3 files" },
-      { kind: "text", text: "src/a.ts" },
-      { kind: "text", text: "src/b.ts" },
-      { kind: "text", text: "src/c.ts" },
-    ];
-    expect(renderChat(items)).toBe(
-      dedent(`
-        • Git Add 3 files
-            src/a.ts
-            src/b.ts
-            src/c.ts
-      `),
-    );
-  });
-
-  test("git-add with truncated file list", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_add", detail: "8 files" },
-      { kind: "text", text: "src/a.ts" },
-      { kind: "text", text: "src/b.ts" },
-      { kind: "truncated", count: 6, unit: "files" },
-    ];
-    expect(renderChat(items)).toBe(
-      dedent(`
-        • Git Add 8 files
-            src/a.ts
-            src/b.ts
-            … +6 files
-      `),
-    );
-  });
-
-  test("git-commit with hash", () => {
-    expect(
-      renderChat([{ kind: "tool-header", labelKey: "tool.label.git_commit", detail: "feat: add feature (abc1234)" }]),
-    ).toBe("• Git Commit feat: add feature (abc1234)");
-  });
-
-  test("git-commit with body lines", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_commit", detail: "feat: add feature (abc1234)" },
-      { kind: "text", text: "Added new auth module" },
-      { kind: "text", text: "Updated config schema" },
-    ];
-    expect(renderChat(items)).toBe(
-      dedent(`
-        • Git Commit feat: add feature (abc1234)
-            Added new auth module
-            Updated config schema
-      `),
-    );
-  });
-
-  test("git-commit with truncated body", () => {
-    const items: ToolOutputPart[] = [
-      { kind: "tool-header", labelKey: "tool.label.git_commit", detail: "refactor: cleanup (def5678)" },
-      { kind: "text", text: "Line 1" },
-      { kind: "text", text: "Line 2" },
-      { kind: "truncated", count: 5, unit: "lines" },
-    ];
-    expect(renderChat(items)).toBe(
-      dedent(`
-        • Git Commit refactor: cleanup (def5678)
-            Line 1
-            Line 2
-            … +5 lines
-      `),
-    );
-  });
-
-  test("skill-activate with name", () => {
-    expect(renderChat([{ kind: "tool-header", labelKey: "tool.label.skill", detail: "build" }])).toBe("• Skill build");
-  });
+  for (const { name, parts, chat } of CASES) {
+    test(name, () => {
+      expect(renderChat(parts)).toBe(chat);
+    });
+  }
 
   test("truncates a long diff line to the terminal width instead of wrapping", () => {
     const items: ToolOutputPart[] = [

--- a/src/tui/test-utils.ts
+++ b/src/tui/test-utils.ts
@@ -1,10 +1,13 @@
-import { createElement as h, type ReactNode } from "react";
+import { createElement as h, type ReactNode, useSyncExternalStore } from "react";
 import { DEFAULT_TERMINAL_WIDTH } from "./constants";
 import { createElement } from "./dom";
 import { setOnCommit } from "./host-config";
 import { renderToString } from "./index";
 import { reconciler } from "./reconciler";
+import { physicalRowCount } from "./render";
 import { stripAnsi } from "./serialize";
+import { ansi } from "./styles";
+import { replayTerminal } from "./vt";
 
 export const trimRightLines = (value: string): string =>
   value
@@ -32,16 +35,12 @@ export function wait(ms = 50): Promise<void> {
 }
 
 /**
- * Render a component into a mocked TTY and return all stdout writes.
- * The setup callback receives an `unmount` function for teardown timing.
+ * Install a mock TTY on `process.stdout` (isTTY + fixed columns/rows) that
+ * captures every write into `writes`. Returns the capture buffer and a
+ * `restore` that puts the real descriptors back.
  */
-export async function renderCapture(
-  setup: (ctx: { unmount: () => void }) => ReactNode,
-  options: { columns?: number; rows?: number } = {},
-): Promise<string[]> {
+function mockTty(columns: number, rows: number): { writes: string[]; restore: () => void } {
   const writes: string[] = [];
-  const columns = options.columns ?? 120;
-  const rows = options.rows ?? 24;
   const saved = {
     write: process.stdout.write,
     isTTY: Object.getOwnPropertyDescriptor(process.stdout, "isTTY"),
@@ -60,6 +59,18 @@ export async function renderCapture(
     for (const key of ["isTTY", "columns", "rows"] as const)
       if (saved[key]) Object.defineProperty(process.stdout, key, saved[key]);
   };
+  return { writes, restore };
+}
+
+/**
+ * Render a component into a mocked TTY and return all stdout writes.
+ * The setup callback receives an `unmount` function for teardown timing.
+ */
+export async function renderCapture(
+  setup: (ctx: { unmount: () => void }) => ReactNode,
+  options: { columns?: number; rows?: number } = {},
+): Promise<string[]> {
+  const { writes, restore } = mockTty(options.columns ?? 120, options.rows ?? 24);
   try {
     const { render } = await import("./render");
     const app = render(setup({ unmount: () => app.unmount() }));
@@ -68,6 +79,155 @@ export async function renderCapture(
     restore();
   }
   return writes;
+}
+
+/** Drop the unmount-cleanup writes (cursor-show onward) so only frames remain. */
+export function frameWrites(writes: string[]): string[] {
+  const cleanup = writes.findIndex((write) => write.includes(ansi.cursorShow));
+  return cleanup >= 0 ? writes.slice(0, cleanup) : writes;
+}
+
+/** Force the reconciler to commit all pending work to the DOM, then drain the
+ *  event loop so any scheduler-deferred commit lands too. */
+async function settleReconciler(): Promise<void> {
+  reconciler.flushSyncWork();
+  reconciler.flushPassiveEffects();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  reconciler.flushSyncWork();
+  reconciler.flushPassiveEffects();
+}
+
+/**
+ * Deterministic frame driver: render each node in `script` as a discrete frame,
+ * forcing a commit between steps via the renderer's `flush()` seam (no throttle
+ * sleeps). Returns the stdout writes captured per frame — `frames[i]` is
+ * everything written while `script[i]` was mounted.
+ *
+ * Frame 0 also carries the mount's setup escapes; subsequent frames carry only
+ * that step's active-region re-render.
+ */
+export async function renderScript(
+  script: ReactNode[],
+  options: { columns?: number; rows?: number } = {},
+): Promise<string[][]> {
+  const { writes, restore } = mockTty(options.columns ?? 120, options.rows ?? 24);
+  let index = 0;
+  const listeners = new Set<() => void>();
+  const store = {
+    get: () => index,
+    subscribe: (listener: () => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    advance: () => {
+      index += 1;
+      for (const listener of listeners) listener();
+    },
+  };
+  function Driver(): ReactNode {
+    const i = useSyncExternalStore(store.subscribe, store.get);
+    return script[i] ?? null;
+  }
+  const frames: string[][] = [];
+  try {
+    const { render } = await import("./render");
+    const app = render(h(Driver));
+    await settleReconciler();
+    app.flush();
+    frames.push(writes.splice(0));
+    for (let i = 1; i < script.length; i++) {
+      store.advance();
+      await settleReconciler();
+      app.flush();
+      frames.push(writes.splice(0));
+    }
+    app.unmount();
+    await app.waitUntilExit();
+  } finally {
+    restore();
+  }
+  return frames;
+}
+
+const CURSOR_ACCOUNTING_VT_ROWS = 4096;
+
+export class CursorAccountingError extends Error {
+  constructor(
+    readonly frame: number,
+    readonly emitted: number,
+    readonly oracleRow: number,
+    readonly renderRow: number,
+  ) {
+    super(
+      `cursor-accounting violation at frame ${frame}\n` +
+        `  emitted cursorUp: ${emitted}\n` +
+        `  VT oracle (real column width): ${oracleRow}\n` +
+        `  render physicalRowCount:       ${renderRow}`,
+    );
+    this.name = "CursorAccountingError";
+  }
+}
+
+/**
+ * Extract one frame's active-region re-render: the `cursorUp(n)` distance it
+ * moves up before erasing, and the live content it then paints. Reads the last
+ * synchronized-output block in the frame (the active render always follows any
+ * static flush within a commit). Returns null when the frame did not re-render
+ * the active region (no synchronized block — an unchanged commit).
+ */
+function parseActiveFrame(writes: string[]): { cursorUp: number; live: string } | null {
+  const joined = writes.join("");
+  const start = joined.lastIndexOf(ansi.syncStart);
+  if (start < 0) return null;
+  const afterStart = start + ansi.syncStart.length;
+  const endIdx = joined.indexOf(ansi.syncEnd, afterStart);
+  const block = endIdx >= 0 ? joined.slice(afterStart, endIdx) : joined.slice(afterStart);
+  // syncWrite appends a trailing `\r` before syncEnd; drop it to recover `normalized`.
+  let rest = block.endsWith("\r") ? block.slice(0, -1) : block;
+  let cursorUp = 0;
+  // eraseSequence is `cursorUp(n)\r eraseDown` (absent/empty when n was 0). Parse it
+  // without a regex control-char literal: match CSI, then digits, then `A\r` + eraseDown.
+  const csi = ansi.cursorUp(1).slice(0, 2); // "ESC["
+  if (rest.startsWith(csi)) {
+    let end = csi.length;
+    for (let ch = rest[end]; ch !== undefined && ch >= "0" && ch <= "9"; ch = rest[end]) end += 1;
+    const suffix = `A\r${ansi.eraseDown}`;
+    if (end > csi.length && rest.slice(end, end + suffix.length) === suffix) {
+      cursorUp = Number.parseInt(rest.slice(csi.length, end), 10);
+      rest = rest.slice(end + suffix.length);
+    }
+  }
+  return { cursorUp, live: rest };
+}
+
+/**
+ * Assert every frame's `cursorUp(n)` equals the physical height of the PRIOR
+ * frame's live region — the invariant a width miscalculation or a foreign write
+ * violates. Cross-checks two independent measures: the width-aware VT (real
+ * column arithmetic) and render's own `physicalRowCount`. A wide-char regression
+ * in the erase math breaks the two apart and is caught here.
+ *
+ * Precondition: no frame overflows into scrollback (the emitted distance then
+ * covers only the bottom slice, not the written content). Drive with a viewport
+ * tall enough to hold the content; scrollback preservation is covered separately
+ * by `assertTranscriptIntegrity`.
+ */
+export function assertCursorAccounting(frames: string[][], columns: number): void {
+  let prevLive: string | null = null;
+  frames.forEach((frame, i) => {
+    const parsed = parseActiveFrame(frame);
+    if (!parsed) return; // unchanged commit — nothing re-rendered this frame
+    if (prevLive === null) {
+      if (parsed.cursorUp !== 0) throw new CursorAccountingError(i, parsed.cursorUp, 0, 0);
+    } else {
+      const oracleRow = replayTerminal([prevLive], CURSOR_ACCOUNTING_VT_ROWS, columns).row;
+      const renderRow = physicalRowCount(prevLive.replace(/\r/g, ""), columns);
+      if (parsed.cursorUp !== oracleRow || parsed.cursorUp !== renderRow) {
+        throw new CursorAccountingError(i, parsed.cursorUp, oracleRow, renderRow);
+      }
+    }
+    prevLive = parsed.live;
+  });
 }
 
 export function renderHook<T>(hookFn: () => T): { result: { current: T }; unmount: () => void } {

--- a/src/tui/test-utils.ts
+++ b/src/tui/test-utils.ts
@@ -54,10 +54,15 @@ function mockTty(columns: number, rows: number): { writes: string[]; restore: ()
     writes.push(data);
     return true;
   }) as typeof process.stdout.write;
+  // render.ts drops synchronized-output markers under TMUX; force them on so the
+  // captured frames are identical whether or not the test host runs inside tmux.
+  const savedTmux = process.env.TMUX;
+  delete process.env.TMUX;
   const restore = () => {
     process.stdout.write = saved.write;
     for (const key of ["isTTY", "columns", "rows"] as const)
       if (saved[key]) Object.defineProperty(process.stdout, key, saved[key]);
+    if (savedTmux !== undefined) process.env.TMUX = savedTmux;
   };
   return { writes, restore };
 }
@@ -87,8 +92,8 @@ export function frameWrites(writes: string[]): string[] {
   return cleanup >= 0 ? writes.slice(0, cleanup) : writes;
 }
 
-/** Force the reconciler to commit all pending work to the DOM, then drain the
- *  event loop so any scheduler-deferred commit lands too. */
+/** The macrotask between the two flushes lets a scheduler-deferred commit land,
+ *  which a single synchronous flush misses on repeated mounts. */
 async function settleReconciler(): Promise<void> {
   reconciler.flushSyncWork();
   reconciler.flushPassiveEffects();
@@ -129,9 +134,10 @@ export async function renderScript(
     return script[i] ?? null;
   }
   const frames: string[][] = [];
+  let app: { flush(): void; unmount(): void; waitUntilExit(): Promise<void> } | null = null;
   try {
     const { render } = await import("./render");
-    const app = render(h(Driver));
+    app = render(h(Driver));
     await settleReconciler();
     app.flush();
     frames.push(writes.splice(0));
@@ -143,7 +149,11 @@ export async function renderScript(
     }
     app.unmount();
     await app.waitUntilExit();
+    app = null;
   } finally {
+    // Unmount on an early throw too, so a failed run can't leave the global
+    // onCommit sink installed for the next test.
+    app?.unmount();
     restore();
   }
   return frames;
@@ -210,17 +220,28 @@ function parseActiveFrame(writes: string[]): { cursorUp: number; live: string } 
  * Precondition: no frame overflows into scrollback (the emitted distance then
  * covers only the bottom slice, not the written content). Drive with a viewport
  * tall enough to hold the content; scrollback preservation is covered separately
- * by `assertTranscriptIntegrity`.
+ * by `assertTranscriptIntegrity`. Pass `rows` to make that precondition
+ * self-checking — an overflowing frame then fails with a clear message instead of
+ * a confusing cursor mismatch.
  */
-export function assertCursorAccounting(frames: string[][], columns: number): void {
+export function assertCursorAccounting(frames: string[][], columns: number, rows?: number): void {
   let prevLive: string | null = null;
   frames.forEach((frame, i) => {
     const parsed = parseActiveFrame(frame);
-    if (!parsed) return; // unchanged commit — nothing re-rendered this frame
+    if (!parsed) return;
     if (prevLive === null) {
       if (parsed.cursorUp !== 0) throw new CursorAccountingError(i, parsed.cursorUp, 0, 0);
     } else {
       const oracleRow = replayTerminal([prevLive], CURSOR_ACCOUNTING_VT_ROWS, columns).row;
+      // A non-overflowing live region spans at most `rows - 1` physical rows, so its
+      // top-row index is at most `rows - 2`. Anything taller scrolled — the invariant
+      // no longer holds and the measurement would be meaningless.
+      if (rows !== undefined && oracleRow >= rows - 1) {
+        throw new Error(
+          `assertCursorAccounting precondition violated at frame ${i}: prior live region spans ` +
+            `${oracleRow + 1} rows, which overflows the ${rows}-row viewport. Use a taller viewport.`,
+        );
+      }
       const renderRow = physicalRowCount(prevLive.replace(/\r/g, ""), columns);
       if (parsed.cursorUp !== oracleRow || parsed.cursorUp !== renderRow) {
         throw new CursorAccountingError(i, parsed.cursorUp, oracleRow, renderRow);

--- a/src/tui/vt.test.tsx
+++ b/src/tui/vt.test.tsx
@@ -2,14 +2,8 @@ import { describe, expect, test } from "bun:test";
 import type React from "react";
 import { useEffect, useState } from "react";
 import { ansi } from "./styles";
-import { renderCapture } from "./test-utils";
+import { frameWrites, renderCapture } from "./test-utils";
 import { assertTranscriptIntegrity, replayTerminal, TranscriptIntegrityError, transcriptLines } from "./vt";
-
-/** Drop the unmount-cleanup writes (cursor-show onward) so only frames remain. */
-function frameWrites(writes: string[]): string[] {
-  const cleanup = writes.findIndex((write) => write.includes(ansi.cursorShow));
-  return cleanup >= 0 ? writes.slice(0, cleanup) : writes;
-}
 
 describe("replayTerminal", () => {
   test("keeps lines that scroll off the top in scrollback", () => {


### PR DESCRIPTION
## Summary

- add a ChatTranscript integrity test asserting no line is lost, duplicated, or spliced across the scrollback boundary
- add a per-frame cursor-accounting invariant that catches wide-char erase regressions
- de-drift the CLI/chat tool-output tests into one shared fixture table, so a missing case is a type error