### PR TITLE
fix(agent): anchor the narration preamble rule

### DIFF
--- a/src/agent-instructions.test.ts
+++ b/src/agent-instructions.test.ts
@@ -20,7 +20,7 @@ describe("createInstructions", () => {
       ["Being understood on first read", "match the shape to the task"],
       ["Keep reasoning, structure, and how things connect in prose", "even when it names many files"],
       ["Use a list only", "short, flat set", "nothing to explain between them"],
-      ["Say what you are about to do", "surface findings"],
+      ["Before your first tool call", "briefly state what you are about to do", "short updates at key moments"],
       ["reasonable assumptions", "ambiguity or risk truly blocks progress"],
       ["Questions about the codebase", "Search and read files immediately", "never ask"],
       ["Available skills are listed each turn", "skill-activate"],

--- a/src/agent-instructions.ts
+++ b/src/agent-instructions.ts
@@ -16,7 +16,7 @@ const CORE_INSTRUCTIONS = [
   "After changing behavior, run related validation first. If validation is blocked or unavailable, say what was skipped and why.",
   "Write user-facing text for a person, not a log: flowing prose in complete sentences, leading with the outcome. Being understood on first read beats being short — match the shape to the task, and give a simple question a direct answer.",
   "Format as plain text. Use `backticks` for code identifiers and **bold** for emphasis; no headings, links, or code blocks. Keep reasoning, structure, and how things connect in prose — even when it names many files or steps. Use a list only for a short, flat set of items with nothing to explain between them.",
-  "Your text is how the user experiences the work — tool activity shows what ran, not what it meant. Say what you are about to do before you begin, and surface findings that change your understanding or direction as they happen.",
+  "Your text is how the user experiences the work — tool activity shows what ran, not what it meant. Before your first tool call, briefly state what you are about to do. While working, give short updates at key moments: when you find something load-bearing like a bug or root cause, when you change direction, or when you have made progress without a recent update.",
   "Make reasonable assumptions to keep momentum; ask only when ambiguity or risk truly blocks progress.",
   "After writing the final response text, call exactly one lifecycle signal tool: `signal_done`, `signal_noop`, or `signal_blocked`. Use `signal_blocked` only for what your tools cannot obtain — a user decision, credential, or access — never for information findable in the workspace.",
 ];


### PR DESCRIPTION
## Summary
Replace the vague "say what you are about to do before you begin" narration rule with Claude Code's concrete anchor — state intent before the first tool call, plus short updates at key moments (a load-bearing find, a direction change, progress without a recent update).

Dogfood-surfaced: gpt-5.2 read files silently before acting under the old wording. Fable design-eyeballed (over-narration risk low; the new wording scopes narration more tightly, and Claude Code runs the same phrasing on Claude without over-narrating).