### PR TITLE
feat(chat): show active skills

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -16,7 +16,7 @@ Acolyte combines a terminal-first client, headless daemon, lifecycle effects, pe
 - configurable locale
 - multi-line input
 - custom terminal renderer with React reconciler and structured output
-- live status line with location, model, token, and PR segments
+- live status line with location, model, token, skill, and PR segments
 - auto-update on startup with progress UI
 - update flags to force or skip auto-update (`--update`, `--no-update`)
 - XDG Base Directory support on Linux

--- a/src/chat-state.ts
+++ b/src/chat-state.ts
@@ -154,6 +154,7 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
     inputTokens: tokenTotals.inputTokens,
     outputTokens: tokenTotals.outputTokens,
     pr,
+    skills: currentSession.activeSkills?.map((s) => s.name) ?? [],
   };
 
   useMountEffect(() => {

--- a/src/chat-status-line.tsx
+++ b/src/chat-status-line.tsx
@@ -5,7 +5,6 @@ import type { PrInfo, PrState } from "./gh-contract";
 import { t } from "./i18n";
 import { palette } from "./palette";
 import { Box, Text } from "./tui";
-import { DEFAULT_TERMINAL_WIDTH } from "./tui/constants";
 
 export type StatusLineState = {
   /** Repo name (git root basename), or the cwd basename outside a git repo. */
@@ -125,7 +124,7 @@ export function StatusLine(state: StatusLineState): React.ReactNode {
   if (!skillSegment) return left;
 
   return (
-    <Box justifyContent="space-between" width={process.stdout.columns ?? DEFAULT_TERMINAL_WIDTH}>
+    <Box justifyContent="space-between" width="terminal">
       {left}
       {/* leading space keeps a separator when a narrow width floors the space-between gap to 0 */}
       <Text color={palette.dim}>{` ${skillSegment}`}</Text>

--- a/src/chat-status-line.tsx
+++ b/src/chat-status-line.tsx
@@ -4,7 +4,8 @@ import { formatCompactNumber } from "./chat-format";
 import type { PrInfo, PrState } from "./gh-contract";
 import { t } from "./i18n";
 import { palette } from "./palette";
-import { Text } from "./tui";
+import { Box, Text } from "./tui";
+import { DEFAULT_TERMINAL_WIDTH } from "./tui/constants";
 
 export type StatusLineState = {
   /** Repo name (git root basename), or the cwd basename outside a git repo. */
@@ -20,8 +21,8 @@ export type StatusLineState = {
   inputTokens: number;
   outputTokens: number;
   pr: PrInfo | null;
+  skills: readonly string[];
 };
-
 export function prColor(state: PrState): string {
   switch (state) {
     case "open":
@@ -63,7 +64,7 @@ export function statusTokenTotals(
 }
 
 export function StatusLine(state: StatusLineState): React.ReactNode {
-  const { repo, worktree, branch, model, effort, inputTokens, outputTokens, pr } = state;
+  const { repo, worktree, branch, model, effort, inputTokens, outputTokens, pr, skills } = state;
   const segments: React.ReactNode[] = [];
 
   // Location: repo · worktree · branch, folded left to right (a name already shown
@@ -107,7 +108,7 @@ export function StatusLine(state: StatusLineState): React.ReactNode {
     );
   }
 
-  return (
+  const left = (
     <Text>
       {"  "}
       {segments.map((segment, index) => (
@@ -118,5 +119,16 @@ export function StatusLine(state: StatusLineState): React.ReactNode {
         </Text>
       ))}
     </Text>
+  );
+
+  const skillSegment = skills.length > 0 ? skills.join(" · ") : null;
+  if (!skillSegment) return left;
+
+  return (
+    <Box justifyContent="space-between" width={process.stdout.columns ?? DEFAULT_TERMINAL_WIDTH}>
+      {left}
+      {/* leading space keeps a separator when a narrow width floors the space-between gap to 0 */}
+      <Text color={palette.dim}>{` ${skillSegment}`}</Text>
+    </Box>
   );
 }

--- a/src/chat-status-line.tsx
+++ b/src/chat-status-line.tsx
@@ -124,10 +124,10 @@ export function StatusLine(state: StatusLineState): React.ReactNode {
   if (!skillSegment) return left;
 
   return (
-    <Box justifyContent="space-between" width="terminal">
+    <Box flexWrap="wrap" justifyContent="space-between" width="terminal">
       {left}
-      {/* leading space keeps a separator when a narrow width floors the space-between gap to 0 */}
-      <Text color={palette.dim}>{` ${skillSegment}`}</Text>
+      {/* leading inset separates a full row and aligns a stacked row with the status */}
+      <Text color={palette.dim}>{`  ${skillSegment}`}</Text>
     </Box>
   );
 }

--- a/src/chat-status-line.tsx
+++ b/src/chat-status-line.tsx
@@ -102,7 +102,9 @@ export function StatusLine(state: StatusLineState): React.ReactNode {
     segments.push(
       <Text>
         <Text color={palette.dim}>PR </Text>
-        <Text color={prColor(pr.state)}>#{pr.number}</Text>
+        <Text color={prColor(pr.state)} dimColor>
+          #{pr.number}
+        </Text>
       </Text>,
     );
   }

--- a/src/chat-status-line.tui.test.tsx
+++ b/src/chat-status-line.tui.test.tsx
@@ -3,6 +3,7 @@ import { prColor, StatusLine, type StatusLineState, statusTokenTotals } from "./
 import { renderToString } from "./tui";
 import { DEFAULT_TERMINAL_WIDTH } from "./tui/constants";
 import { stripAnsi } from "./tui/serialize";
+import { ansi, colorToFg } from "./tui/styles";
 import { renderPlain, trimRightLines } from "./tui/test-utils";
 
 function entry(inputTokens: number, outputTokens: number) {
@@ -81,6 +82,15 @@ describe("StatusLine", () => {
   test("renders the PR number at the end", () => {
     const out = render({ pr: { number: 281, state: "open", title: "x", url: "https://example.test/pr/281" } });
     expect(out).toBe("  acolyte · main · gpt-5.2 medium · PR #281");
+  });
+
+  test("dims the PR state color", () => {
+    const out = renderToString(
+      <StatusLine {...BASE} pr={{ number: 281, state: "open", title: "x", url: "https://example.test/pr/281" }} />,
+    );
+    const dimGreen = `${ansi.dim}${colorToFg("green")}`;
+    expect(out).toContain(`${dimGreen}#${ansi.reset}`);
+    expect(out).toContain(`${dimGreen}281${ansi.reset}`);
   });
 
   test("right-justifies active skills against the terminal width", () => {

--- a/src/chat-status-line.tui.test.tsx
+++ b/src/chat-status-line.tui.test.tsx
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { prColor, StatusLine, type StatusLineState, statusTokenTotals } from "./chat-status-line";
-import { renderPlain } from "./tui/test-utils";
+import { renderToString } from "./tui";
+import { DEFAULT_TERMINAL_WIDTH } from "./tui/constants";
+import { stripAnsi } from "./tui/serialize";
+import { renderPlain, trimRightLines } from "./tui/test-utils";
 
 function entry(inputTokens: number, outputTokens: number) {
   return { usage: { inputTokens, outputTokens } };
@@ -35,6 +38,7 @@ const BASE: StatusLineState = {
   inputTokens: 0,
   outputTokens: 0,
   pr: null,
+  skills: [],
 };
 
 function render(overrides: Partial<StatusLineState> = {}): string {
@@ -77,6 +81,37 @@ describe("StatusLine", () => {
   test("renders the PR number at the end", () => {
     const out = render({ pr: { number: 281, state: "open", title: "x", url: "https://example.test/pr/281" } });
     expect(out).toBe("  acolyte · main · gpt-5.2 medium · PR #281");
+  });
+
+  test("right-justifies active skills against the terminal width", () => {
+    const out = renderPlain(<StatusLine {...BASE} skills={["build", "debug"]} />, 60);
+    expect(out).toBe(`  acolyte · main · gpt-5.2 medium${" ".repeat(14)}build · debug`);
+  });
+
+  test("keeps a separator before skills when the width is too narrow to justify", () => {
+    const out = renderPlain(<StatusLine {...BASE} skills={["build", "debug"]} />, 40);
+    expect(out).toBe("  acolyte · main · gpt-5.2 medium build · debug");
+    expect(out).not.toContain("mediumbuild");
+  });
+
+  test("falls back to the default width when the terminal width is unknown (non-TTY)", () => {
+    const descriptor = Object.getOwnPropertyDescriptor(process.stdout, "columns");
+    delete (process.stdout as { columns?: number }).columns;
+    try {
+      const out = trimRightLines(
+        stripAnsi(renderToString(<StatusLine {...BASE} skills={["build", "debug"]} />)),
+      ).trimEnd();
+      expect(out).toBe(
+        renderPlain(<StatusLine {...BASE} skills={["build", "debug"]} />, DEFAULT_TERMINAL_WIDTH).trimEnd(),
+      );
+      expect(out).not.toContain("mediumbuild");
+    } finally {
+      if (descriptor) Object.defineProperty(process.stdout, "columns", descriptor);
+    }
+  });
+
+  test("renders no trailing padding when there are no active skills", () => {
+    expect(render({ skills: [] })).toBe("  acolyte · main · gpt-5.2 medium");
   });
 
   test("omits effort when absent", () => {

--- a/src/chat-status-line.tui.test.tsx
+++ b/src/chat-status-line.tui.test.tsx
@@ -88,10 +88,9 @@ describe("StatusLine", () => {
     expect(out).toBe(`  acolyte · main · gpt-5.2 medium${" ".repeat(14)}build · debug`);
   });
 
-  test("keeps a separator before skills when the width is too narrow to justify", () => {
+  test("stacks skills below the status when the terminal is too narrow", () => {
     const out = renderPlain(<StatusLine {...BASE} skills={["build", "debug"]} />, 40);
-    expect(out).toBe("  acolyte · main · gpt-5.2 medium build · debug");
-    expect(out).not.toContain("mediumbuild");
+    expect(out).toBe("  acolyte · main · gpt-5.2 medium\n  build · debug");
   });
 
   test("falls back to the default width when the terminal width is unknown (non-TTY)", () => {

--- a/src/chat-stream.int.test.tsx
+++ b/src/chat-stream.int.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { createElement as reactCreateElement, useState } from "react";
+import { DEFAULT_TERMINAL_WIDTH } from "./tui/constants";
 import { createElement } from "./tui/dom";
 import { setOnCommit } from "./tui/host-config";
 import { reconciler } from "./tui/reconciler";
@@ -42,7 +43,7 @@ describe("streaming renders", () => {
     const ref: Ref<(fn: (prev: string[]) => string[]) => void> = { current: () => {} };
     const commits: string[] = [];
     const root = createElement("tui-root", {});
-    setOnCommit(() => commits.push(serialize(root)));
+    setOnCommit(() => commits.push(serialize(root, DEFAULT_TERMINAL_WIDTH)));
 
     function App() {
       const [rows, setRows] = useState<string[]>([]);

--- a/src/chat.tui.test.tsx
+++ b/src/chat.tui.test.tsx
@@ -19,6 +19,7 @@ const DEFAULT_STATUS_LINE = {
   inputTokens: 0,
   outputTokens: 0,
   pr: null,
+  skills: [],
 } as const;
 
 const noopCursorLine = () => {};

--- a/src/tui/components.tsx
+++ b/src/tui/components.tsx
@@ -4,7 +4,7 @@ type BoxProps = {
   flexDirection?: "row" | "column";
   justifyContent?: "flex-start" | "flex-end" | "space-between";
   flexWrap?: "nowrap" | "wrap";
-  width?: number;
+  width?: number | "terminal";
   children?: React.ReactNode;
   key?: React.Key;
 };

--- a/src/tui/dom.ts
+++ b/src/tui/dom.ts
@@ -5,7 +5,7 @@ export interface TuiProps {
   flexDirection?: "row" | "column";
   justifyContent?: "flex-start" | "flex-end" | "space-between";
   flexWrap?: "nowrap" | "wrap";
-  width?: number;
+  width?: number | "terminal";
   // Text
   color?: string;
   dimColor?: boolean;

--- a/src/tui/render-to-string.ts
+++ b/src/tui/render-to-string.ts
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { DEFAULT_TERMINAL_WIDTH } from "./constants";
 import { createElement } from "./dom";
 import { reconciler } from "./reconciler";
 import { serialize } from "./serialize";
@@ -21,5 +22,5 @@ export function renderToString(node: ReactNode): string {
   );
   reconciler.updateContainerSync(node, container, null, () => {});
   reconciler.flushSyncWork();
-  return serialize(root);
+  return serialize(root, process.stdout.columns ?? DEFAULT_TERMINAL_WIDTH);
 }

--- a/src/tui/render.test.tsx
+++ b/src/tui/render.test.tsx
@@ -586,6 +586,23 @@ describe("render", () => {
     expect(resizeTestWrites.length).toBeGreaterThanOrEqual(2);
   });
 
+  test("terminal-width boxes resolve their width again on resize", async () => {
+    for (const [from, to] of [
+      [80, 60],
+      [60, 80],
+    ] as const) {
+      const writes = await captureResize(
+        <tui-box justifyContent="space-between" width="terminal">
+          <tui-text>left</tui-text>
+          <tui-text>right</tui-text>
+        </tui-box>,
+        { columns: from, rows: 24 },
+        { columns: to, rows: 24 },
+      );
+      expect(writes.join("")).toContain(`left${" ".repeat(to - 9)}right`);
+    }
+  });
+
   test("syncWrite skips BSU/ESU when TMUX is set", async () => {
     const savedTmux = process.env.TMUX;
     process.env.TMUX = "/tmp/tmux-1000/default,12345,0";

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -147,8 +147,8 @@ export function render(node: ReactNode): RenderInstance {
 
   function commitRender() {
     if (exited) return;
-    const { staticItems, active } = serializeSplit(root);
     const cols = stdout.columns ?? DEFAULT_COLUMNS;
+    const { staticItems, active } = serializeSplit(root, cols);
     const maxLiveRows = (stdout.rows ?? 24) - 1;
 
     // Erasing with a stale count is transcript loss. On a width change the terminal

--- a/src/tui/serialize.ts
+++ b/src/tui/serialize.ts
@@ -119,7 +119,7 @@ function padLine(line: string, width: number): string {
  * the render loop flush them once to scrollback and only re-render the
  * active (non-static) portion of the tree.
  */
-function serializeNode(node: TuiNode, inherited: StyleStack, staticAcc?: string[]): string {
+function serializeNode(node: TuiNode, inherited: StyleStack, terminalWidth: number, staticAcc?: string[]): string {
   if (node.kind === "text") {
     const text = sanitizeText(node.value);
     if (text.length === 0) return "";
@@ -132,24 +132,24 @@ function serializeNode(node: TuiNode, inherited: StyleStack, staticAcc?: string[
   const el = node;
 
   if (el.type === "tui-virtual") {
-    return el.children.map((child) => serializeNode(child, inherited, staticAcc)).join("");
+    return el.children.map((child) => serializeNode(child, inherited, terminalWidth, staticAcc)).join("");
   }
 
   if (el.type === "tui-text") {
     const style = mergeStyle(inherited, el.props);
-    return el.children.map((child) => serializeNode(child, style, staticAcc)).join("");
+    return el.children.map((child) => serializeNode(child, style, terminalWidth, staticAcc)).join("");
   }
 
   if (el.type === "tui-static") {
     if (staticAcc) {
       // Collect each virtual child separately for incremental flushing.
       for (const child of el.children) {
-        staticAcc.push(serializeNode(child, inherited));
+        staticAcc.push(serializeNode(child, inherited, terminalWidth));
       }
       return "";
     }
     // No accumulator — render inline (used by serialize / renderToString).
-    return el.children.map((child) => serializeNode(child, inherited)).join("\n");
+    return el.children.map((child) => serializeNode(child, inherited, terminalWidth)).join("\n");
   }
 
   if (el.type === "tui-box") {
@@ -157,10 +157,12 @@ function serializeNode(node: TuiNode, inherited: StyleStack, staticAcc?: string[
     const isColumn = el.props.flexDirection === "column";
 
     if (isColumn) {
-      const parts = el.children.map((child) => serializeNode(child, style, staticAcc)).filter((p) => p.length > 0);
+      const parts = el.children
+        .map((child) => serializeNode(child, style, terminalWidth, staticAcc))
+        .filter((p) => p.length > 0);
       let joined = parts.join("\n");
       if (el.props.width !== undefined) {
-        const w = el.props.width;
+        const w = el.props.width === "terminal" ? terminalWidth : el.props.width;
         joined = joined
           .split("\n")
           .map((line) => padLine(line, w))
@@ -170,8 +172,8 @@ function serializeNode(node: TuiNode, inherited: StyleStack, staticAcc?: string[
     }
 
     // Row direction: concatenate children horizontally.
-    const childOutputs = el.children.map((child) => serializeNode(child, style, staticAcc));
-    const boxWidth = el.props.width;
+    const childOutputs = el.children.map((child) => serializeNode(child, style, terminalWidth, staticAcc));
+    const boxWidth = el.props.width === "terminal" ? terminalWidth : el.props.width;
     const justify = el.props.justifyContent;
     const wrap = el.props.flexWrap === "wrap";
 
@@ -218,7 +220,7 @@ function serializeNode(node: TuiNode, inherited: StyleStack, staticAcc?: string[
 
   // Root — render children as column
   return el.children
-    .map((child) => serializeNode(child, inherited, staticAcc))
+    .map((child) => serializeNode(child, inherited, terminalWidth, staticAcc))
     .filter((p) => p.length > 0)
     .join("\n");
 }
@@ -291,9 +293,9 @@ function joinRow(childOutputs: string[], boxWidth?: number): string {
   return result;
 }
 
-export function serialize(root: TuiElement): string {
+export function serialize(root: TuiElement, terminalWidth: number): string {
   const emptyStyle: StyleStack = {};
-  return serializeNode(root, emptyStyle);
+  return serializeNode(root, emptyStyle, terminalWidth);
 }
 
 /**
@@ -302,9 +304,9 @@ export function serialize(root: TuiElement): string {
  * `staticItems` instead of rendered inline, so the render loop can flush them
  * once to scrollback and only re-draw the active portion each frame.
  */
-export function serializeSplit(root: TuiElement): { staticItems: string[]; active: string } {
+export function serializeSplit(root: TuiElement, terminalWidth: number): { staticItems: string[]; active: string } {
   const emptyStyle: StyleStack = {};
   const staticItems: string[] = [];
-  const active = serializeNode(root, emptyStyle, staticItems);
+  const active = serializeNode(root, emptyStyle, terminalWidth, staticItems);
   return { staticItems, active };
 }

--- a/src/tui/test-utils.ts
+++ b/src/tui/test-utils.ts
@@ -22,6 +22,7 @@ export function withTerminalWidth(width: number, run: () => string): string {
     return run();
   } finally {
     if (descriptor) Object.defineProperty(process.stdout, "columns", descriptor);
+    else delete (process.stdout as { columns?: number }).columns;
   }
 }
 
@@ -62,6 +63,7 @@ function mockTty(columns: number, rows: number): { writes: string[]; restore: ()
     process.stdout.write = saved.write;
     for (const key of ["isTTY", "columns", "rows"] as const)
       if (saved[key]) Object.defineProperty(process.stdout, key, saved[key]);
+      else delete (process.stdout as unknown as Record<string, unknown>)[key];
     if (savedTmux !== undefined) process.env.TMUX = savedTmux;
   };
   return { writes, restore };


### PR DESCRIPTION
## Motivation

Active skills change agent behavior across turns, so their session state should remain visible while chatting.

## Summary

- show active skill names at the right edge of the status line
- stack status groups on narrow terminals instead of truncating them
- keep skill alignment correct when the terminal is resized
- dim PR state colors to preserve the status line hierarchy