### PR TITLE
fix(render): panel duplication on repeated resize

### DIFF
--- a/src/tui/render.test.tsx
+++ b/src/tui/render.test.tsx
@@ -509,6 +509,57 @@ describe("render", () => {
     }
   });
 
+  test("consecutive width resizes do not strand accumulating stale tail copies", async () => {
+    // Each width-change repaint skips its erase and strands a copy of the tail. The
+    // debt survives only one transition, so a run of resizes (a slow drag, or an
+    // idle tab whose pane keeps reflowing) before any same-width erase would orphan
+    // every copy but the last — the input panel stacking on screen. The debt must
+    // accumulate so one later same-width erase (focus-in here) reclaims them all.
+    // A committed static line sits above the live region: an erase that overshoots
+    // the strands (the transcript-loss direction) would eat it and drop its count.
+    const COMMITTED = "committed";
+    const LINES = ["border-top", "input", "border-bot", "status"];
+    const stdin = mockStdinTty();
+    try {
+      const writes = await withMockedStdout(
+        async (captured) => {
+          const { render } = await import("./render");
+          const app = render(
+            <tui-box flexDirection="column">
+              <tui-static>
+                <tui-text key={COMMITTED}>{COMMITTED}</tui-text>
+              </tui-static>
+              {LINES.map((line) => (
+                <tui-text key={line}>{line}</tui-text>
+              ))}
+            </tui-box>,
+          );
+          await drainFrame(() => app.flush(), captured);
+          for (const width of [38, 36, 34]) {
+            const before = captured.length;
+            Object.defineProperty(process.stdout, "columns", { value: width, configurable: true });
+            process.stdout.emit("resize");
+            for (let attempt = 0; attempt < 300 && captured.length === before; attempt++) {
+              await new Promise((resolve) => setTimeout(resolve, 2));
+            }
+          }
+          stdin.emit("\x1b[I"); // same-width redraw must reclaim every stranded copy
+          app.unmount();
+          await app.waitUntilExit();
+        },
+        { columns: 40, rows: 20 },
+      );
+
+      const vt = replayTerminal(frameWrites(writes), 20, 34);
+      const transcript = [...vt.scrollback, ...vt.screen];
+      for (const line of [COMMITTED, ...LINES]) {
+        expect(transcript.filter((row) => row.trim() === line).length).toBe(1);
+      }
+    } finally {
+      stdin.restore();
+    }
+  });
+
   test("a live line taller than the viewport is erased before its repaint", async () => {
     // The last live line is never frozen (it may still be streaming), so it owns the
     // tail alone. When it outgrows the viewport the split loop breaks before adding

--- a/src/tui/render.ts
+++ b/src/tui/render.ts
@@ -50,12 +50,14 @@ export function render(node: ReactNode, options: RenderOptions = {}): RenderInst
   let lastActive = "";
   let lastActiveLineCount = 0;
   let paintForced = false;
-  // Rows of a stale tail copy left by a width-change repaint (which must skip its
-  // erase). Repaid by the next same-width erase so the copy doesn't dangle forever.
-  let staleTailRows = 0;
+  // Lines of stale tail copies left by width-change repaints (which must skip their
+  // erase). Reclaimed by the next same-width erase so the copies don't dangle. Kept
+  // as text, not a count, so consecutive width changes can revalidate that every
+  // stranded row still fits the new width before carrying the combined distance.
+  let staleTail: string[] = [];
   // Debt armed by the width guard but not yet owed: the first paint at the new
   // width is the one that strands the copy, so only that paint activates it.
-  let pendingStaleRows = 0;
+  let pendingStaleTail: string[] = [];
   // A change since the last frame means the terminal may have reflowed the tail.
   let lastRenderColumns = stdout.columns ?? DEFAULT_COLUMNS;
   let flushedStaticCount = 0;
@@ -126,7 +128,7 @@ export function render(node: ReactNode, options: RenderOptions = {}): RenderInst
   }
 
   function eraseSequence(): string {
-    const distance = lastActiveLineCount + staleTailRows;
+    const distance = lastActiveLineCount + staleTail.length;
     if (!stdout.isTTY || distance <= 0) return "";
     return `${ansi.cursorUp(distance)}\r${ansi.eraseDown}`;
   }
@@ -182,14 +184,23 @@ export function render(node: ReactNode, options: RenderOptions = {}): RenderInst
     // into frozen history.
     if (cols !== lastRenderColumns) {
       const minCols = Math.min(cols, lastRenderColumns);
+      // The skipped-erase paint strands this tail's rows above the new one (all but
+      // the last, which the new first line overwrites) on top of any copies already
+      // stranded by earlier width changes. One later erase can reclaim them all only
+      // if every row still occupies a single line at both widths, so carry the combined
+      // set when they all fit; otherwise the distance would be wrong and we abandon it.
       const prevTail = lastActive.split("\n").slice(frozenLineCount);
-      pendingStaleRows =
-        lastActiveLineCount > 0 && prevTail.every((line) => stripAnsiLength(line) <= minCols) ? lastActiveLineCount : 0;
-      staleTailRows = 0;
+      const stranded = [...staleTail, ...prevTail.slice(0, -1)];
+      // Validate the whole prevTail, including its overwritten last line: if that line
+      // is over-width it soft-wraps, so its reflow moves the cursor by an uncounted
+      // amount and the carried distance stops being exact — abandon rather than guess.
+      const fits = (line: string) => stripAnsiLength(line) <= minCols;
+      pendingStaleTail = staleTail.every(fits) && prevTail.every(fits) ? stranded : [];
+      staleTail = [];
       lastActiveLineCount = 0;
       lastRenderColumns = cols;
     } else {
-      if (lastActiveLineCount + staleTailRows > maxLiveRows) staleTailRows = 0;
+      if (lastActiveLineCount + staleTail.length > maxLiveRows) staleTail = [];
       if (lastActiveLineCount > maxLiveRows) lastActiveLineCount = maxLiveRows;
     }
 
@@ -218,8 +229,8 @@ export function render(node: ReactNode, options: RenderOptions = {}): RenderInst
       lastActive = "";
       lastActiveLineCount = 0;
       // Any stale copy now sits above the flushed static lines — unreachable.
-      staleTailRows = 0;
-      pendingStaleRows = 0;
+      staleTail = [];
+      pendingStaleTail = [];
     }
 
     // Only re-render the active region if it changed.
@@ -252,7 +263,7 @@ export function render(node: ReactNode, options: RenderOptions = {}): RenderInst
     }
 
     const erase = eraseSequence();
-    staleTailRows = 0;
+    staleTail = [];
     const liveLines = allLines.slice(frozenLineCount);
 
     let physRows = 0;
@@ -289,8 +300,8 @@ export function render(node: ReactNode, options: RenderOptions = {}): RenderInst
     // now-committed rows, out of eraseSequence()'s reach — repaying the debt would
     // cursor-up through the frozen tail and wipe it, so drop it (as the static
     // flush does).
-    staleTailRows = splitIdx > 0 ? 0 : pendingStaleRows;
-    pendingStaleRows = 0;
+    staleTail = splitIdx > 0 ? [] : pendingStaleTail;
+    pendingStaleTail = [];
   }
 
   const RENDER_THROTTLE_MS = 32;


### PR DESCRIPTION
## Summary

- fix duplicate input panels stacking on an idle tab after repeated resizes
- carry width-change stale-tail debt as the stranded lines so consecutive resizes accumulate into one reclaimable erase instead of orphaning earlier copies
- revalidate each stranded row still fits the new width before carrying, else abandon the debt