### PR TITLE
feat(trace): count duplicate discovery calls

### DIFF
--- a/src/cli-trace.ts
+++ b/src/cli-trace.ts
@@ -86,6 +86,8 @@ function compactSummary(fields: Record<string, string>): string {
   if (fields.read_calls && fields.read_calls !== "0") breakdown.push(`read=${fields.read_calls}`);
   if (fields.search_calls && fields.search_calls !== "0") breakdown.push(`search=${fields.search_calls}`);
   if (fields.write_calls && fields.write_calls !== "0") breakdown.push(`write=${fields.write_calls}`);
+  if (fields.duplicate_discovery_calls && fields.duplicate_discovery_calls !== "0")
+    breakdown.push(`dup=${fields.duplicate_discovery_calls}`);
   if (breakdown.length > 0) parts[parts.length - 1] += ` (${breakdown.join(" ")})`;
   if (fields.budget_exhausted_count && fields.budget_exhausted_count !== "0")
     parts.push(`budget_exhausted=${fields.budget_exhausted_count}`);

--- a/src/lifecycle-finalize.test.ts
+++ b/src/lifecycle-finalize.test.ts
@@ -166,6 +166,36 @@ describe("phaseFinalize", () => {
     expect(summary?.pre_write_discovery_calls).toBe(2);
   });
 
+  test("counts duplicate discovery calls (repeated tool+args), independent of arg order", () => {
+    const session = createSessionContext("task_dup");
+    session.callLog.push(
+      { toolName: "file-read", args: { path: "a.ts" }, taskId: "task_dup", status: "succeeded" },
+      // Same read again — a duplicate.
+      { toolName: "file-read", args: { path: "a.ts" }, taskId: "task_dup", status: "succeeded" },
+      // Distinct read — not a duplicate.
+      { toolName: "file-read", args: { path: "b.ts" }, taskId: "task_dup", status: "succeeded" },
+      { toolName: "file-search", args: { pattern: "x", path: "src" }, taskId: "task_dup", status: "succeeded" },
+      // Same search, keys in a different order — still a duplicate.
+      { toolName: "file-search", args: { path: "src", pattern: "x" }, taskId: "task_dup", status: "succeeded" },
+      // Recall probes are excluded from discovery, so their repeat does not count.
+      { toolName: "session-search", args: { query: "y" }, taskId: "task_dup", status: "succeeded" },
+      { toolName: "session-search", args: { query: "y" }, taskId: "task_dup", status: "succeeded" },
+    );
+    let summary: Record<string, unknown> | undefined;
+    const ctx = createRunContext({
+      taskId: "task_dup",
+      session,
+      result: { text: "done", toolCalls: [] },
+      debug: (event, fields) => {
+        if (event === "lifecycle.summary") summary = fields;
+      },
+    });
+
+    phaseFinalize(ctx);
+
+    expect(summary?.duplicate_discovery_calls).toBe(2);
+  });
+
   test("lifecycle.summary debug event has all catalog display fields", () => {
     const debugEvents: Array<{ event: string; fields: Record<string, unknown> }> = [];
     const ctx = createRunContext({

--- a/src/lifecycle-finalize.ts
+++ b/src/lifecycle-finalize.ts
@@ -5,6 +5,21 @@ import { promptUsageTotalTokens, type RunContext } from "./lifecycle-contract";
 import { DISCOVERY_TOOL_SET, READ_TOOL_SET, SEARCH_TOOL_SET, WRITE_TOOL_SET } from "./tool-registry";
 import { scopedCallLog } from "./tool-session";
 
+// Stable key for a tool call so identical (tool, args) pairs collapse regardless of arg
+// key order — a repeated discovery call (re-read or re-search) counts as a duplicate.
+function toolCallKey(toolName: string, args: Record<string, unknown>): string {
+  const canonical = (value: unknown): string => {
+    if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+    if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+    const obj = value as Record<string, unknown>;
+    return `{${Object.keys(obj)
+      .sort()
+      .map((k) => `${JSON.stringify(k)}:${canonical(obj[k])}`)
+      .join(",")}}`;
+  };
+  return `${toolName}\u0000${canonical(args)}`;
+}
+
 function signalOutput(ctx: RunContext): string {
   if (ctx.acceptedSignal === "blocked") {
     return ctx.result?.signalReason?.trim() ?? "";
@@ -59,6 +74,18 @@ export function phaseFinalize(ctx: RunContext): ChatResponse {
       ? callLog.slice(0, firstWriteIndex).filter(isCodeDiscovery).length
       : callLog.filter(isCodeDiscovery).length;
 
+  // Discovery calls (reads + searches) repeating an identical earlier (tool, args) within the
+  // task — the field that splits over-exploration into harness-induced re-derivation (high)
+  // vs. genuine breadth (≈0), per the RC5a diagnosis.
+  const seenDiscoveryKeys = new Set<string>();
+  let duplicateDiscoveryCalls = 0;
+  for (const entry of callLog) {
+    if (!isCodeDiscovery(entry)) continue;
+    const key = toolCallKey(entry.toolName, entry.args);
+    if (seenDiscoveryKeys.has(key)) duplicateDiscoveryCalls += 1;
+    else seenDiscoveryKeys.add(key);
+  }
+
   ctx.debug("lifecycle.summary", {
     task_id: ctx.taskId ?? null,
     model: ctx.model,
@@ -75,6 +102,7 @@ export function phaseFinalize(ctx: RunContext): ChatResponse {
     memory_search_calls: memorySearchCalls,
     session_search_calls: sessionSearchCalls,
     pre_write_discovery_calls: preWriteDiscoveryCalls,
+    duplicate_discovery_calls: duplicateDiscoveryCalls,
     lifecycle_signal: ctx.acceptedSignal ?? null,
     budget_blocked: ctx.errorStats["budget-exhausted"] > 0,
     active_skills: ctx.request.activeSkills?.map((s) => s.name) ?? null,

--- a/src/trace-event-catalog.ts
+++ b/src/trace-event-catalog.ts
@@ -153,6 +153,7 @@ export const TRACE_EVENT_CATALOG: Record<TraceEventName, TraceEventDefinition> =
     { key: "memory_search_calls", label: "memory_search" },
     { key: "session_search_calls", label: "session_search" },
     { key: "pre_write_discovery_calls", label: "pre_write_discovery" },
+    { key: "duplicate_discovery_calls", label: "dup_discovery" },
     { key: "budget_exhausted_count", label: "budget_exhausted" },
     "has_error",
   ]),


### PR DESCRIPTION
## Summary

- add `duplicate_discovery_calls` to `lifecycle.summary` — repeated identical (tool, args) discovery calls within a task
- surface it in `acolyte trace` as `dup=N`
