### PR TITLE
fix(render): stop duplicating frozen scrollback

### DIFF
--- a/src/chat-transcript.integrity.test.tsx
+++ b/src/chat-transcript.integrity.test.tsx
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import type React from "react";
 import { type ChatRow, createRow } from "./chat-contract";
-import { ChatTranscript } from "./chat-transcript";
+import { ChatTranscript, ChatTranscriptRow } from "./chat-transcript";
+import { Box, Static, Text } from "./tui";
 import { assertCursorAccounting, frameWrites, renderScript } from "./tui/test-utils";
 import { assertTranscriptIntegrity, replayTerminal, transcriptLines } from "./tui/vt";
 
@@ -61,6 +62,34 @@ describe("ChatTranscript transcript integrity", () => {
     const vt = replayTerminal(frameWrites(frames.flat()), 6, COLUMNS);
     // Every line the tall oracle shows survives exactly once, in order, across the
     // scrollback boundary — no drop, duplicate, or column-splice.
+    assertTranscriptIntegrity(vt, expected);
+  });
+
+  test("promoting an overflowed turn to <Static> duplicates nothing", async () => {
+    // Mirror chat-app's split: completed rows live in <Static> (write-once
+    // scrollback), the in-progress turn re-renders live via ChatTranscript. The
+    // duplication bug: the turn overflows into scrollback while active, then
+    // promotes to <Static> — the static flush re-emits its already-frozen top.
+    const contentWidth = Math.max(24, COLUMNS - 2);
+    const chatLike = (promoted: ChatRow[], active: ChatRow[]): React.JSX.Element => (
+      <Box flexDirection="column">
+        <Static items={promoted}>
+          {(item: ChatRow) => (
+            <Box key={item.id} flexDirection="column">
+              <Text> </Text>
+              <ChatTranscriptRow row={item} contentWidth={contentWidth} toolContentWidth={contentWidth} />
+            </Box>
+          )}
+        </Static>
+        <ChatTranscript rows={active} pendingFrame={0} />
+      </Box>
+    );
+    // Ground truth: the fully-promoted turn rendered once in a tall viewport.
+    const oracleFrames = await renderScript([chatLike(ROWS, [])], { columns: COLUMNS, rows: 200 });
+    const expected = transcriptLines(replayTerminal(frameWrites(oracleFrames.flat()), 200, COLUMNS));
+    // Live turn overflows a short viewport, then promotes to <Static>.
+    const frames = await renderScript([chatLike([], ROWS), chatLike(ROWS, [])], { columns: COLUMNS, rows: 6 });
+    const vt = replayTerminal(frameWrites(frames.flat()), 6, COLUMNS);
     assertTranscriptIntegrity(vt, expected);
   });
 

--- a/src/tui/render.test.tsx
+++ b/src/tui/render.test.tsx
@@ -39,6 +39,43 @@ async function drainFrame(flush: () => void, writes: string[]): Promise<void> {
   }
 }
 
