### PR TITLE
fix(chat): render blocked reason after prose

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepare": "bash scripts/setup-hooks.sh",
     "start": "bun run src/cli.ts",
     "dev": "ACOLYTE_SERVER_RESTART=1 ./scripts/with-server.sh serve:watch bun run src/cli.ts",
-    "dogfood": "bun run src/cli.ts stop; bun run src/cli.ts",
+    "dogfood": "bun run src/cli.ts stop; ACOLYTE_DEBUG=1 bun run src/cli.ts",
     "run": "bun run src/cli.ts run",
     "behavior:run": "bun run scripts/run-behavior.ts",
     "perf:run": "bun run scripts/run-perf.ts",

--- a/src/agent-contract.ts
+++ b/src/agent-contract.ts
@@ -12,6 +12,11 @@ export type ToolCallEntry = {
 export type GenerateResult = {
   /** The model's latest non-blank assistant text; later steps supersede earlier ones. */
   text: string;
+  /** Whether `text` was emitted to the client as streamed deltas. False for host-synthesized
+   *  text (e.g. a yield/stopped notice injected after the stream ended) so the client knows to
+   *  render it rather than assume it is already on screen. Absent counts as false — a result
+   *  built outside the streamer (a host notice) was never streamed. */
+  textStreamed?: boolean;
   toolCalls: ToolCallEntry[];
   signal?: LifecycleSignal;
   signalReason?: string;

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -312,6 +312,7 @@ export function createAgentStream(
       streamController.close();
       return {
         text: answerText,
+        textStreamed: answerText.trim().length > 0,
         toolCalls: allToolCalls,
         ...(lifecycleSignal ? { signal: lifecycleSignal } : {}),
         ...(lifecycleSignalReason ? { signalReason: lifecycleSignalReason } : {}),

--- a/src/api.ts
+++ b/src/api.ts
@@ -17,6 +17,12 @@ export interface ChatRequest {
 
 export interface ChatResponse {
   output: string;
+  /** Whether `output` was already streamed to the client as text deltas. False when
+   *  `output` is signal-sourced (a `signal_blocked`/`signal_done` reason the model
+   *  delivered via the tool argument, never as prose) — the client must render it as a
+   *  bubble so it still shows; true means it is already on screen and re-rendering would
+   *  duplicate. */
+  outputStreamed: boolean;
   model: string;
   usage?: TokenUsage;
   promptBreakdown?: PromptBreakdown;

--- a/src/chat-message-handler-stream.int.test.ts
+++ b/src/chat-message-handler-stream.int.test.ts
@@ -30,7 +30,7 @@ describe("chat message handler stream behavior", () => {
             content: { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "echo hi" },
           });
           input.onEvent({ type: "text-delta", text: "done" });
-          return { model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", outputStreamed: true, output: "done" };
         },
         status: async () => ({}),
       }),
@@ -53,6 +53,7 @@ describe("chat message handler stream behavior", () => {
       client: createClient({
         replyStream: async () => ({
           model: "gpt-5-mini",
+          outputStreamed: false,
           output: "done",
           toolCalls: ["shell-run"],
         }),
@@ -84,7 +85,7 @@ describe("chat message handler stream behavior", () => {
             isError: false,
           });
           input.onEvent({ type: "text-delta", text: "No matches found." });
-          return { model: "gpt-5-mini", output: "No matches found." };
+          return { model: "gpt-5-mini", outputStreamed: true, output: "No matches found." };
         },
       }),
     });
@@ -149,7 +150,7 @@ describe("chat message handler stream behavior", () => {
           callCount += 1;
           if (callCount === 1) throw new Error("Remote server stream timed out after 120000ms");
           input.onEvent({ type: "text-delta", text: "ok" });
-          return { model: "gpt-5-mini", output: "ok" };
+          return { model: "gpt-5-mini", outputStreamed: true, output: "ok" };
         },
       }),
     });
@@ -275,7 +276,7 @@ describe("chat message handler stream behavior", () => {
             type: "text-delta",
             text: "This is a long streamed answer that should not be truncated at finalize.",
           });
-          return { model: "gpt-5-mini", output: finalOutput };
+          return { model: "gpt-5-mini", outputStreamed: true, output: finalOutput };
         },
       }),
     });
@@ -306,7 +307,7 @@ describe("chat message handler stream behavior", () => {
             errorCode: "E_GUARD_BLOCKED",
             error: { code: "E_GUARD_BLOCKED", category: "budget-exhausted" },
           });
-          return { model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", outputStreamed: false, output: "done" };
         },
       }),
     });
@@ -349,7 +350,7 @@ describe("chat message handler stream behavior", () => {
             toolName: "file-edit",
             content: { kind: "diff", lineNumber: 2, marker: "add", text: "export const b = 2;" },
           });
-          return { model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", outputStreamed: false, output: "done" };
         },
       }),
     });
