### PR TITLE
fix(tui): nest chat diffs under sub-headers

### DIFF
--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -71,6 +71,7 @@ function renderToolPart(
   index: number,
   lineNumWidth: number,
   toolContentWidth: number,
+  diffIndent: string,
 ): React.ReactNode {
   if (part.kind === "diff") {
     const num = String(part.lineNumber).padStart(lineNumWidth);
@@ -78,7 +79,7 @@ function renderToolPart(
     const marker = part.marker === "add" ? "+" : part.marker === "remove" ? "-" : " ";
     // Cut the content to the display budget (indent + gutter prefix + 1-col marker) before
     // padding, so the colored bar still fills the width but the line never overflows and wraps.
-    const budget = Math.max(0, toolContentWidth - TOOL_LINE_INDENT - prefix.length - 1);
+    const budget = Math.max(0, toolContentWidth - TOOL_LINE_INDENT - diffIndent.length - prefix.length - 1);
     const content = truncateToWidth(part.text, budget);
     const padWidth = Math.max(0, budget - Bun.stringWidth(content));
     const padded = content + " ".repeat(padWidth);
@@ -87,7 +88,7 @@ function renderToolPart(
       const fg = part.marker === "add" ? palette.diffAddText : palette.diffRemoveText;
       return (
         <Text key={`tool-${index}`}>
-          {"\n  "}
+          {`\n  ${diffIndent}`}
           <Text backgroundColor={bg}>
             <Text color={fg}>
               {prefix}
@@ -100,7 +101,7 @@ function renderToolPart(
     }
     return (
       <Text key={`tool-${index}`}>
-        {"\n  "}
+        {`\n  ${diffIndent}`}
         <Text dimColor>{prefix} </Text>
         <Text color={palette.text}>{content}</Text>
       </Text>
@@ -126,6 +127,7 @@ function renderToolPart(
         </Text>
       );
     }
+    const indent = part.kind === "truncated" ? diffIndent : "";
     const display =
       part.kind === "truncated"
         ? `${"⋮".padStart(lineNumWidth)}  ${text.slice(2)}`
@@ -133,7 +135,7 @@ function renderToolPart(
     return (
       <Text key={`tool-${index}`}>
         {"\n  "}
-        <Text dimColor>{truncateToWidth(` ${display}`, toolContentWidth - TOOL_LINE_INDENT)}</Text>
+        <Text dimColor>{truncateToWidth(`${indent} ${display}`, toolContentWidth - TOOL_LINE_INDENT)}</Text>
       </Text>
     );
   }
@@ -179,10 +181,14 @@ function renderToolOutput(parts: ToolOutputPart[], toolContentWidth: number): Re
     (max, part) => (part.kind === "diff" ? Math.max(max, String(part.lineNumber).length) : max),
     0,
   );
+  // Multi-file edits interleave per-file sub-headers (text) with diff lines; nest the
+  // diffs 2 columns under their sub-header, mirroring the CLI's 2-col nest (tool-output-render
+  // `hasFileHeaders`). The absolute column still differs by chat's leading-space gutter.
+  const diffIndent = lineNumWidth > 0 && rest.some((part) => part.kind === "text") ? "  " : "";
   return (
     <>
       {renderHeader(first)}
-      {rest.map((part, i) => renderToolPart(part, i, lineNumWidth, toolContentWidth))}
+      {rest.map((part, i) => renderToolPart(part, i, lineNumWidth, toolContentWidth, diffIndent))}
     </>
   );
 }

--- a/src/tool-output.tui.test.tsx
+++ b/src/tool-output.tui.test.tsx
@@ -195,11 +195,11 @@ const CASES: ToolCase[] = [
     chat: dedent(`
       • Edit 14 files (+28 -28)
           src/short-id.ts (+1 -1)
-           2 -export function generateId(size = 8): string {
-           2 +export function generateId(size = 8): string {
+             2 -export function generateId(size = 8): string {
+             2 +export function generateId(size = 8): string {
           src/chat-contract.ts (+2 -2)
-           4 -import { generateId } from "./short-id";
-           4 +import { generateId } from "./short-id";
+             4 -import { generateId } from "./short-id";
+             4 +import { generateId } from "./short-id";
     `),
   },
   {
@@ -576,5 +576,22 @@ describe("tool output TUI — chat (Ink rendering)", () => {
     expect(diffLine.endsWith("…")).toBe(true); // content was cut, not wrapped
     expect(Bun.stringWidth(diffLine)).toBeLessThanOrEqual(40);
     expect(out).toContain("• Edit notes.ts (+1 -0)");
+  });
+
+  test("nested multi-file diff lines never exceed the terminal width", () => {
+    // The per-file sub-header adds a 2-col diffIndent; the extra indent must come out of the
+    // content budget so a nested diff/truncated line still fits and never wraps at narrow width.
+    const items: ToolOutputPart[] = [
+      { kind: "edit-header", labelKey: "tool.label.file_edit", path: "9 files", files: 9, added: 9, removed: 9 },
+      { kind: "text", text: "src/some/really/long/module.ts (+1 -1)" },
+      { kind: "diff", lineNumber: 200, marker: "add", text: "X".repeat(80) },
+      { kind: "truncated", count: 3, unit: "lines" },
+      { kind: "diff", lineNumber: 2, marker: "remove", text: "Y".repeat(80) },
+    ];
+    for (const columns of [30, 40, 60, 96]) {
+      for (const line of renderChat(items, columns).split("\n")) {
+        expect(Bun.stringWidth(line)).toBeLessThanOrEqual(columns);
+      }
+    }
   });
 });

--- a/src/tui/test-utils.ts
+++ b/src/tui/test-utils.ts
@@ -92,15 +92,7 @@ export function frameWrites(writes: string[]): string[] {
   return cleanup >= 0 ? writes.slice(0, cleanup) : writes;
 }
 
-/** The macrotask between the two flushes lets a scheduler-deferred commit land,
- *  which a single synchronous flush misses on repeated mounts. */
-async function settleReconciler(): Promise<void> {
-  reconciler.flushSyncWork();
-  reconciler.flushPassiveEffects();
-  await new Promise((resolve) => setTimeout(resolve, 0));
-  reconciler.flushSyncWork();
-  reconciler.flushPassiveEffects();
-}
+const STEP_DRAIN_ATTEMPTS = 200;
 
 /**
  * Deterministic frame driver: render each node in `script` as a discrete frame,
@@ -137,19 +129,31 @@ export async function renderScript(
   let app: { flush(): void; unmount(): void; waitUntilExit(): Promise<void> } | null = null;
   try {
     const { render } = await import("./render");
-    app = render(h(Driver));
-    await settleReconciler();
-    app.flush();
-    frames.push(writes.splice(0));
+    const instance = render(h(Driver));
+    app = instance;
+    // Advance to the next frame by forcing the reconciler to commit and the
+    // renderer to flush, then wait until this step's write actually lands.
+    // React may commit on a microtask/macrotask, and coverage instrumentation
+    // slows that past a single drain — so loop the flush until the frame emits
+    // rather than guessing a fixed delay (the source of prior flakiness).
+    const flushFrame = async (): Promise<string[]> => {
+      const before = writes.length;
+      for (let attempt = 0; attempt < STEP_DRAIN_ATTEMPTS && writes.length === before; attempt++) {
+        reconciler.flushSyncWork();
+        reconciler.flushPassiveEffects();
+        instance.flush();
+        if (writes.length === before) await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      return writes.splice(0);
+    };
+    frames.push(await flushFrame());
     for (let i = 1; i < script.length; i++) {
       store.advance();
-      await settleReconciler();
-      app.flush();
-      frames.push(writes.splice(0));
+      frames.push(await flushFrame());
     }
-    app.unmount();
-    await app.waitUntilExit();
     app = null;
+    instance.unmount();
+    await instance.waitUntilExit();
   } finally {
     // Unmount on an early throw too, so a failed run can't leave the global
     // onCommit sink installed for the next test.


### PR DESCRIPTION
## Summary

- nest chat diff and truncated lines 2 columns under per-file sub-headers in multi-file edits, mirroring the CLI renderer's mechanism
- the extra indent comes out of the content budget, so nested lines still truncate to width — regression test added
- make the renderScript test frame driver deterministic (drain until each frame's write lands), fixing a coverage-only flake in the streaming integrity test