### PR TITLE
fix(skill): show active skill live during turn

### DIFF
--- a/src/chat-message-handler.int.test.ts
+++ b/src/chat-message-handler.int.test.ts
@@ -378,6 +378,22 @@ describe("chat message handler", () => {
     expect(proseContents).toEqual(["Let me check the file.", "Done editing."]);
   });
 
+  test("a skill activated mid-turn updates the session live", async () => {
+    const { handleMessage, session } = createMessageHandlerHarness({
+      client: createClient({
+        status: async () => ({}),
+        replyStream: async (input) => {
+          input.onEvent({ type: "skill-activated", skill: { name: "build", instructions: "slice it" } });
+          return { model: "gpt-5-mini", outputStreamed: true, output: "on it" };
+        },
+      }),
+    });
+
+    await handleMessage("use the build skill");
+
+    expect(session.activeSkills?.map((s) => s.name)).toEqual(["build"]);
+  });
+
   test("toggles shortcuts on ? input", async () => {
     const { handleMessage, calls } = createMessageHandlerHarness();
     await handleMessage("?");

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -5,6 +5,7 @@ import { invalidateRepoPathCandidates } from "./chat-file-ref";
 import { formatSubmitError, isAbortError, resolveNaturalRememberDirective } from "./chat-message-handler-helpers";
 import { createMessageStreamState } from "./chat-message-handler-stream";
 import { startRemoteTaskFollowup } from "./chat-message-handler-task-followup";
+import { addActiveSkill } from "./chat-skill-activator";
 import { isKnownSlashToken, suggestSlashCommands } from "./chat-slash";
 import {
   appendInputHistory,
@@ -141,6 +142,9 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
             case "tool-call":
               runningToolCallIds.add(event.toolCallId);
               input.setPendingState({ kind: "running", toolCalls: runningToolCallIds.size });
+              break;
+            case "skill-activated":
+              addActiveSkill(input.currentSession, event.skill);
               break;
           }
         },

--- a/src/client-contract.test.ts
+++ b/src/client-contract.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { parseStreamEvent, type StreamEvent } from "./client-contract";
+
+describe("parseStreamEvent", () => {
+  test("accepts a skill-activated event", () => {
+    const event: StreamEvent = { type: "skill-activated", skill: { name: "build", instructions: "slice it" } };
+    expect(parseStreamEvent(event)).toEqual(event);
+  });
+
+  test("rejects a skill-activated event with a malformed skill", () => {
+    expect(parseStreamEvent({ type: "skill-activated", skill: { name: "build" } })).toBeNull();
+  });
+});

--- a/src/client-contract.ts
+++ b/src/client-contract.ts
@@ -4,7 +4,7 @@ import { invariant } from "./assert";
 import { checklistItemSchema } from "./checklist-contract";
 import { rpcServerMessageSchema } from "./rpc-protocol";
 import { promptBreakdownSchema, tokenCountSchema, tokenUsageSchema } from "./session-contract";
-import { activeSkillsSchema } from "./skill-contract";
+import { activeSkillSchema, activeSkillsSchema } from "./skill-contract";
 import type { StatusFields } from "./status-contract";
 import { streamErrorSchema } from "./stream-error";
 import type { TaskId, TaskRecord } from "./task-contract";
@@ -60,6 +60,10 @@ const checklistEventSchema = z.object({
   groupTitle: z.string().min(1),
   items: z.array(checklistItemSchema),
 });
+const skillActivatedEventSchema = z.object({
+  type: z.literal("skill-activated"),
+  skill: activeSkillSchema,
+});
 const errorEventSchema = z.object({
   type: z.literal("error"),
   errorMessage: z.string(),
@@ -84,6 +88,7 @@ export const streamEventSchema = z.discriminatedUnion("type", [
   streamUsageEventSchema,
   statusEventSchema,
   checklistEventSchema,
+  skillActivatedEventSchema,
   errorEventSchema,
   noticeEventSchema,
 ]);

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -8,7 +8,7 @@ import type { ResolvedFeatureFlags } from "./feature-flags-contract";
 import type { LifecyclePolicy } from "./lifecycle-policy";
 import type { McpToolListing } from "./mcp-client";
 import type { MemoryCommitMetrics } from "./memory-contract";
-import type { ChecklistListener, SessionContext } from "./tool-contract";
+import type { ChecklistListener, SessionContext, SkillActivatedListener } from "./tool-contract";
 import type { ToolOutputPart } from "./tool-output-contract";
 import type { Toolset } from "./tool-registry";
 
@@ -69,6 +69,7 @@ export type PhasePrepareInput = {
   debug: RunContext["debug"];
   onOutput: (event: ToolOutputEvent) => void;
   onChecklist: ChecklistListener;
+  onSkillActivated: SkillActivatedListener;
   mcpListings: McpToolListing[];
 };
 export type PhasePrepareResult = {

--- a/src/lifecycle-finalize.test.ts
+++ b/src/lifecycle-finalize.test.ts
@@ -348,6 +348,27 @@ describe("phaseFinalize", () => {
     const response = phaseFinalize(ctx);
     expect(response.activeSkills).toBeUndefined();
   });
+
+  test("summary active_skills reflects the end-of-turn session set, not the request", () => {
+    const events: { event: string; fields?: Record<string, unknown> }[] = [];
+    const ctx = createRunContext({
+      request: {
+        model: "gpt-5-mini",
+        message: "test",
+        history: [],
+        activeSkills: [{ name: "build", instructions: "x" }],
+      },
+      result: { text: "Done.", toolCalls: [] },
+      debug: (event, fields) => events.push({ event, fields }),
+    });
+    ctx.session.activeSkills = [
+      { name: "build", instructions: "x" },
+      { name: "tdd", instructions: "y" },
+    ];
+    phaseFinalize(ctx);
+    const summary = events.find((e) => e.event === "lifecycle.summary");
+    expect(summary?.fields?.active_skills).toEqual(["build", "tdd"]);
+  });
 });
 
 describe("parseChatResponse activeSkills", () => {

--- a/src/lifecycle-finalize.ts
+++ b/src/lifecycle-finalize.ts
@@ -105,7 +105,7 @@ export function phaseFinalize(ctx: RunContext): ChatResponse {
     duplicate_discovery_calls: duplicateDiscoveryCalls,
     lifecycle_signal: ctx.acceptedSignal ?? null,
     budget_blocked: ctx.errorStats["budget-exhausted"] > 0,
-    active_skills: ctx.request.activeSkills?.map((s) => s.name) ?? null,
+    active_skills: ctx.session.activeSkills?.map((s) => s.name) ?? null,
     last_error_code: ctx.currentError?.code ?? null,
     last_error_category: ctx.currentError?.category ?? null,
     timeout_error_count: ctx.errorStats.timeout,

--- a/src/lifecycle-generate.test.ts
+++ b/src/lifecycle-generate.test.ts
@@ -495,6 +495,7 @@ describe("phaseGenerate", () => {
       session,
       onOutput: () => {},
       onChecklist: () => {},
+      onSkillActivated: () => {},
     }) as unknown as Record<string, ToolDefinition>;
 
     // Turn 1: tool call (triggers onBeforeNextCall before turn 2)
@@ -575,6 +576,7 @@ describe("phaseGenerate", () => {
       session,
       onOutput: () => {},
       onChecklist: () => {},
+      onSkillActivated: () => {},
     }) as unknown as Record<string, ToolDefinition>;
     const turns: LanguageModelV4StreamPart[][] = [
       [
@@ -637,6 +639,7 @@ describe("phaseGenerate", () => {
       session,
       onOutput: () => {},
       onChecklist: () => {},
+      onSkillActivated: () => {},
     }) as unknown as Record<string, ToolDefinition>;
 
     const turns: LanguageModelV4StreamPart[][] = [
@@ -711,6 +714,7 @@ describe("phaseGenerate", () => {
       session,
       onOutput: () => {},
       onChecklist: () => {},
+      onSkillActivated: () => {},
     }) as unknown as Record<string, ToolDefinition>;
     if (input.callLog) session.callLog.push(...input.callLog);
     const model = scriptedModel(input.turns, []);
@@ -806,6 +810,7 @@ describe("phaseGenerate", () => {
       session,
       onOutput: () => {},
       onChecklist: () => {},
+      onSkillActivated: () => {},
     }) as unknown as Record<string, ToolDefinition>;
     if (input.callLog) session.callLog.push(...input.callLog);
     const argsCapture: Array<Record<string, unknown>> = [];

--- a/src/lifecycle-prepare.test.ts
+++ b/src/lifecycle-prepare.test.ts
@@ -28,6 +28,7 @@ describe("phasePrepare", () => {
       debug: () => {},
       onOutput: () => {},
       onChecklist: () => {},
+      onSkillActivated: () => {},
       mcpListings: [],
     });
     expect(prepared.session.toolTimeoutMs).toBe(1_234);
@@ -46,6 +47,7 @@ describe("phasePrepare", () => {
       debug: () => {},
       onOutput: () => {},
       onChecklist: () => {},
+      onSkillActivated: () => {},
       mcpListings: [],
     });
     const withRules = phasePrepare({
@@ -59,6 +61,7 @@ describe("phasePrepare", () => {
       debug: () => {},
       onOutput: () => {},
       onChecklist: () => {},
+      onSkillActivated: () => {},
       mcpListings: [],
     });
     expect(withRules.promptUsage.systemPromptTokens).toBeGreaterThan(base.promptUsage.systemPromptTokens);
@@ -76,6 +79,7 @@ describe("phasePrepare", () => {
       debug: (event, fields) => events.push({ event, fields }),
       onOutput: () => {},
       onChecklist: () => {},
+      onSkillActivated: () => {},
       mcpListings: [],
     });
     const drop = events.find((e) => e.event === "lifecycle.window.drop");
@@ -98,6 +102,7 @@ describe("phasePrepare", () => {
       debug: () => {},
       onOutput: () => {},
       onChecklist: () => {},
+      onSkillActivated: () => {},
       mcpListings: [],
     });
     expect(prepared.session.activeSkills).toEqual(activeSkills);
@@ -120,6 +125,7 @@ describe("phasePrepare", () => {
       debug: () => {},
       onOutput: () => {},
       onChecklist: () => {},
+      onSkillActivated: () => {},
       mcpListings: [],
     });
     addActiveSkill(prepared.session, { name: "tdd", instructions: "red green" });
@@ -137,6 +143,7 @@ describe("phasePrepare", () => {
       debug: () => {},
       onOutput: () => {},
       onChecklist: () => {},
+      onSkillActivated: () => {},
       mcpListings: [],
     });
     expect(prepared.session.activeSkills).toBeUndefined();
@@ -154,6 +161,7 @@ describe("phasePrepare", () => {
       debug: (event) => events.push(event),
       onOutput: () => {},
       onChecklist: () => {},
+      onSkillActivated: () => {},
       mcpListings: [],
     });
     expect(events).not.toContain("lifecycle.window.drop");

--- a/src/lifecycle-prepare.ts
+++ b/src/lifecycle-prepare.ts
@@ -22,6 +22,7 @@ export function phasePrepare(input: PhasePrepareInput): PhasePrepareResult {
     workspace: input.workspace,
     onOutput: input.onOutput,
     onChecklist: input.onChecklist,
+    onSkillActivated: input.onSkillActivated,
     taskId: input.taskId,
     sessionId: input.request.sessionId,
     mcpListings: input.mcpListings,

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -297,6 +297,9 @@ export async function runLifecycle(input: LifecycleInput, deps: LifecycleDeps = 
     onChecklist: (event) => {
       emit({ type: "checklist", groupId: event.groupId, groupTitle: event.groupTitle, items: event.items });
     },
+    onSkillActivated: (skill) => {
+      emit({ type: "skill-activated", skill });
+    },
     mcpListings,
   });
 

--- a/src/signal-toolkit.test.ts
+++ b/src/signal-toolkit.test.ts
@@ -11,6 +11,7 @@ function toolkit() {
     session: createSessionContext("task_signal"),
     onOutput: noop,
     onChecklist: noop,
+    onSkillActivated: noop,
   });
 }
 
@@ -56,6 +57,7 @@ describe("signal tools", () => {
       session,
       onOutput: noop,
       onChecklist: noop,
+      onSkillActivated: noop,
     });
 
     const result = await tools.signalDone.execute({}, "call_done");

--- a/src/skill-toolkit.int.test.ts
+++ b/src/skill-toolkit.int.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import type { ActiveSkill } from "./skill-contract";
 import { loadSkills, resetSkillCache } from "./skill-ops";
 import { createSkillToolkit } from "./skill-toolkit";
 import { tempDir } from "./test-utils";
@@ -13,12 +14,13 @@ const { createDir, cleanupDirs } = tempDir();
 
 type OutputEvent = { toolName: string; content: unknown; toolCallId?: string };
 
-function createToolkitInput(workspace: string, outputs?: OutputEvent[]): ToolkitInput {
+function createToolkitInput(workspace: string, outputs?: OutputEvent[], activations?: ActiveSkill[]): ToolkitInput {
   return {
     workspace,
     session: createSessionContext(),
     onOutput: (event) => outputs?.push(event),
     onChecklist: () => {},
+    onSkillActivated: (skill) => activations?.push(skill),
   };
 }
 
@@ -46,6 +48,17 @@ describe("skill-activate", () => {
     expect(result.activated[0]?.source).toBe("bundled");
     expect(result.activated[0]?.instructions.length).toBeGreaterThan(0);
     expect(input.session.activeSkills).toEqual([{ name: "build", instructions: result.activated[0]?.instructions }]);
+  });
+
+  test("emits onSkillActivated for each activated skill", async () => {
+    const dir = createDir("acolyte-skill-activate-emit-");
+    await loadSkills(dir);
+    const activations: ActiveSkill[] = [];
+    const input = createToolkitInput(dir, undefined, activations);
+    const toolkit = createSkillToolkit(input);
+    await toolkit.activateSkill.execute({ names: ["build", "git"] }, "call-emit");
+    expect(activations.map((s) => s.name)).toEqual(["build", "git"]);
+    expect(activations[0]?.instructions.length).toBeGreaterThan(0);
   });
 
   test("activates project skill", async () => {

--- a/src/skill-toolkit.ts
+++ b/src/skill-toolkit.ts
@@ -49,6 +49,7 @@ function createActivateSkillTool(input: ToolkitInput) {
         for (const skill of skills) {
           const instructions = await readSkillInstructions(skill.path, toolInput.args);
           addActiveSkill(input.session, { name: skill.name, instructions });
+          input.onSkillActivated({ name: skill.name, instructions });
           activated.push({ name: skill.name, source: skill.source, instructions });
         }
         return { kind: "skill-activate" as const, activated };

--- a/src/test-toolkit.test.ts
+++ b/src/test-toolkit.test.ts
@@ -11,6 +11,7 @@ function createToolkit(testCommand?: { bin: string; args: string[] }) {
     session,
     onOutput: (e) => output.push(e),
     onChecklist: () => {},
+    onSkillActivated: () => {},
   });
   return { toolkit, output };
 }

--- a/src/tool-contract.ts
+++ b/src/tool-contract.ts
@@ -24,12 +24,15 @@ export type ToolDefinition<TInput = unknown, TOutput = unknown> = {
 
 export type ChecklistListener = (event: { groupId: string; groupTitle: string; items: ChecklistItem[] }) => void;
 
+export type SkillActivatedListener = (skill: ActiveSkill) => void;
+
 export type ToolkitInput = {
   workspace: string;
   session: SessionContext;
   sessionId?: string;
   onOutput: ToolOutputListener;
   onChecklist: ChecklistListener;
+  onSkillActivated: SkillActivatedListener;
 };
 
 export type RunToolResult<T = unknown> = { result: T; effectOutput?: string };

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -14,7 +14,14 @@ import { createSkillToolkit } from "./skill-toolkit";
 import { createTestToolkit } from "./test-toolkit";
 import { createToolCache } from "./tool-cache";
 import { getDefaultToolCacheStore } from "./tool-cache-store";
-import type { ChecklistListener, SessionContext, ToolCategory, ToolDefinition, ToolkitInput } from "./tool-contract";
+import type {
+  ChecklistListener,
+  SessionContext,
+  SkillActivatedListener,
+  ToolCategory,
+  ToolDefinition,
+  ToolkitInput,
+} from "./tool-contract";
 import type { ToolOutputListener } from "./tool-output-format";
 import { createSessionContext } from "./tool-session";
 import { createUndoToolkit } from "./undo-toolkit";
@@ -103,17 +110,22 @@ export const TOOLKIT_REGISTRY: {
 
 const noopOutput: ToolOutputListener = () => {};
 const noopChecklist: ChecklistListener = () => {};
+const noopSkillActivated: SkillActivatedListener = () => {};
 
 function collectTools(
   workspace: string,
   session: SessionContext,
   onOutput: ToolOutputListener = noopOutput,
   onChecklist: ChecklistListener = noopChecklist,
+  onSkillActivated: SkillActivatedListener = noopSkillActivated,
   sessionId?: string,
 ): ToolMap {
   const combined: ToolMap = {};
   for (const toolkit of TOOLKIT_REGISTRY) {
-    Object.assign(combined, toolkit.createToolkit({ workspace, session, sessionId, onOutput, onChecklist }));
+    Object.assign(
+      combined,
+      toolkit.createToolkit({ workspace, session, sessionId, onOutput, onChecklist, onSkillActivated }),
+    );
   }
   return combined;
 }
@@ -162,6 +174,7 @@ export function toolsForAgent(options?: {
   workspace?: string;
   onOutput?: ToolOutputListener;
   onChecklist?: ChecklistListener;
+  onSkillActivated?: SkillActivatedListener;
   taskId?: string;
   sessionId?: string;
   mcpListings?: McpToolListing[];
@@ -172,7 +185,14 @@ export function toolsForAgent(options?: {
   const workspace = options?.workspace ?? resolve(process.cwd());
   const session = createSessionContext(options?.taskId, WRITE_TOOL_SET);
   session.cache = createToolCache(DISCOVERY_TOOL_SET, undefined, getDefaultToolCacheStore(options?.sessionId));
-  const base = collectTools(workspace, session, options?.onOutput, options?.onChecklist, options?.sessionId);
+  const base = collectTools(
+    workspace,
+    session,
+    options?.onOutput,
+    options?.onChecklist,
+    options?.onSkillActivated,
+    options?.sessionId,
+  );
   if (options?.mcpListings?.length) {
     const nativeIds = new Set(Object.keys(base));
     Object.assign(base, bindMcpTools(options.mcpListings, session, nativeIds, options.sessionId));


### PR DESCRIPTION
## Summary

- surface an activated skill on the status line live (mid-turn) instead of only after the turn resolves
- add a typed `skill-activated` stream event carrying the skill; the server emits it on activation and the client applies it to the live session, which the post-turn reconcile then confirms
- make `lifecycle.summary.active_skills` report the end-of-turn session set, so a skill activated mid-turn shows in that turn's trace instead of a turn late
