### PR TITLE
fix(chat): transcript render and resume integrity

### DIFF
--- a/src/chat-app.int.test.ts
+++ b/src/chat-app.int.test.ts
@@ -164,4 +164,77 @@ describe("runChat call-site", () => {
     expect(stdout.join("")).not.toMatch(/level=debug/);
     expect(stdout.join("")).not.toContain("runChat.sink.check");
   });
+
+  test("persists the final turn's transcript on clean exit", async () => {
+    const home = dirs.createDir("acolyte-runchat-persist-");
+    const saved = {
+      home: process.env.HOME,
+      xdgState: process.env.XDG_STATE_HOME,
+      isTTY: Object.getOwnPropertyDescriptor(process.stdout, "isTTY"),
+      write: process.stdout.write,
+    };
+    process.env.HOME = home;
+    delete process.env.XDG_STATE_HOME;
+    delete process.env.ACOLYTE_DEBUG;
+    mkdirSync(stateDir(), { recursive: true });
+    Object.defineProperty(process.stdout, "isTTY", { value: false, configurable: true });
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+
+    const sessionId = sessionIdSchema.parse("sess_persistexit") as SessionId;
+    const now = new Date().toISOString();
+    const session: Session = {
+      id: sessionId,
+      createdAt: now,
+      updatedAt: now,
+      model: "test-model",
+      title: "Test",
+      messages: [],
+      tokenUsage: [],
+    };
+    const sessionState: SessionState = { sessions: [session], activeSessionId: sessionId };
+
+    // Model the real timing: turn-boundary persist runs while the transcript is
+    // still stale, then the sync effect settles before the user exits.
+    const persistedTranscripts: number[] = [];
+    const finalRow = { id: "row_final", kind: "assistant" as const, content: "the last answer" };
+    const persist = async (): Promise<void> => {
+      persistedTranscripts.push((session.transcript ?? []).length);
+    };
+
+    try {
+      setLogSink(null);
+      await runChat(
+        {
+          client: {
+            replyStream: async () => {
+              throw new Error("not called");
+            },
+            status: async () => ({}),
+            taskStatus: async () => null,
+          },
+          session,
+          sessionState,
+          persist,
+          version: "0.0.0-test",
+        },
+        async (app) => {
+          await persist();
+          session.transcript = [finalRow];
+          app.unmount();
+        },
+      );
+    } finally {
+      process.stdout.write = saved.write;
+      if (saved.isTTY) Object.defineProperty(process.stdout, "isTTY", saved.isTTY);
+      if (saved.home === undefined) delete process.env.HOME;
+      else process.env.HOME = saved.home;
+      if (saved.xdgState === undefined) delete process.env.XDG_STATE_HOME;
+      else process.env.XDG_STATE_HOME = saved.xdgState;
+      setLogSink(() => {});
+    }
+
+    expect(persistedTranscripts.at(0)).toBe(0);
+    expect(persistedTranscripts.at(-1)).toBe(1);
+    expect(persistedTranscripts.length).toBeGreaterThan(1);
+  });
 });

