### PR TITLE
fix(skill): seed session skills from request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ scripts/demo.sh
 acolyte
 *.bun-build
 scripts/data/memory-bench/
+docs/notes/

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -29,6 +29,17 @@ else
   echo "no primary .env to link (skipping)"
 fi
 
+# docs/notes/ holds gitignored private notes (plan, design records) — link the
+# primary's so a worktree sees the same notes instead of an empty folder.
+step "docs/notes — link from the primary checkout"
+if [ -n "${primary:-}" ] && [ "$primary" != "$root" ] && [ -d "$primary/docs/notes" ] && [ ! -e "$root/docs/notes" ]; then
+  ln -s "$primary/docs/notes" "$root/docs/notes" && echo "linked docs/notes -> $primary/docs/notes"
+elif [ -e "$root/docs/notes" ]; then
+  echo "docs/notes already present"
+else
+  echo "no primary docs/notes to link (skipping)"
+fi
+
 if [ "$rc" -eq 0 ]; then
   echo "worktree-setup: done"
 else

--- a/src/lifecycle-prepare.test.ts
+++ b/src/lifecycle-prepare.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { ChatRequest } from "./api";
+import { addActiveSkill } from "./chat-skill-activator";
 import { MAX_RECENT_TURNS } from "./lifecycle-constants";
 import { defaultLifecyclePolicy } from "./lifecycle-policy";
 import { phasePrepare } from "./lifecycle-prepare";
@@ -83,6 +84,62 @@ describe("phasePrepare", () => {
     expect(drop?.fields?.tokens_idle_at_drop).toBeGreaterThan(0);
     expect(drop?.fields?.kept_history_tokens).toBeGreaterThan(0);
     expect(drop?.fields?.missing_turns).toBe(2);
+  });
+
+  test("seeds session activeSkills from the request", () => {
+    const activeSkills = [{ name: "build", instructions: "slice it" }];
+    const prepared = phasePrepare({
+      request: { model: "gpt-5-mini", message: "go", history: [], activeSkills },
+      workspace: undefined,
+      taskId: "task_seed",
+      soulPrompt: "",
+      model: "gpt-5-mini",
+      policy: defaultLifecyclePolicy,
+      debug: () => {},
+      onOutput: () => {},
+      onChecklist: () => {},
+      mcpListings: [],
+    });
+    expect(prepared.session.activeSkills).toEqual(activeSkills);
+    expect(prepared.session.activeSkills).not.toBe(activeSkills);
+  });
+
+  test("activating a skill merges onto the seeded set instead of dropping it", () => {
+    const prepared = phasePrepare({
+      request: {
+        model: "gpt-5-mini",
+        message: "go",
+        history: [],
+        activeSkills: [{ name: "build", instructions: "slice it" }],
+      },
+      workspace: undefined,
+      taskId: "task_merge",
+      soulPrompt: "",
+      model: "gpt-5-mini",
+      policy: defaultLifecyclePolicy,
+      debug: () => {},
+      onOutput: () => {},
+      onChecklist: () => {},
+      mcpListings: [],
+    });
+    addActiveSkill(prepared.session, { name: "tdd", instructions: "red green" });
+    expect(prepared.session.activeSkills?.map((s) => s.name)).toEqual(["build", "tdd"]);
+  });
+
+  test("leaves session activeSkills unset when the request has none", () => {
+    const prepared = phasePrepare({
+      request: { model: "gpt-5-mini", message: "go", history: [] },
+      workspace: undefined,
+      taskId: "task_noskills",
+      soulPrompt: "",
+      model: "gpt-5-mini",
+      policy: defaultLifecyclePolicy,
+      debug: () => {},
+      onOutput: () => {},
+      onChecklist: () => {},
+      mcpListings: [],
+    });
+    expect(prepared.session.activeSkills).toBeUndefined();
   });
 
   test("does not emit lifecycle.window.drop when history fits the window", () => {

--- a/src/lifecycle-prepare.ts
+++ b/src/lifecycle-prepare.ts
@@ -54,6 +54,7 @@ export function phasePrepare(input: PhasePrepareInput): PhasePrepareResult {
   }
 
   if (input.request.activeSkills?.length) {
+    session.activeSkills = [...input.request.activeSkills];
     input.debug("lifecycle.skill.context", {
       skill_names: input.request.activeSkills.map((s) => s.name),
     });


### PR DESCRIPTION
## Summary

- seed `session.activeSkills` from the request in `phasePrepare` so activating a skill no longer drops previously active ones
- add regression tests for seeding, cross-turn merge, and the no-skills case
