### PR TITLE
fix(lifecycle): stop GPT signal-as-text leak

### DIFF
--- a/src/lifecycle-generate.test.ts
+++ b/src/lifecycle-generate.test.ts
@@ -34,6 +34,7 @@ const noopRateLimiter: RateLimiter = {
 function scriptedModel(
   turns: LanguageModelV4StreamPart[][],
   promptCapture: LanguageModelV4Message[][],
+  argsCapture?: Array<Record<string, unknown>>,
 ): LanguageModelV4 {
   let call = 0;
   return {
@@ -41,8 +42,9 @@ function scriptedModel(
     provider: "test",
     modelId: "test-model",
     supportedUrls: {},
-    async doStream(args: { prompt: LanguageModelV4Message[] }) {
+    async doStream(args: { prompt: LanguageModelV4Message[]; toolChoice?: unknown }) {
       promptCapture.push(args.prompt.map((m) => ({ ...m })));
+      argsCapture?.push(args);
       const parts = turns[call] ?? [];
       call += 1;
       return {
@@ -751,5 +753,82 @@ describe("phaseGenerate", () => {
     expect(ctx.currentError?.message).not.toContain("you called");
     expect(resolveSignal(ctx)).toBeUndefined();
     expect(debugEvents.find((e) => e.event === "lifecycle.signal.rejected")?.fields?.reason).toBe("empty-answer");
+  });
+
+  // Provider-scoped toolChoice: OpenAI forces every step (grammar constraint against the
+  // signal-as-text leak); the empty-answer retry drops back to "auto" (prose before signal);
+  // Anthropic never forces (a prefill would suppress prose / 400 under thinking).
+  async function captureToolChoice(input: {
+    model: string;
+    turns: LanguageModelV4StreamPart[][];
+    callLog?: ToolCallRecord[];
+  }): Promise<Array<{ type: unknown } | undefined>> {
+    const session = createSessionContext(undefined, WRITE_TOOL_SET);
+    const signalTools = createSignalToolkit({
+      workspace: process.cwd(),
+      session,
+      onOutput: () => {},
+      onChecklist: () => {},
+    }) as unknown as Record<string, ToolDefinition>;
+    if (input.callLog) session.callLog.push(...input.callLog);
+    const argsCapture: Array<Record<string, unknown>> = [];
+    const model = scriptedModel(input.turns, [], argsCapture);
+    const agentStream = createAgentStream(model, "sys", signalTools, noopRateLimiter);
+    const ctx = createRunContext({
+      request: { model: input.model, message: "test", history: [] },
+      model: input.model,
+      session,
+      agent: {
+        id: "test-agent",
+        name: "test-agent",
+        instructions: "sys",
+        model: model as unknown as RunContext["agent"]["model"],
+        tools: signalTools,
+        stream: agentStream,
+      },
+    });
+    await phaseGenerate(ctx, { timeoutMs: 5000 });
+    return argsCapture.map((a) => a.toolChoice as { type: unknown } | undefined);
+  }
+
+  const cleanDone: LanguageModelV4StreamPart[] = [
+    { type: "text-start", id: "t" },
+    { type: "text-delta", id: "t", delta: "Done." },
+    { type: "text-end", id: "t" },
+    { type: "tool-call", toolCallId: "tc", toolName: "signal_done", input: "{}" },
+    finishPart("tool-calls"),
+  ];
+
+  test("forces toolChoice on every step for OpenAI models", async () => {
+    const choices = await captureToolChoice({ model: "gpt-5-mini", turns: [cleanDone] });
+    expect(choices[0]).toEqual({ type: "required" });
+  });
+
+  test("keeps toolChoice auto for non-OpenAI models (prose-suppression / thinking-400 guard)", async () => {
+    const choices = await captureToolChoice({ model: "anthropic/claude-opus-4-8", turns: [cleanDone] });
+    expect(choices.every((c) => c?.type === "auto")).toBe(true);
+  });
+
+  test("empty-answer reopen drops back to auto on OpenAI, then default resumes", async () => {
+    const emptyDone: LanguageModelV4StreamPart[] = [
+      { type: "tool-call", toolCallId: "tc_1", toolName: "signal_done", input: "{}" },
+      finishPart("tool-calls"),
+    ];
+    const choices = await captureToolChoice({ model: "gpt-5-mini", turns: [emptyDone, cleanDone] });
+    // Step 1 forced; reopened empty-answer retry uses auto so the model can write prose.
+    expect(choices[0]).toEqual({ type: "required" });
+    expect(choices[1]).toEqual({ type: "auto" });
+  });
+
+  test("missing-signal retry inherits the required default on OpenAI (O7 backstop preserved)", async () => {
+    const bareText: LanguageModelV4StreamPart[] = [
+      { type: "text-start", id: "t1" },
+      { type: "text-delta", id: "t1", delta: "answer, no signal" },
+      { type: "text-end", id: "t1" },
+      finishPart("stop"),
+    ];
+    const choices = await captureToolChoice({ model: "gpt-5-mini", turns: [bareText, cleanDone] });
+    expect(choices[0]).toEqual({ type: "required" });
+    expect(choices[1]).toEqual({ type: "required" });
   });
 });

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -199,9 +199,10 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
     const temperature = reasoning ? undefined : ctx.temperature;
     const streamOutput = await ctx.agent.stream(prompt, {
       // OpenAI-only: forcing tool choice grammar-constrains decoding so GPT can't emit the
-      // signal call as text into the answer. Anthropic/Google map forced choice to a prose-
-      // suppressing prefill (and 400 under extended thinking), so they stay "auto" and lean on
-      // the missing-signal retry as the backstop.
+      // signal call as text. Anthropic/Google map forced choice to a prose-suppressing prefill
+      // (400 under thinking), and gateway-routed GPT classifies as "vercel" (one provider string
+      // for every family, so can't force without breaking gateway Anthropic) — all stay "auto"
+      // and lean on the missing-signal retry as backstop.
       toolChoice: provider === "openai" ? "required" : "auto",
       preCallInputTokenLimit: ctx.policy.contextMaxTokens,
       onBeforeNextCall: (messages) => {
@@ -262,9 +263,8 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
               path: decision.block.path,
               action: "continue",
             });
-            // Empty-answer recovery needs prose before the signal, so the reopened step must
-            // not inherit the OpenAI "required" default (forcing a bare re-signal would just
-            // re-trip the empty-answer gate).
+            // Reopens need room to write prose or run validation before re-signaling, so drop
+            // the OpenAI "required" default to "auto" — forcing a bare re-signal re-trips the gate.
             return { messages: renderFinishPolicyMessages(decision), toolChoice: "auto" };
           case "completion-block":
             ctx.currentError = {

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -198,7 +198,11 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
     const reasoning = ctx.reasoning;
     const temperature = reasoning ? undefined : ctx.temperature;
     const streamOutput = await ctx.agent.stream(prompt, {
-      toolChoice: "auto",
+      // OpenAI-only: forcing tool choice grammar-constrains decoding so GPT can't emit the
+      // signal call as text into the answer. Anthropic/Google map forced choice to a prose-
+      // suppressing prefill (and 400 under extended thinking), so they stay "auto" and lean on
+      // the missing-signal retry as the backstop.
+      toolChoice: provider === "openai" ? "required" : "auto",
       preCallInputTokenLimit: ctx.policy.contextMaxTokens,
       onBeforeNextCall: (messages) => {
         const reminders = collectReminders({
@@ -238,9 +242,10 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
         switch (decision.kind) {
           case "missing-signal-continue":
             ctx.debug("lifecycle.signal.missing", { action: "continue" });
-            // Force the retry step to use toolChoice:"required" so the Responses API
-            // grammar-constrains decoding — prevents GPT-5.x from emitting the call as text.
-            return { messages: renderFinishPolicyMessages(decision), toolChoice: "required" };
+            // No per-step override: the run-level default already forces tool choice on
+            // OpenAI (the grammar constraint) and keeps it "auto" elsewhere (where forcing
+            // suppresses prose and 400s under extended thinking).
+            return renderFinishPolicyMessages(decision);
           case "missing-signal-block":
             ctx.currentError = {
               message: t("lifecycle.completion.missing_signal"),
@@ -257,7 +262,10 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
               path: decision.block.path,
               action: "continue",
             });
-            break;
+            // Empty-answer recovery needs prose before the signal, so the reopened step must
+            // not inherit the OpenAI "required" default (forcing a bare re-signal would just
+            // re-trip the empty-answer gate).
+            return { messages: renderFinishPolicyMessages(decision), toolChoice: "auto" };
           case "completion-block":
             ctx.currentError = {
               message: userFacingCompletionMessage(decision.block),


### PR DESCRIPTION
## Summary

- force `toolChoice: "required"` on OpenAI so GPT can't emit the completion signal as text; other providers stay "auto"
- drop reopened completion-rejection steps back to "auto" so the model can act before re-signaling
- known gap: GPT via the Vercel gateway classifies as "vercel" and still leaks