### PR TITLE
fix(shell): stop forcing color in subprocess env

### DIFF
--- a/src/shell-ops.test.ts
+++ b/src/shell-ops.test.ts
@@ -25,6 +25,29 @@ describe("runShellCommand", () => {
     });
   });
 
+  test("does not forward FORCE_COLOR or COLORTERM into the subprocess", async () => {
+    const originalForceColor = process.env.FORCE_COLOR;
+    const originalColorTerm = process.env.COLORTERM;
+
+    try {
+      process.env.FORCE_COLOR = "1";
+      process.env.COLORTERM = "truecolor";
+
+      // `runShellCommand` pipes stdout/stderr; `env` prints to stdout.
+      const stdout = await runShellCommand(WORKSPACE, { cmd: "env" });
+
+      expect(stdout).toContain("PATH=");
+      expect(stdout).not.toContain("FORCE_COLOR=");
+      expect(stdout).not.toContain("COLORTERM=");
+    } finally {
+      if (originalForceColor === undefined) delete process.env.FORCE_COLOR;
+      else process.env.FORCE_COLOR = originalForceColor;
+
+      if (originalColorTerm === undefined) delete process.env.COLORTERM;
+      else process.env.COLORTERM = originalColorTerm;
+    }
+  });
+
   test("rejects empty command", async () => {
     await expect(runShellCommand(WORKSPACE, { cmd: "" })).rejects.toThrow("Command cannot be empty");
   });

--- a/src/shell-ops.ts
+++ b/src/shell-ops.ts
@@ -16,8 +16,6 @@ const SAFE_ENV_KEYS = [
   "TMP",
   "CI",
   "NO_COLOR",
-  "FORCE_COLOR",
-  "COLORTERM",
   "ComSpec",
   "PATHEXT",
   "SystemRoot",


### PR DESCRIPTION
## Summary

- drop `FORCE_COLOR`/`COLORTERM` from the subprocess env allowlist so captured command output isn't polluted with ANSI codes
- add a regression test asserting neither is forwarded