--- a/src/chat-app.test.ts
+++ b/src/chat-app.test.ts
@@ -73,7 +73,7 @@ describe("chat-ui helpers", () => {
 
   test("appendPromotedItems ignores duplicate row ids", () => {
     const initial = [
-      { id: "header_sess_demo", kind: "header" as const, lines: [] },
+      { id: "header_sess_demo", kind: "header" as const, sessionId: "sess_demo", lines: [] },
       { id: "row_1", kind: "user" as const, content: "hello" },
     ];
     const next = [
@@ -82,7 +82,7 @@ describe("chat-ui helpers", () => {
     ];
 
     expect(appendPromotedItems(initial, next)).toEqual([
-      { id: "header_sess_demo", kind: "header", lines: [] },
+      { id: "header_sess_demo", kind: "header", sessionId: "sess_demo", lines: [] },
       { id: "row_1", kind: "user", content: "hello" },
       { id: "row_2", kind: "assistant", content: "hi" },
     ]);

--- a/src/chat-app.tsx
+++ b/src/chat-app.tsx
@@ -113,6 +113,10 @@ export async function runChat(
   try {
     onMount?.(app);
     await app.waitUntilExit();
+    // The last turn's turn-boundary persist ran before its transcript row
+    // committed; catch it up here. Signal/fatal exits process.exit before this
+    // resumes, so it stays clean-exit-only.
+    await props.persist();
   } finally {
     setLogSink(null);
   }

--- a/src/chat-app.tsx
+++ b/src/chat-app.tsx
@@ -106,9 +106,10 @@ export function installClientLogSink(): void {
 export async function runChat(
   props: ChatAppProps,
   onMount?: (app: { flush: () => void; unmount: () => void }) => void,
+  onFatalError?: (error: unknown) => void,
 ): Promise<void> {
   installClientLogSink();
-  const app = render(<ChatApp {...props} />);
+  const app = render(<ChatApp {...props} />, { onFatalError });
   try {
     onMount?.(app);
     await app.waitUntilExit();

--- a/src/chat-commands-contract.ts
+++ b/src/chat-commands-contract.ts
@@ -17,7 +17,6 @@ export type CommandContext = {
   currentSession: Session;
   setCurrentSession: (next: Session) => void;
   setTokenUsage?: (updater: (current: SessionTokenUsageEntry[]) => SessionTokenUsageEntry[]) => void;
-  toRows: (messages: Session["messages"]) => ChatRow[];
   setRows: (updater: (current: ChatRow[]) => ChatRow[]) => void;
   setShowHelp: (updater: (current: boolean) => boolean) => void;
   setValue: (next: string) => void;
@@ -29,6 +28,7 @@ export type CommandContext = {
   persistModelConfig?: (key: string, value: string, scope: ConfigScope) => Promise<void>;
   activateSkill?: (skillName: string, args: string) => Promise<boolean>;
   startAssistantTurn?: (userText: string) => Promise<void>;
+  resumeTranscript: (session: Session) => void;
   clearTranscript: (sessionId?: string) => void;
   tokenUsage: SessionTokenUsageEntry[];
   memoryApi?: {

--- a/src/chat-commands-resume.ts
+++ b/src/chat-commands-resume.ts
@@ -61,8 +61,7 @@ async function handleResume(ctx: CommandContext): Promise<CommandResult> {
   ctx.sessionState.activeSessionId = target.id;
   ctx.setCurrentSession(target);
   ctx.setTokenUsage?.(() => target.tokenUsage);
-  ctx.clearTranscript(target.id);
-  ctx.setRows(() => ctx.toRows(target.messages));
+  ctx.resumeTranscript(target);
   ctx.setShowHelp(() => false);
   await ctx.persist();
   return { stop: true, userText: text };

--- a/src/chat-commands-workspaces.ts
+++ b/src/chat-commands-workspaces.ts
@@ -136,7 +136,6 @@ async function handleNew(ctx: CommandContext, parsed: ParsedCommand): Promise<Co
   ctx.setCurrentSession(next);
   ctx.setTokenUsage?.(() => []);
   ctx.clearTranscript(next.id);
-  ctx.setRows(() => ctx.toRows(next.messages));
   ctx.setShowHelp(() => false);
   await ctx.persist();
   ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.created", { name }))]);
@@ -164,8 +163,7 @@ async function handleSwitch(ctx: CommandContext, parsed: ParsedCommand): Promise
   ctx.sessionState.activeSessionId = target.id;
   ctx.setCurrentSession(target);
   ctx.setTokenUsage?.(() => target.tokenUsage);
-  ctx.clearTranscript(target.id);
-  ctx.setRows(() => ctx.toRows(target.messages));
+  ctx.resumeTranscript(target);
   ctx.setShowHelp(() => false);
   await ctx.persist();
   ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.switched", { name: name.data }))]);

--- a/src/chat-message-handler-stream.int.test.ts
+++ b/src/chat-message-handler-stream.int.test.ts
@@ -249,7 +249,6 @@ describe("chat message handler stream behavior", () => {
       }),
       session,
       sessionState,
-      toRows: (messages) => messages.map((msg) => ({ id: msg.id, kind: msg.role, content: msg.content })),
     });
 
     await handleMessage("first");
@@ -506,7 +505,6 @@ describe("chat message handler stream behavior", () => {
         setCurrentSession: (next) => {
           currentSession = next;
         },
-        toRows: (messages) => messages.map((msg) => ({ id: msg.id, kind: msg.role, content: msg.content })),
         setRows,
         setShowHelp: () => {},
         setValue: () => {},
@@ -527,6 +525,9 @@ describe("chat message handler stream behavior", () => {
         createMessage,
         nowIso: () => "2026-02-20T00:00:00.000Z",
         setInterrupt: () => {},
+        resumeTranscript: () => {
+          rows.splice(0, rows.length);
+        },
         clearTranscript: () => {
           rows.splice(0, rows.length);
         },

--- a/src/chat-message-handler-stream.ts
+++ b/src/chat-message-handler-stream.ts
@@ -34,6 +34,7 @@ const STREAM_FLUSH_MS = 50;
 
 export function createMessageStreamState(input: {
   setRows: (updater: (current: ChatRow[]) => ChatRow[]) => void;
+  promoteRows?: (rows: readonly ChatRow[]) => void;
 }): MessageStreamState {
   // --- agent streaming state ---
   let activeRowId: string | null = null;
@@ -44,10 +45,18 @@ export function createMessageStreamState(input: {
 
   // --- tool output state ---
   const toolRowIdByCallId = new Map<string, string>();
+  // Tool rows still streaming output (no result yet) — mutable, so they block
+  // promotion of everything below them until resolved.
+  const pendingToolRowIds = new Set<string>();
   const toolOutput = createToolOutputState();
 
   // --- checklist state ---
   const checklistRowIdByGroupId = new Map<string, string>();
+
+  // Signature of the last row appended, when it was a progress notice — lets a repeat
+  // notice dedupe even after the prior one was promoted out of the active region.
+  // Cleared whenever any other row is appended, so only adjacent repeats collapse.
+  let lastNoticeKey: string | null = null;
 
   function cancelFlushTimer(): void {
     if (flushTimer) {
@@ -56,12 +65,31 @@ export function createMessageStreamState(input: {
     }
   }
 
+  // Move the longest contiguous prefix of finalized rows into write-once scrollback.
+  // A row is still mutable — and blocks the prefix — while it is the live prose row,
+  // an unresolved tool row, or a checklist row (which is removed, not promoted, at
+  // finalize). Static renders above the whole active region, so promoting anything
+  // but a front-anchored prefix would reorder the transcript.
+  function promoteFinalizedPrefix(): void {
+    if (!input.promoteRows) return;
+    const checklistRowIds = new Set(checklistRowIdByGroupId.values());
+    const blocked = (id: string): boolean => id === activeRowId || pendingToolRowIds.has(id) || checklistRowIds.has(id);
+    input.setRows((current) => {
+      let n = 0;
+      while (n < current.length && !blocked(current[n]?.id ?? "")) n++;
+      if (n === 0) return current;
+      input.promoteRows?.(current.slice(0, n));
+      return current.slice(n);
+    });
+  }
+
   function flush(): void {
     cancelFlushTimer();
     // Leading whitespace stripped every call so `content` is a pure function of
     // agentContent (no mutation), keeping the updater idempotent.
     const content = agentContent.replace(/^\s+/, "");
     if (content.length === 0) return;
+    lastNoticeKey = null;
     // Row identity is assigned OUTSIDE the updater: React may invoke a setRows
     // updater more than once (StrictMode) or after sealAgentRow/finalize reset
     // the closure, so the updater must be a pure function of `current` only —
@@ -122,6 +150,7 @@ export function createMessageStreamState(input: {
 
     onToolCall: () => {
       sealAgentRow();
+      promoteFinalizedPrefix();
     },
 
     onOutput: (entry) => {
@@ -138,6 +167,8 @@ export function createMessageStreamState(input: {
         agentContent = "";
         const rowId = `row_${createId()}`;
         toolRowIdByCallId.set(entry.toolCallId, rowId);
+        pendingToolRowIds.add(rowId);
+        lastNoticeKey = null;
         // Decide (and track) any fallback assistant row OUTSIDE the updater, for
         // the same pure-updater reason as flush().
         const fallbackAssistantId =
@@ -154,6 +185,7 @@ export function createMessageStreamState(input: {
           }
           return [...rows, { id: rowId, kind: "tool" as const, content: { parts: update.items } }];
         });
+        promoteFinalizedPrefix();
         return;
       }
       // Existing tool call: update in place.
@@ -177,6 +209,7 @@ export function createMessageStreamState(input: {
         toolRowIdByCallId.delete(entry.toolCallId);
         toolOutput.delete(entry.toolCallId);
         if (!rowId) return;
+        pendingToolRowIds.delete(rowId);
         input.setRows((current) => current.filter((row) => row.id !== rowId));
         return;
       }
@@ -186,6 +219,10 @@ export function createMessageStreamState(input: {
       input.setRows((current) =>
         current.map((row) => (row.id === rowId ? { ...row, style: { ...row.style, marker: markerColor } } : row)),
       );
+      // The marker is now final, so the row is immutable: promote it (and any prefix
+      // it was blocking) into write-once scrollback.
+      pendingToolRowIds.delete(rowId);
+      promoteFinalizedPrefix();
     },
 
     onChecklist: (entry) => {
@@ -195,7 +232,9 @@ export function createMessageStreamState(input: {
         sealAgentRow();
         const rowId = `row_${createId()}`;
         checklistRowIdByGroupId.set(entry.groupId, rowId);
+        lastNoticeKey = null;
         input.setRows((current) => [...current, { id: rowId, kind: "task" as const, content }]);
+        promoteFinalizedPrefix();
         return;
       }
       input.setRows((current) => current.map((row) => (row.id === existingRowId ? { ...row, content } : row)));
@@ -205,21 +244,23 @@ export function createMessageStreamState(input: {
       // Flush buffered prose first so it renders before the notice, not after the
       // pending flush timer fires (which would invert their order).
       sealAgentRow();
-      input.setRows((current) => {
-        const last = current[current.length - 1];
-        if (last?.style?.text === palette.error && last.content === error) return current;
-        return [...current, createRow("system", error, { dim: true, text: palette.error })];
-      });
+      const key = `error:${error}`;
+      if (key !== lastNoticeKey) {
+        input.setRows((current) => [...current, createRow("system", error, { dim: true, text: palette.error })]);
+        lastNoticeKey = key;
+      }
+      promoteFinalizedPrefix();
     },
 
     onProgressNotice: (notice) => {
       sealAgentRow();
       const color = notice.level === "error" ? palette.error : palette.yellow;
-      input.setRows((current) => {
-        const last = current[current.length - 1];
-        if (last?.style?.text === color && last.content === notice.message) return current;
-        return [...current, createRow("system", notice.message, { dim: true, text: color })];
-      });
+      const key = `${color}:${notice.message}`;
+      if (key !== lastNoticeKey) {
+        input.setRows((current) => [...current, createRow("system", notice.message, { dim: true, text: color })]);
+        lastNoticeKey = key;
+      }
+      promoteFinalizedPrefix();
     },
 
     streamedText: () => agentContent,

--- a/src/chat-message-handler.int.test.ts
+++ b/src/chat-message-handler.int.test.ts
@@ -253,16 +253,16 @@ describe("chat message handler", () => {
     expect(promoted.some((row) => row.kind === "assistant" && row.content === "Removed sum.rs.")).toBe(true);
   });
 
-  test("commits the authoritative reply.output, not the streamed partial", async () => {
+  test("keeps the streamed prose as the authoritative transcript", async () => {
     const { handleMessage, calls } = createMessageHandlerHarness({
       client: createClient({
         status: async () => ({}),
         replyStream: async (input) => {
-          input.onEvent({ type: "text-delta", text: "partial " });
+          input.onEvent({ type: "text-delta", text: "the complete streamed answer." });
           return {
             state: "done" as const,
             model: "gpt-5-mini",
-            output: "partial plus the complete authoritative answer.",
+            output: "the complete streamed answer.",
           };
         },
       }),
@@ -272,7 +272,26 @@ describe("chat message handler", () => {
 
     const assistantRows = calls.promotedSnapshots.flat().filter((row) => row.kind === "assistant");
     expect(assistantRows).toHaveLength(1);
-    expect(assistantRows[0]?.content).toBe("partial plus the complete authoritative answer.");
+    expect(assistantRows[0]?.content).toBe("the complete streamed answer.");
+  });
+
+  test("falls back to reply.output when the stream emits no prose", async () => {
+    const { handleMessage, calls } = createMessageHandlerHarness({
+      client: createClient({
+        status: async () => ({}),
+        replyStream: async () => ({
+          state: "done" as const,
+          model: "gpt-5-mini",
+          output: "answer delivered without deltas.",
+        }),
+      }),
+    });
+
+    await handleMessage("tell me about this project");
+
+    const assistantRows = calls.promotedSnapshots.flat().filter((row) => row.kind === "assistant");
+    expect(assistantRows).toHaveLength(1);
+    expect(assistantRows[0]?.content).toBe("answer delivered without deltas.");
   });
 
   test("clears running usage in the same commit as the token entry, before stop-pending", async () => {
@@ -324,6 +343,41 @@ describe("chat message handler", () => {
     expect(assistantRows[0]?.content).toBe("The complete answer.");
   });
 
+  test("preserves prose/tool interleaving instead of collapsing prose to the end", async () => {
+    const { handleMessage, calls } = createMessageHandlerHarness({
+      client: createClient({
+        status: async () => ({}),
+        replyStream: async (input) => {
+          input.onEvent({ type: "text-delta", text: "Let me check the file." });
+          input.onEvent({ type: "tool-call", toolCallId: "call_1", toolName: "file-edit", args: { path: "a.rs" } });
+          input.onEvent({
+            type: "tool-output",
+            toolCallId: "call_1",
+            toolName: "file-edit",
+            content: { kind: "tool-header", labelKey: "tool.label.file_edit", detail: "a.rs" },
+          });
+          input.onEvent({ type: "text-delta", text: "Done editing." });
+          return { state: "done" as const, model: "gpt-5-mini", output: "Let me check the file.\nDone editing." };
+        },
+      }),
+    });
+
+    await handleMessage("edit a.rs");
+
+    const promoted = calls.promotedSnapshots.flat();
+    const kinds = promoted.map((row) => row.kind);
+    const firstProse = kinds.indexOf("assistant");
+    const toolIdx = kinds.indexOf("tool");
+    const lastProse = kinds.lastIndexOf("assistant");
+    // Prose that streamed before the tool call stays before it; a second prose row
+    // follows. The old drop-and-recommit collapsed both into one bubble after the tool.
+    expect(firstProse).toBeGreaterThanOrEqual(0);
+    expect(toolIdx).toBeGreaterThan(firstProse);
+    expect(lastProse).toBeGreaterThan(toolIdx);
+    const proseContents = promoted.filter((row) => row.kind === "assistant").map((row) => row.content);
+    expect(proseContents).toEqual(["Let me check the file.", "Done editing."]);
+  });
+
   test("toggles shortcuts on ? input", async () => {
     const { handleMessage, calls } = createMessageHandlerHarness();
     await handleMessage("?");
@@ -361,7 +415,6 @@ describe("chat message handler", () => {
       sessionState,
       currentSession: session,
       setCurrentSession: () => {},
-      toRows: () => [],
       setRows: (updater) => {
         rows.splice(0, rows.length, ...updater(rows));
       },
@@ -389,6 +442,7 @@ describe("chat message handler", () => {
         interruptRegistered = handler !== null;
         if (handler) interruptHandler = handler;
       },
+      resumeTranscript: () => {},
       clearTranscript: () => {},
     });
 
@@ -442,7 +496,6 @@ describe("chat message handler", () => {
       sessionState,
       currentSession: session,
       setCurrentSession: () => {},
-      toRows: () => [],
       setRows: (updater) => {
         rows.splice(0, rows.length, ...updater(rows));
       },
@@ -470,6 +523,7 @@ describe("chat message handler", () => {
         interruptRegistered = handler !== null;
         if (handler) interruptHandler = handler;
       },
+      resumeTranscript: () => {},
       clearTranscript: () => {},
     });
 
@@ -592,7 +646,6 @@ describe("chat message handler", () => {
       sessionState,
       currentSession: session,
       setCurrentSession: () => {},
-      toRows: () => [],
       setRows: (updater) => {
         updater([]);
       },
@@ -619,6 +672,7 @@ describe("chat message handler", () => {
       setInterrupt: (handler) => {
         interruptHandler = handler;
       },
+      resumeTranscript: () => {},
       clearTranscript: () => {},
     });
 
@@ -642,8 +696,7 @@ describe("chat message handler", () => {
 
     await handleMessage("hello");
 
-    expect(calls.promotedSnapshots).toHaveLength(1);
-    const promoted = calls.promotedSnapshots[0] ?? [];
+    const promoted = calls.promotedSnapshots.flat();
     expect(promoted.some((r) => r.kind === "user")).toBe(true);
     expect(promoted.some((r) => r.kind === "assistant")).toBe(true);
   });
@@ -668,8 +721,7 @@ describe("chat message handler", () => {
 
     await handleMessage("edit a file");
 
-    expect(calls.promotedSnapshots).toHaveLength(1);
-    const promoted = calls.promotedSnapshots[0] ?? [];
+    const promoted = calls.promotedSnapshots.flat();
     expect(promoted.some((r) => r.kind === "tool")).toBe(true);
   });
 
@@ -689,6 +741,63 @@ describe("chat message handler", () => {
 
     const promoted = calls.promotedSnapshots[0] ?? [];
     expect(promoted.some((r) => r.kind === "assistant" && r.content === "No changes needed.")).toBe(true);
+  });
+
+  test("eagerly promotes finalized rows mid-turn, before the turn completes", async () => {
+    const { handleMessage, calls } = createMessageHandlerHarness({
+      client: createClient({
+        status: async () => ({}),
+        replyStream: async (input) => {
+          input.onEvent({ type: "text-delta", text: "Checking the file." });
+          input.onEvent({ type: "tool-call", toolCallId: "c1", toolName: "file-edit", args: { path: "a.rs" } });
+          input.onEvent({
+            type: "tool-output",
+            toolCallId: "c1",
+            toolName: "file-edit",
+            content: { kind: "tool-header", labelKey: "tool.label.file_edit", detail: "a.rs" },
+          });
+          input.onEvent({ type: "tool-result", toolCallId: "c1", toolName: "file-edit" });
+          input.onEvent({ type: "text-delta", text: "Done." });
+          return { state: "done" as const, model: "gpt-5-mini", output: "Checking the file.\nDone." };
+        },
+      }),
+    });
+
+    await handleMessage("edit a.rs");
+
+    // Promotion happens incrementally: the first prose row and the resolved tool row
+    // move to scrollback while the turn is still streaming, not in one turn-end batch.
+    expect(calls.promotedSnapshots.length).toBeGreaterThan(1);
+    const firstBatch = calls.promotedSnapshots[0] ?? [];
+    expect(firstBatch.some((r) => r.kind === "assistant" && r.content === "Checking the file.")).toBe(true);
+    // Every row still lands in scrollback exactly once across the incremental batches.
+    const promoted = calls.promotedSnapshots.flat();
+    const proseContents = promoted.filter((r) => r.kind === "assistant").map((r) => r.content);
+    expect(proseContents).toEqual(["Checking the file.", "Done."]);
+    expect(promoted.filter((r) => r.kind === "tool")).toHaveLength(1);
+    const ids = promoted.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("de-duplicates a repeated progress notice even after it is promoted", async () => {
+    const { handleMessage, calls } = createMessageHandlerHarness({
+      client: createClient({
+        status: async () => ({}),
+        replyStream: async (input) => {
+          input.onEvent({ type: "error", errorMessage: "rate limited, retrying" });
+          input.onEvent({ type: "error", errorMessage: "rate limited, retrying" });
+          input.onEvent({ type: "text-delta", text: "ok" });
+          return { state: "done" as const, model: "gpt-5-mini", output: "ok" };
+        },
+      }),
+    });
+
+    await handleMessage("go");
+
+    const notices = calls.promotedSnapshots
+      .flat()
+      .filter((r) => r.kind === "system" && r.content === "rate limited, retrying");
+    expect(notices).toHaveLength(1);
   });
 
   test("promote clears dynamic rows", async () => {
@@ -753,7 +862,6 @@ describe("chat message handler", () => {
       sessionState,
       currentSession: session,
       setCurrentSession: () => {},
-      toRows: () => [],
       setRows: (updater) => {
         rows.splice(0, rows.length, ...updater(rows));
       },
@@ -785,6 +893,7 @@ describe("chat message handler", () => {
         promotedSnapshots.push([...rows]);
         rows.splice(0, rows.length);
       },
+      resumeTranscript: () => {},
       clearTranscript: () => {},
     });
 

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -25,7 +25,6 @@ type CreateMessageHandlerInput = {
   sessionState: SessionState;
   currentSession: Session;
   setCurrentSession: (next: Session) => void;
-  toRows: (messages: ChatMessage[]) => ChatRow[];
   setRows: (updater: (current: ChatRow[]) => ChatRow[]) => void;
   setShowHelp: (next: boolean | ((current: boolean) => boolean)) => void;
   setValue: (next: string) => void;
@@ -49,6 +48,8 @@ type CreateMessageHandlerInput = {
   nowIso: () => string;
   setInterrupt: (handler: (() => void) | null) => void;
   promote?: () => void;
+  promoteRows?: (rows: readonly ChatRow[]) => void;
+  resumeTranscript: (session: Session) => void;
   clearTranscript: (sessionId?: string) => void;
 };
 
@@ -98,6 +99,7 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
     const runningToolCallIds = new Set<string>();
     const streamState = createMessageStreamState({
       setRows: input.setRows,
+      promoteRows: input.promoteRows,
     });
 
     await input.persist();
@@ -176,12 +178,19 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
       } else {
         input.setPendingState(null);
       }
-      // Honor finalize()'s replacement contract: drop the transient streamed
-      // rows and commit the authoritative answer (reply.output) exactly once, so
-      // the transcript never depends on a streamed row surviving a re-render.
-      const finalRows =
-        assistantMessage.content.trim().length > 0 ? [createRow("assistant", assistantMessage.content)] : [];
-      input.setRows((current) => [...current.filter((row) => !streamedRowIds.has(row.id)), ...finalRows, ...turn.rows]);
+      // The streamed rows are the authoritative display transcript: they carry the
+      // turn's true interleaving (prose, tool, prose) and are already committed to the
+      // screen. reply.output is the same prose reassembled for model history, so
+      // re-committing it here only reshuffles prose below the tool rows and re-emits
+      // content that may have scrolled into append-only scrollback — a duplicate.
+      // Keep the streamed rows and append this turn's status/error rows. Only when no
+      // prose streamed (a provider that returns output without deltas) fall back to a
+      // bubble so the answer still shows.
+      const fallbackRows =
+        streamedRowIds.size === 0 && assistantMessage.content.trim().length > 0
+          ? [createRow("assistant", assistantMessage.content)]
+          : [];
+      input.setRows((current) => [...current, ...fallbackRows, ...turn.rows]);
       if (!turn.awaitingInput) input.promote?.();
       invalidateRepoPathCandidates();
       input.currentSession.tokenUsage.push(turn.tokenEntry);
@@ -325,7 +334,6 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
       currentSession: input.currentSession,
       setCurrentSession: input.setCurrentSession,
       setTokenUsage: input.setTokenUsage,
-      toRows: (messages) => input.toRows(messages),
       setRows: input.setRows,
       setShowHelp: input.setShowHelp,
       setValue: input.setValue,
@@ -337,6 +345,7 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
       openResumePanel: input.openResumePanel,
       openModelPanel: input.openModelPanel,
       tokenUsage: input.tokenUsage,
+      resumeTranscript: input.resumeTranscript,
       clearTranscript: input.clearTranscript,
     });
     log.debug("chat.command.result", { stop: commandResult.stop, userText: commandResult.userText });

--- a/src/chat-picker-handlers.test.ts
+++ b/src/chat-picker-handlers.test.ts
@@ -34,7 +34,7 @@ describe("chat picker handlers", () => {
     await handlers.handlePickerSelect({ kind: "resume", items: [first, second], index: 1, scrollOffset: 0 });
     expect(sessionState.activeSessionId).toBe(second.id);
     expect(spies.currentSessions).toEqual([second]);
-    expect(spies.rowsDirectSets.at(-1)).toEqual([]);
+    expect(spies.resumedSessions.at(-1)).toBe(second);
     expect(spies.pickerValues.at(-1)).toBeNull();
   });
 

--- a/src/chat-picker-handlers.ts
+++ b/src/chat-picker-handlers.ts
@@ -1,6 +1,5 @@
 import { setModel } from "./app-config";
 import { unreachable } from "./assert";
-import type { ChatMessage } from "./chat-contract";
 import { type ChatRow, createRow } from "./chat-contract";
 import type { PickerState } from "./chat-picker";
 import { createModelPicker, createPicker, createResumePicker } from "./chat-picker-actions";
@@ -16,16 +15,15 @@ export type CreatePickerHandlersInput = {
   setCurrentSession: (next: Session) => void;
   setTokenUsage?: (updater: (current: SessionTokenUsageEntry[]) => SessionTokenUsageEntry[]) => void;
   setRows: (updater: (current: ChatRow[]) => ChatRow[]) => void;
-  setRowsDirect: (next: ChatRow[]) => void;
   setPicker: (next: PickerState | null) => void;
   setShowHelp: (next: boolean | ((current: boolean) => boolean)) => void;
   setValue: (next: string) => void;
   persist: () => Promise<void>;
-  toRows: (messages: ChatMessage[]) => ChatRow[];
   nowIso: () => string;
   persistConfig?: (key: string, value: string, scope: "project") => Promise<void>;
   activateSkill: (skillName: string, args: string) => Promise<boolean>;
   startAssistantTurn: (userText: string) => Promise<void>;
+  resumeTranscript: (session: Session) => void;
   clearTranscript: (sessionId?: string) => void;
 };
 
@@ -131,8 +129,7 @@ export function createPickerHandlers(input: CreatePickerHandlersInput): {
           input.sessionState.activeSessionId = selected.id;
           input.setCurrentSession(selected);
           input.setTokenUsage?.(() => selected.tokenUsage);
-          input.clearTranscript(selected.id);
-          input.setRowsDirect(input.toRows(selected.messages));
+          input.resumeTranscript(selected);
           await input.persist();
         }
         input.setPicker(null);

--- a/src/chat-promotion.test.tsx
+++ b/src/chat-promotion.test.tsx
@@ -1,6 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import type { ChatRow } from "./chat-contract";
-import { appendPromotedItems, usePromotion } from "./chat-promotion";
+import {
+  appendPromotedItems,
+  createHeaderItem,
+  currentSegment,
+  type PromotedItem,
+  usePromotion,
+} from "./chat-promotion";
 import { createSession } from "./test-utils";
 import { renderHook, wait } from "./tui/test-utils";
 
@@ -20,6 +26,51 @@ describe("promotion pure helpers", () => {
     const current = [{ id: "a", kind: "user" as const, content: "hello" }];
     const same = [{ id: "a", kind: "user" as const, content: "hello" }];
     expect(appendPromotedItems(current, same)).toBe(current);
+  });
+
+  test("currentSegment returns the tail after the last header", () => {
+    const log: PromotedItem[] = [
+      createHeaderItem("1.0", "sess_a"),
+      { id: "row_a1", kind: "user", content: "a1" },
+      { id: "row_a2", kind: "assistant", content: "a2" },
+    ];
+    expect(currentSegment(log)).toEqual({
+      sessionId: "sess_a",
+      rows: [
+        { id: "row_a1", kind: "user", content: "a1" },
+        { id: "row_a2", kind: "assistant", content: "a2" },
+      ],
+    });
+  });
+
+  test("currentSegment of a freshly opened segment is empty (post-clear)", () => {
+    const log: PromotedItem[] = [
+      createHeaderItem("1.0", "sess_a"),
+      { id: "row_a1", kind: "user", content: "a1" },
+      createHeaderItem("1.0", "sess_a"),
+    ];
+    expect(currentSegment(log)).toEqual({ sessionId: "sess_a", rows: [] });
+  });
+
+  test("currentSegment ignores rows from prior sessions' segments", () => {
+    const log: PromotedItem[] = [
+      createHeaderItem("1.0", "sess_a"),
+      { id: "row_a1", kind: "user", content: "a1" },
+      createHeaderItem("1.0", "sess_b"),
+      { id: "row_b1", kind: "user", content: "b1" },
+      { id: "row_b2", kind: "assistant", content: "b2" },
+    ];
+    expect(currentSegment(log)).toEqual({
+      sessionId: "sess_b",
+      rows: [
+        { id: "row_b1", kind: "user", content: "b1" },
+        { id: "row_b2", kind: "assistant", content: "b2" },
+      ],
+    });
+  });
+
+  test("currentSegment with no header yields a null session", () => {
+    expect(currentSegment([])).toEqual({ sessionId: null, rows: [] });
   });
 });
 
@@ -50,6 +101,52 @@ describe("usePromotion hook", () => {
     unmount();
   });
 
+  test("seeds from the persisted transcript when present (resume parity)", () => {
+    const transcript: ChatRow[] = [
+      { id: "row_u", kind: "user", content: "edit a.rs" },
+      { id: "row_a", kind: "assistant", content: "Checking." },
+      { id: "row_t", kind: "tool", content: { parts: [] } },
+      { id: "row_b", kind: "assistant", content: "Done." },
+    ];
+    const session = createSession({
+      id: "sess_par1",
+      // Divergent messages prove the transcript, not toRows(messages), seeds the resume.
+      messages: [{ id: "msg_1", role: "assistant", content: "collapsed", timestamp: "2026-01-01T00:00:00.000Z" }],
+    });
+    session.transcript = transcript;
+
+    const { result, unmount } = renderHook(() =>
+      usePromotion({ version: "1.0", session, currentSessionId: session.id, setRows: () => {} }),
+    );
+
+    const { promotedRows } = result.current;
+    expect(promotedRows[0]).toMatchObject({ kind: "header" });
+    expect(promotedRows.slice(1)).toEqual(transcript);
+    unmount();
+  });
+
+  test("promoteRows appends the given finalized rows", async () => {
+    const session = createSession({ id: "sess_pr1" });
+    const { result, unmount } = renderHook(() =>
+      usePromotion({ version: "1.0", session, currentSessionId: session.id, setRows: () => {} }),
+    );
+
+    const before = result.current.promotedRows.length;
+    result.current.promoteRows([
+      { id: "row_x", kind: "assistant", content: "one" },
+      { id: "row_y", kind: "tool", content: { parts: [] } },
+    ]);
+    await wait();
+
+    expect(result.current.promotedRows.length).toBe(before + 2);
+    expect(result.current.promotedRows.some((r) => r.id === "row_x")).toBe(true);
+    // Idempotent under repeat (StrictMode double-invoke): dedupes by id.
+    result.current.promoteRows([{ id: "row_x", kind: "assistant", content: "one" }]);
+    await wait();
+    expect(result.current.promotedRows.filter((r) => r.id === "row_x")).toHaveLength(1);
+    unmount();
+  });
+
   test("clearTranscript replaces header without duplicating", async () => {
     const session = createSession({ id: "sess_clear1" });
     const { result, unmount } = renderHook(() =>
@@ -75,6 +172,125 @@ describe("usePromotion hook", () => {
     // No duplicate key warnings — all IDs are unique
     const ids = result.current.promotedRows.map((r) => r.id);
     expect(new Set(ids).size).toBe(ids.length);
+
+    unmount();
+  });
+
+  test("clearTranscript empties the current session's projection", async () => {
+    const session = createSession({ id: "sess_clearproj" });
+    const { result, unmount } = renderHook(() =>
+      usePromotion({ version: "1.0", session, currentSessionId: session.id, setRows: () => {} }),
+    );
+    result.current.promoteRows([{ id: "row_1", kind: "assistant", content: "before clear" }]);
+    await wait();
+    expect(currentSegment(result.current.promotedRows).rows).toHaveLength(1);
+
+    result.current.clearTranscript();
+    await wait();
+    expect(currentSegment(result.current.promotedRows)).toEqual({ sessionId: "sess_clearproj", rows: [] });
+
+    unmount();
+  });
+
+  test("resumeTranscript seeds a new segment from the target's transcript with fresh ids", async () => {
+    const session = createSession({ id: "sess_from" });
+    const { result, unmount } = renderHook(() =>
+      usePromotion({ version: "1.0", session, currentSessionId: session.id, setRows: () => {} }),
+    );
+
+    const target = createSession({ id: "sess_to" });
+    target.transcript = [
+      { id: "row_orig1", kind: "user", content: "target q" },
+      { id: "row_orig2", kind: "assistant", content: "target a" },
+    ];
+    result.current.resumeTranscript(target);
+    await wait();
+
+    const segment = currentSegment(result.current.promotedRows);
+    expect(segment.sessionId).toBe("sess_to");
+    expect(segment.rows.map((r) => [r.kind, r.content])).toEqual([
+      ["user", "target q"],
+      ["assistant", "target a"],
+    ]);
+    // Fresh ids: reusing the target's persisted ids would collide with an earlier display.
+    expect(segment.rows.map((r) => r.id)).not.toEqual(["row_orig1", "row_orig2"]);
+    const ids = result.current.promotedRows.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+
+    unmount();
+  });
+
+  test("resumeTranscript falls back to messages, and empty stays empty (not undefined)", async () => {
+    const session = createSession({ id: "sess_from2" });
+    const { result, unmount } = renderHook(() =>
+      usePromotion({ version: "1.0", session, currentSessionId: session.id, setRows: () => {} }),
+    );
+
+    const withMessages = createSession({
+      id: "sess_msgs",
+      messages: [{ id: "msg_1", role: "user", content: "from messages", timestamp: "2026-01-01T00:00:00.000Z" }],
+    });
+    result.current.resumeTranscript(withMessages);
+    await wait();
+    expect(currentSegment(result.current.promotedRows).rows.map((r) => r.content)).toEqual(["from messages"]);
+
+    const empty = createSession({ id: "sess_empty" });
+    result.current.resumeTranscript(empty);
+    await wait();
+    expect(currentSegment(result.current.promotedRows)).toEqual({ sessionId: "sess_empty", rows: [] });
+
+    unmount();
+  });
+
+  test("resume A->B->A keeps every promoted id globally unique", async () => {
+    const a = createSession({ id: "sess_a" });
+    a.transcript = [{ id: "row_a", kind: "assistant", content: "answer a" }];
+    const { result, unmount } = renderHook(() =>
+      usePromotion({
+        version: "1.0",
+        session: createSession({ id: "sess_seed" }),
+        currentSessionId: "sess_seed",
+        setRows: () => {},
+      }),
+    );
+
+    const b = createSession({ id: "sess_b" });
+    b.transcript = [{ id: "row_b", kind: "assistant", content: "answer b" }];
+    result.current.resumeTranscript(a);
+    await wait();
+    result.current.resumeTranscript(b);
+    await wait();
+    result.current.resumeTranscript(a);
+    await wait();
+
+    const ids = result.current.promotedRows.map((r) => r.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    // The last segment is A again, rendered afresh — not deduped away.
+    expect(currentSegment(result.current.promotedRows).rows.map((r) => r.content)).toEqual(["answer a"]);
+
+    unmount();
+  });
+
+  test("resume does not leak the outgoing session's rows into the incoming projection", async () => {
+    // The bug: the sync effect projects currentSegment into currentSession.transcript.
+    // Before the segment scoping, resuming B while A's rows were still in the log wrote
+    // A's rows into B.transcript. This mirrors that effect against the real hook.
+    const a = createSession({ id: "sess_leak_a" });
+    const { result, unmount } = renderHook(() =>
+      usePromotion({ version: "1.0", session: a, currentSessionId: a.id, setRows: () => {} }),
+    );
+    result.current.promoteRows([{ id: "row_a1", kind: "assistant", content: "A only" }]);
+    await wait();
+
+    const b = createSession({ id: "sess_leak_b" });
+    result.current.resumeTranscript(b);
+    await wait();
+
+    // Emulate chat-state's guarded sync effect for the now-current session B.
+    const segment = currentSegment(result.current.promotedRows);
+    if (segment.sessionId === b.id) b.transcript = segment.rows;
+    expect(b.transcript).toEqual([]);
+    expect(b.transcript?.some((r) => r.content === "A only")).toBe(false);
 
     unmount();
   });

--- a/src/chat-promotion.ts
+++ b/src/chat-promotion.ts
@@ -4,9 +4,10 @@ import type { HeaderLine } from "./chat-header";
 import { toRows } from "./chat-session";
 import { log } from "./log";
 import type { Session } from "./session-contract";
+import { createId } from "./short-id";
 import { clearScreen } from "./ui";
 
-export type HeaderItem = { id: string; kind: "header"; lines: HeaderLine[] };
+export type HeaderItem = { id: string; kind: "header"; sessionId: string; lines: HeaderLine[] };
 export type PromotedItem = ChatRow | HeaderItem;
 
 export function appendPromotedItems(current: PromotedItem[], next: readonly PromotedItem[]): PromotedItem[] {
@@ -29,12 +30,29 @@ export function createHeaderItem(version: string, sessionId: string): HeaderItem
   return {
     id: `header_${sessionId}`,
     kind: "header",
+    sessionId,
     lines: [
       { id: "title", text: "Acolyte" },
       { id: "session", text: `version ${version}` },
       { id: "context", text: `session ${sessionId}` },
     ],
   };
+}
+
+/** The current session's display transcript is the tail of the append-only log: every
+ *  row after the last header. Headers partition the process-lifetime log into per-session
+ *  segments, so this is the single source of truth for what one session displays. */
+export function currentSegment(items: PromotedItem[]): { sessionId: string | null; rows: ChatRow[] } {
+  for (let i = items.length - 1; i >= 0; i--) {
+    const item = items[i];
+    if (item && isHeaderItem(item)) {
+      return {
+        sessionId: item.sessionId,
+        rows: items.slice(i + 1).filter((row): row is ChatRow => !isHeaderItem(row)),
+      };
+    }
+  }
+  return { sessionId: null, rows: [] };
 }
 
 type UsePromotionInput = {
@@ -47,6 +65,8 @@ type UsePromotionInput = {
 type UsePromotionResult = {
   promotedRows: PromotedItem[];
   promote: () => void;
+  promoteRows: (rows: readonly ChatRow[]) => void;
+  resumeTranscript: (session: Session) => void;
   clearTranscript: (sessionId?: string) => void;
   setPromotedRows: (updater: (prev: PromotedItem[]) => PromotedItem[]) => void;
 };
@@ -54,7 +74,9 @@ type UsePromotionResult = {
 export function usePromotion(input: UsePromotionInput): UsePromotionResult {
   const [promotedRows, setPromotedRows] = useState<PromotedItem[]>(() => [
     createHeaderItem(input.version, input.session.id),
-    ...toRows(input.session.messages),
+    // Resume from the persisted display projection when present (byte-exact live/resume
+    // parity); pre-parity sessions have none, so fall back to the collapsed messages.
+    ...(input.session.transcript ?? toRows(input.session.messages)),
   ]);
 
   const promote = useCallback(() => {
@@ -66,6 +88,15 @@ export function usePromotion(input: UsePromotionInput): UsePromotionResult {
       return [];
     });
   }, [input.setRows]);
+
+  // Promote a finalized prefix of the active region mid-turn. Write-once scrollback
+  // is immutable, so a row must be settled before it moves; the caller guarantees the
+  // rows are finalized. appendPromotedItems dedupes by id, keeping the paired
+  // setState idempotent under StrictMode's double-invoke.
+  const promoteRows = useCallback((rows: readonly ChatRow[]) => {
+    if (rows.length === 0) return;
+    setPromotedRows((prev) => appendPromotedItems(prev, rows));
+  }, []);
 
   const currentSessionIdRef = useRef(input.currentSessionId);
   currentSessionIdRef.current = input.currentSessionId;
@@ -85,5 +116,25 @@ export function usePromotion(input: UsePromotionInput): UsePromotionResult {
     [input.version, input.setRows],
   );
 
-  return { promotedRows, promote, clearTranscript, setPromotedRows };
+  // Open a new segment for an in-app session switch, seeded with the target's transcript.
+  // Fresh row ids: the log is process-lifetime and Static keys by id, so reusing the
+  // target's persisted ids (or the deterministic ids from toRows) would collide with an
+  // earlier display of the same session and get deduped away.
+  const resumeTranscript = useCallback(
+    (session: Session) => {
+      clearScreen();
+      clearCountRef.current += 1;
+      const header = createHeaderItem(input.version, session.id);
+      header.id = `${header.id}_${clearCountRef.current}`;
+      const seed = (session.transcript ?? toRows(session.messages)).map((row) => ({
+        ...row,
+        id: `row_${createId()}`,
+      }));
+      setPromotedRows((prev) => [...prev, header, ...seed]);
+      input.setRows(() => []);
+    },
+    [input.version, input.setRows],
+  );
+
+  return { promotedRows, promote, promoteRows, resumeTranscript, clearTranscript, setPromotedRows };
 }

--- a/src/chat-state.ts
+++ b/src/chat-state.ts
@@ -12,8 +12,8 @@ import { suggestModels } from "./chat-model-autocomplete";
 import { usePendingState } from "./chat-pending";
 import { type PickerState, pickerItemCount } from "./chat-picker";
 import { createPickerHandlers } from "./chat-picker-handlers";
-import { type PromotedItem, usePromotion } from "./chat-promotion";
-import { createMessage, toRows } from "./chat-session";
+import { currentSegment, type PromotedItem, usePromotion } from "./chat-promotion";
+import { createMessage } from "./chat-session";
 import { createSkillActivator } from "./chat-skill-activator";
 import { type StatusLineState, statusTokenTotals } from "./chat-status-line";
 import { enqueueQueuedMessage, resolveQueueSubmit } from "./chat-submit";
@@ -131,12 +131,23 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
   const [git, setGit] = useState<GitStatus | null>(null);
   const [pr, setPr] = useState<PrInfo | null>(null);
 
-  const { promotedRows, promote, clearTranscript } = usePromotion({
+  const { promotedRows, promote, promoteRows, resumeTranscript, clearTranscript } = usePromotion({
     version: props.version,
     session,
     currentSessionId: currentSession.id,
     setRows,
   });
+
+  // Keep the persisted display projection in sync with what's on screen so a resumed
+  // session renders byte-exactly what streamed. The log spans every session opened this
+  // process, so project only the current segment (the tail after its header) and write
+  // it only when the segment belongs to the current session — a switch that hasn't
+  // opened its segment yet must never inherit the outgoing session's rows. Disk
+  // persistence is owned by the handler's turn-boundary persist() and the exit persist.
+  useSyncEffect(() => {
+    const segment = currentSegment(promotedRows);
+    if (segment.sessionId === currentSession.id) currentSession.transcript = segment.rows;
+  }, [promotedRows, currentSession]);
 
   const interruptRef = useRef<(() => void) | null>(null);
   const handleSubmitRef = useRef<((text: string) => Promise<void>) | null>(null);
@@ -206,15 +217,14 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
     setCurrentSession: updateSession,
     setTokenUsage,
     setRows,
-    setRowsDirect: setRows,
     setPicker,
     setShowHelp,
     setValue,
     persist,
-    toRows,
     nowIso,
     activateSkill,
     startAssistantTurn: (userText) => startAssistantTurn(userText),
+    resumeTranscript,
     clearTranscript,
   });
 
@@ -223,7 +233,6 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
     sessionState,
     currentSession,
     setCurrentSession: updateSession,
-    toRows,
     setRows,
     setShowHelp,
     setValue,
@@ -258,6 +267,8 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
       interruptRef.current = handler;
     },
     promote,
+    promoteRows,
+    resumeTranscript,
     clearTranscript,
   });
   handleSubmitRef.current = handleSubmit;

--- a/src/cli-chat.ts
+++ b/src/cli-chat.ts
@@ -107,16 +107,28 @@ export async function chatModeWithOptions(options: { resumeLatest: boolean; resu
     activeSession = next;
   };
 
+  // Runs after the renderer has restored the terminal, so the error prints cleanly.
+  // process.exit skips the finally below, so release the session lock here too.
+  const onFatalError = (error: unknown): void => {
+    releaseSessionLock(session.id);
+    printError(error instanceof Error ? (error.stack ?? error.message) : String(error));
+    process.exit(1);
+  };
+
   try {
     if (output.isTTY) clearScreen();
-    await runChat({
-      client,
-      session,
-      sessionState: state,
-      persist,
-      onSessionChange,
-      version: CLI_VERSION,
-    });
+    await runChat(
+      {
+        client,
+        session,
+        sessionState: state,
+        persist,
+        onSessionChange,
+        version: CLI_VERSION,
+      },
+      undefined,
+      onFatalError,
+    );
     if (output.isTTY) clearScreen();
     const resumeId = state.activeSessionId ?? session.id;
     printDim(t("chat.resume.with_command", { command: formatResumeCommand(resumeId) }));

--- a/src/session-contract.ts
+++ b/src/session-contract.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
-import { type ChatMessage, type MessageId, messageIdSchema, messageSchema } from "./chat-contract";
+import {
+  type ChatMessage,
+  type ChatRow,
+  chatRowSchema,
+  type MessageId,
+  messageIdSchema,
+  messageSchema,
+} from "./chat-contract";
 import { type IsoDateTimeString, isoDateTimeSchema } from "./datetime";
 import { domainIdSchema } from "./id-contract";
 import { type ActiveSkill, activeSkillSchema } from "./skill-contract";
@@ -54,6 +61,9 @@ export const sessionSchema = z.object({
   workspaceBranch: z.string().min(1).optional(),
   activeSkills: z.array(activeSkillSchema).optional(),
   messages: z.array(messageSchema),
+  // Display projection (interleaved prose/tool rows) for live/resume parity. Optional:
+  // its absence marks a pre-parity session, which resumes from `messages` (collapsed).
+  transcript: z.array(chatRowSchema).optional(),
   tokenUsage: z.array(sessionTokenUsageEntrySchema),
 });
 
@@ -68,6 +78,7 @@ export interface Session {
   workspaceBranch?: string;
   activeSkills?: ActiveSkill[];
   messages: ChatMessage[];
+  transcript?: ChatRow[];
   tokenUsage: SessionTokenUsageEntry[];
 }
 

--- a/src/session-store-contract.test-suite.ts
+++ b/src/session-store-contract.test-suite.ts
@@ -77,6 +77,18 @@ export function sessionStoreContractTests(
       expect(all).toHaveLength(1);
     });
 
+    test("concurrent saveSession calls neither crash nor lose updates", async () => {
+      const s = await getStore();
+      const sessions = Array.from({ length: 12 }, (_, i) => makeSession({ id: `sess_conc${i}` }));
+      // Fired together: without serialized writes these race the rename and clobber
+      // each other's read-modify-write, dropping sessions or throwing ENOENT.
+      await Promise.all(sessions.map((session) => s.saveSession(session)));
+      const listed = await s.listSessions();
+      for (const session of sessions) {
+        expect(listed.some((x) => x.id === session.id)).toBe(true);
+      }
+    });
+
     test("saveSession persists messages as JSONB", async () => {
       const s = await getStore();
       const session = makeSession({

--- a/src/session-store.test.ts
+++ b/src/session-store.test.ts
@@ -89,6 +89,43 @@ describe("storage", () => {
     expect(normalized.sessions[0]?.tokenUsage[0]?.promptBreakdown?.skillTokens).toBe(0);
   });
 
+  const validSession = (id: string, extra: Record<string, unknown> = {}) => ({
+    id,
+    createdAt: "2026-02-24T00:00:00.000Z",
+    updatedAt: "2026-02-24T00:00:00.000Z",
+    model: "gpt-5-mini",
+    title: "New Session",
+    messages: [],
+    tokenUsage: [],
+    ...extra,
+  });
+
+  test("parseSessionState salvages a session with a corrupt transcript instead of dropping it", () => {
+    const normalized = parseSessionState({
+      activeSessionId: "sess_1",
+      sessions: [validSession("sess_1", { transcript: [{ id: "row_1", kind: "not-a-kind", content: "x" }] })],
+    });
+
+    expect(normalized.sessions).toHaveLength(1);
+    expect(normalized.sessions[0]?.id).toBe("sess_1");
+    expect(normalized.sessions[0]?.transcript).toBeUndefined();
+  });
+
+  test("parseSessionState keeps healthy sessions when a sibling is unsalvageable", () => {
+    const normalized = parseSessionState({
+      activeSessionId: "sess_good",
+      sessions: [
+        validSession("sess_good"),
+        { id: "sess_bad", model: "gpt-5-mini" }, // missing required fields, no transcript to strip
+        validSession("sess_good2", { transcript: [{ id: "row_x", kind: "assistant", content: "hi" }] }),
+      ],
+    });
+
+    const ids = normalized.sessions.map((s) => s.id);
+    expect(ids).toEqual(["sess_good", "sess_good2"]);
+    expect(normalized.activeSessionId).toBe("sess_good");
+  });
+
   test("parseSessionState defaults missing message kind to text", () => {
     const normalized = parseSessionState({
       activeSessionId: "sess_1",

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -1,18 +1,48 @@
 import { existsSync } from "node:fs";
 import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { z } from "zod";
 import { t } from "./i18n";
+import { log } from "./log";
 import { dataDir } from "./paths";
 import type { SessionStore } from "./session-contract";
-import { type Session, type SessionId, type SessionState, sessionStateSchema } from "./session-contract";
+import { type Session, type SessionId, type SessionState, sessionIdSchema, sessionSchema } from "./session-contract";
 import { searchMessages } from "./session-ops";
 import { createId } from "./short-id";
 
 const DEFAULT_SESSION_STATE: SessionState = { sessions: [] };
 
-export function parseSessionState(input: SessionState): SessionState {
-  const result = sessionStateSchema.safeParse(input);
-  return result.success ? result.data : DEFAULT_SESSION_STATE;
+const sessionEnvelopeSchema = z.object({
+  sessions: z.array(z.unknown()).default([]),
+  activeSessionId: z.unknown().optional(),
+});
+
+export function parseSessionState(input: unknown): SessionState {
+  const envelope = sessionEnvelopeSchema.safeParse(input);
+  if (!envelope.success) return DEFAULT_SESSION_STATE;
+  const sessions: Session[] = [];
+  for (const raw of envelope.data.sessions) {
+    const parsed = sessionSchema.safeParse(raw);
+    if (parsed.success) {
+      sessions.push(parsed.data);
+      continue;
+    }
+    // A malformed field must not drop the whole session — and must never (via the old
+    // whole-store reset) drop every other session. The transcript is optional and
+    // reconstructible from messages, so retry without it before giving up on the session.
+    if (raw && typeof raw === "object" && "transcript" in raw) {
+      const withoutTranscript = { ...(raw as Record<string, unknown>) };
+      delete withoutTranscript.transcript;
+      const salvaged = sessionSchema.safeParse(withoutTranscript);
+      if (salvaged.success) {
+        sessions.push(salvaged.data);
+        continue;
+      }
+    }
+    log.warn("session.parse.dropped", { error: parsed.error.message });
+  }
+  const activeSessionId = sessionIdSchema.safeParse(envelope.data.activeSessionId);
+  return { sessions, activeSessionId: activeSessionId.success ? activeSessionId.data : undefined };
 }
 
 export function createSession(model: string): Session {
@@ -33,11 +63,24 @@ export function createFileSessionStore(storePath?: string): SessionStore {
   const resolvedPath = storePath ?? join(dataDir(), "sessions.json");
   const resolvedDir = dirname(resolvedPath);
 
+  // Serialize every read-modify-write so concurrent saves can't race the rename or
+  // clobber each other's session (a lost update). Each mutation runs after the prior
+  // one settles; a failed write doesn't stall the chain.
+  let writeQueue: Promise<unknown> = Promise.resolve();
+  function enqueue<T>(op: () => Promise<T>): Promise<T> {
+    const run = writeQueue.then(op, op);
+    writeQueue = run.then(
+      () => undefined,
+      () => undefined,
+    );
+    return run;
+  }
+
   async function readState(): Promise<SessionState> {
     if (!existsSync(resolvedPath)) return { sessions: [], activeSessionId: undefined };
     try {
       const raw = await readFile(resolvedPath, "utf8");
-      return parseSessionState(JSON.parse(raw) as SessionState);
+      return parseSessionState(JSON.parse(raw));
     } catch {
       return { sessions: [], activeSessionId: undefined };
     }
@@ -45,7 +88,9 @@ export function createFileSessionStore(storePath?: string): SessionStore {
 
   async function writeState(state: SessionState): Promise<void> {
     await mkdir(resolvedDir, { recursive: true });
-    const tmp = `${resolvedPath}.tmp`;
+    // Unique temp name so a stray concurrent writer (another instance) can't have its
+    // rename target pulled out from under it.
+    const tmp = `${resolvedPath}.${process.pid}.${createId()}.tmp`;
     await writeFile(tmp, JSON.stringify(state, null, 2), "utf8");
     await rename(tmp, resolvedPath);
   }
@@ -63,22 +108,26 @@ export function createFileSessionStore(storePath?: string): SessionStore {
       return state.sessions.find((s) => s.id === id) ?? null;
     },
 
-    async saveSession(session) {
-      const state = await readState();
-      const idx = state.sessions.findIndex((s) => s.id === session.id);
-      if (idx >= 0) {
-        state.sessions[idx] = session;
-      } else {
-        state.sessions.unshift(session);
-      }
-      await writeState(state);
+    saveSession(session) {
+      return enqueue(async () => {
+        const state = await readState();
+        const idx = state.sessions.findIndex((s) => s.id === session.id);
+        if (idx >= 0) {
+          state.sessions[idx] = session;
+        } else {
+          state.sessions.unshift(session);
+        }
+        await writeState(state);
+      });
     },
 
-    async removeSession(id) {
-      const state = await readState();
-      state.sessions = state.sessions.filter((s) => s.id !== id);
-      if (state.activeSessionId === id) state.activeSessionId = undefined;
-      await writeState(state);
+    removeSession(id) {
+      return enqueue(async () => {
+        const state = await readState();
+        state.sessions = state.sessions.filter((s) => s.id !== id);
+        if (state.activeSessionId === id) state.activeSessionId = undefined;
+        await writeState(state);
+      });
     },
 
     async getActiveSessionId() {
@@ -86,10 +135,12 @@ export function createFileSessionStore(storePath?: string): SessionStore {
       return state.activeSessionId;
     },
 
-    async setActiveSessionId(id) {
-      const state = await readState();
-      state.activeSessionId = id;
-      await writeState(state);
+    setActiveSessionId(id) {
+      return enqueue(async () => {
+        const state = await readState();
+        state.activeSessionId = id;
+        await writeState(state);
+      });
     },
 
     async searchSession(id, query, options) {

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -8,6 +8,7 @@ import type { CommandContext } from "./chat-commands-contract";
 import type { ChatMessage, ChatRow } from "./chat-contract";
 import { createMessageHandler } from "./chat-message-handler";
 import { type CreatePickerHandlersInput, createPickerHandlers } from "./chat-picker-handlers";
+import { toRows } from "./chat-session";
 import type { Client, PendingState, StreamEvent } from "./client-contract";
 import { createErrorStats } from "./error-handling";
 import { DEFAULT_FEATURE_FLAGS } from "./feature-flags-contract";
@@ -299,7 +300,6 @@ export function createMessageHandlerHarness(overrides?: {
   session?: Session;
   sessionState?: SessionState;
   tokenUsage?: SessionTokenUsageEntry[];
-  toRows?: (messages: ChatMessage[]) => ChatRow[];
 }): MessageHandlerHarness {
   const rows: ChatRow[] = [];
   const allRows: ChatRow[] = [];
@@ -328,7 +328,6 @@ export function createMessageHandlerHarness(overrides?: {
     setCurrentSession: (next) => {
       calls.setCurrentSessionIds.push(next.id);
     },
-    toRows: overrides?.toRows ?? (() => []),
     setRows: (updater) => {
       const next = updater(rows);
       rows.splice(0, rows.length, ...next);
@@ -384,6 +383,17 @@ export function createMessageHandlerHarness(overrides?: {
       calls.promotedSnapshots.push(snapshot);
       rows.splice(0, rows.length);
     },
+    // Eager promotion records what moved; setRows removes them from the active mirror,
+    // matching the real setPromotedRows/setRows split.
+    promoteRows: (promoted) => {
+      calls.promotedSnapshots.push([...promoted]);
+    },
+    resumeTranscript: (resumed) => {
+      const seed = resumed.transcript ?? toRows(resumed.messages);
+      calls.promotedSnapshots.push([...seed]);
+      for (const row of seed) if (!allRows.includes(row)) allRows.push(row);
+      rows.splice(0, rows.length);
+    },
     clearTranscript: () => {
       rows.splice(0, rows.length);
     },
@@ -395,7 +405,7 @@ export type PickerHandlerSpies = {
   rows: ChatRow[];
   pickerValues: unknown[];
   currentSessions: Session[];
-  rowsDirectSets: ChatRow[][];
+  resumedSessions: Session[];
   assistantTurnTexts: string[];
   persistCalls: number;
 };
@@ -408,7 +418,7 @@ export function createPickerHandlerHarness(overrides?: Partial<CreatePickerHandl
     rows: [],
     pickerValues: [],
     currentSessions: [],
-    rowsDirectSets: [],
+    resumedSessions: [],
     assistantTurnTexts: [],
     persistCalls: 0,
   };
@@ -423,9 +433,6 @@ export function createPickerHandlerHarness(overrides?: Partial<CreatePickerHandl
       spies.rows.length = 0;
       spies.rows.push(...next);
     },
-    setRowsDirect: (next) => {
-      spies.rowsDirectSets.push(next);
-    },
     setPicker: (next) => {
       spies.pickerValues.push(next);
     },
@@ -434,11 +441,14 @@ export function createPickerHandlerHarness(overrides?: Partial<CreatePickerHandl
     persist: async () => {
       spies.persistCalls++;
     },
-    toRows: () => [],
     nowIso: () => "2026-02-20T00:00:00.000Z",
     activateSkill: async () => true,
     startAssistantTurn: async (text) => {
       spies.assistantTurnTexts.push(text);
+    },
+    resumeTranscript: (session) => {
+      spies.resumedSessions.push(session);
+      spies.rows.length = 0;
     },
     clearTranscript: () => {},
     ...overrides,
@@ -450,6 +460,7 @@ export type CommandContextSpies = {
   rows: ChatRow[];
   openedModel: boolean;
   currentSessionIds: string[];
+  resumedSessionIds: string[];
   tokenUsageSets: SessionTokenUsageEntry[][];
   persistCalls: number;
 };
@@ -559,6 +570,7 @@ export function createCommandContext(
     rows: [],
     openedModel: false,
     currentSessionIds: [],
+    resumedSessionIds: [],
     tokenUsageSets: [],
     persistCalls: 0,
   };
@@ -574,7 +586,6 @@ export function createCommandContext(
     setTokenUsage: (updater) => {
       spies.tokenUsageSets.push(updater([]));
     },
-    toRows: (messages) => messages.map((m) => ({ id: m.id, kind: m.role, content: m.content })),
     setRows: (updater) => {
       spies.rows = updater(spies.rows);
     },
@@ -588,6 +599,10 @@ export function createCommandContext(
     openResumePanel: () => {},
     openModelPanel: () => {
       spies.openedModel = true;
+    },
+    resumeTranscript: (session) => {
+      spies.resumedSessionIds.push(session.id);
+      spies.rows = [];
     },
     clearTranscript: () => {
       spies.rows = [];

--- a/src/tui/render.test.tsx
+++ b/src/tui/render.test.tsx
@@ -150,6 +150,33 @@ function OverflowShrinkApp(props: { onUnmount: () => void }): React.JSX.Element 
 }
 
 describe("render", () => {
+  test("installs process-level fatal handlers only when onFatalError is given", async () => {
+    const before = {
+      uncaught: process.listenerCount("uncaughtException"),
+      rejection: process.listenerCount("unhandledRejection"),
+    };
+
+    await withMockedStdout(async () => {
+      const { render } = await import("./render");
+      // No callback (the default tests use) must never add a process-exiting handler,
+      // or a stray rejection anywhere in the suite would kill the runner.
+      const bare = render(h("tui-text", null, "x"));
+      expect(process.listenerCount("uncaughtException")).toBe(before.uncaught);
+      expect(process.listenerCount("unhandledRejection")).toBe(before.rejection);
+      bare.unmount();
+      await bare.waitUntilExit();
+
+      const guarded = render(h("tui-text", null, "x"), { onFatalError: () => {} });
+      expect(process.listenerCount("uncaughtException")).toBe(before.uncaught + 1);
+      expect(process.listenerCount("unhandledRejection")).toBe(before.rejection + 1);
+      guarded.unmount();
+      await guarded.waitUntilExit();
+      // Cleanup removes them — no global handler survives an unmounted render.
+      expect(process.listenerCount("uncaughtException")).toBe(before.uncaught);
+      expect(process.listenerCount("unhandledRejection")).toBe(before.rejection);
+    });
+  });
+
   test("commitRender wraps output in sync markers", async () => {
     const writes = await withMockedStdout(async () => {
       const { render } = await import("./render");
@@ -479,6 +506,59 @@ describe("render", () => {
       }
     } finally {
       stdin.restore();
+    }
+  });
+
+  test("a live line taller than the viewport is erased before its repaint", async () => {
+    // The last live line is never frozen (it may still be streaming), so it owns the
+    // tail alone. When it outgrows the viewport the split loop breaks before adding
+    // its height, and a stored erase distance of 0 would repaint it below its own
+    // stale copy — the whole line twice.
+    const ROWS = 10;
+    const COLS = 40;
+    const tall = "x".repeat(COLS * (ROWS + 3));
+    const frames = await renderScript(
+      [
+        <tui-box key="a" flexDirection="column">
+          <tui-text>{tall}</tui-text>
+        </tui-box>,
+        <tui-box key="b" flexDirection="column">
+          <tui-text>{tall}</tui-text>
+          <tui-text>after</tui-text>
+        </tui-box>,
+      ],
+      { columns: COLS, rows: ROWS },
+    );
+    const vt = replayTerminal(frameWrites(frames.flat()), ROWS, COLS);
+    const painted = [...vt.scrollback, ...vt.screen].filter((row) => row.includes("x")).length;
+    // The repaint reclaims every row still on screen; only the rows that genuinely
+    // scrolled off the top survive as a stale prefix.
+    expect(painted).toBe(ROWS + 3 + (ROWS + 3 - ROWS));
+  });
+
+  test("an edit above the fold repaints the tail without duplicating scrollback", async () => {
+    // A long-open turn overflows the viewport, freezing its top rows into scrollback.
+    // When a row above the fold then changes in place (a tool row going running->done),
+    // the frozen prefix stops matching. Re-emitting the whole region would paint a
+    // second copy of every scrolled row; only the unreachable tail may go stale.
+    const ROWS = 10;
+    const COLS = 40;
+    const build = (key: string, marker: string) => {
+      const lines = Array.from({ length: 30 }, (_, i) => (i === 2 ? `tool ${marker}` : `row-${i}`));
+      return (
+        <tui-box key={key} flexDirection="column">
+          {lines.map((line) => (
+            <tui-text key={line}>{line}</tui-text>
+          ))}
+        </tui-box>
+      );
+    };
+    const frames = await renderScript([build("a", "running"), build("b", "done")], { columns: COLS, rows: ROWS });
+    const vt = replayTerminal(frameWrites(frames.flat()), ROWS, COLS);
+    const transcript = [...vt.scrollback, ...vt.screen];
+    for (let i = 0; i < 30; i++) {
+      if (i === 2) continue; // the tool row, not a "row-N" label
+      expect(transcript.filter((row) => row.trim() === `row-${i}`).length).toBe(1);
     }
   });
 

--- a/src/tui/render.test.tsx
+++ b/src/tui/render.test.tsx
@@ -438,6 +438,50 @@ describe("render", () => {
     }
   });
 
+  test("focus-in after a width resize erases the stale tail copy", async () => {
+    // A width-change repaint must skip its erase (reflow makes the stored count
+    // unsafe), leaving a stale copy of the tail above the new one. When every tail
+    // line fits both widths the copy's height is reflow-invariant, so the next
+    // same-width erase (here: focus-in) must reclaim it instead of erasing only
+    // the newest copy and letting stale blocks accumulate.
+    const LINES = ["alpha", "beta", "input"];
+    const stdin = mockStdinTty();
+    try {
+      const writes = await withMockedStdout(
+        async (captured) => {
+          const { render } = await import("./render");
+          const app = render(
+            <tui-box flexDirection="column">
+              {LINES.map((line) => (
+                <tui-text key={line}>{line}</tui-text>
+              ))}
+            </tui-box>,
+          );
+          await drainFrame(() => app.flush(), captured);
+          const before = captured.length;
+          Object.defineProperty(process.stdout, "columns", { value: 30, configurable: true });
+          process.stdout.emit("resize");
+          for (let attempt = 0; attempt < 300 && captured.length === before; attempt++) {
+            await new Promise((resolve) => setTimeout(resolve, 2));
+          }
+          stdin.emit("\x1b[I"); // focus-in → forceRedraw, synchronous commit
+          stdin.emit("\x1b[I"); // repeat redraws must stay stable, not re-append
+          app.unmount();
+          await app.waitUntilExit();
+        },
+        { columns: 20, rows: 12 },
+      );
+
+      const vt = replayTerminal(frameWrites(writes), 12, 30);
+      const transcript = [...vt.scrollback, ...vt.screen];
+      for (const line of LINES) {
+        expect(transcript.filter((row) => row.includes(line)).length).toBe(1);
+      }
+    } finally {
+      stdin.restore();
+    }
+  });
+
   test("width resize skips the erase and does not re-emit frozen scrollback", async () => {
     // A width change may reflow the tail, so the stored erase count is unsafe.
     const LINES = ["L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8"];

--- a/src/tui/render.test.tsx
+++ b/src/tui/render.test.tsx
@@ -562,6 +562,48 @@ describe("render", () => {
     }
   });
 
+  test("width-change debt does not erase overflow frozen in the same paint", async () => {
+    // A width change arms stale-tail debt (the reflowed copy stranded above the new
+    // tail, repaid on the next same-width erase). If that same paint also freezes
+    // overflow into scrollback, the stale copy is pushed out of eraseSequence()'s
+    // reach — repaying the debt would then cursor-up through the frozen tail and
+    // wipe committed transcript. The debt must be dropped when overflow froze.
+    const setLines: { current: (value: string[]) => void } = { current: () => {} };
+    const many = Array.from({ length: 12 }, (_, i) => `line-${i}`);
+    const writes = await withMockedStdout(
+      async (buf) => {
+        const { render } = await import("./render");
+        function App(): React.JSX.Element {
+          const [lines, setLinesState] = useState(["prompt", "input"]);
+          setLines.current = setLinesState;
+          return (
+            <tui-box flexDirection="column">
+              {lines.map((line) => (
+                <tui-text key={line}>{line}</tui-text>
+              ))}
+            </tui-box>
+          );
+        }
+        const app = render(<App />);
+        await drainFrame(() => app.flush(), buf); // frame A: 2-line tail at 20 cols
+        Object.defineProperty(process.stdout, "columns", { value: 30, configurable: true });
+        setLines.current(many); // frame B: width change + overflow freeze, arms debt
+        await drainFrame(() => app.flush(), buf);
+        setLines.current([...many, "line-12"]); // frame C: erase must not reach the frozen tail
+        await drainFrame(() => app.flush(), buf);
+        app.unmount();
+        await app.waitUntilExit();
+      },
+      { columns: 20, rows: 8 },
+    );
+
+    const vt = replayTerminal(frameWrites(writes), 8, 30);
+    const transcript = [...vt.scrollback, ...vt.screen];
+    for (let i = 0; i <= 12; i++) {
+      expect(transcript.filter((row) => row.trim() === `line-${i}`).length).toBe(1);
+    }
+  });
+
   test("width resize skips the erase and does not re-emit frozen scrollback", async () => {
     // A width change may reflow the tail, so the stored erase count is unsafe.
     const LINES = ["L1", "L2", "L3", "L4", "L5", "L6", "L7", "L8"];

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -285,7 +285,11 @@ export function render(node: ReactNode, options: RenderOptions = {}): RenderInst
     }
     lastActiveLineCount = physRows > 0 ? physRows - 1 : 0;
     lastActive = active;
-    staleTailRows = pendingStaleRows;
+    // A paint that froze overflow into scrollback pushed the stale copy above the
+    // now-committed rows, out of eraseSequence()'s reach — repaying the debt would
+    // cursor-up through the frozen tail and wipe it, so drop it (as the static
+    // flush does).
+    staleTailRows = splitIdx > 0 ? 0 : pendingStaleRows;
     pendingStaleRows = 0;
   }
 

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -30,7 +30,18 @@ type RenderInstance = {
   flush: () => void;
 };
 
-export function render(node: ReactNode): RenderInstance {
+type RenderOptions = {
+  /** Policy for an otherwise-unhandled error. Passing it opts into process-level
+   *  `uncaughtException`/`unhandledRejection` handlers that restore the terminal
+   *  before invoking this — so error text never lands on a live TUI. Callers that
+   *  omit it (tests) install nothing. The callback owns printing and process exit;
+   *  since `process.exit` skips `finally`, it must also run any crash-critical
+   *  teardown (e.g. releasing the session lock). */
+  onFatalError?: (error: unknown) => void;
+};
+
+export function render(node: ReactNode, options: RenderOptions = {}): RenderInstance {
+  const { onFatalError } = options;
   const root = createElement("tui-root", {});
   const stdout = process.stdout;
   const stdin = process.stdin;
@@ -216,11 +227,28 @@ export function render(node: ReactNode): RenderInstance {
 
     const allLines = active.split("\n");
 
-    // If frozen lines no longer match the current active prefix (non-append-only
-    // change), invalidate the frozen state so we repaint from scratch.
+    // Frozen lines scrolled into append-only scrollback; eraseSequence() cannot reach
+    // them. When the frozen prefix no longer matches — an edit above the fold, or a
+    // wholesale replacement — those lines are stale but immutable, so re-emitting them
+    // just paints a second copy below the first. Rebase the frozen boundary on the
+    // current content's fold and repaint the reachable tail alone: content that now
+    // fits the viewport repaints in full, content that still overflows keeps a stale
+    // (never duplicated) prefix in scrollback.
     if (frozenLineCount > 0 && allLines.slice(0, frozenLineCount).join("\n") !== frozenScrollbackText) {
-      frozenLineCount = 0;
-      frozenScrollbackText = "";
+      let rows = 0;
+      let fold = 0;
+      for (let i = allLines.length - 1; i >= 0; i--) {
+        const lineRows = linePhysRows(allLines[i] ?? "", cols);
+        if (rows + lineRows > maxLiveRows) {
+          fold = i + 1;
+          break;
+        }
+        rows += lineRows;
+      }
+      // Keep the last line live — it may still be streaming, and the split loop below
+      // needs a non-empty tail to anchor the erase distance.
+      frozenLineCount = Math.min(fold, allLines.length - 1);
+      frozenScrollbackText = allLines.slice(0, frozenLineCount).join("\n");
     }
 
     const erase = eraseSequence();
@@ -237,9 +265,12 @@ export function render(node: ReactNode): RenderInstance {
       }
       physRows += rows;
     }
-    // Never freeze the last live line — it may still be streaming.
+    // Never freeze the last live line — it may still be streaming. It then owns the
+    // tail alone, so its height is the erase distance even when it overruns the
+    // viewport (the clamp on the next paint caps the reach at what stayed visible).
     if (splitIdx > 0 && splitIdx === liveLines.length) {
       splitIdx = liveLines.length - 1;
+      physRows = linePhysRows(liveLines[splitIdx] ?? "", cols);
     }
 
     if (splitIdx > 0) {
@@ -287,7 +318,7 @@ export function render(node: ReactNode): RenderInstance {
     null,
     "",
     (error: Error) => {
-      console.error(error);
+      onFatal(error);
     },
     () => {},
     () => {},
@@ -312,6 +343,8 @@ export function render(node: ReactNode): RenderInstance {
     process.removeListener("SIGINT", onSignal);
     process.removeListener("SIGTERM", onSignal);
     process.removeListener("exit", onExit);
+    process.removeListener("uncaughtException", onFatal);
+    process.removeListener("unhandledRejection", onFatal);
     if (stdin.isTTY) {
       stdin.removeListener("data", onStdinData);
       stdin.setRawMode(false);
@@ -344,9 +377,20 @@ export function render(node: ReactNode): RenderInstance {
     }
   }
 
+  // Restore the terminal before the error reaches the app's policy, so no error text
+  // ever lands on a live TUI. exit() is idempotent, so a later 'exit' fire is a no-op.
+  function onFatal(error: unknown) {
+    exit();
+    onFatalError?.(error);
+  }
+
   process.on("SIGINT", onSignal);
   process.on("SIGTERM", onSignal);
   process.on("exit", onExit);
+  if (onFatalError) {
+    process.on("uncaughtException", onFatal);
+    process.on("unhandledRejection", onFatal);
+  }
 
   return {
     waitUntilExit: () => exitPromise,

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -38,6 +38,13 @@ export function render(node: ReactNode): RenderInstance {
   const useKittyProtocol = stdout.isTTY && KITTY_TERMINALS.includes(termProgram);
   let lastActive = "";
   let lastActiveLineCount = 0;
+  let paintForced = false;
+  // Rows of a stale tail copy left by a width-change repaint (which must skip its
+  // erase). Repaid by the next same-width erase so the copy doesn't dangle forever.
+  let staleTailRows = 0;
+  // Debt armed by the width guard but not yet owed: the first paint at the new
+  // width is the one that strands the copy, so only that paint activates it.
+  let pendingStaleRows = 0;
   // A change since the last frame means the terminal may have reflowed the tail.
   let lastRenderColumns = stdout.columns ?? DEFAULT_COLUMNS;
   let flushedStaticCount = 0;
@@ -94,7 +101,7 @@ export function render(node: ReactNode): RenderInstance {
       resizeTimer = null;
       // Frozen state and erase geometry are reconciled in commitRender, which
       // must own it anyway to catch a streaming commit landing mid-resize.
-      lastActive = "";
+      paintForced = true;
       commitRender();
     }, 16);
   };
@@ -108,8 +115,9 @@ export function render(node: ReactNode): RenderInstance {
   }
 
   function eraseSequence(): string {
-    if (!stdout.isTTY || lastActiveLineCount <= 0) return "";
-    return `${ansi.cursorUp(lastActiveLineCount)}\r${ansi.eraseDown}`;
+    const distance = lastActiveLineCount + staleTailRows;
+    if (!stdout.isTTY || distance <= 0) return "";
+    return `${ansi.cursorUp(distance)}\r${ansi.eraseDown}`;
   }
 
   function linePhysRows(line: string, cols: number): number {
@@ -138,10 +146,10 @@ export function render(node: ReactNode): RenderInstance {
 
   /** Repaint the active region on focus-in. Frozen scrollback is left intact —
    *  it physically scrolled off and the erase can't reach it, so re-emitting would
-   *  duplicate. Clearing lastActive forces a repaint of the live tail only. */
+   *  duplicate. The forced flag repaints the live tail only. */
   function forceRedraw() {
     if (exited || !stdout.isTTY) return;
-    lastActive = "";
+    paintForced = true;
     commitRender();
   }
 
@@ -150,16 +158,28 @@ export function render(node: ReactNode): RenderInstance {
     const cols = stdout.columns ?? DEFAULT_COLUMNS;
     const { staticItems, active } = serializeSplit(root, cols);
     const maxLiveRows = (stdout.rows ?? 24) - 1;
+    const forced = paintForced;
+    paintForced = false;
 
     // Erasing with a stale count is transcript loss. On a width change the terminal
     // may reflow the tail, so cursor-up would overshoot into promoted scrollback —
-    // skip the erase (a stale tail copy is merely cosmetic). On a height shrink,
-    // clamp so cursor-up can't reach through the viewport top into frozen history.
+    // skip the erase. Terminals only reflow soft-wrapped rows and every row we write
+    // is hard-broken, so when each previous tail line fits both widths its height is
+    // reflow-invariant and the skipped distance stays exact: carry it as debt and
+    // repay it on the next same-width erase instead of leaving the copy dangling.
+    // On a height shrink, clamp so cursor-up can't reach through the viewport top
+    // into frozen history.
     if (cols !== lastRenderColumns) {
+      const minCols = Math.min(cols, lastRenderColumns);
+      const prevTail = lastActive.split("\n").slice(frozenLineCount);
+      pendingStaleRows =
+        lastActiveLineCount > 0 && prevTail.every((line) => stripAnsiLength(line) <= minCols) ? lastActiveLineCount : 0;
+      staleTailRows = 0;
       lastActiveLineCount = 0;
       lastRenderColumns = cols;
-    } else if (lastActiveLineCount > maxLiveRows) {
-      lastActiveLineCount = maxLiveRows;
+    } else {
+      if (lastActiveLineCount + staleTailRows > maxLiveRows) staleTailRows = 0;
+      if (lastActiveLineCount > maxLiveRows) lastActiveLineCount = maxLiveRows;
     }
 
     // Flush any new static items (write-once scrollback).
@@ -186,10 +206,13 @@ export function render(node: ReactNode): RenderInstance {
       syncWrite(buf);
       lastActive = "";
       lastActiveLineCount = 0;
+      // Any stale copy now sits above the flushed static lines — unreachable.
+      staleTailRows = 0;
+      pendingStaleRows = 0;
     }
 
     // Only re-render the active region if it changed.
-    if (active === lastActive) return;
+    if (active === lastActive && !forced) return;
 
     const allLines = active.split("\n");
 
@@ -201,6 +224,7 @@ export function render(node: ReactNode): RenderInstance {
     }
 
     const erase = eraseSequence();
+    staleTailRows = 0;
     const liveLines = allLines.slice(frozenLineCount);
 
     let physRows = 0;
@@ -230,6 +254,8 @@ export function render(node: ReactNode): RenderInstance {
     }
     lastActiveLineCount = physRows > 0 ? physRows - 1 : 0;
     lastActive = active;
+    staleTailRows = pendingStaleRows;
+    pendingStaleRows = 0;
   }
 
   const RENDER_THROTTLE_MS = 32;


### PR DESCRIPTION
## Motivation

A resumed session could render a duplicated or missing transcript, inherit another session's history, or lose its final turn; a single corrupt session could wipe the whole store.

## Summary

- persist a display-transcript projection so a resumed session renders byte-exactly what streamed, falling back to collapsed messages for pre-parity sessions
- scope the projection to the current session's log segment so in-app resume and `/clear` can't bleed another session's rows into the persisted transcript
- keep streamed rows authoritative and promote finalized rows eagerly mid-turn, so prose/tool interleaving isn't collapsed or duplicated on re-render
- persist the final turn on clean exit, which the turn-boundary save misses
- route uncaught render errors through a fatal-error policy that restores the terminal before printing
- rebase the frozen prefix and repay stale-tail debt on repaint so resize and focus-in don't duplicate or strand scrollback
- serialize session-store writes and salvage per-session on parse failure so one bad session can't wipe the store