+/** The cursorUp distances (`ESC[nA`) emitted across a set of writes. */
+function cursorUpCounts(writes: string[]): number[] {
+  const counts: number[] = [];
+  const joined = writes.join("");
+  // fromCharCode(27) is ESC — keeps the control char out of a regex literal (lint).
+  const re = new RegExp(`${String.fromCharCode(27)}\\[(\\d+)A`, "g");
+  let m: RegExpExecArray | null = re.exec(joined);
+  while (m !== null) {
+    counts.push(Number(m[1]));
+    m = re.exec(joined);
+  }
+  return counts;
+}
+
+/** Render `node` at `from` dimensions, commit, then resize to `to` and let the
+ *  debounce fire. Returns the writes belonging to the resize repaint only. */
+async function captureResize(
+  node: React.ReactNode,
+  from: { columns: number; rows: number },
+  to: { columns: number; rows: number },
+): Promise<string[]> {
+  let splitIdx = 0;
+  const all = await withMockedStdout(async (writes) => {
+    const { render } = await import("./render");
+    const app = render(node);
+    await drainFrame(() => app.flush(), writes); // initial frame at `from`
+    splitIdx = writes.length;
+    Object.defineProperty(process.stdout, "columns", { value: to.columns, configurable: true });
+    Object.defineProperty(process.stdout, "rows", { value: to.rows, configurable: true });
+    process.stdout.emit("resize");
+    await new Promise((resolve) => setTimeout(resolve, 40)); // > 16ms debounce
+    app.unmount();
+    await app.waitUntilExit();
+  }, from);
+  return frameWrites(all.slice(splitIdx));
+}
+
 function withMockedStdout(
   fn: (writes: string[]) => void | Promise<void>,
   options: { columns?: number; rows?: number } = {},
@@ -343,12 +380,10 @@ describe("render", () => {
     const LINES = ["L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8"];
     const lineNodes = LINES.map((line) => <tui-text key={line}>{line}</tui-text>);
     const script = [
-      // Live turn overflows: top rows freeze into scrollback.
       <tui-box key="active" flexDirection="column">
         {lineNodes}
         <tui-text>input</tui-text>
       </tui-box>,
-      // Turn completes: same rows promote into <tui-static>.
       <tui-box key="promoted" flexDirection="column">
         <tui-static>{lineNodes}</tui-static>
         <tui-text>input</tui-text>
@@ -397,6 +432,94 @@ describe("render", () => {
     } finally {
       stdin.restore();
     }
+  });
+
+  test("width resize skips the erase and does not re-emit frozen scrollback", async () => {
+    // A width change may reflow the tail, so the stored erase count is unsafe.
+    const LINES = ["L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8"];
+    const resize = await captureResize(
+      <tui-box flexDirection="column">
+        {LINES.map((line) => (
+          <tui-text key={line}>{line}</tui-text>
+        ))}
+        <tui-text>input</tui-text>
+      </tui-box>,
+      { columns: 20, rows: 6 },
+      { columns: 30, rows: 6 },
+    );
+    const joined = resize.join("");
+    expect(cursorUpCounts(resize)).toEqual([]);
+    expect(joined).not.toContain(ansi.eraseDown);
+    expect(joined).not.toContain("L1"); // L1 is the frozen top — must not reappear
+  });
+
+  test("height-only resize still erases the live tail", async () => {
+    // Width unchanged → no reflow → the stored erase count stays valid.
+    const resize = await captureResize(
+      <tui-box flexDirection="column">
+        <tui-text>alpha</tui-text>
+        <tui-text>beta</tui-text>
+      </tui-box>,
+      { columns: 20, rows: 10 },
+      { columns: 20, rows: 8 },
+    );
+    expect(cursorUpCounts(resize).length).toBeGreaterThan(0);
+    expect(resize.join("")).toContain(ansi.eraseDown);
+  });
+
+  test("height-shrink resize clamps the erase to the viewport, keeping frozen", async () => {
+    const LINES = ["L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8"];
+    const resize = await captureResize(
+      <tui-box flexDirection="column">
+        {LINES.map((line) => (
+          <tui-text key={line}>{line}</tui-text>
+        ))}
+        <tui-text>input</tui-text>
+      </tui-box>,
+      { columns: 20, rows: 6 },
+      { columns: 20, rows: 4 },
+    );
+    // Erase distance can never exceed the new viewport's top row (rows - 1 = 3),
+    // else cursor-up reaches through the top into frozen history.
+    expect(cursorUpCounts(resize).every((n) => n <= 3)).toBe(true);
+    expect(resize.join("")).not.toContain("L1"); // L1 is the frozen top — must not reappear
+  });
+
+  test("width change before the resize debounce skips the erase (loss guard)", async () => {
+    // A streaming commit can land after stdout.columns changed but before the
+    // 16ms resize debounce fires. The geometry guard lives in commitRender, so
+    // even this state-driven commit must skip the now-invalid erase.
+    const setText: { current: (value: string) => void } = { current: () => {} };
+    await withMockedStdout(
+      async (writes) => {
+        const { render } = await import("./render");
+        function App(): React.JSX.Element {
+          const [text, setTextState] = useState("one");
+          setText.current = setTextState;
+          // Multi-line so lastActiveLineCount > 0 — without the guard the "two"
+          // commit would erase (cursorUp), which is exactly what must be skipped.
+          return (
+            <tui-box flexDirection="column">
+              <tui-text>alpha</tui-text>
+              <tui-text>beta</tui-text>
+              <tui-text>{text}</tui-text>
+            </tui-box>
+          );
+        }
+        const app = render(<App />);
+        await drainFrame(() => app.flush(), writes);
+        const before = writes.length;
+        Object.defineProperty(process.stdout, "columns", { value: 40, configurable: true });
+        setText.current("two"); // drives a commit directly, not via the resize debounce
+        await drainFrame(() => app.flush(), writes);
+        const frame = writes.slice(before);
+        expect(frame.join("")).toContain("two");
+        expect(cursorUpCounts(frame)).toEqual([]);
+        app.unmount();
+        await app.waitUntilExit();
+      },
+      { columns: 20, rows: 6 },
+    );
   });
 
   test("overflow erase and repaint are atomic within one syncWrite", async () => {
@@ -637,42 +760,6 @@ describe("render", () => {
     const joined = visible.join("\n");
     expect(joined).toContain("B".repeat(20));
     expect(joined).not.toContain("A".repeat(20));
-  });
-
-  test("resize resets lastActiveLineCount so post-resize render does not use stale erase geometry", async () => {
-    const writes = await withMockedStdout(
-      async () => {
-        const { render } = await import("./render");
-
-        function App(): React.JSX.Element {
-          return (
-            <tui-box flexDirection="column">
-              <tui-text>resize line 1</tui-text>
-              <tui-text>resize line 2</tui-text>
-              <tui-text>resize line 3</tui-text>
-            </tui-box>
-          );
-        }
-
-        const app = render(<App />);
-        // Let initial render settle — lastActiveLineCount is now > 0.
-        await new Promise((r) => setTimeout(r, 50));
-        process.stdout.emit("resize");
-        // Wait for 16ms debounce + throttle window.
-        await new Promise((r) => setTimeout(r, 80));
-        app.unmount();
-      },
-      { columns: 80, rows: 24 },
-    );
-
-    const frameWrites = extractFrameWrites(writes);
-    const contentWrites = frameWrites.filter((w) => w.includes("resize line 1"));
-    // Initial render + post-resize render.
-    expect(contentWrites.length).toBeGreaterThanOrEqual(2);
-    // Post-resize: lastActiveLineCount was reset to 0, so eraseSequence() returns "".
-    // The post-resize write must not contain a cursor-up erase for the old row count.
-    const postResizeWrite = contentWrites[contentWrites.length - 1] ?? "";
-    expect(postResizeWrite).not.toContain(ansi.cursorUp(2));
   });
 
   test("overflow after static flush is tracked so re-render does not re-emit frozen overflow lines", async () => {

--- a/src/tui/render.test.tsx
+++ b/src/tui/render.test.tsx
@@ -3,7 +3,7 @@ import type React from "react";
 import { createElement as h, useEffect, useState } from "react";
 import { physicalRowCount } from "./render";
 import { ansi } from "./styles";
-import { renderCapture } from "./test-utils";
+import { frameWrites, renderCapture, renderScript } from "./test-utils";
 import { replayTerminal } from "./vt";
 
 function withMockedStdout(
@@ -298,6 +298,36 @@ describe("render", () => {
     // HEADER must appear exactly once — never duplicated by forceRedraw.
     const headerCount = allOutput.split("HEADER").length - 1;
     expect(headerCount).toBe(1);
+  });
+
+  test("promoting an overflowed turn to static does not duplicate scrollback", async () => {
+    // A chat turn whose active region overflows the viewport (top rows freeze into
+    // scrollback), then completes and moves into <tui-static> — the exact promotion
+    // path. The static flush erases only the live tail, so any frozen line it
+    // re-emits would duplicate: it already scrolled off, un-erasable. Driven on the
+    // deterministic flush() seam (renderScript) — real timers race the throttle and
+    // can skip the overflow frame, silently vacating the pin.
+    const LINES = ["L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8"];
+    const lineNodes = LINES.map((line) => <tui-text key={line}>{line}</tui-text>);
+    const script = [
+      // Live turn overflows: top rows freeze into scrollback.
+      <tui-box key="active" flexDirection="column">
+        {lineNodes}
+        <tui-text>input</tui-text>
+      </tui-box>,
+      // Turn completes: same rows promote into <tui-static>.
+      <tui-box key="promoted" flexDirection="column">
+        <tui-static>{lineNodes}</tui-static>
+        <tui-text>input</tui-text>
+      </tui-box>,
+    ];
+    const frames = await renderScript(script, { columns: 20, rows: 6 });
+    const vt = replayTerminal(frameWrites(frames.flat()), 6, 20);
+    const transcript = [...vt.scrollback, ...vt.screen];
+    for (const line of LINES) {
+      const count = transcript.filter((row) => row.includes(line)).length;
+      expect(count).toBe(1);
+    }
   });
 
   test("overflow erase and repaint are atomic within one syncWrite", async () => {

--- a/src/tui/render.test.tsx
+++ b/src/tui/render.test.tsx
@@ -1,10 +1,43 @@
 import { describe, expect, test } from "bun:test";
 import type React from "react";
 import { createElement as h, useEffect, useState } from "react";
+import { reconciler } from "./reconciler";
 import { physicalRowCount } from "./render";
 import { ansi } from "./styles";
 import { frameWrites, renderCapture, renderScript } from "./test-utils";
 import { replayTerminal } from "./vt";
+
+/** Mock process.stdin as a TTY so render() installs its focus-in handler.
+ *  Returns `emit` to feed raw bytes and `restore` to put the real stdin back. */
+function mockStdinTty(): { emit: (data: string) => void; restore: () => void } {
+  const stdin = process.stdin;
+  const savedIsTTY = Object.getOwnPropertyDescriptor(stdin, "isTTY");
+  const savedSetRawMode = (stdin as { setRawMode?: unknown }).setRawMode;
+  Object.defineProperty(stdin, "isTTY", { value: true, configurable: true });
+  (stdin as { setRawMode: (m: boolean) => void }).setRawMode = () => {};
+  return {
+    emit: (data: string) => {
+      stdin.emit("data", Buffer.from(data));
+    },
+    restore: () => {
+      if (savedIsTTY) Object.defineProperty(stdin, "isTTY", savedIsTTY);
+      else delete (stdin as { isTTY?: boolean }).isTTY;
+      (stdin as { setRawMode?: unknown }).setRawMode = savedSetRawMode;
+    },
+  };
+}
+
+/** Force React to commit and the renderer to flush until a write lands — the
+ *  deterministic seam renderScript uses, inlined for tests that also inject stdin. */
+async function drainFrame(flush: () => void, writes: string[]): Promise<void> {
+  const before = writes.length;
+  for (let attempt = 0; attempt < 200 && writes.length === before; attempt++) {
+    reconciler.flushSyncWork();
+    reconciler.flushPassiveEffects();
+    flush();
+    if (writes.length === before) await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
 
 function withMockedStdout(
   fn: (writes: string[]) => void | Promise<void>,
@@ -327,6 +360,42 @@ describe("render", () => {
     for (const line of LINES) {
       const count = transcript.filter((row) => row.includes(line)).length;
       expect(count).toBe(1);
+    }
+  });
+
+  test("focus-in redraw does not duplicate frozen scrollback", async () => {
+    // Focus-in (\x1b[I) triggers forceRedraw. Once the active region has overflowed
+    // into scrollback, a from-scratch repaint re-emits the frozen top rows the erase
+    // can no longer reach — duplication. forceRedraw must repaint only the live tail.
+    const LINES = ["L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8"];
+    const stdin = mockStdinTty();
+    try {
+      const writes = await withMockedStdout(
+        async (captured) => {
+          const { render } = await import("./render");
+          const app = render(
+            <tui-box flexDirection="column">
+              {LINES.map((line) => (
+                <tui-text key={line}>{line}</tui-text>
+              ))}
+              <tui-text>input</tui-text>
+            </tui-box>,
+          );
+          await drainFrame(() => app.flush(), captured); // initial commit → top rows freeze
+          stdin.emit("\x1b[I"); // focus-in → forceRedraw, synchronous commit
+          app.unmount();
+          await app.waitUntilExit();
+        },
+        { columns: 20, rows: 6 },
+      );
+
+      const vt = replayTerminal(frameWrites(writes), 6, 20);
+      const transcript = [...vt.scrollback, ...vt.screen];
+      for (const line of LINES) {
+        expect(transcript.filter((row) => row.includes(line)).length).toBe(1);
+      }
+    } finally {
+      stdin.restore();
     }
   });
 

--- a/src/tui/render.test.tsx
+++ b/src/tui/render.test.tsx
@@ -69,7 +69,11 @@ async function captureResize(
     Object.defineProperty(process.stdout, "columns", { value: to.columns, configurable: true });
     Object.defineProperty(process.stdout, "rows", { value: to.rows, configurable: true });
     process.stdout.emit("resize");
-    await new Promise((resolve) => setTimeout(resolve, 40)); // > 16ms debounce
+    // Poll until the debounced (16ms) resize commit lands rather than sleeping a
+    // fixed span — a starved CI can push the timer past any constant.
+    for (let attempt = 0; attempt < 300 && writes.length === splitIdx; attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, 2));
+    }
     app.unmount();
     await app.waitUntilExit();
   }, from);

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -38,6 +38,8 @@ export function render(node: ReactNode): RenderInstance {
   const useKittyProtocol = stdout.isTTY && KITTY_TERMINALS.includes(termProgram);
   let lastActive = "";
   let lastActiveLineCount = 0;
+  // A change since the last frame means the terminal may have reflowed the tail.
+  let lastRenderColumns = stdout.columns ?? DEFAULT_COLUMNS;
   let flushedStaticCount = 0;
   // Lines from the active region that have already been written to scrollback.
   // Lets us emit only the delta on subsequent frames instead of re-emitting.
@@ -90,10 +92,9 @@ export function render(node: ReactNode): RenderInstance {
     if (resizeTimer) clearTimeout(resizeTimer);
     resizeTimer = setTimeout(() => {
       resizeTimer = null;
-      frozenLineCount = 0;
-      frozenScrollbackText = "";
+      // Frozen state and erase geometry are reconciled in commitRender, which
+      // must own it anyway to catch a streaming commit landing mid-resize.
       lastActive = "";
-      lastActiveLineCount = 0;
       commitRender();
     }, 16);
   };
@@ -149,6 +150,17 @@ export function render(node: ReactNode): RenderInstance {
     const { staticItems, active } = serializeSplit(root);
     const cols = stdout.columns ?? DEFAULT_COLUMNS;
     const maxLiveRows = (stdout.rows ?? 24) - 1;
+
+    // Erasing with a stale count is transcript loss. On a width change the terminal
+    // may reflow the tail, so cursor-up would overshoot into promoted scrollback —
+    // skip the erase (a stale tail copy is merely cosmetic). On a height shrink,
+    // clamp so cursor-up can't reach through the viewport top into frozen history.
+    if (cols !== lastRenderColumns) {
+      lastActiveLineCount = 0;
+      lastRenderColumns = cols;
+    } else if (lastActiveLineCount > maxLiveRows) {
+      lastActiveLineCount = maxLiveRows;
+    }
 
     // Flush any new static items (write-once scrollback).
     if (staticItems.length > flushedStaticCount) {

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -135,11 +135,11 @@ export function render(node: ReactNode): RenderInstance {
     }
   }
 
-  /** Repaint the active region on focus-in. */
+  /** Repaint the active region on focus-in. Frozen scrollback is left intact —
+   *  it physically scrolled off and the erase can't reach it, so re-emitting would
+   *  duplicate. Clearing lastActive forces a repaint of the live tail only. */
   function forceRedraw() {
     if (exited || !stdout.isTTY) return;
-    frozenLineCount = 0;
-    frozenScrollbackText = "";
     lastActive = "";
     commitRender();
   }

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -152,12 +152,22 @@ export function render(node: ReactNode): RenderInstance {
 
     // Flush any new static items (write-once scrollback).
     if (staticItems.length > flushedStaticCount) {
-      let buf = eraseSequence();
       let appendedStatic = "";
       for (let i = flushedStaticCount; i < staticItems.length; i++) {
         appendedStatic += `${staticItems[i]}\n`;
       }
-      buf += appendedStatic;
+      // When an overflowing active turn is promoted to static, its top lines are
+      // already frozen in scrollback — they scrolled off and eraseSequence() can
+      // only reach the live tail, so re-emitting them duplicates. Adopt the frozen
+      // prefix: write only the delta below it. A rendering mismatch (prefix no
+      // longer matches) falls back to the full write, no worse than before.
+      if (frozenLineCount > 0) {
+        const frozenPrefix = `${frozenScrollbackText}\n`;
+        if (appendedStatic.startsWith(frozenPrefix)) {
+          appendedStatic = appendedStatic.slice(frozenPrefix.length);
+        }
+      }
+      const buf = eraseSequence() + appendedStatic;
       flushedStaticCount = staticItems.length;
       frozenLineCount = 0;
       frozenScrollbackText = "";


### PR DESCRIPTION
## Motivation

During a turn the whole in-progress turn is the live region; when it overflows into terminal scrollback and is then repainted, already-frozen rows were re-emitted — the erase can only reach the live tail, never the lines that scrolled off — duplicating the transcript. Surfaced in dogfooding.

## Summary

- adopt the frozen prefix when a turn promotes to static — write only the delta, never re-emit scrolled-off rows
- repaint only the live tail on focus-in instead of from scratch
- guard erase geometry across resize: skip the erase on a width change (terminal reflow can make cursor-up overshoot into scrollback and delete it), clamp on height shrink
- close a pre-existing loss where a streaming commit landing mid-resize erased with stale geometry
- width-change resize still leaves one stale tail copy (cosmetic) — reflow geometry is unrecoverable without a cursor-position query