### PR TITLE
fix(agent): force tool choice for gateway GPT

### DIFF
--- a/src/lifecycle-generate.test.ts
+++ b/src/lifecycle-generate.test.ts
@@ -174,6 +174,43 @@ describe("phaseGenerate", () => {
     expect(capturedOptions?.providerOptions?.openai?.promptCacheKey).toBeString();
   });
 
+  test("forces tool choice for gateway-routed GPT but not gateway Anthropic", async () => {
+    // Regression for the #303 gap: gateway GPT classifies as "vercel", yet the harmony signal
+    // call must stay grammar-constrained or it leaks as text and degenerates into garbage tokens.
+    async function capturedToolChoice(model: string): Promise<unknown> {
+      let capturedOptions: StreamOptions | undefined;
+      const ctx = createRunContext({
+        model,
+        agent: {
+          id: "test-agent",
+          name: "test-agent",
+          instructions: "",
+          model: {} as RunContext["agent"]["model"],
+          tools: {},
+          async stream(_prompt, options) {
+            capturedOptions = options;
+            return {
+              fullStream: new ReadableStream({
+                start(controller) {
+                  controller.close();
+                },
+              }),
+              async getFullOutput() {
+                return { text: "done", toolCalls: [] };
+              },
+            };
+          },
+        },
+      });
+      await phaseGenerate(ctx, { timeoutMs: 1000 });
+      return capturedOptions?.toolChoice;
+    }
+
+    expect(await capturedToolChoice("vercel/openai/gpt-5.2")).toBe("required");
+    expect(await capturedToolChoice("openai/gpt-5.2")).toBe("required");
+    expect(await capturedToolChoice("vercel/anthropic/claude-sonnet-4")).toBe("auto");
+  });
+
   test("a no-match search does not gate a later done", async () => {
     const debugEvents: LifecycleDebugEvent[] = [];
     const ctx = createRunContext({

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -25,7 +25,7 @@ import {
 } from "./lifecycle-contract";
 import { createFinishPolicyState, decideFinish, renderFinishPolicyMessages } from "./lifecycle-generate-policy";
 import { createPromptCacheKey, promptCacheProviderOptions } from "./prompt-cache";
-import { providerFromModel } from "./provider-config";
+import { forcesToolChoice, providerFromModel } from "./provider-config";
 import type { StreamError } from "./stream-error";
 import type { ToolDefinition } from "./tool-contract";
 import { extractToolErrorCode } from "./tool-error";
@@ -198,12 +198,12 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
     const reasoning = ctx.reasoning;
     const temperature = reasoning ? undefined : ctx.temperature;
     const streamOutput = await ctx.agent.stream(prompt, {
-      // OpenAI-only: forcing tool choice grammar-constrains decoding so GPT can't emit the
-      // signal call as text. Anthropic/Google map forced choice to a prose-suppressing prefill
-      // (400 under thinking), and gateway-routed GPT classifies as "vercel" (one provider string
-      // for every family, so can't force without breaking gateway Anthropic) — all stay "auto"
-      // and lean on the missing-signal retry as backstop.
-      toolChoice: provider === "openai" ? "required" : "auto",
+      // OpenAI/harmony family: forcing tool choice grammar-constrains decoding so GPT can't emit
+      // the signal call as text. forcesToolChoice sees through the Vercel gateway prefix, so
+      // gateway-routed GPT (vercel/openai/...) is forced too while gateway Anthropic is not.
+      // Anthropic/Google map forced choice to a prose-suppressing prefill (400 under thinking),
+      // so they stay "auto" and lean on the missing-signal retry as backstop.
+      toolChoice: forcesToolChoice(ctx.model) ? "required" : "auto",
       preCallInputTokenLimit: ctx.policy.contextMaxTokens,
       onBeforeNextCall: (messages) => {
         const reminders = collectReminders({
@@ -243,9 +243,9 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
         switch (decision.kind) {
           case "missing-signal-continue":
             ctx.debug("lifecycle.signal.missing", { action: "continue" });
-            // No per-step override: the run-level default already forces tool choice on
-            // OpenAI (the grammar constraint) and keeps it "auto" elsewhere (where forcing
-            // suppresses prose and 400s under extended thinking).
+            // No per-step override: the run-level default already forces tool choice for the
+            // OpenAI/harmony family (the grammar constraint) and keeps it "auto" elsewhere
+            // (where forcing suppresses prose and 400s under extended thinking).
             return renderFinishPolicyMessages(decision);
           case "missing-signal-block":
             ctx.currentError = {

--- a/src/provider-config.test.ts
+++ b/src/provider-config.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { formatModel, isProviderAvailable, normalizeModel, providerFromModel } from "./provider-config";
+import {
+  forcesToolChoice,
+  formatModel,
+  isProviderAvailable,
+  modelCreator,
+  normalizeModel,
+  providerFromModel,
+} from "./provider-config";
 
 describe("provider config", () => {
   test("normalizeModel prefixes unqualified model ids", () => {
@@ -35,6 +42,31 @@ describe("provider config", () => {
     expect(providerFromModel("vercel/anthropic/claude-sonnet-4")).toBe("vercel");
     expect(providerFromModel("xai/grok-4.1")).toBe("vercel");
     expect(providerFromModel("mistral/mistral-large")).toBe("vercel");
+  });
+
+  test("modelCreator sees through the Vercel gateway to the model family", () => {
+    expect(modelCreator("openai/gpt-5.2")).toBe("openai");
+    expect(modelCreator("vercel/openai/gpt-5.2")).toBe("openai");
+    expect(modelCreator("vercel/anthropic/claude-sonnet-4")).toBe("anthropic");
+    expect(modelCreator("gpt-5.2")).toBe("openai");
+    expect(modelCreator("claude-sonnet-4-6")).toBe("anthropic");
+    expect(modelCreator("google/gemini-2.5-pro")).toBe("google");
+    expect(modelCreator("xai/grok-4.1")).toBe("vercel");
+  });
+
+  test("forcesToolChoice forces the OpenAI/harmony family, native or gateway-routed", () => {
+    // Regression for the #303 gap: gateway-routed GPT classifies as "vercel" but must still
+    // be forced, or signal_done leaks as text and degenerates into garbage tokens.
+    expect(forcesToolChoice("vercel/openai/gpt-5.2")).toBe(true);
+    expect(forcesToolChoice("openai/gpt-5.2")).toBe(true);
+    expect(forcesToolChoice("gpt-5.2")).toBe(true);
+    // Gateway Anthropic must stay auto: forced choice becomes a prefill that 400s under thinking.
+    expect(forcesToolChoice("vercel/anthropic/claude-sonnet-4")).toBe(false);
+    expect(forcesToolChoice("claude-sonnet-4-6")).toBe(false);
+    expect(forcesToolChoice("google/gemini-2.5-pro")).toBe(false);
+    expect(forcesToolChoice("vercel/google/gemini-2.5-pro")).toBe(false);
+    // Gateway families Acolyte doesn't model first-class must not be force-decoded.
+    expect(forcesToolChoice("xai/grok-4.1")).toBe(false);
   });
 
   test("isProviderAvailable validates credential requirements", () => {

--- a/src/provider-config.ts
+++ b/src/provider-config.ts
@@ -70,6 +70,30 @@ export function providerFromModel(model: string): Provider {
   return "vercel";
 }
 
+// The model family (creator), seen through the Vercel gateway's transport prefix:
+// native `openai/gpt-5.2` and gateway-routed `vercel/openai/gpt-5.2` both resolve to "openai".
+// providerFromModel conflates transport (which SDK/endpoint) with family (which behavior);
+// this names the family so family-conditional logic doesn't re-parse the gateway id by hand.
+// Gateway creators Acolyte doesn't model first-class (xai, mistral, ...) collapse to "vercel".
+export function modelCreator(model: string): Provider {
+  const provider = providerFromModel(model);
+  if (provider !== "vercel") return provider;
+  const gatewayId = model
+    .trim()
+    .toLowerCase()
+    .replace(/^vercel\//, "");
+  const creatorPrefix = gatewayId.split("/", 1)[0] ?? "";
+  const parsed = providerSchema.safeParse(creatorPrefix);
+  return parsed.success ? parsed.data : "vercel";
+}
+
+// Whether to grammar-constrain decoding with toolChoice: "required". True for the OpenAI/harmony
+// family (native or gateway-routed), where forcing stops the signal call from leaking as text.
+// Anthropic/Google map forced choice to a prose-suppressing prefill that 400s under thinking.
+export function forcesToolChoice(model: string): boolean {
+  return modelCreator(model) === "openai";
+}
+
 export type ProviderCredentials = { apiKey?: string; baseUrl?: string };
 
 export const DEFAULT_REASONING = "medium";


### PR DESCRIPTION
## Summary
- force `toolChoice: "required"` for gateway-routed GPT (`vercel/openai/...`), which classified as `vercel`, stayed `auto`, and leaked `signal_done` as text
- resolve model family through the gateway prefix so gateway Anthropic stays `auto`

Follows up #303.