@@ -374,8 +375,8 @@ describe("chat message handler stream behavior", () => {
 
   test("does not merge tool rows across separate user turns", async () => {
     const replies = [
-      { model: "gpt-5-mini", output: "first done" },
-      { model: "gpt-5-mini", output: "second done" },
+      { model: "gpt-5-mini", outputStreamed: false, output: "first done" },
+      { model: "gpt-5-mini", outputStreamed: false, output: "second done" },
     ];
     const eventsByTurn: StreamEvent[][] = [
       [
@@ -419,7 +420,7 @@ describe("chat message handler stream behavior", () => {
           for (const event of events) {
             input.onEvent(event);
           }
-          return replies[turn] ?? { model: "gpt-5-mini", output: "done" };
+          return replies[turn] ?? { model: "gpt-5-mini", outputStreamed: false, output: "done" };
         },
       }),
     });
@@ -443,6 +444,7 @@ describe("chat message handler stream behavior", () => {
         status: async () => ({}),
         replyStream: async () => ({
           model: "gpt-5-mini",
+          outputStreamed: false,
           output: "done",
           usage: {
             inputTokens: 12,
@@ -480,7 +482,7 @@ describe("chat message handler stream behavior", () => {
         replyCount += 1;
         input.onEvent({ type: "status", state: { kind: "running" } });
         input.onEvent({ type: "text-delta", text: `reply-${replyCount}` });
-        return { model: "gpt-5-mini", output: `reply-${replyCount}` };
+        return { model: "gpt-5-mini", outputStreamed: true, output: `reply-${replyCount}` };
       },
     });
 
@@ -578,7 +580,7 @@ describe("chat message handler stream behavior", () => {
             toolCallId: "call_1",
             toolName: "shell-run",
           });
-          return { model: "gpt-5-mini", output: "I will run the command." };
+          return { model: "gpt-5-mini", outputStreamed: true, output: "I will run the command." };
         },
         status: async () => ({}),
       }),
@@ -645,7 +647,7 @@ describe("chat message handler stream behavior", () => {
             toolCallId: "call_B",
             toolName: "code-edit",
           });
-          return { model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", outputStreamed: false, output: "done" };
         },
         status: async () => ({}),
       }),

--- a/src/chat-message-handler-stream.test.ts
+++ b/src/chat-message-handler-stream.test.ts
@@ -53,16 +53,15 @@ describe("chat-message-handler-stream", () => {
     state.dispose();
   });
 
-  test("finalize returns pending row id and clears state", async () => {
+  test("finalize seals the streamed row and clears buffered state", async () => {
     const { rows, setRows } = createRowsHarness();
     const state = createMessageStreamState({ setRows });
 
     state.onDelta("hello");
-    // Force flush via timer
     await new Promise((resolve) => setTimeout(resolve, 60));
     expect(rows).toHaveLength(1);
-    const rowId = state.finalize();
-    expect(rowId).toBeTruthy();
+    state.finalize();
+    expect(rows).toHaveLength(1);
     expect(state.streamedText()).toBe("");
     state.dispose();
   });
@@ -135,11 +134,10 @@ describe("chat-message-handler-stream", () => {
     state.dispose();
   });
 
-  test("finalize keeps tool rows and returns only agent row ids", async () => {
+  test("finalize keeps streamed prose and tool rows committed", async () => {
     const { rows, setRows } = createRowsHarness();
     const state = createMessageStreamState({ setRows });
 
-    // Simulate: agent text → tool call → more agent text
     state.onDelta("thinking...");
     await new Promise((resolve) => setTimeout(resolve, 60));
     expect(rows).toHaveLength(1);
@@ -157,28 +155,12 @@ describe("chat-message-handler-stream", () => {
     await new Promise((resolve) => setTimeout(resolve, 60));
     expect(rows).toHaveLength(3);
 
-    const streamingIds = state.finalize();
-    // finalize should return only agent row ids, not tool row ids
-    const toolRows = rows.filter((r) => r.kind === "tool");
-    expect(toolRows).toHaveLength(1);
-    for (const toolRow of toolRows) {
-      expect(streamingIds).not.toContain(toolRow.id);
-    }
-
-    // Simulate handler replacement: content rows at streaming position, status at end
-    const removeSet = new Set(streamingIds);
-    const contentRows: ChatRow[] = [{ id: "final_assistant", kind: "assistant", content: "done" }];
-    const statusRows: ChatRow[] = [{ id: "final_status", kind: "status", content: "Worked 5s" }];
-    const filtered = rows.filter((row) => !removeSet.has(row.id));
-    const insertIndex = rows.findIndex((row) => removeSet.has(row.id));
-    if (insertIndex >= 0) filtered.splice(insertIndex, 0, ...contentRows);
-    else filtered.push(...contentRows);
-    filtered.push(...statusRows);
-
-    // Tool rows should appear BEFORE the status row
-    const toolIndex = filtered.findIndex((r) => r.kind === "tool");
-    const statusIndex = filtered.findIndex((r) => r.kind === "status");
-    expect(toolIndex).toBeLessThan(statusIndex);
+    state.finalize();
+    expect(rows).toHaveLength(3);
+    expect(rows.filter((r) => r.kind === "tool")).toHaveLength(1);
+    expect(rows.filter((r) => r.kind === "assistant").map((r) => r.content)).toEqual(["thinking...", "done now"]);
+    expect(state.streamedText()).toBe("");
+    state.dispose();
   });
 
   test("onToolCall flushes pending text before tool output arrives", () => {
@@ -325,11 +307,9 @@ describe("chat-message-handler-stream", () => {
     const h = createStrictHarness();
     const state = createMessageStreamState({ setRows: h.setRows });
     state.onDelta("Tail that must not vanish.");
-    const ids = state.finalize(); // enqueues flush, then resets the closure — before render
+    state.finalize(); // enqueues flush, then resets the closure — before render
     h.render();
     expect(h.rows.filter((r) => r.kind === "assistant").map((r) => r.content)).toEqual(["Tail that must not vanish."]);
-    // finalize()'s returned ids must reference rows that actually committed.
-    for (const id of ids) expect(h.rows.some((r) => r.id === id)).toBe(true);
     state.dispose();
   });
 

--- a/src/chat-message-handler-stream.ts
+++ b/src/chat-message-handler-stream.ts
@@ -25,8 +25,8 @@ export type MessageStreamState = {
   onProgressError: (error: string) => void;
   onProgressNotice: (notice: { message: string; level: "warn" | "error"; source?: string }) => void;
   streamedText: () => string;
-  /** Flush remaining content and return IDs of all streaming agent rows (for replacement by final turn rows). */
-  finalize: () => string[];
+  /** Flush remaining buffered prose and detach: seal the live agent row and drop unresolved checklist rows. */
+  finalize: () => void;
   dispose: () => void;
 };
 
@@ -40,7 +40,7 @@ export function createMessageStreamState(input: {
   let activeRowId: string | null = null;
   let agentContent = "";
   let flushTimer: ReturnType<typeof setTimeout> | null = null;
-  /** Every agent row ID we've created. Collected at finalize for caller to remove. */
+  /** Every agent row ID we've created, so dispose() can remove them on the error path. */
   const agentRowIds: string[] = [];
 
   // --- tool output state ---
@@ -272,9 +272,7 @@ export function createMessageStreamState(input: {
       if (checklistIds.size > 0) {
         input.setRows((current) => current.filter((row) => !checklistIds.has(row.id)));
       }
-      const ids = [...agentRowIds];
       agentRowIds.length = 0;
-      return ids;
     },
 
     dispose: () => {

--- a/src/chat-message-handler.int.test.ts
+++ b/src/chat-message-handler.int.test.ts
@@ -143,7 +143,7 @@ describe("chat message handler", () => {
       client: createClient({
         replyStream: async (input) => {
           requestedModel = input.request.model;
-          return { model: input.request.model, output: "ok" };
+          return { model: input.request.model, outputStreamed: false, output: "ok" };
         },
       }),
     });
@@ -155,12 +155,13 @@ describe("chat message handler", () => {
 
   test("keeps create-edit-delete tool output visible across submits", async () => {
     const replies = [
-      { model: "gpt-5-mini", output: "Created sum.rs." },
+      { model: "gpt-5-mini", outputStreamed: true, output: "Created sum.rs." },
       {
         model: "gpt-5-mini",
+        outputStreamed: true,
         output: "Updated sum.rs for three args.",
       },
-      { model: "gpt-5-mini", output: "Removed sum.rs." },
+      { model: "gpt-5-mini", outputStreamed: true, output: "Removed sum.rs." },
     ];
     const eventsByTurn: StreamEvent[][] = [
       [
@@ -216,7 +217,7 @@ describe("chat message handler", () => {
           for (const event of events) {
             input.onEvent(event);
           }
-          return replies[turn] ?? { model: "gpt-5-mini", output: "done" };
+          return replies[turn] ?? { model: "gpt-5-mini", outputStreamed: false, output: "done" };
         },
       }),
     });
@@ -260,6 +261,7 @@ describe("chat message handler", () => {
           input.onEvent({ type: "text-delta", text: "the complete streamed answer." });
           return {
             model: "gpt-5-mini",
+            outputStreamed: true,
             output: "the complete streamed answer.",
           };
         },
@@ -279,6 +281,7 @@ describe("chat message handler", () => {
         status: async () => ({}),
         replyStream: async () => ({
           model: "gpt-5-mini",
+          outputStreamed: false,
           output: "answer delivered without deltas.",
         }),
       }),
@@ -300,7 +303,7 @@ describe("chat message handler", () => {
         status: async () => ({}),
         replyStream: async (input) => {
           input.onEvent({ type: "text-delta", text: "answer" });
-          return { model: "gpt-5-mini", output: "answer" };
+          return { model: "gpt-5-mini", outputStreamed: true, output: "answer" };
         },
       }),
     });
@@ -325,6 +328,7 @@ describe("chat message handler", () => {
           input.onEvent({ type: "tool-call", toolCallId: "sig_1", toolName: "signal_done", args: {} });
           return {
             model: "gpt-5-mini",
+            outputStreamed: true,
             output: "The complete answer.",
             toolCalls: ["signal_done"],
           };
@@ -353,7 +357,7 @@ describe("chat message handler", () => {
             content: { kind: "tool-header", labelKey: "tool.label.file_edit", detail: "a.rs" },
           });
           input.onEvent({ type: "text-delta", text: "Done editing." });
-          return { model: "gpt-5-mini", output: "Let me check the file.\nDone editing." };
+          return { model: "gpt-5-mini", outputStreamed: true, output: "Let me check the file.\nDone editing." };
         },
       }),
     });
@@ -485,7 +489,7 @@ describe("chat message handler", () => {
             });
           }
           input.onEvent({ type: "text-delta", text: "Second answer." });
-          return { model: "gpt-5-mini", output: "Second answer." };
+          return { model: "gpt-5-mini", outputStreamed: true, output: "Second answer." };
         },
         status: async () => ({}),
       }),
@@ -553,7 +557,7 @@ describe("chat message handler", () => {
         replyStream: async (input) => {
           replyCalls += 1;
           input.onEvent({ type: "text-delta", text: "ok" });
-          return { model: "gpt-5-mini", output: "ok" };
+          return { model: "gpt-5-mini", outputStreamed: true, output: "ok" };
         },
         status: async () => ({}),
       }),
@@ -579,7 +583,7 @@ describe("chat message handler", () => {
           replyStream: async (input) => {
             replyCalls += 1;
             input.onEvent({ type: "text-delta", text: "ok" });
-            return { model: "gpt-5-mini", output: "ok" };
+            return { model: "gpt-5-mini", outputStreamed: true, output: "ok" };
           },
           status: async () => ({}),
         }),
@@ -605,7 +609,7 @@ describe("chat message handler", () => {
           replyCount++;
           await Bun.sleep(10);
           input.onEvent({ type: "text-delta", text: "ok" });
-          return { model: "gpt-5-mini", output: "ok" };
+          return { model: "gpt-5-mini", outputStreamed: true, output: "ok" };
         },
         status: async () => ({}),
       }),
@@ -684,7 +688,7 @@ describe("chat message handler", () => {
       client: createClient({
         replyStream: async (input) => {
           input.onEvent({ type: "text-delta", text: "done" });
-          return { model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", outputStreamed: true, output: "done" };
         },
         status: async () => ({}),
       }),
@@ -709,7 +713,7 @@ describe("chat message handler", () => {
             content: { kind: "tool-header", labelKey: "tool.label.file_edit", detail: "test.ts" },
           });
           input.onEvent({ type: "text-delta", text: "edited" });
-          return { model: "gpt-5-mini", output: "edited" };
+          return { model: "gpt-5-mini", outputStreamed: true, output: "edited" };
         },
         status: async () => ({}),
       }),
@@ -726,6 +730,7 @@ describe("chat message handler", () => {
       client: createClient({
         replyStream: async () => ({
           model: "gpt-5-mini",
+          outputStreamed: false,
           output: "No changes needed.",
         }),
         status: async () => ({}),
@@ -753,7 +758,7 @@ describe("chat message handler", () => {
           });
           input.onEvent({ type: "tool-result", toolCallId: "c1", toolName: "file-edit" });
           input.onEvent({ type: "text-delta", text: "Done." });
-          return { model: "gpt-5-mini", output: "Checking the file.\nDone." };
+          return { model: "gpt-5-mini", outputStreamed: true, output: "Checking the file.\nDone." };
         },
       }),
     });
@@ -782,7 +787,7 @@ describe("chat message handler", () => {
           input.onEvent({ type: "error", errorMessage: "rate limited, retrying" });
           input.onEvent({ type: "error", errorMessage: "rate limited, retrying" });
           input.onEvent({ type: "text-delta", text: "ok" });
-          return { model: "gpt-5-mini", output: "ok" };
+          return { model: "gpt-5-mini", outputStreamed: true, output: "ok" };
         },
       }),
     });
@@ -800,7 +805,7 @@ describe("chat message handler", () => {
       client: createClient({
         replyStream: async (input) => {
           input.onEvent({ type: "text-delta", text: "done" });
-          return { model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", outputStreamed: true, output: "done" };
         },
         status: async () => ({}),
       }),
@@ -818,6 +823,7 @@ describe("chat message handler", () => {
         // signal_blocked with no prose: the reason arrives via output, nothing streams.
         replyStream: async () => ({
           model: "gpt-5-mini",
+          outputStreamed: false,
           output: "Which credential should I use?",
         }),
         status: async () => ({}),
@@ -840,6 +846,7 @@ describe("chat message handler", () => {
       client: createClient({
         replyStream: async () => ({
           model: "gpt-5-mini",
+          outputStreamed: false,
           output: "",
           error: "completion blocked: missing signal",
         }),
@@ -858,6 +865,79 @@ describe("chat message handler", () => {
     expect(calls.pendingTransitions.at(-1)).toBe(false);
   });
 
+  test("a blocked question after tool calls still renders its reason", async () => {
+    const reason = "Which layer should the rate limit live in — the RPC accept loop or per-session?";
+    const { handleMessage, session, calls } = createMessageHandlerHarness({
+      client: createClient({
+        // Mirrors a real signal_blocked turn: the model runs tools, streams NO prose, then
+        // blocks. The reason arrives via output only, never as a text-delta.
+        replyStream: async (input) => {
+          input.onEvent({ type: "text-delta", text: "\n" });
+          input.onEvent({ type: "reasoning", text: "Considering where the limit belongs." });
+          input.onEvent({
+            type: "tool-call",
+            toolCallId: "c1",
+            toolName: "file-read",
+            args: { path: "src/server.ts" },
+          });
+          input.onEvent({
+            type: "tool-output",
+            toolCallId: "c1",
+            toolName: "file-read",
+            content: { kind: "tool-header", labelKey: "tool.file_read.header", detail: "src/server.ts" },
+          });
+          input.onEvent({ type: "tool-result", toolCallId: "c1", toolName: "file-read" });
+          input.onEvent({ type: "text-delta", text: "\n" });
+          return { model: "gpt-5-mini", outputStreamed: false, output: reason };
+        },
+        status: async () => ({}),
+      }),
+    });
+
+    await handleMessage("Add rate limiting to the RPC server.");
+
+    const promoted = calls.promotedSnapshots.flat();
+    expect(promoted.some((r) => r.kind === "assistant" && r.content === reason)).toBe(true);
+    expect(session.messages.some((m) => m.role === "assistant" && m.content === reason)).toBe(true);
+  });
+
+  test("a blocked reason renders even when narration prose streamed first", async () => {
+    // F7: the model streams a preamble (a real prose row), runs tools, then blocks with the
+    // answer delivered only via output (never as deltas). Earlier narration must not be
+    // mistaken for the answer and suppress rendering the blocked reason.
+    const narration = "I'm going to locate the RPC server and add rate limiting.";
+    const reason = "Which layer should the rate limit live in — the RPC accept loop or per-session?";
+    const { handleMessage, session, calls } = createMessageHandlerHarness({
+      client: createClient({
+        replyStream: async (input) => {
+          input.onEvent({ type: "text-delta", text: narration });
+          input.onEvent({
+            type: "tool-call",
+            toolCallId: "c1",
+            toolName: "file-read",
+            args: { path: "src/server.ts" },
+          });
+          input.onEvent({
+            type: "tool-output",
+            toolCallId: "c1",
+            toolName: "file-read",
+            content: { kind: "tool-header", labelKey: "tool.file_read.header", detail: "src/server.ts" },
+          });
+          input.onEvent({ type: "tool-result", toolCallId: "c1", toolName: "file-read" });
+          return { model: "gpt-5-mini", outputStreamed: false, output: reason };
+        },
+        status: async () => ({}),
+      }),
+    });
+
+    await handleMessage("Add rate limiting to the RPC server.");
+
+    const promoted = calls.promotedSnapshots.flat();
+    expect(promoted.some((r) => r.kind === "assistant" && r.content === narration)).toBe(true);
+    expect(promoted.some((r) => r.kind === "assistant" && r.content === reason)).toBe(true);
+    expect(session.messages.some((m) => m.role === "assistant" && m.content === reason)).toBe(true);
+  });
+
   test("answering a blocked turn in-process does not duplicate the reason row", async () => {
     let call = 0;
     const { handleMessage, calls } = createMessageHandlerHarness({
@@ -865,8 +945,8 @@ describe("chat message handler", () => {
         replyStream: async () => {
           call += 1;
           return call === 1
-            ? { model: "gpt-5-mini", output: "Which credential should I use?" }
-            : { model: "gpt-5-mini", output: "Deployed." };
+            ? { model: "gpt-5-mini", outputStreamed: false, output: "Which credential should I use?" }
+            : { model: "gpt-5-mini", outputStreamed: false, output: "Deployed." };
         },
         status: async () => ({}),
       }),
@@ -962,7 +1042,7 @@ describe("chat message handler", () => {
       client: createClient({
         replyStream: async (input) => {
           input.onEvent({ type: "text-delta", text: "What input?" });
-          return { model: "gpt-5-mini", output: "What input?" };
+          return { model: "gpt-5-mini", outputStreamed: false, output: "What input?" };
         },
         status: async () => ({}),
       }),

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -148,7 +148,7 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
         createMessage: input.createMessage,
       });
       const assistantMessage = turn.assistantMessage;
-      const streamedRowIds = new Set(streamState.finalize());
+      streamState.finalize();
 
       if (turn.activeSkills?.length) {
         input.currentSession.activeSkills = turn.activeSkills;
@@ -176,11 +176,12 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
       // screen. reply.output is the same prose reassembled for model history, so
       // re-committing it here only reshuffles prose below the tool rows and re-emits
       // content that may have scrolled into append-only scrollback — a duplicate.
-      // Keep the streamed rows and append this turn's status/error rows. Only when no
-      // prose streamed (a provider that returns output without deltas) fall back to a
-      // bubble so the answer still shows.
+      // Keep the streamed rows and append this turn's status/error rows. When `output`
+      // was not streamed as deltas — a provider that returns output without them, or a
+      // signal reason the model delivered via the tool argument (a blocked/done turn whose
+      // only prose was narration) — fall back to a bubble so the answer still shows.
       const fallbackRows =
-        streamedRowIds.size === 0 && assistantMessage.content.trim().length > 0
+        !turn.outputStreamed && assistantMessage.content.trim().length > 0
           ? [createRow("assistant", assistantMessage.content)]
           : [];
       input.setRows((current) => [...current, ...fallbackRows, ...turn.rows]);

--- a/src/chat-turn.test.ts
+++ b/src/chat-turn.test.ts
@@ -124,6 +124,7 @@ describe("chat turn helpers", () => {
       client: {
         replyStream: async () => ({
           model: "gpt-5-mini",
+          outputStreamed: false,
           output: "done",
         }),
         status: async () => ({}),
@@ -154,6 +155,7 @@ describe("chat turn helpers", () => {
       client: {
         replyStream: async () => ({
           model: "gpt-5-mini",
+          outputStreamed: false,
           output: "done",
           activeSkills: skills,
         }),
@@ -181,6 +183,7 @@ describe("chat turn helpers", () => {
       client: {
         replyStream: async () => ({
           model: "gpt-5-mini",
+          outputStreamed: false,
           output: "done",
           toolCalls: ["file-read"],
         }),
@@ -208,6 +211,7 @@ describe("chat turn helpers", () => {
       client: {
         replyStream: async () => ({
           model: "gpt-5-mini",
+          outputStreamed: false,
           output: "The answer is 42.",
           toolCalls: ["signal_done"],
         }),
@@ -235,6 +239,7 @@ describe("chat turn helpers", () => {
       client: {
         replyStream: async () => ({
           model: "gpt-5-mini",
+          outputStreamed: false,
           output: "Reading the file.",
           toolCalls: ["file-read", "signal_done"],
         }),
@@ -262,6 +267,7 @@ describe("chat turn helpers", () => {
       client: {
         replyStream: async () => ({
           model: "gpt-5-mini",
+          outputStreamed: false,
           output: "done",
           toolCalls: ["file-read", "signal_done"],
           usage: { inputTokens: 52000, outputTokens: 586, totalTokens: 52586 },

--- a/src/chat-turn.ts
+++ b/src/chat-turn.ts
@@ -116,6 +116,7 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
   assistantMessage: ChatMessage;
   tokenEntry: SessionTokenUsageEntry;
   rows: ChatRow[];
+  outputStreamed: boolean;
   activeSkills?: ActiveSkill[];
 }> {
   const reply = await params.client.replyStream({
@@ -170,6 +171,7 @@ export async function runAssistantTurn(params: RunAssistantTurnParams): Promise<
     assistantMessage,
     tokenEntry,
     rows,
+    outputStreamed: reply.outputStreamed,
     activeSkills: reply.activeSkills,
   };
 }

--- a/src/checklist.int.test.ts
+++ b/src/checklist.int.test.ts
@@ -23,7 +23,7 @@ describe("checklist integration", () => {
             ],
           });
           snapshot = [...rows];
-          return { model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", outputStreamed: false, output: "done" };
         },
       }),
     });
@@ -68,7 +68,7 @@ describe("checklist integration", () => {
             ],
           });
           snapshot = [...rows];
-          return { model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", outputStreamed: false, output: "done" };
         },
       }),
     });
@@ -103,7 +103,7 @@ describe("checklist integration", () => {
             items: [{ id: "b1", label: "step B1", status: "pending", order: 0 }],
           });
           snapshot = [...rows];
-          return { model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", outputStreamed: false, output: "done" };
         },
       }),
     });
@@ -142,7 +142,7 @@ describe("checklist integration", () => {
             content: { kind: "tool-header", labelKey: "tool.label.file_read", detail: "a.ts" },
           });
           snapshot = [...rows];
-          return { model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", outputStreamed: false, output: "done" };
         },
       }),
     });
@@ -187,7 +187,7 @@ describe("checklist integration", () => {
             toolName: "file-edit",
           });
           snapshot = [...rows];
-          return { model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", outputStreamed: false, output: "done" };
         },
       }),
     });
@@ -212,7 +212,7 @@ describe("checklist integration", () => {
             groupTitle: "Steps",
             items: [{ id: "s1", label: "do thing", status: "done", order: 0 }],
           });
-          return { model: "gpt-5-mini", output: "done" };
+          return { model: "gpt-5-mini", outputStreamed: false, output: "done" };
         },
       }),
     });

--- a/src/cli-prompt-golden.test.ts
+++ b/src/cli-prompt-golden.test.ts
@@ -29,7 +29,12 @@ function client(events: StreamEvent[], reply: { output: string; error?: string }
   return {
     replyStream: async (input) => {
       for (const event of events) input.onEvent(event);
-      return { ...reply, model: "gpt-5-mini", toolCalls: reply.error ? [] : ["file-read"] };
+      return {
+        ...reply,
+        model: "gpt-5-mini",
+        toolCalls: reply.error ? [] : ["file-read"],
+        outputStreamed: events.some((event) => event.type === "text-delta" && event.text.trim().length > 0),
+      };
     },
     status: async () => ({}),
     taskStatus: async () => null,

--- a/src/cli-prompt.test.ts
+++ b/src/cli-prompt.test.ts
@@ -23,7 +23,7 @@ function createStreamingClient(events: StreamEvent[]): Client {
   return {
     replyStream: async (input) => {
       for (const event of events) input.onEvent(event);
-      return { output: "done", model: "gpt-5-mini", toolCalls: ["code-edit"] };
+      return { outputStreamed: false, output: "done", model: "gpt-5-mini", toolCalls: ["code-edit"] };
     },
     status: async () => ({}),
     taskStatus: async () => null,
@@ -55,6 +55,7 @@ describe("cli-prompt", () => {
     const session = createTestSession();
     const client: Client = {
       replyStream: async () => ({
+        outputStreamed: false,
         output: "done",
         model: "gpt-5-mini",
         toolCalls: ["file-read"],
@@ -72,6 +73,7 @@ describe("cli-prompt", () => {
     const session = createTestSession();
     const client: Client = {
       replyStream: async () => ({
+        outputStreamed: false,
         output: "file-edit failed: Find text matched 2 locations",
         model: "gpt-5-mini",
         error: "file-edit failed: Find text matched 2 locations",
@@ -169,7 +171,7 @@ describe("cli-prompt", () => {
     const client: Client = {
       replyStream: async (input) => {
         input.onEvent({ type: "text-delta", text: "Hello there.\n" });
-        return { output: "Hello there.", model: "gpt-5-mini", toolCalls: [] };
+        return { outputStreamed: false, output: "Hello there.", model: "gpt-5-mini", toolCalls: [] };
       },
       status: async () => ({}),
       taskStatus: async () => null,

--- a/src/cli-visual.int.test.ts
+++ b/src/cli-visual.int.test.ts
@@ -12,6 +12,7 @@ async function withDualTransportChatServer<T>(fn: (baseUrl: string) => Promise<T
   const reply = {
     model: "gpt-5-mini",
     output: "Transport parity ok.",
+    outputStreamed: false,
   };
   const server = Bun.serve({
     port: 0,

--- a/src/client-contract.ts
+++ b/src/client-contract.ts
@@ -123,6 +123,7 @@ export function parseStreamEvent(raw: unknown): StreamEvent | null {
 
 const chatResponseSchema = z.object({
   output: z.string(),
+  outputStreamed: z.boolean(),
   model: z.string().min(1),
   usage: tokenUsageSchema.optional(),
   promptBreakdown: promptBreakdownSchema.optional(),

--- a/src/client-rpc.test.ts
+++ b/src/client-rpc.test.ts
@@ -56,7 +56,9 @@ describe("rpc websocket lifecycle", () => {
             event: { type: "tool-call", toolCallId: "call_1", toolName: "file-read", args: { path: "a.ts" } },
           }),
         );
-        queueMicrotask(() => sendMessage({ type: "chat.done", reply: { output: "done", model: "gpt-5-mini" } }));
+        queueMicrotask(() =>
+          sendMessage({ type: "chat.done", reply: { output: "done", model: "gpt-5-mini", outputStreamed: false } }),
+        );
       }
 
       close(): void {

--- a/src/lifecycle-finalize.test.ts
+++ b/src/lifecycle-finalize.test.ts
@@ -10,6 +10,7 @@ describe("ChatResponse error field", () => {
     const response = parseChatResponse({
       output: "No output from model.",
       model: "gpt-5-mini",
+      outputStreamed: false,
       error: "Your credit balance is too low",
     });
     expect(response).not.toBeNull();
@@ -20,6 +21,7 @@ describe("ChatResponse error field", () => {
     const response = parseChatResponse({
       output: "Hello",
       model: "gpt-5-mini",
+      outputStreamed: false,
     });
     expect(response).not.toBeNull();
     expect(response?.error).toBeUndefined();
@@ -29,6 +31,7 @@ describe("ChatResponse error field", () => {
     const response = parseChatResponse({
       output: "Hello",
       model: "gpt-5-mini",
+      outputStreamed: false,
       error: 42,
     });
     expect(response).toBeNull();
@@ -124,6 +127,38 @@ describe("phaseFinalize", () => {
     const response = phaseFinalize(ctx);
     expect(response.output).toBe("Missing deployment environment. I will deploy once it is provided.");
     expect(response.error).toBeUndefined();
+  });
+
+  test("marks a streamed answer outputStreamed so the client does not re-render it", () => {
+    const ctx = createRunContext({
+      result: { text: "All done.", textStreamed: true, toolCalls: [], signal: "done" },
+      acceptedSignal: "done",
+    });
+    expect(phaseFinalize(ctx).outputStreamed).toBe(true);
+  });
+
+  test("marks host-synthesized output (never streamed) outputStreamed=false so the client renders it", () => {
+    // Mirrors the yield/stopped paths (lifecycle.ts): result.text is a host notice injected
+    // after the stream ended, so textStreamed stays false and the client must show it.
+    const ctx = createRunContext({
+      result: { text: "Yielding to a newer pending message.", toolCalls: [] },
+    });
+    const response = phaseFinalize(ctx);
+    expect(response.output).toBe("Yielding to a newer pending message.");
+    expect(response.outputStreamed).toBe(false);
+  });
+
+  test("marks a blocked reason (delivered via signal, not streamed) outputStreamed=false", () => {
+    const ctx = createRunContext({
+      result: {
+        text: "",
+        toolCalls: [],
+        signal: "blocked",
+        signalReason: "Which environment should I deploy to?",
+      },
+      acceptedSignal: "blocked",
+    });
+    expect(phaseFinalize(ctx).outputStreamed).toBe(false);
   });
 
   test("counts recall probes separately and keeps them out of search/discovery", () => {
@@ -321,6 +356,7 @@ describe("parseChatResponse activeSkills", () => {
     const response = parseChatResponse({
       output: "Hello",
       model: "gpt-5-mini",
+      outputStreamed: false,
       activeSkills: skills,
     });
     expect(response?.activeSkills).toEqual(skills);
@@ -330,6 +366,7 @@ describe("parseChatResponse activeSkills", () => {
     const response = parseChatResponse({
       output: "Hello",
       model: "gpt-5-mini",
+      outputStreamed: false,
     });
     expect(response?.activeSkills).toBeUndefined();
   });

--- a/src/lifecycle-finalize.ts
+++ b/src/lifecycle-finalize.ts
@@ -117,6 +117,10 @@ export function phaseFinalize(ctx: RunContext): ChatResponse {
   return {
     model: ctx.model,
     output,
+    // `output` was streamed iff it carries the model's streamed answer text. A signal reason,
+    // a neutral fallback, or a host-synthesized notice (yield/stopped) is in `output` but never
+    // reached the client as deltas, so the client must render it rather than assume it is shown.
+    outputStreamed: ctx.result?.textStreamed ?? false,
     ...(ctx.currentError ? { error: ctx.currentError.message } : {}),
     toolCalls: callLog.map((entry) => entry.toolName),
     modelCalls: ctx.modelCallCount,

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -17,7 +17,7 @@ describe("runLifecycle", () => {
     expect(deps.createRunAgent).toHaveBeenCalledTimes(1);
     expect(deps.phaseGenerate).toHaveBeenCalledTimes(1);
     expect(deps.phaseFinalize).toHaveBeenCalledTimes(1);
-    expect(response).toEqual({ model: "gpt-5-mini", output: "Generated output" });
+    expect(response).toEqual({ model: "gpt-5-mini", outputStreamed: true, output: "Generated output" });
   });
 
   test("threads reasoning and temperature from input into the run context", async () => {
@@ -41,6 +41,7 @@ describe("runLifecycle", () => {
         (ctx: { promptUsage: { memoryTokens: number } }): ChatResponse => ({
           model: "gpt-5-mini",
           output: String(ctx.promptUsage.memoryTokens),
+          outputStreamed: false,
         }),
       ),
     });
@@ -67,6 +68,7 @@ describe("runLifecycle", () => {
         (ctx: { promptUsage: { memoryTokens: number } }): ChatResponse => ({
           model: "gpt-5-mini",
           output: String(ctx.promptUsage.memoryTokens),
+          outputStreamed: false,
         }),
       ),
     });
@@ -311,6 +313,7 @@ describe("runLifecycle yield", () => {
       phaseFinalize: mock(
         (ctx: { result?: { text: string } }): ChatResponse => ({
           model: "gpt-5-mini",
+          outputStreamed: false,
           output: ctx.result?.text ?? "",
         }),
       ),

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -209,7 +209,7 @@ function acceptResult(ctx: RunContext): void {
       last_error_code: ctx.currentError?.code ?? null,
     });
     if (ctx.result && !ctx.result.text.trim()) {
-      ctx.result = { text: t("lifecycle.stopped_unknown_errors"), toolCalls: [] };
+      ctx.result = { text: t("lifecycle.stopped_unknown_errors"), textStreamed: false, toolCalls: [] };
     }
   }
 }
@@ -323,7 +323,11 @@ export async function runLifecycle(input: LifecycleInput, deps: LifecycleDeps = 
   if (input.runControl?.shouldYield()) {
     ctx.debug("lifecycle.yield", {});
     if (!ctx.result.text.trim()) {
-      ctx.result = { text: "Yielding to a newer pending message.", toolCalls: ctx.result.toolCalls };
+      ctx.result = {
+        text: "Yielding to a newer pending message.",
+        textStreamed: false,
+        toolCalls: ctx.result.toolCalls,
+      };
     }
     return deps.phaseFinalize(ctx);
   }

--- a/src/server-http.test.ts
+++ b/src/server-http.test.ts
@@ -13,7 +13,7 @@ function createTestDeps(overrides: Partial<Parameters<typeof createServerFetchHa
       return typeof candidate.message === "string";
     },
     runChatRequest: async (_chatRequest: ChatRequest, handlers: RunChatHandlers) => {
-      handlers.onDone({ output: "ok", model: "gpt-5-mini" });
+      handlers.onDone({ outputStreamed: false, output: "ok", model: "gpt-5-mini" });
     },
     serverError: (_message: string, _error: unknown, _details: Record<string, unknown>, status = 500) =>
       new Response("server error", { status }),
@@ -65,7 +65,7 @@ describe("server-http auth coverage", () => {
         hasValidAuth: () => false,
         runChatRequest: async (_chatRequest: ChatRequest, handlers: RunChatHandlers) => {
           runCalls += 1;
-          handlers.onDone({ output: "ok", model: "gpt-5-mini" });
+          handlers.onDone({ outputStreamed: false, output: "ok", model: "gpt-5-mini" });
         },
       }),
     );

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -260,7 +260,11 @@ export function createClient(overrides?: {
           input.onEvent(event);
         }
       }
-      return { model: "gpt-5-mini", output: "ok" };
+      return {
+        model: "gpt-5-mini",
+        output: "ok",
+        outputStreamed: events?.some((event) => event.type === "text-delta" && event.text.trim().length > 0) ?? false,
+      };
     });
   return {
     replyStream,
@@ -501,12 +505,13 @@ export function createLifecycleDeps(overrides?: Partial<LifecycleDeps>): Lifecyc
       },
     })),
     phaseGenerate: mock(async (ctx: { result?: unknown }) => {
-      ctx.result = { text: "Generated output", toolCalls: [], signal: "done" };
+      ctx.result = { text: "Generated output", textStreamed: true, toolCalls: [], signal: "done" };
     }),
     phaseFinalize: mock(
       (ctx: { result?: { text: string } }): ChatResponse => ({
         model: "gpt-5-mini",
         output: ctx.result?.text ?? "",
+        outputStreamed: (ctx.result?.text ?? "").trim().length > 0,
       }),
     ),
     ...overrides,


### PR DESCRIPTION
## Motivation

A `signal_blocked` turn delivers its reason via the signal argument, not as streamed prose. The client rendered the reason as a fallback bubble only when *no* prose had streamed — so any narration suppressed it, and a correct block showed as an empty-looking turn (tool rows + "Worked", nothing else).

## Summary

- carry `outputStreamed` on the reply so the client knows whether `output` already reached the screen as deltas
- gate the fallback bubble on `outputStreamed`, replacing the "any prose streamed" row-count proxy that misread narration as the answer
- mark host-synthesized notices (yield / stopped-on-errors) as not-streamed so they still render
- enable debug logging in `bun run dogfood` so the client log is captured while dogfooding
