### PR TITLE
fix(chat): stop false prompt on blocked turns

### DIFF
--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -11,7 +11,7 @@ resolve → prepare → generate → finalize
 - **resolve**: pick model and policy
 - **prepare**: build base agent input, tools, session context, and policy state
 - **generate**: run model + tool loop; effects (format, lint) apply per-tool-result via callback; the model terminates with a lifecycle signal tool (`signal_done`, `signal_noop`, `signal_blocked`)
-- **finalize**: accept lifecycle signal, emit final response and summary events; a `blocked` signal maps to `ChatResponseState = "awaiting-input"`
+- **finalize**: accept lifecycle signal, emit final response and summary events; a `blocked` signal ends the turn normally with the model's question as `output`
 
 ## Generation loop feedback
 
@@ -20,7 +20,7 @@ Generation owns one model/tool loop. Effects apply inline during tool execution.
 - unresolved tool errors are sent back once so the model can inspect evidence and retry instead of falsely finalizing
 - missing post-write validation is sent back once so the model can run focused validation or explicitly block
 
-If the model still cannot recover, finalize returns an awaiting-input response with the unresolved error.
+If the model still cannot recover, finalize returns the unresolved error on `error`, which the client renders as an error row.
 
 ## Effects
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,4 +1,3 @@
-import { z } from "zod";
 import type { ChatMessage } from "./chat-contract";
 import type { ResourceId } from "./resource-id";
 import type { PromptBreakdown, SessionId, TokenUsage } from "./session-contract";
@@ -16,11 +15,7 @@ export interface ChatRequest {
   readonly workspace?: string;
 }
 
-export const chatResponseStateSchema = z.enum(["done", "awaiting-input"]);
-export type ChatResponseState = z.infer<typeof chatResponseStateSchema>;
-
 export interface ChatResponse {
-  state: ChatResponseState;
   output: string;
   model: string;
   usage?: TokenUsage;

--- a/src/chat-message-handler-stream.int.test.ts
+++ b/src/chat-message-handler-stream.int.test.ts
@@ -30,7 +30,7 @@ describe("chat message handler stream behavior", () => {
             content: { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "echo hi" },
           });
           input.onEvent({ type: "text-delta", text: "done" });
-          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", output: "done" };
         },
         status: async () => ({}),
       }),
@@ -52,7 +52,6 @@ describe("chat message handler stream behavior", () => {
     const { handleMessage, rows, session } = createMessageHandlerHarness({
       client: createClient({
         replyStream: async () => ({
-          state: "done" as const,
           model: "gpt-5-mini",
           output: "done",
           toolCalls: ["shell-run"],
@@ -85,7 +84,7 @@ describe("chat message handler stream behavior", () => {
             isError: false,
           });
           input.onEvent({ type: "text-delta", text: "No matches found." });
-          return { state: "done" as const, model: "gpt-5-mini", output: "No matches found." };
+          return { model: "gpt-5-mini", output: "No matches found." };
         },
       }),
     });
@@ -150,7 +149,7 @@ describe("chat message handler stream behavior", () => {
           callCount += 1;
           if (callCount === 1) throw new Error("Remote server stream timed out after 120000ms");
           input.onEvent({ type: "text-delta", text: "ok" });
-          return { state: "done" as const, model: "gpt-5-mini", output: "ok" };
+          return { model: "gpt-5-mini", output: "ok" };
         },
       }),
     });
@@ -276,7 +275,7 @@ describe("chat message handler stream behavior", () => {
             type: "text-delta",
             text: "This is a long streamed answer that should not be truncated at finalize.",
           });
-          return { state: "done" as const, model: "gpt-5-mini", output: finalOutput };
+          return { model: "gpt-5-mini", output: finalOutput };
         },
       }),
     });
@@ -307,7 +306,7 @@ describe("chat message handler stream behavior", () => {
             errorCode: "E_GUARD_BLOCKED",
             error: { code: "E_GUARD_BLOCKED", category: "budget-exhausted" },
           });
-          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", output: "done" };
         },
       }),
     });
@@ -350,7 +349,7 @@ describe("chat message handler stream behavior", () => {
             toolName: "file-edit",
             content: { kind: "diff", lineNumber: 2, marker: "add", text: "export const b = 2;" },
           });
-          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", output: "done" };
         },
       }),
     });
