### PR TITLE
test(tool-utils): isolate git config in int tests

### DIFF
--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Bootstrap a fresh Acolyte worktree so an agent (or you) can build and run
+# immediately instead of hitting a missing-node_modules or missing-.env wall.
+# Invoked by `wt` on worktree creation; safe to run by hand from any worktree.
+# Idempotent. Steps are independent — one failing does not block the others.
+set -uo pipefail
+
+# Worktree root is this script's parent dir's parent (scripts/..).
+root=$(cd "$(dirname "$0")/.." && pwd)
+
+step() { printf '\n── %s\n' "$*"; }
+rc=0
+
+step "install — bun install"
+if ! ( cd "$root" && bun install --frozen-lockfile ); then
+  echo "worktree-setup: bun install failed" >&2
+  rc=1
+fi
+
+# .env is gitignored, so a fresh worktree has none — link the primary checkout's so
+# serve/dogfood work without copying secrets around. Non-fatal if the primary has none.
+step "env — link .env from the primary checkout"
+primary=$(cd "$root" && git worktree list --porcelain | sed -n '1s/^worktree //p')
+if [ -n "${primary:-}" ] && [ "$primary" != "$root" ] && [ -f "$primary/.env" ] && [ ! -e "$root/.env" ]; then
+  ln -s "$primary/.env" "$root/.env" && echo "linked .env -> $primary/.env"
+elif [ -e "$root/.env" ]; then
+  echo ".env already present"
+else
+  echo "no primary .env to link (skipping)"
+fi
+
+if [ "$rc" -eq 0 ]; then
+  echo "worktree-setup: done"
+else
+  echo "worktree-setup: finished with errors" >&2
+fi
+exit "$rc"

--- a/src/git-ops.ts
+++ b/src/git-ops.ts
@@ -18,14 +18,18 @@ export async function gitDiff(workspace: string, pathInput?: string, contextLine
   return stdout.trim();
 }
 
-export async function gitLog(workspace: string, options?: { path?: string; limit?: number }): Promise<string> {
+export async function gitLog(
+  workspace: string,
+  options?: { path?: string; limit?: number },
+  envOverride?: Record<string, string>,
+): Promise<string> {
   const limit = Math.max(1, Math.min(50, options?.limit ?? 10));
   const args = ["git", "log", "--oneline", "--decorate", `-n`, String(limit)];
   if (options?.path) {
     ensurePathWithinSandbox(options.path, workspace);
     args.push("--", options.path);
   }
-  const { code, stdout, stderr } = await runCommand(args, workspace);
+  const { code, stdout, stderr } = await runCommand(args, workspace, envOverride);
   if (code !== 0) throw new Error(stderr.trim() || "git log failed");
   return stdout.trim();
 }
@@ -33,6 +37,7 @@ export async function gitLog(workspace: string, options?: { path?: string; limit
 export async function gitShow(
   workspace: string,
   options?: { ref?: string; path?: string; contextLines?: number },
+  envOverride?: Record<string, string>,
 ): Promise<string> {
   const contextLines = Math.max(0, Math.min(20, options?.contextLines ?? 3));
   const ref = options?.ref?.trim() ? options.ref.trim() : "HEAD";
@@ -41,7 +46,7 @@ export async function gitShow(
     ensurePathWithinSandbox(options.path, workspace);
     args.push("--", options.path);
   }
-  const { code, stdout, stderr } = await runCommand(args, workspace);
+  const { code, stdout, stderr } = await runCommand(args, workspace, envOverride);
   if (code !== 0) throw new Error(stderr.trim() || "git show failed");
   return stdout.trim();
 }

--- a/src/tool-utils.int.test.ts
+++ b/src/tool-utils.int.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { mkdir, realpath, rm, writeFile } from "node:fs/promises";
+import { devNull } from "node:os";
 import { join } from "node:path";
 import { gitLog, gitShow } from "./git-ops";
 import { tempDir, testUuid } from "./test-utils";
@@ -13,8 +14,14 @@ afterAll(async () => {
   await Promise.all(tempDirs.map(async (d) => rm(d, { recursive: true, force: true })));
 });
 
+// Point global and system git config at nothing so these tests never inherit the developer's
+// ~/.gitconfig. Commit signing in particular needs an SSH/GPG agent the sandboxed tool shell
+// can't reach (SSH_AUTH_SOCK is stripped), so an inherited `commit.gpgsign` made the tests fail
+// wherever signing was on — the same failure the agent hits running verify in-app.
+const ISOLATED_GIT_CONFIG = { GIT_CONFIG_GLOBAL: devNull, GIT_CONFIG_SYSTEM: devNull };
+
 async function runGit(dirPath: string, args: string[]): Promise<string> {
-  const { code, stdout, stderr } = await runCommand(["git", ...args], dirPath);
+  const { code, stdout, stderr } = await runCommand(["git", ...args], dirPath, ISOLATED_GIT_CONFIG);
   if (code !== 0) throw new Error(stderr.trim() || stdout.trim() || `git ${args.join(" ")} failed`);
   return stdout.trim();
 }
@@ -40,7 +47,7 @@ describe("gitLog", () => {
     await writeFile(join(dirPath, "b.txt"), "b\n", "utf8");
     await runGit(dirPath, ["add", "b.txt"]);
     await runGit(dirPath, ["commit", "-m", "second"]);
-    const log = await gitLog(dirPath, { limit: 2 });
+    const log = await gitLog(dirPath, { limit: 2 }, ISOLATED_GIT_CONFIG);
     const lines = log.split("\n").filter((line) => line.trim().length > 0);
     expect(lines.length).toBe(2);
     expect(lines[0]).toContain("second");
@@ -57,7 +64,7 @@ describe("gitShow", () => {
     await writeFile(join(dirPath, "a.txt"), "a changed\n", "utf8");
     await runGit(dirPath, ["add", "a.txt"]);
     await runGit(dirPath, ["commit", "-m", "second"]);
-    const output = await gitShow(dirPath, { ref: "HEAD", contextLines: 0 });
+    const output = await gitShow(dirPath, { ref: "HEAD", contextLines: 0 }, ISOLATED_GIT_CONFIG);
     expect(output).toContain("second");
     expect(output).toContain("diff --git a/a.txt b/a.txt");
     expect(output).toContain("+a changed");

--- a/src/tool-utils.ts
+++ b/src/tool-utils.ts
@@ -24,9 +24,11 @@ const GIT_ENV_KEYS = [
 export async function runCommand(
   cmd: string[],
   workspace: string,
+  envOverride?: Record<string, string>,
 ): Promise<{ code: number; stdout: string; stderr: string }> {
   const env = { ...process.env };
   for (const key of GIT_ENV_KEYS) delete env[key];
+  if (envOverride) Object.assign(env, envOverride);
   const proc = Bun.spawn({
     cmd,
     cwd: workspace,


### PR DESCRIPTION
## Summary

Isolate git config in the git integration tests so they inherit no global/system config — the dev's SSH commit-signing can't reach an agent in Acolyte's sandboxed tool shell, which was failing `bun run verify` in-app.