### PR TITLE
fix(shell): scrub control sequences from output

### DIFF
--- a/src/shell-ops.test.ts
+++ b/src/shell-ops.test.ts
@@ -113,6 +113,10 @@ describe("createControlSequenceScrubber", () => {
     expect(scrubOnce("10%\r20%\r30%")).toBe("10%\n20%\n30%");
   });
 
+  test("aborts a malformed CSI on a control byte instead of swallowing text", () => {
+    expect(scrubOnce("\x1b[1\nkept")).toBe("\nkept");
+  });
+
   test("carries a CSI sequence split across chunks", () => {
     const scrubber = createControlSequenceScrubber();
     expect(scrubber.push("\x1b[")).toBe("");

--- a/src/shell-ops.test.ts
+++ b/src/shell-ops.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { resolve } from "node:path";
 import { ERROR_KINDS, TOOL_ERROR_CODES } from "./error-contract";
-import { parseExitCode, runShellCommand } from "./shell-ops";
+import { createControlSequenceScrubber, parseExitCode, runShellCommand } from "./shell-ops";
+
+function scrubOnce(text: string): string {
+  const scrubber = createControlSequenceScrubber();
+  return scrubber.push(text) + scrubber.flush();
+}
 
 const WORKSPACE = resolve(process.cwd());
 
@@ -78,5 +83,72 @@ describe("parseExitCode", () => {
 
   test("returns undefined for malformed exit code", () => {
     expect(parseExitCode("exit_code=abc")).toBeUndefined();
+  });
+});
+
+describe("createControlSequenceScrubber", () => {
+  test("strips the bun screen-clear sequence", () => {
+    expect(scrubOnce("\x1b[2J\x1b[3J\x1b[Hdone")).toBe("done");
+  });
+
+  test("strips SGR color", () => {
+    expect(scrubOnce("\x1b[32m✓ pass\x1b[39m")).toBe("✓ pass");
+  });
+
+  test("strips OSC clipboard and title sequences", () => {
+    expect(scrubOnce("\x1b]52;c;Zm9v\x07keep")).toBe("keep");
+    expect(scrubOnce("\x1b]0;title\x1b\\keep")).toBe("keep");
+  });
+
+  test("drops lone control chars but keeps tab and newline", () => {
+    expect(scrubOnce("a\x00b\x07c\td\ne")).toBe("abc\td\ne");
+  });
+
+  test("preserves unicode and plain text", () => {
+    expect(scrubOnce("✓ 20 pass — café 日本語")).toBe("✓ 20 pass — café 日本語");
+  });
+
+  test("folds CRLF and lone CR to newlines", () => {
+    expect(scrubOnce("a\r\nb")).toBe("a\nb");
+    expect(scrubOnce("10%\r20%\r30%")).toBe("10%\n20%\n30%");
+  });
+
+  test("carries a CSI sequence split across chunks", () => {
+    const scrubber = createControlSequenceScrubber();
+    expect(scrubber.push("\x1b[")).toBe("");
+    expect(scrubber.push("2Jhi")).toBe("hi");
+  });
+
+  test("carries an OSC sequence split across chunks", () => {
+    const scrubber = createControlSequenceScrubber();
+    expect(scrubber.push("\x1b]0;ti")).toBe("");
+    expect(scrubber.push("tle\x07x")).toBe("x");
+  });
+
+  test("carries a trailing CR across chunks and folds a following LF", () => {
+    const scrubber = createControlSequenceScrubber();
+    expect(scrubber.push("x\r")).toBe("x");
+    expect(scrubber.push("\ny")).toBe("\ny");
+  });
+
+  test("flushes a carried CR as newline and drops an incomplete escape", () => {
+    const withCr = createControlSequenceScrubber();
+    expect(withCr.push("x\r")).toBe("x");
+    expect(withCr.flush()).toBe("\n");
+    const withEsc = createControlSequenceScrubber();
+    expect(withEsc.push("a\x1b[")).toBe("a");
+    expect(withEsc.flush()).toBe("");
+  });
+});
+
+describe("runShellCommand output scrubbing", () => {
+  test("strips control sequences from captured stdout", async () => {
+    const result = await runShellCommand(WORKSPACE, {
+      cmd: "bun",
+      args: ["-e", "process.stdout.write('\\u001b[2Jclean output')"],
+    });
+    expect(result).toContain("clean output");
+    expect(result).not.toContain("[2J");
+    expect(result).not.toContain("\x1b");
   });
 });

--- a/src/shell-ops.test.ts
+++ b/src/shell-ops.test.ts
@@ -117,6 +117,16 @@ describe("createControlSequenceScrubber", () => {
     expect(scrubOnce("\x1b[1\nkept")).toBe("\nkept");
   });
 
+  test("aborts a malformed CSI on an out-of-range byte", () => {
+    expect(scrubOnce("\x1b[1日done")).toBe("日done");
+  });
+
+  test("carries an OSC whose ST terminator is split across chunks", () => {
+    const scrubber = createControlSequenceScrubber();
+    expect(scrubber.push("\x1b]0;title\x1b")).toBe("");
+    expect(scrubber.push("\\rest")).toBe("rest");
+  });
+
   test("carries a CSI sequence split across chunks", () => {
     const scrubber = createControlSequenceScrubber();
     expect(scrubber.push("\x1b[")).toBe("");

--- a/src/shell-ops.ts
+++ b/src/shell-ops.ts
@@ -120,6 +120,102 @@ function createRestrictedEnv(): Record<string, string> {
   return env;
 }
 
+function isStrippableControlChar(code: number): boolean {
+  // Keep LF and TAB; drop the other C0 controls, DEL, and C1 (0x80-0x9f).
+  if (code === 0x0a || code === 0x09) return false;
+  if (code < 0x20) return true;
+  if (code === 0x7f) return true;
+  return code >= 0x80 && code <= 0x9f;
+}
+
+// Index past a complete ESC sequence starting at `i` (input[i] === ESC), or -1 if it runs to
+// the end of the buffer unterminated (so the caller carries it into the next chunk).
+function skipEscape(input: string, i: number): number {
+  const next = input[i + 1];
+  if (next === undefined) return -1;
+  if (next === "[") {
+    // CSI: parameter bytes then a final byte 0x40-0x7e.
+    for (let j = i + 2; j < input.length; j++) {
+      const code = input.charCodeAt(j);
+      if (code >= 0x40 && code <= 0x7e) return j + 1;
+    }
+    return -1;
+  }
+  if (next === "]" || next === "P" || next === "_" || next === "^" || next === "X") {
+    // OSC / DCS / APC / PM / SOS: string terminated by BEL or ST (ESC \).
+    for (let j = i + 2; j < input.length; j++) {
+      if (input[j] === "\x07") return j + 1;
+      if (input[j] === "\x1b") {
+        if (input[j + 1] === undefined) return -1;
+        if (input[j + 1] === "\\") return j + 2;
+      }
+    }
+    return -1;
+  }
+  if (next === "(" || next === ")" || next === "*" || next === "+") {
+    // Charset designator: ESC ( <one byte>.
+    return input[i + 2] === undefined ? -1 : i + 3;
+  }
+  return i + 2; // Other single-byte escapes (ESC 7, ESC M, ...).
+}
+
+// Subprocess stdout is arbitrary bytes — build/test tools emit VT control sequences (screen
+// clears, cursor moves, OSC title/hyperlink/clipboard, color). Those bytes are data in
+// Acolyte's transcript, not commands: left raw they wipe the screen in run mode (`ui.ts`
+// writes straight to the TTY) and pollute the model-facing result and the session record.
+// Scrub at capture so all three sinks are clean. Stateful because a CSI/OSC sequence or a CR
+// can straddle a chunk boundary — the unresolved tail is carried into the next push.
+export function createControlSequenceScrubber(): { push(text: string): string; flush(): string } {
+  let carry = "";
+  const push = (text: string): string => {
+    const input = carry + text;
+    carry = "";
+    let out = "";
+    let i = 0;
+    while (i < input.length) {
+      const code = input.charCodeAt(i);
+      if (code === 0x1b) {
+        const end = skipEscape(input, i);
+        if (end === -1) {
+          carry = input.slice(i);
+          return out;
+        }
+        i = end;
+        continue;
+      }
+      if (code === 0x0d) {
+        // Fold CRLF and lone CR to LF so progress-bar rewrites become separate lines.
+        if (i === input.length - 1) {
+          carry = "\r";
+          return out;
+        }
+        if (input[i + 1] === "\n") {
+          i += 1;
+          continue;
+        }
+        out += "\n";
+        i += 1;
+        continue;
+      }
+      if (isStrippableControlChar(code)) {
+        i += 1;
+        continue;
+      }
+      out += input[i];
+      i += 1;
+    }
+    return out;
+  };
+  const flush = (): string => {
+    // A carried CR at EOF becomes a final newline; a carried incomplete escape sequence is
+    // dropped — it was a control sequence, never printable content.
+    const rest = carry === "\r" ? "\n" : "";
+    carry = "";
+    return rest;
+  };
+  return { push, flush };
+}
+
 async function readStreamText(
   stream: ReadableStream<Uint8Array> | null | undefined,
   streamName: "stdout" | "stderr",
@@ -129,25 +225,27 @@ async function readStreamText(
   if (!stream) return "";
   const reader = stream.getReader();
   const decoder = new TextDecoder();
+  const scrubber = createControlSequenceScrubber();
   let combined = "";
   const onAbort = (): void => {
     reader.cancel().catch(() => {});
   };
   signal?.addEventListener("abort", onAbort, { once: true });
+  const emit = (text: string): void => {
+    if (!text) return;
+    combined += text;
+    onChunk?.({ stream: streamName, text });
+  };
   try {
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
       const text = decoder.decode(value, { stream: true });
       if (!text) continue;
-      combined += text;
-      onChunk?.({ stream: streamName, text });
+      emit(scrubber.push(text));
     }
-    const tail = decoder.decode();
-    if (tail) {
-      combined += tail;
-      onChunk?.({ stream: streamName, text: tail });
-    }
+    emit(scrubber.push(decoder.decode()));
+    emit(scrubber.flush());
   } catch {
     // Stream cancelled by abort signal — return what we have.
   } finally {

--- a/src/shell-ops.ts
+++ b/src/shell-ops.ts
@@ -134,13 +134,13 @@ function skipEscape(input: string, i: number): number {
   const next = input[i + 1];
   if (next === undefined) return -1;
   if (next === "[") {
-    // CSI: parameter/intermediate bytes then a final byte 0x40-0x7e. A C0 control can't appear
-    // inside a valid CSI, so treat one as an aborted/truncated sequence and hand the byte back
-    // to the scanner rather than swallowing it and the text after it.
+    // CSI: parameter/intermediate bytes (0x20-0x3f) then a final byte (0x40-0x7e). Any byte
+    // outside 0x20-0x7e can't appear in a valid CSI, so treat it as an aborted/truncated
+    // sequence and hand it back to the scanner rather than swallowing it and the text after it.
     for (let j = i + 2; j < input.length; j++) {
       const code = input.charCodeAt(j);
-      if (code < 0x20) return j;
-      if (code >= 0x40 && code <= 0x7e) return j + 1;
+      if (code < 0x20 || code > 0x7e) return j;
+      if (code >= 0x40) return j + 1;
     }
     return -1;
   }

--- a/src/shell-ops.ts
+++ b/src/shell-ops.ts
@@ -134,9 +134,12 @@ function skipEscape(input: string, i: number): number {
   const next = input[i + 1];
   if (next === undefined) return -1;
   if (next === "[") {
-    // CSI: parameter bytes then a final byte 0x40-0x7e.
+    // CSI: parameter/intermediate bytes then a final byte 0x40-0x7e. A C0 control can't appear
+    // inside a valid CSI, so treat one as an aborted/truncated sequence and hand the byte back
+    // to the scanner rather than swallowing it and the text after it.
     for (let j = i + 2; j < input.length; j++) {
       const code = input.charCodeAt(j);
+      if (code < 0x20) return j;
       if (code >= 0x40 && code <= 0x7e) return j + 1;
     }
     return -1;

--- a/src/tui/serialize.test.tsx
+++ b/src/tui/serialize.test.tsx
@@ -194,12 +194,13 @@ describe("serialize", () => {
   });
 
   describe("text sanitization", () => {
-    test("strips ESC byte from escape sequences", () => {
-      expect(renderPlain(<Text>{"\x1b[2Jhello"}</Text>)).toBe("[2Jhello");
+    test("strips whole CSI escape sequences", () => {
+      expect(renderPlain(<Text>{"\x1b[2J\x1b[3J\x1b[Hhello"}</Text>)).toBe("hello");
+      expect(renderPlain(<Text>{"\x1b[32mgreen\x1b[39m"}</Text>)).toBe("green");
     });
 
-    test("strips ESC byte from OSC sequences", () => {
-      expect(renderPlain(<Text>{"\x1b]0;evil title\x07world"}</Text>)).toBe("]0;evil titleworld");
+    test("strips whole OSC sequences", () => {
+      expect(renderPlain(<Text>{"\x1b]0;evil title\x07world"}</Text>)).toBe("world");
     });
 
     test("preserves newlines and tabs", () => {

--- a/src/tui/serialize.ts
+++ b/src/tui/serialize.ts
@@ -10,14 +10,27 @@ interface StyleStack {
   inverse?: boolean;
 }
 
-/** Strip C0 control chars and ESC from text to prevent terminal escape injection. */
+/**
+ * Strip control sequences from foreign text to prevent terminal escape injection — the
+ * renderer's last-line backstop for any content it doesn't own (assistant text, web fetches,
+ * tool output the capture layer missed). Skips whole ESC sequences (not just the ESC byte, or
+ * a stray `[2J` body renders) and drops C0 controls except LF and TAB.
+ */
 function sanitizeText(text: string): string {
   let out = "";
-  for (let i = 0; i < text.length; i++) {
+  let i = 0;
+  while (i < text.length) {
     const code = text.charCodeAt(i);
-    if (code === 0x1b) continue;
-    if (code < 0x20 && code !== 0x0a && code !== 0x09) continue;
+    if (code === 0x1b) {
+      i = skipEscapeSequence(text, i + 1);
+      continue;
+    }
+    if (code < 0x20 && code !== 0x0a && code !== 0x09) {
+      i += 1;
+      continue;
+    }
     out += text[i];
+    i += 1;
   }
   return out;
 }


### PR DESCRIPTION
## Summary

- scrub VT control sequences from captured subprocess output — raw, they wiped the screen in run mode and leaked into model input and the session record
- backstop: drop whole escape sequences in the renderer, not just the ESC byte