@@ -375,8 +374,8 @@ describe("chat message handler stream behavior", () => {
 
   test("does not merge tool rows across separate user turns", async () => {
     const replies = [
-      { state: "done" as const, model: "gpt-5-mini", output: "first done" },
-      { state: "done" as const, model: "gpt-5-mini", output: "second done" },
+      { model: "gpt-5-mini", output: "first done" },
+      { model: "gpt-5-mini", output: "second done" },
     ];
     const eventsByTurn: StreamEvent[][] = [
       [
@@ -420,7 +419,7 @@ describe("chat message handler stream behavior", () => {
           for (const event of events) {
             input.onEvent(event);
           }
-          return replies[turn] ?? { state: "done" as const, model: "gpt-5-mini", output: "done" };
+          return replies[turn] ?? { model: "gpt-5-mini", output: "done" };
         },
       }),
     });
@@ -443,7 +442,6 @@ describe("chat message handler stream behavior", () => {
       client: createClient({
         status: async () => ({}),
         replyStream: async () => ({
-          state: "done" as const,
           model: "gpt-5-mini",
           output: "done",
           usage: {
@@ -482,7 +480,7 @@ describe("chat message handler stream behavior", () => {
         replyCount += 1;
         input.onEvent({ type: "status", state: { kind: "running" } });
         input.onEvent({ type: "text-delta", text: `reply-${replyCount}` });
-        return { state: "done" as const, model: "gpt-5-mini", output: `reply-${replyCount}` };
+        return { model: "gpt-5-mini", output: `reply-${replyCount}` };
       },
     });
 
@@ -580,7 +578,7 @@ describe("chat message handler stream behavior", () => {
             toolCallId: "call_1",
             toolName: "shell-run",
           });
-          return { state: "done" as const, model: "gpt-5-mini", output: "I will run the command." };
+          return { model: "gpt-5-mini", output: "I will run the command." };
         },
         status: async () => ({}),
       }),
@@ -647,7 +645,7 @@ describe("chat message handler stream behavior", () => {
             toolCallId: "call_B",
             toolName: "code-edit",
           });
-          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", output: "done" };
         },
         status: async () => ({}),
       }),

--- a/src/chat-message-handler-stream.test.ts
+++ b/src/chat-message-handler-stream.test.ts
@@ -276,8 +276,8 @@ describe("chat-message-handler-stream", () => {
 
     state.finalize();
 
-    // Simulate message handler appending status row (awaiting-input)
-    setRows((current) => [...current, { id: "status_1", kind: "status", content: "Waiting for your reply" }]);
+    // Simulate message handler appending a status row after the turn
+    setRows((current) => [...current, { id: "status_1", kind: "status", content: "Worked 3s" }]);
 
     // The streamed assistant text must still be present
     const assistantRow = rows.find((r) => r.kind === "assistant");

--- a/src/chat-message-handler.int.test.ts
+++ b/src/chat-message-handler.int.test.ts
@@ -143,7 +143,7 @@ describe("chat message handler", () => {
       client: createClient({
         replyStream: async (input) => {
           requestedModel = input.request.model;
-          return { state: "done" as const, model: input.request.model, output: "ok" };
+          return { model: input.request.model, output: "ok" };
         },
       }),
     });
@@ -155,13 +155,12 @@ describe("chat message handler", () => {
 
   test("keeps create-edit-delete tool output visible across submits", async () => {
     const replies = [
-      { state: "done" as const, model: "gpt-5-mini", output: "Created sum.rs." },
+      { model: "gpt-5-mini", output: "Created sum.rs." },
       {
-        state: "done" as const,
         model: "gpt-5-mini",
         output: "Updated sum.rs for three args.",
       },
-      { state: "done" as const, model: "gpt-5-mini", output: "Removed sum.rs." },
+      { model: "gpt-5-mini", output: "Removed sum.rs." },
     ];
     const eventsByTurn: StreamEvent[][] = [
       [
@@ -217,7 +216,7 @@ describe("chat message handler", () => {
           for (const event of events) {
             input.onEvent(event);
           }
-          return replies[turn] ?? { state: "done" as const, model: "gpt-5-mini", output: "done" };
+          return replies[turn] ?? { model: "gpt-5-mini", output: "done" };
         },
       }),
     });
@@ -260,7 +259,6 @@ describe("chat message handler", () => {
         replyStream: async (input) => {
           input.onEvent({ type: "text-delta", text: "the complete streamed answer." });
           return {
-            state: "done" as const,
             model: "gpt-5-mini",
             output: "the complete streamed answer.",
           };
@@ -280,7 +278,6 @@ describe("chat message handler", () => {
       client: createClient({
         status: async () => ({}),
         replyStream: async () => ({
-          state: "done" as const,
           model: "gpt-5-mini",
           output: "answer delivered without deltas.",
         }),
@@ -303,7 +300,7 @@ describe("chat message handler", () => {
         status: async () => ({}),
         replyStream: async (input) => {
           input.onEvent({ type: "text-delta", text: "answer" });
-          return { state: "done" as const, model: "gpt-5-mini", output: "answer" };
+          return { model: "gpt-5-mini", output: "answer" };
         },
       }),
     });
@@ -327,7 +324,6 @@ describe("chat message handler", () => {
           input.onEvent({ type: "text-delta", text: "The complete answer." });
           input.onEvent({ type: "tool-call", toolCallId: "sig_1", toolName: "signal_done", args: {} });
           return {
-            state: "done" as const,
             model: "gpt-5-mini",
             output: "The complete answer.",
             toolCalls: ["signal_done"],
@@ -357,7 +353,7 @@ describe("chat message handler", () => {
             content: { kind: "tool-header", labelKey: "tool.label.file_edit", detail: "a.rs" },
           });
           input.onEvent({ type: "text-delta", text: "Done editing." });
-          return { state: "done" as const, model: "gpt-5-mini", output: "Let me check the file.\nDone editing." };
+          return { model: "gpt-5-mini", output: "Let me check the file.\nDone editing." };
         },
       }),
     });
@@ -489,7 +485,7 @@ describe("chat message handler", () => {
             });
           }
           input.onEvent({ type: "text-delta", text: "Second answer." });
-          return { state: "done" as const, model: "gpt-5-mini", output: "Second answer." };
+          return { model: "gpt-5-mini", output: "Second answer." };
         },
         status: async () => ({}),
       }),
@@ -557,7 +553,7 @@ describe("chat message handler", () => {
         replyStream: async (input) => {
           replyCalls += 1;
           input.onEvent({ type: "text-delta", text: "ok" });
-          return { state: "done" as const, model: "gpt-5-mini", output: "ok" };
+          return { model: "gpt-5-mini", output: "ok" };
         },
         status: async () => ({}),
       }),
@@ -583,7 +579,7 @@ describe("chat message handler", () => {
           replyStream: async (input) => {
             replyCalls += 1;
             input.onEvent({ type: "text-delta", text: "ok" });
-            return { state: "done" as const, model: "gpt-5-mini", output: "ok" };
+            return { model: "gpt-5-mini", output: "ok" };
           },
           status: async () => ({}),
         }),
@@ -609,7 +605,7 @@ describe("chat message handler", () => {
           replyCount++;
           await Bun.sleep(10);
           input.onEvent({ type: "text-delta", text: "ok" });
-          return { state: "done" as const, model: "gpt-5-mini", output: "ok" };
+          return { model: "gpt-5-mini", output: "ok" };
         },
         status: async () => ({}),
       }),
@@ -688,7 +684,7 @@ describe("chat message handler", () => {
       client: createClient({
         replyStream: async (input) => {
           input.onEvent({ type: "text-delta", text: "done" });
-          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", output: "done" };
         },
         status: async () => ({}),
       }),
@@ -713,7 +709,7 @@ describe("chat message handler", () => {
             content: { kind: "tool-header", labelKey: "tool.label.file_edit", detail: "test.ts" },
           });
           input.onEvent({ type: "text-delta", text: "edited" });
-          return { state: "done" as const, model: "gpt-5-mini", output: "edited" };
+          return { model: "gpt-5-mini", output: "edited" };
         },
         status: async () => ({}),
       }),
@@ -729,7 +725,6 @@ describe("chat message handler", () => {
     const { handleMessage, calls } = createMessageHandlerHarness({
       client: createClient({
         replyStream: async () => ({
-          state: "done" as const,
           model: "gpt-5-mini",
           output: "No changes needed.",
         }),
@@ -758,7 +753,7 @@ describe("chat message handler", () => {
           });
           input.onEvent({ type: "tool-result", toolCallId: "c1", toolName: "file-edit" });
           input.onEvent({ type: "text-delta", text: "Done." });
-          return { state: "done" as const, model: "gpt-5-mini", output: "Checking the file.\nDone." };
+          return { model: "gpt-5-mini", output: "Checking the file.\nDone." };
         },
       }),
     });
@@ -787,7 +782,7 @@ describe("chat message handler", () => {
           input.onEvent({ type: "error", errorMessage: "rate limited, retrying" });
           input.onEvent({ type: "error", errorMessage: "rate limited, retrying" });
           input.onEvent({ type: "text-delta", text: "ok" });
-          return { state: "done" as const, model: "gpt-5-mini", output: "ok" };
+          return { model: "gpt-5-mini", output: "ok" };
         },
       }),
     });
@@ -805,7 +800,7 @@ describe("chat message handler", () => {
       client: createClient({
         replyStream: async (input) => {
           input.onEvent({ type: "text-delta", text: "done" });
-          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", output: "done" };
         },
         status: async () => ({}),
       }),
@@ -817,12 +812,11 @@ describe("chat message handler", () => {
     expect(rows).toHaveLength(0);
   });
 
-  test("awaiting-input promotes the block reason into the durable transcript", async () => {
+  test("a blocked question promotes the reason into the durable transcript", async () => {
     const { handleMessage, rows, session, calls } = createMessageHandlerHarness({
       client: createClient({
         // signal_blocked with no prose: the reason arrives via output, nothing streams.
         replyStream: async () => ({
-          state: "awaiting-input" as const,
           model: "gpt-5-mini",
           output: "Which credential should I use?",
         }),
@@ -841,11 +835,10 @@ describe("chat message handler", () => {
     );
   });
 
-  test("awaiting-input from a blocking error promotes the reason without inventing prose", async () => {
+  test("a blocking error renders as an error row with no prompt or invented prose", async () => {
     const { handleMessage, session, calls } = createMessageHandlerHarness({
       client: createClient({
         replyStream: async () => ({
-          state: "awaiting-input" as const,
           model: "gpt-5-mini",
           output: "",
           error: "completion blocked: missing signal",
@@ -861,6 +854,8 @@ describe("chat message handler", () => {
     expect(promoted.some((r) => r.kind === "system" && r.content === "completion blocked: missing signal")).toBe(true);
     expect(promoted.some((r) => r.kind === "assistant")).toBe(false);
     expect(session.messages.some((m) => m.role === "assistant")).toBe(false);
+    expect(calls.pendingStates.at(-1)).toBeNull();
+    expect(calls.pendingTransitions.at(-1)).toBe(false);
   });
 
   test("answering a blocked turn in-process does not duplicate the reason row", async () => {
@@ -870,8 +865,8 @@ describe("chat message handler", () => {
         replyStream: async () => {
           call += 1;
           return call === 1
-            ? { state: "awaiting-input" as const, model: "gpt-5-mini", output: "Which credential should I use?" }
-            : { state: "done" as const, model: "gpt-5-mini", output: "Deployed." };
+            ? { model: "gpt-5-mini", output: "Which credential should I use?" }
+            : { model: "gpt-5-mini", output: "Deployed." };
         },
         status: async () => ({}),
       }),
@@ -962,12 +957,12 @@ describe("chat message handler", () => {
     expect(promoted.some((r) => r.kind === "task" && r.content === "Interrupted")).toBe(true);
   });
 
-  test("awaiting-input preserves pending state after turn completes", async () => {
+  test("a blocked question ends the turn with no pending indicator", async () => {
     const { handleMessage, calls } = createMessageHandlerHarness({
       client: createClient({
         replyStream: async (input) => {
           input.onEvent({ type: "text-delta", text: "What input?" });
-          return { state: "awaiting-input" as const, model: "gpt-5-mini", output: "What input?" };
+          return { model: "gpt-5-mini", output: "What input?" };
         },
         status: async () => ({}),
       }),
@@ -975,8 +970,7 @@ describe("chat message handler", () => {
 
     await handleMessage("ask me for some input");
 
-    const last = calls.pendingStates[calls.pendingStates.length - 1];
-    expect(last).toEqual({ kind: "awaiting-input" });
-    expect(calls.pendingTransitions.at(-1)).toBe(true);
+    expect(calls.pendingStates.at(-1)).toBeNull();
+    expect(calls.pendingTransitions.at(-1)).toBe(false);
   });
 });

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -103,7 +103,7 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
     });
 
     await input.persist();
-    let cleanup: "full" | "turn-only" | "none" = "full";
+    let cleanup: "full" | "none" = "full";
 
     try {
       const suggestions: string[] = [];
@@ -170,14 +170,7 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
       // Clear the pending indicator in the same synchronous block as
       // adding the worked/status rows so React batches them into one
       // commit — avoids a frame where both "Working" and "Worked" show.
-      // For awaiting-input, keep the indicator alive and tell the
-      // finally block to skip pending cleanup.
-      if (turn.awaitingInput) {
-        cleanup = "turn-only";
-        input.setPendingState({ kind: "awaiting-input" });
-      } else {
-        input.setPendingState(null);
-      }
+      input.setPendingState(null);
       // The streamed rows are the authoritative display transcript: they carry the
       // turn's true interleaving (prose, tool, prose) and are already committed to the
       // screen. reply.output is the same prose reassembled for model history, so

--- a/src/chat-pending.ts
+++ b/src/chat-pending.ts
@@ -25,8 +25,7 @@ export type PendingStateResult = {
 
 export function usePendingState(): PendingStateResult {
   const [pendingState, setPendingState] = useState<PendingState | null>(null);
-  const hasIndicator = pendingState !== null;
-  const isPending = hasIndicator && pendingState.kind !== "awaiting-input";
+  const isPending = pendingState !== null;
   const [pendingFrame, setPendingFrame] = useState(0);
   const [pendingStartedAt, setPendingStartedAt] = useState<number | null>(null);
   const [ctrlCPending, setCtrlCPending] = useState(false);
@@ -38,13 +37,13 @@ export function usePendingState(): PendingStateResult {
       setPendingStartedAt((current) => current ?? Date.now());
     } else {
       setPendingStartedAt(null);
-      if (!hasIndicator) setPendingFrame(0);
+      setPendingFrame(0);
     }
-  }, [isPending, hasIndicator]);
+  }, [isPending]);
 
   useInterval(
     () => setPendingFrame((current) => nextPendingFrame(current, PENDING_PULSE_FRAMES)),
-    hasIndicator ? PENDING_ANIMATION_INTERVAL_MS : null,
+    isPending ? PENDING_ANIMATION_INTERVAL_MS : null,
   );
 
   return {

--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -24,7 +24,6 @@ const MARKERS: Record<ChatRow["kind"], string> = {
 };
 
 const PENDING_MARKER_COLORS: Record<PendingState["kind"], string> = {
-  "awaiting-input": palette.brand,
   queued: palette.queued,
   accepted: palette.accepted,
   running: palette.running,
@@ -245,7 +244,7 @@ export function ChatTranscript(props: ChatTranscriptProps): React.ReactNode {
     kind === "running" && typeof pendingStartedAt === "number"
       ? Math.max(0, Math.floor((Date.now() - pendingStartedAt) / 1000))
       : 0;
-  const isAnimated = kind === "running" || kind === "awaiting-input";
+  const isAnimated = kind === "running";
   const blinkOn = Math.abs(pendingFrame) % pulsePeriod < pulsePeriod / 2;
   const marker = isAnimated && !blinkOn ? " " : "•";
   const markerColor = kind ? PENDING_MARKER_COLORS[kind] : "";
@@ -271,9 +270,6 @@ export function ChatTranscript(props: ChatTranscriptProps): React.ReactNode {
     }
     if (pendingState.kind === "accepted") {
       return t("rpc.status.accepted");
-    }
-    if (pendingState.kind === "awaiting-input") {
-      return t("chat.awaiting_input");
     }
     return "";
   })();

--- a/src/chat-turn.test.ts
+++ b/src/chat-turn.test.ts
@@ -123,7 +123,6 @@ describe("chat turn helpers", () => {
     const turn = await runAssistantTurn({
       client: {
         replyStream: async () => ({
-          state: "done" as const,
           model: "gpt-5-mini",
           output: "done",
         }),
@@ -154,7 +153,6 @@ describe("chat turn helpers", () => {
     const turn = await runAssistantTurn({
       client: {
         replyStream: async () => ({
-          state: "done" as const,
           model: "gpt-5-mini",
           output: "done",
           activeSkills: skills,
@@ -182,7 +180,6 @@ describe("chat turn helpers", () => {
     const turn = await runAssistantTurn({
       client: {
         replyStream: async () => ({
-          state: "done" as const,
           model: "gpt-5-mini",
           output: "done",
           toolCalls: ["file-read"],
@@ -210,7 +207,6 @@ describe("chat turn helpers", () => {
     const turn = await runAssistantTurn({
       client: {
         replyStream: async () => ({
-          state: "done" as const,
           model: "gpt-5-mini",
           output: "The answer is 42.",
           toolCalls: ["signal_done"],
@@ -238,7 +234,6 @@ describe("chat turn helpers", () => {
     const turn = await runAssistantTurn({
       client: {
         replyStream: async () => ({
-          state: "done" as const,
           model: "gpt-5-mini",
           output: "Reading the file.",
           toolCalls: ["file-read", "signal_done"],
@@ -266,7 +261,6 @@ describe("chat turn helpers", () => {
     const turn = await runAssistantTurn({
       client: {
         replyStream: async () => ({
-          state: "done" as const,
           model: "gpt-5-mini",
           output: "done",
           toolCalls: ["file-read", "signal_done"],

--- a/src/chat-turn.ts
+++ b/src/chat-turn.ts
@@ -117,7 +117,6 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
   tokenEntry: SessionTokenUsageEntry;
   rows: ChatRow[];
   activeSkills?: ActiveSkill[];
-  awaitingInput: boolean;
 }> {
   const reply = await params.client.replyStream({
     request: {
@@ -149,25 +148,22 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
 
     modelCalls: reply.modelCalls,
   };
-  const awaitingInput = reply.state === "awaiting-input";
-  if (!awaitingInput) {
-    const durationMs = Date.now() - params.pendingStartedAt;
-    if (durationMs >= 300) {
-      const duration = formatDuration(durationMs);
-      const toolCount = reply.toolCalls?.length ?? 0;
-      const { inputTokens, outputTokens } = tokenEntry.usage;
-      const details: string[] = [];
-      if (toolCount > 0) details.push(t("unit.tool", { count: toolCount }));
-      if (inputTokens + outputTokens > 0)
-        details.push(
-          t("unit.token.arrows", {
-            input: formatCompactNumber(inputTokens),
-            output: formatCompactNumber(outputTokens),
-          }),
-        );
-      const suffix = details.length > 0 ? ` (${details.join(" · ")})` : "";
-      rows.push(createRow("status", t("chat.worked", { duration, suffix }), { marker: palette.success, dim: true }));
-    }
+  const durationMs = Date.now() - params.pendingStartedAt;
+  if (durationMs >= 300) {
+    const duration = formatDuration(durationMs);
+    const toolCount = reply.toolCalls?.length ?? 0;
+    const { inputTokens, outputTokens } = tokenEntry.usage;
+    const details: string[] = [];
+    if (toolCount > 0) details.push(t("unit.tool", { count: toolCount }));
+    if (inputTokens + outputTokens > 0)
+      details.push(
+        t("unit.token.arrows", {
+          input: formatCompactNumber(inputTokens),
+          output: formatCompactNumber(outputTokens),
+        }),
+      );
+    const suffix = details.length > 0 ? ` (${details.join(" · ")})` : "";
+    rows.push(createRow("status", t("chat.worked", { duration, suffix }), { marker: palette.success, dim: true }));
   }
 
   return {
@@ -175,6 +171,5 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
     tokenEntry,
     rows,
     activeSkills: reply.activeSkills,
-    awaitingInput,
   };
 }

--- a/src/checklist.int.test.ts
+++ b/src/checklist.int.test.ts
@@ -23,7 +23,7 @@ describe("checklist integration", () => {
             ],
           });
           snapshot = [...rows];
-          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", output: "done" };
         },
       }),
     });
@@ -68,7 +68,7 @@ describe("checklist integration", () => {
             ],
           });
           snapshot = [...rows];
-          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", output: "done" };
         },
       }),
     });
@@ -103,7 +103,7 @@ describe("checklist integration", () => {
             items: [{ id: "b1", label: "step B1", status: "pending", order: 0 }],
           });
           snapshot = [...rows];
-          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", output: "done" };
         },
       }),
     });
@@ -142,7 +142,7 @@ describe("checklist integration", () => {
             content: { kind: "tool-header", labelKey: "tool.label.file_read", detail: "a.ts" },
           });
           snapshot = [...rows];
-          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", output: "done" };
         },
       }),
     });
@@ -187,7 +187,7 @@ describe("checklist integration", () => {
             toolName: "file-edit",
           });
           snapshot = [...rows];
-          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", output: "done" };
         },
       }),
     });
@@ -212,7 +212,7 @@ describe("checklist integration", () => {
             groupTitle: "Steps",
             items: [{ id: "s1", label: "do thing", status: "done", order: 0 }],
           });
-          return { state: "done" as const, model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", output: "done" };
         },
       }),
     });

--- a/src/cli-prompt-golden.test.ts
+++ b/src/cli-prompt-golden.test.ts
@@ -25,14 +25,11 @@ function session(): Session {
   };
 }
 
-function client(
-  events: StreamEvent[],
-  reply: { state: "done" | "awaiting-input"; output: string; error?: string },
-): Client {
+function client(events: StreamEvent[], reply: { output: string; error?: string }): Client {
   return {
     replyStream: async (input) => {
       for (const event of events) input.onEvent(event);
-      return { ...reply, model: "gpt-5-mini", toolCalls: reply.state === "done" ? ["file-read"] : [] };
+      return { ...reply, model: "gpt-5-mini", toolCalls: reply.error ? [] : ["file-read"] };
     },
     status: async () => ({}),
     taskStatus: async () => null,
@@ -47,10 +44,7 @@ function capture(prompt: string, c: Client): Promise<string> {
 
 describe("cli-prompt golden output (output-path fold safety net)", () => {
   test("streamed answer", async () => {
-    const out = await capture(
-      "hi",
-      client([{ type: "text-delta", text: "Hello there." }], { state: "done", output: "Hello there." }),
-    );
+    const out = await capture("hi", client([{ type: "text-delta", text: "Hello there." }], { output: "Hello there." }));
     expect(out).toBe("❯ hi\n• Hello there.");
   });
 
@@ -75,7 +69,7 @@ describe("cli-prompt golden output (output-path fold safety net)", () => {
       },
       { type: "notice", level: "warn", message: "trace sink is dark" },
     ];
-    const out = await capture("check config", client(events, { state: "done", output: "Updated the config." }));
+    const out = await capture("check config", client(events, { output: "Updated the config." }));
     // The final answer ("Updated the config.") diverges from the streamed preview ("Let
     // me check the config.") and now appears in full — previously it was dropped.
     expect(out).toBe(
@@ -87,7 +81,6 @@ describe("cli-prompt golden output (output-path fold safety net)", () => {
     const out = await capture(
       "fix",
       client([{ type: "text-delta", text: "Trying the edit." }], {
-        state: "awaiting-input",
         output: "",
         error: "Cannot finish yet: validation missing",
       }),
@@ -107,7 +100,7 @@ describe("cli-prompt golden output (output-path fold safety net)", () => {
             content: { kind: "tool-header", labelKey: "tool.memory_search.header" },
           },
         ],
-        { state: "done", output: "Done." },
+        { output: "Done." },
       ),
     );
     expect(out).toBe("❯ search\n\n• Done.");
@@ -125,7 +118,7 @@ describe("cli-prompt golden output (output-path fold safety net)", () => {
           { type: "checklist", groupId: "g1", groupTitle: "Steps", items: items(false) },
           { type: "checklist", groupId: "g1", groupTitle: "Steps", items: items(true) },
         ],
-        { state: "done", output: "Done." },
+        { output: "Done." },
       ),
     );
     expect(out).toBe("❯ run\n• Steps (0/2)\n  ○ read\n  ○ edit\n• Steps (1/2)\n  ● read\n  ○ edit\n\n\n• Done.");

--- a/src/cli-prompt.test.ts
+++ b/src/cli-prompt.test.ts
@@ -23,7 +23,7 @@ function createStreamingClient(events: StreamEvent[]): Client {
   return {
     replyStream: async (input) => {
       for (const event of events) input.onEvent(event);
-      return { state: "done" as const, output: "done", model: "gpt-5-mini", toolCalls: ["code-edit"] };
+      return { output: "done", model: "gpt-5-mini", toolCalls: ["code-edit"] };
     },
     status: async () => ({}),
     taskStatus: async () => null,
@@ -55,7 +55,6 @@ describe("cli-prompt", () => {
     const session = createTestSession();
     const client: Client = {
       replyStream: async () => ({
-        state: "done" as const,
         output: "done",
         model: "gpt-5-mini",
         toolCalls: ["file-read"],
@@ -73,7 +72,6 @@ describe("cli-prompt", () => {
     const session = createTestSession();
     const client: Client = {
       replyStream: async () => ({
-        state: "awaiting-input" as const,
         output: "file-edit failed: Find text matched 2 locations",
         model: "gpt-5-mini",
         error: "file-edit failed: Find text matched 2 locations",
@@ -171,7 +169,7 @@ describe("cli-prompt", () => {
     const client: Client = {
       replyStream: async (input) => {
         input.onEvent({ type: "text-delta", text: "Hello there.\n" });
-        return { state: "done" as const, output: "Hello there.", model: "gpt-5-mini", toolCalls: [] };
+        return { output: "Hello there.", model: "gpt-5-mini", toolCalls: [] };
       },
       status: async () => ({}),
       taskStatus: async () => null,

--- a/src/client-contract.ts
+++ b/src/client-contract.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { type ChatRequest, type ChatResponse, chatResponseStateSchema } from "./api";
+import type { ChatRequest, ChatResponse } from "./api";
 import { invariant } from "./assert";
 import { checklistItemSchema } from "./checklist-contract";
 import { rpcServerMessageSchema } from "./rpc-protocol";
@@ -17,7 +17,6 @@ export const pendingStateSchema = z.discriminatedUnion("kind", [
     kind: z.literal("running"),
     toolCalls: z.number().int().nonnegative().optional(),
   }),
-  z.object({ kind: z.literal("awaiting-input") }),
 ]);
 export type PendingState = z.infer<typeof pendingStateSchema>;
 
@@ -125,7 +124,6 @@ export function parseStreamEvent(raw: unknown): StreamEvent | null {
 const chatResponseSchema = z.object({
   output: z.string(),
   model: z.string().min(1),
-  state: chatResponseStateSchema.catch("done"),
   usage: tokenUsageSchema.optional(),
   promptBreakdown: promptBreakdownSchema.optional(),
   toolCalls: z.array(z.string()).optional(),

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -91,7 +91,6 @@ export const EN_MESSAGES = {
   "chat.usage.metric.total": "Total",
   "chat.usage.none": "No usage data yet. Send a prompt first.",
   "chat.unresolved_path": "No file or folder found: @{path}",
-  "chat.awaiting_input": "Waiting for your reply",
   "chat.worked": "Worked {duration}{suffix}",
   "cli.config.api_key_unsupported": "Config apiKey is not supported. Use ACOLYTE_API_KEY in .env instead.",
   "cli.config.invalid_value": "Invalid value for {key}: {reason}",

--- a/src/lifecycle-finalize.test.ts
+++ b/src/lifecycle-finalize.test.ts
@@ -96,7 +96,7 @@ describe("phaseFinalize", () => {
     expect(response.promptBreakdown?.usedTokens).toBe(80);
   });
 
-  test("sets state to awaiting-input when signal is blocked", () => {
+  test("ends a blocked signal with the question as output and no error", () => {
     const ctx = createRunContext({
       result: {
         text: "Which environment should I deploy to?",
@@ -107,8 +107,8 @@ describe("phaseFinalize", () => {
       acceptedSignal: "blocked",
     });
     const response = phaseFinalize(ctx);
-    expect(response.state).toBe("awaiting-input");
     expect(response.output).toBe("Which environment should I deploy to?");
+    expect(response.error).toBeUndefined();
   });
 
   test("uses blocked signal reason when final text is empty", () => {
@@ -122,17 +122,8 @@ describe("phaseFinalize", () => {
       acceptedSignal: "blocked",
     });
     const response = phaseFinalize(ctx);
-    expect(response.state).toBe("awaiting-input");
     expect(response.output).toBe("Missing deployment environment. I will deploy once it is provided.");
-  });
-
-  test("sets state to done when signal is done", () => {
-    const ctx = createRunContext({
-      result: { text: "Done.", toolCalls: [], signal: "done" },
-      acceptedSignal: "done",
-    });
-    const response = phaseFinalize(ctx);
-    expect(response.state).toBe("done");
+    expect(response.error).toBeUndefined();
   });
 
   test("counts recall probes separately and keeps them out of search/discovery", () => {
@@ -262,7 +253,6 @@ describe("phaseFinalize", () => {
 
     const response = phaseFinalize(ctx);
 
-    expect(response.state).toBe("done");
     expect(response.output).toBe("I updated the tests.");
     expect(response.error).toBeUndefined();
   });
@@ -279,7 +269,6 @@ describe("phaseFinalize", () => {
 
     const response = phaseFinalize(ctx);
 
-    expect(response.state).toBe("awaiting-input");
     expect(response.output).toBe("I updated the file.");
     expect(response.error).toBe("Cannot finish yet: `src/app.ts` changed after the last successful validation.");
   });
@@ -292,19 +281,18 @@ describe("phaseFinalize", () => {
 
     const response = phaseFinalize(ctx);
 
-    expect(response.state).toBe("awaiting-input");
     // The error row is authoritative; no placeholder output to render beside it.
     expect(response.output).toBe("");
     expect(response.error).toBe("Cannot finish yet: validation missing");
   });
 
-  test("does not use an unaccepted blocked signal for response state", () => {
+  test("passes a non-blocking error through an unaccepted blocked signal", () => {
     const ctx = createRunContext({
       currentError: { message: "tool failed", category: "other" },
       result: { text: "Cannot proceed.", toolCalls: [], signal: "blocked" },
     });
     const response = phaseFinalize(ctx);
-    expect(response.state).toBe("done");
+    expect(response.output).toBe("Cannot proceed.");
     expect(response.error).toBe("tool failed");
   });
 

--- a/src/lifecycle-finalize.ts
+++ b/src/lifecycle-finalize.ts
@@ -115,7 +115,6 @@ export function phaseFinalize(ctx: RunContext): ChatResponse {
   });
 
   return {
-    state: blockingError || ctx.acceptedSignal === "blocked" ? "awaiting-input" : "done",
     model: ctx.model,
     output,
     ...(ctx.currentError ? { error: ctx.currentError.message } : {}),

--- a/src/lifecycle.int.test.ts
+++ b/src/lifecycle.int.test.ts
@@ -167,7 +167,6 @@ describe("lifecycle integration", () => {
     });
 
     const reply = await run("update x to 3");
-    expect(reply.state).toBe("done");
     expect(reply.error).toBeUndefined();
     expect(reply.output).toContain("Updated x to 3.");
   });
@@ -197,7 +196,6 @@ describe("lifecycle integration", () => {
     // recovery turn, and the model's own next decision (here, a done) is accepted directly.
     expect(turnCount).toBe(2);
     expect(secondTurnBody).not.toContain("tool-error-recovery");
-    expect(reply.state).toBe("done");
     expect(reply.output).toContain("No matches found");
   });
 
@@ -210,7 +208,7 @@ describe("lifecycle integration", () => {
     expect(reply.output).toContain("Nothing to do.");
   });
 
-  test("signal_blocked returns awaiting-input state", async () => {
+  test("signal_blocked ends the run with the question as output and no error", async () => {
     let turnCount = 0;
     setupFakeProvider((ctx) => {
       turnCount += 1;
@@ -234,7 +232,8 @@ describe("lifecycle integration", () => {
     });
 
     const reply = await run("update x to 3");
-    expect(reply.state).toBe("awaiting-input");
+    expect(reply.output).toContain("Cannot proceed.");
+    expect(reply.error).toBeUndefined();
   });
 
   test("signal_blocked uses tool reason when final text is empty", async () => {
@@ -245,8 +244,8 @@ describe("lifecycle integration", () => {
     });
 
     const reply = await run("deploy");
-    expect(reply.state).toBe("awaiting-input");
     expect(reply.output).toBe("Missing deployment environment. I will deploy once it is provided.");
+    expect(reply.error).toBeUndefined();
   });
 
   test("rejects duplicate lifecycle signal tools", async () => {
@@ -275,7 +274,6 @@ describe("lifecycle integration", () => {
     });
 
     const reply = await run("finish");
-    expect(reply.state).toBe("done");
     expect(reply.error).toContain("more than one lifecycle signal tool");
   });
 
@@ -305,7 +303,6 @@ describe("lifecycle integration", () => {
     });
 
     const reply = await run("read and finish");
-    expect(reply.state).toBe("done");
     expect(reply.error).toContain("must be the only tool call");
     expect(reply.toolCalls).toEqual([]);
   });
@@ -402,7 +399,6 @@ exit 1
     );
 
     expect(turnCount).toBe(3);
-    expect(reply.state).toBe("awaiting-input");
     // User-audience terminal error — never the model-facing "Run a related test…" nudge.
     expect(reply.error).toContain("finished without validating its changes");
     expect(reply.error).not.toContain("Run a related test");
@@ -521,7 +517,6 @@ exit 1
 
     const reply = await run("update x to 4");
     expect(turnCount).toBe(4);
-    expect(reply.state).toBe("done");
     expect(reply.error).toBeUndefined();
     expect(reply.output).toContain("Here is the summary of what changed.");
     expect(reply.output).not.toContain("Running the tests once more.");

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -17,7 +17,7 @@ describe("runLifecycle", () => {
     expect(deps.createRunAgent).toHaveBeenCalledTimes(1);
     expect(deps.phaseGenerate).toHaveBeenCalledTimes(1);
     expect(deps.phaseFinalize).toHaveBeenCalledTimes(1);
-    expect(response).toEqual({ state: "done", model: "gpt-5-mini", output: "Generated output" });
+    expect(response).toEqual({ model: "gpt-5-mini", output: "Generated output" });
   });
 
   test("threads reasoning and temperature from input into the run context", async () => {
@@ -39,7 +39,6 @@ describe("runLifecycle", () => {
     const deps = createLifecycleDeps({
       phaseFinalize: mock(
         (ctx: { promptUsage: { memoryTokens: number } }): ChatResponse => ({
-          state: "done",
           model: "gpt-5-mini",
           output: String(ctx.promptUsage.memoryTokens),
         }),
@@ -66,7 +65,6 @@ describe("runLifecycle", () => {
       }),
       phaseFinalize: mock(
         (ctx: { promptUsage: { memoryTokens: number } }): ChatResponse => ({
-          state: "done",
           model: "gpt-5-mini",
           output: String(ctx.promptUsage.memoryTokens),
         }),
@@ -312,7 +310,6 @@ describe("runLifecycle yield", () => {
       }),
       phaseFinalize: mock(
         (ctx: { result?: { text: string } }): ChatResponse => ({
-          state: "done",
           model: "gpt-5-mini",
           output: ctx.result?.text ?? "",
         }),

--- a/src/server-http.test.ts
+++ b/src/server-http.test.ts
@@ -13,7 +13,7 @@ function createTestDeps(overrides: Partial<Parameters<typeof createServerFetchHa
       return typeof candidate.message === "string";
     },
     runChatRequest: async (_chatRequest: ChatRequest, handlers: RunChatHandlers) => {
-      handlers.onDone({ state: "done", output: "ok", model: "gpt-5-mini" });
+      handlers.onDone({ output: "ok", model: "gpt-5-mini" });
     },
     serverError: (_message: string, _error: unknown, _details: Record<string, unknown>, status = 500) =>
       new Response("server error", { status }),
@@ -65,7 +65,7 @@ describe("server-http auth coverage", () => {
         hasValidAuth: () => false,
         runChatRequest: async (_chatRequest: ChatRequest, handlers: RunChatHandlers) => {
           runCalls += 1;
-          handlers.onDone({ state: "done", output: "ok", model: "gpt-5-mini" });
+          handlers.onDone({ output: "ok", model: "gpt-5-mini" });
         },
       }),
     );

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -260,7 +260,7 @@ export function createClient(overrides?: {
           input.onEvent(event);
         }
       }
-      return { model: "gpt-5-mini", output: "ok", state: "done" as const };
+      return { model: "gpt-5-mini", output: "ok" };
     });
   return {
     replyStream,
@@ -505,7 +505,6 @@ export function createLifecycleDeps(overrides?: Partial<LifecycleDeps>): Lifecyc
     }),
     phaseFinalize: mock(
       (ctx: { result?: { text: string } }): ChatResponse => ({
-        state: "done",
         model: "gpt-5-mini",
         output: ctx.result?.text ?? "",
       }),


### PR DESCRIPTION
## Motivation

The `awaiting-input` turn state rendered a persistent "Waiting for your reply" prompt for two opposite outcomes: a model question (`signal_blocked`) and a harness blocking error. The second was a false prompt — nothing was asked.

## Summary

- a blocked question ends the turn normally, with the question itself as the affordance
- a harness blocking error renders as an error row, not a prompt
- discriminate the two by `error`-presence instead of a dedicated turn state, since an accepted signal clears the run error
- blocking-error turns now show the "Worked (Ns)" row alongside the error, consistent with errored-`done` turns
