### PR TITLE
refactor(tui): unify tool-output render path

### DIFF
--- a/src/chat-transcript.tsx
+++ b/src/chat-transcript.tsx
@@ -8,9 +8,7 @@ import { ShimmerText } from "./chat-shimmer";
 import type { PendingState } from "./client-contract";
 import { t } from "./i18n";
 import { palette } from "./palette";
-import type { ToolOutputPart } from "./tool-output-contract";
-import { renderToolOutput as renderToolOutputText, resolveHeader } from "./tool-output-render";
-import { truncateToWidth } from "./truncate-text";
+import { renderToolOutputTui } from "./tool-output-tui";
 import { Box, Text } from "./tui";
 import { DEFAULT_COLUMNS } from "./tui/constants";
 
@@ -61,135 +59,6 @@ function renderCommandOutput(output: CommandOutput): React.ReactNode {
   );
 }
 
-// Columns of the leading "\n  " indent every tool body line renders with; width budgets
-// subtract it so a truncated line plus its indent still fits toolContentWidth.
-const TOOL_LINE_INDENT = 2;
-
-function renderToolPart(
-  part: ToolOutputPart,
-  index: number,
-  lineNumWidth: number,
-  toolContentWidth: number,
-  diffIndent: string,
-): React.ReactNode {
-  if (part.kind === "diff") {
-    const num = String(part.lineNumber).padStart(lineNumWidth);
-    const prefix = ` ${num} `;
-    const marker = part.marker === "add" ? "+" : part.marker === "remove" ? "-" : " ";
-    // Cut the content to the display budget (indent + gutter prefix + 1-col marker) before
-    // padding, so the colored bar still fills the width but the line never overflows and wraps.
-    const budget = Math.max(0, toolContentWidth - TOOL_LINE_INDENT - diffIndent.length - prefix.length - 1);
-    const content = truncateToWidth(part.text, budget);
-    const padWidth = Math.max(0, budget - Bun.stringWidth(content));
-    const padded = content + " ".repeat(padWidth);
-    if (part.marker === "add" || part.marker === "remove") {
-      const bg = part.marker === "add" ? palette.diffAdd : palette.diffRemove;
-      const fg = part.marker === "add" ? palette.diffAddText : palette.diffRemoveText;
-      return (
-        <Text key={`tool-${index}`}>
-          {`\n  ${diffIndent}`}
-          <Text backgroundColor={bg}>
-            <Text color={fg}>
-              {prefix}
-              {marker}
-            </Text>
-            <Text color={palette.text}>{padded}</Text>
-          </Text>
-        </Text>
-      );
-    }
-    return (
-      <Text key={`tool-${index}`}>
-        {`\n  ${diffIndent}`}
-        <Text dimColor>{prefix} </Text>
-        <Text color={palette.text}>{content}</Text>
-      </Text>
-    );
-  }
-  if (part.kind === "shell-output") {
-    return (
-      <Text key={`tool-${index}`}>
-        {"\n  "}
-        <Text dimColor>{truncateToWidth(part.text, toolContentWidth - TOOL_LINE_INDENT)}</Text>
-      </Text>
-    );
-  }
-  const text = renderToolOutputText(part);
-  if (lineNumWidth > 0) {
-    if (part.kind === "text") {
-      return (
-        <Text key={`tool-${index}`}>
-          {"\n  "}
-          <Text dimColor>{truncateToWidth(text, toolContentWidth - TOOL_LINE_INDENT)}</Text>
-        </Text>
-      );
-    }
-    const indent = part.kind === "truncated" ? diffIndent : "";
-    const display =
-      part.kind === "truncated"
-        ? `${"⋮".padStart(lineNumWidth)}  ${text.slice(2)}`
-        : `${" ".repeat(lineNumWidth + 2)}${text}`;
-    return (
-      <Text key={`tool-${index}`}>
-        {"\n  "}
-        <Text dimColor>{truncateToWidth(`${indent} ${display}`, toolContentWidth - TOOL_LINE_INDENT)}</Text>
-      </Text>
-    );
-  }
-  return (
-    <Text key={`tool-${index}`}>
-      {"\n  "}
-      <Text dimColor>{truncateToWidth(text, toolContentWidth - TOOL_LINE_INDENT)}</Text>
-    </Text>
-  );
-}
-
-function renderHeaderMeta(meta: Record<string, unknown>): React.ReactNode {
-  if ("added" in meta && "removed" in meta) {
-    return (
-      <>
-        <Text dimColor> (</Text>
-        <Text color={palette.diffAddText}>{`+${meta.added}`}</Text>
-        <Text dimColor> </Text>
-        <Text color={palette.diffRemoveText}>{`-${meta.removed}`}</Text>
-        <Text dimColor>)</Text>
-      </>
-    );
-  }
-  return null;
-}
-
-function renderHeader(part: ToolOutputPart): React.ReactNode {
-  const header = resolveHeader(part);
-  if (!header) return null;
-  return (
-    <>
-      <Text bold>{header.label}</Text>
-      {header.detail ? <Text dimColor>{` ${header.detail}`}</Text> : null}
-      {header.meta ? renderHeaderMeta(header.meta) : null}
-    </>
-  );
-}
-
-function renderToolOutput(parts: ToolOutputPart[], toolContentWidth: number): React.ReactNode {
-  const [first, ...rest] = parts;
-  if (!first) return null;
-  const lineNumWidth = parts.reduce(
-    (max, part) => (part.kind === "diff" ? Math.max(max, String(part.lineNumber).length) : max),
-    0,
-  );
-  // Multi-file edits interleave per-file sub-headers (text) with diff lines; nest the
-  // diffs 2 columns under their sub-header, mirroring the CLI's 2-col nest (tool-output-render
-  // `hasFileHeaders`). The absolute column still differs by chat's leading-space gutter.
-  const diffIndent = lineNumWidth > 0 && rest.some((part) => part.kind === "text") ? "  " : "";
-  return (
-    <>
-      {renderHeader(first)}
-      {rest.map((part, i) => renderToolPart(part, i, lineNumWidth, toolContentWidth, diffIndent))}
-    </>
-  );
-}
-
 type ChatTranscriptRowProps = {
   row: ChatRow;
   contentWidth: number;
@@ -208,7 +77,7 @@ export function ChatTranscriptRow({ row, contentWidth, toolContentWidth }: ChatT
       </Box>
       <Box width={row.kind === "tool" ? toolContentWidth : contentWidth}>
         {isToolOutput(row.content) ? (
-          <Text>{renderToolOutput(row.content.parts, toolContentWidth)}</Text>
+          <Text>{renderToolOutputTui(row.content.parts, toolContentWidth)}</Text>
         ) : isCommandOutput(row.content) ? (
           <Text>{renderCommandOutput(row.content)}</Text>
         ) : row.kind === "assistant" && typeof row.content === "string" ? (

--- a/src/shell-toolkit.ts
+++ b/src/shell-toolkit.ts
@@ -3,7 +3,6 @@ import { formatShellCommand, parseExitCode, runShellCommand } from "./shell-ops"
 import { createTool, type ToolkitInput } from "./tool-contract";
 import { runTool } from "./tool-execution";
 import { emitParts, shellHeadTailParts } from "./tool-output-format";
-import { truncateText } from "./truncate-text";
 
 function createRunCommandTool(input: ToolkitInput) {
   return createTool({
@@ -38,7 +37,7 @@ function createRunCommandTool(input: ToolkitInput) {
             content: {
               kind: "tool-header",
               labelKey: "tool.label.shell_run",
-              detail: truncateText(displayCommand),
+              detail: displayCommand,
             },
             toolCallId: callId,
           });

--- a/src/test-toolkit.ts
+++ b/src/test-toolkit.ts
@@ -3,7 +3,6 @@ import { parseExitCode, runShellCommand } from "./shell-ops";
 import { createTool, type ToolkitInput } from "./tool-contract";
 import { runTool } from "./tool-execution";
 import { emitParts, shellHeadTailParts } from "./tool-output-format";
-import { truncateText } from "./truncate-text";
 import { formatWorkspaceCommand, resolveCommandFiles } from "./workspace-profile";
 
 function createRunTestsTool(input: ToolkitInput) {
@@ -40,7 +39,7 @@ function createRunTestsTool(input: ToolkitInput) {
         const command = formatWorkspaceCommand(resolved);
         onOutput({
           toolName: "test-run",
-          content: { kind: "tool-header", labelKey: "tool.label.test_run", detail: truncateText(command) },
+          content: { kind: "tool-header", labelKey: "tool.label.test_run", detail: command },
           toolCallId: callId,
         });
         const streamed: Array<{ stream: "stdout" | "stderr"; text: string }> = [];

--- a/src/tool-output-layout.test.ts
+++ b/src/tool-output-layout.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import type { ToolOutputPart } from "./tool-output-contract";
+import { fitLine, layoutToolOutput, resolveHeader, visibleLineWidth } from "./tool-output-layout";
+
+const DIFF_PARTS: ToolOutputPart[] = [
+  { kind: "edit-header", labelKey: "tool.label.file_edit", path: "notes.ts", added: 2, removed: 1 },
+  { kind: "diff", lineNumber: 9, marker: "context", text: "const x = 1;" },
+  { kind: "diff", lineNumber: 10, marker: "remove", text: "const y = 2;" },
+  { kind: "diff", lineNumber: 100, marker: "add", text: "X".repeat(80) },
+  { kind: "truncated", count: 3, unit: "lines" },
+];
+
+const NESTED_PARTS: ToolOutputPart[] = [
+  { kind: "edit-header", labelKey: "tool.label.file_edit", path: "9 files", added: 9, removed: 9 },
+  { kind: "text", text: "src/some/really/long/module.ts (+1 -1)" },
+  { kind: "diff", lineNumber: 200, marker: "add", text: "Y".repeat(80) },
+];
+
+const SHELL_PARTS: ToolOutputPart[] = [
+  { kind: "tool-header", labelKey: "tool.label.shell_run", detail: "bun test src/really/long/path/module.test.ts" },
+  { kind: "shell-output", stream: "stdout", text: "Z".repeat(80) },
+  { kind: "shell-output", stream: "stderr", text: "warning".repeat(20) },
+];
+
+describe("layoutToolOutput", () => {
+  test("computes the gutter width from the widest line number", () => {
+    const [, context, , add] = layoutToolOutput(DIFF_PARTS);
+    expect(context?.segments[0]?.text).toBe("   9  ");
+    expect(add?.segments[0]?.text).toBe(" 100 +");
+  });
+
+  test("nests diff lines under per-file sub-headers", () => {
+    const [, subHeader, diff] = layoutToolOutput(NESTED_PARTS);
+    expect(subHeader?.indent).toBe(2);
+    expect(diff?.indent).toBe(4);
+  });
+
+  test("marks add/remove lines with a fill and leaves context unfilled", () => {
+    const [, context, remove, add] = layoutToolOutput(DIFF_PARTS);
+    expect(context?.fill).toBeUndefined();
+    expect(remove?.fill).toBe("diff-remove");
+    expect(add?.fill).toBe("diff-add");
+  });
+
+  test("fitLine with no width leaves every line untouched", () => {
+    for (const line of layoutToolOutput(DIFF_PARTS)) {
+      expect(fitLine(line, undefined)).toEqual(line);
+    }
+  });
+});
+
+describe("fitLine width invariant", () => {
+  const scenarios = [DIFF_PARTS, NESTED_PARTS, SHELL_PARTS];
+  for (const width of [12, 20, 30, 40, 96]) {
+    test(`every fitted line fits ${width} columns`, () => {
+      for (const parts of scenarios) {
+        for (const line of layoutToolOutput(parts)) {
+          expect(visibleLineWidth(fitLine(line, width))).toBeLessThanOrEqual(width);
+        }
+      }
+    });
+  }
+});
+
+describe("resolveHeader", () => {
+  test("returns the label for a header part and null otherwise", () => {
+    expect(resolveHeader(DIFF_PARTS[0] as ToolOutputPart)?.label).toBeDefined();
+    expect(resolveHeader({ kind: "no-output" })).toBeNull();
+  });
+});

--- a/src/tool-output-layout.ts
+++ b/src/tool-output-layout.ts
@@ -1,0 +1,239 @@
+import { z } from "zod";
+import { unreachable } from "./assert";
+import { t, tDynamic } from "./i18n";
+import type { ToolOutputPart } from "./tool-output-contract";
+import { truncateMiddleToWidth, truncateToWidth } from "./truncate-text";
+
+export const segmentRoleSchema = z.enum([
+  "label",
+  "detail",
+  "meta-punct",
+  "meta-add",
+  "meta-remove",
+  "diff-gutter",
+  "diff-text",
+  "dim",
+  "stream-tag",
+]);
+export type SegmentRole = z.infer<typeof segmentRoleSchema>;
+
+export const layoutSegmentSchema = z.object({ role: segmentRoleSchema, text: z.string() });
+export type LayoutSegment = z.infer<typeof layoutSegmentSchema>;
+
+export const layoutFillSchema = z.enum(["diff-add", "diff-remove"]);
+export type LayoutFill = z.infer<typeof layoutFillSchema>;
+
+export const layoutLineSchema = z.object({
+  kind: z.enum(["header", "body"]),
+  indent: z.number().int().nonnegative(),
+  segments: z.array(layoutSegmentSchema),
+  fill: layoutFillSchema.optional(),
+});
+export type LayoutLine = z.infer<typeof layoutLineSchema>;
+
+export type ResolvedHeader = { label: string; detail?: string; meta?: Record<string, unknown> };
+
+export function resolveHeader(content: ToolOutputPart): ResolvedHeader | null {
+  switch (content.kind) {
+    case "tool-header": {
+      const label = tDynamic(content.labelKey);
+      const detail = content.detail && content.detail !== "." ? content.detail : undefined;
+      return { label, detail };
+    }
+    case "file-header": {
+      const label = tDynamic(content.labelKey);
+      const detail =
+        content.count === 1 && content.targets.length === 1
+          ? content.targets[0]
+          : t("unit.file", { count: content.count });
+      return { label, detail };
+    }
+    case "scope-header": {
+      const label = tDynamic(content.labelKey);
+      const scopeSuffix = content.scope !== "workspace" ? ` in ${content.scope}` : "";
+      const detail =
+        content.patterns.length === 1
+          ? `${content.patterns[0]}${scopeSuffix}`
+          : `${t("unit.pattern", { count: content.patterns.length })}${scopeSuffix}`;
+      return { label, detail };
+    }
+    case "edit-header": {
+      const label = tDynamic(content.labelKey);
+      const path = content.path === "." ? undefined : content.path;
+      return { label, detail: path, meta: { added: content.added, removed: content.removed } };
+    }
+    default:
+      return null;
+  }
+}
+
+const TRUNCATED_UNIT_KEYS: Record<string, string> = {
+  lines: "unit.line",
+  matches: "unit.match",
+  files: "unit.file",
+};
+
+function truncatedText(count: number | undefined, unit: string | undefined): string {
+  if (!count) return "…";
+  const text = tDynamic(TRUNCATED_UNIT_KEYS[unit ?? ""] ?? "unit.more", { count });
+  return `… +${text}`;
+}
+
+function headerSegments(header: ResolvedHeader): LayoutSegment[] {
+  const segments: LayoutSegment[] = [{ role: "label", text: header.label }];
+  if (header.detail) segments.push({ role: "detail", text: ` ${header.detail}` });
+  const meta = header.meta;
+  if (meta && "added" in meta && "removed" in meta) {
+    segments.push(
+      { role: "meta-punct", text: " (" },
+      { role: "meta-add", text: `+${meta.added}` },
+      { role: "meta-punct", text: " " },
+      { role: "meta-remove", text: `-${meta.removed}` },
+      { role: "meta-punct", text: ")" },
+    );
+  }
+  return segments;
+}
+
+/** Segments for a single part rendered inline (no gutter, no indent) — the header line form. */
+export function inlineSegments(part: ToolOutputPart): LayoutSegment[] {
+  const header = resolveHeader(part);
+  if (header) return headerSegments(header);
+  switch (part.kind) {
+    case "text":
+      return [{ role: "dim", text: part.text }];
+    case "diff": {
+      const marker = part.marker === "add" ? "+" : part.marker === "remove" ? "-" : " ";
+      return [{ role: "dim", text: `${part.lineNumber} ${marker}${part.text}` }];
+    }
+    case "shell-output":
+      return [
+        { role: "stream-tag", text: `${part.stream === "stdout" ? "out" : "err"} | ` },
+        { role: "dim", text: part.text },
+      ];
+    case "no-output":
+      return [{ role: "dim", text: t("tool.content.no_output") }];
+    case "truncated":
+      return [{ role: "dim", text: truncatedText(part.count, part.unit) }];
+    case "tool-header":
+    case "file-header":
+    case "scope-header":
+    case "edit-header":
+      return [];
+    default:
+      return unreachable(part);
+  }
+}
+
+function bodyLine(part: ToolOutputPart, numWidth: number, diffIndent: number): LayoutLine {
+  switch (part.kind) {
+    case "diff": {
+      const num = String(part.lineNumber).padStart(numWidth);
+      const marker = part.marker === "add" ? "+" : part.marker === "remove" ? "-" : " ";
+      const fill: LayoutFill | undefined =
+        part.marker === "add" ? "diff-add" : part.marker === "remove" ? "diff-remove" : undefined;
+      return {
+        kind: "body",
+        indent: 2 + diffIndent,
+        segments: [
+          { role: "diff-gutter", text: ` ${num} ${marker}` },
+          { role: "diff-text", text: part.text },
+        ],
+        fill,
+      };
+    }
+    case "truncated": {
+      if (numWidth > 0) {
+        const suffix = truncatedText(part.count, part.unit);
+        const gutter = ` ${"⋮".padStart(numWidth)}`;
+        const segments: LayoutSegment[] = [{ role: "diff-gutter", text: suffix === "…" ? gutter : `${gutter}  ` }];
+        if (suffix !== "…") segments.push({ role: "dim", text: suffix.slice(2) });
+        return { kind: "body", indent: 2 + diffIndent, segments };
+      }
+      return { kind: "body", indent: 2, segments: [{ role: "dim", text: truncatedText(part.count, part.unit) }] };
+    }
+    case "shell-output":
+      return {
+        kind: "body",
+        indent: 2,
+        segments: [
+          { role: "stream-tag", text: `${part.stream === "stdout" ? "out" : "err"} | ` },
+          { role: "dim", text: part.text },
+        ],
+      };
+    case "text":
+      return { kind: "body", indent: 2, segments: [{ role: "dim", text: part.text }] };
+    case "no-output":
+      return { kind: "body", indent: 2, segments: [{ role: "dim", text: t("tool.content.no_output") }] };
+    case "tool-header":
+    case "file-header":
+    case "scope-header":
+    case "edit-header":
+      return { kind: "body", indent: 2, segments: inlineSegments(part) };
+    default:
+      return unreachable(part);
+  }
+}
+
+export function layoutToolOutput(parts: ToolOutputPart[]): LayoutLine[] {
+  const [first, ...rest] = parts;
+  if (!first) return [];
+  const numWidth = rest.reduce(
+    (max, part) => (part.kind === "diff" ? Math.max(max, String(part.lineNumber).length) : max),
+    0,
+  );
+  const diffIndent = numWidth > 0 && rest.some((part) => part.kind === "text") ? 2 : 0;
+  const headerLine: LayoutLine = { kind: "header", indent: 0, segments: inlineSegments(first) };
+  return [headerLine, ...rest.map((part) => bodyLine(part, numWidth, diffIndent))];
+}
+
+export function segmentsWidth(segments: LayoutSegment[]): number {
+  return segments.reduce((sum, segment) => sum + Bun.stringWidth(segment.text), 0);
+}
+
+export function visibleLineWidth(line: LayoutLine): number {
+  return line.indent + segmentsWidth(line.segments);
+}
+
+function fitBody(segments: LayoutSegment[], avail: number): LayoutSegment[] {
+  const out: LayoutSegment[] = [];
+  let used = 0;
+  for (const segment of segments) {
+    const width = Bun.stringWidth(segment.text);
+    if (used + width <= avail) {
+      out.push(segment);
+      used += width;
+      continue;
+    }
+    const remaining = avail - used;
+    if (remaining > 0) out.push({ role: segment.role, text: truncateToWidth(segment.text, remaining) });
+    break;
+  }
+  return out;
+}
+
+function fitHeader(segments: LayoutSegment[], avail: number): LayoutSegment[] {
+  if (segmentsWidth(segments) <= avail) return segments;
+  const detailIndex = segments.findIndex((segment) => segment.role === "detail");
+  const detail = detailIndex === -1 ? undefined : segments[detailIndex];
+  if (!detail) return fitBody(segments, avail);
+  const detailBudget = avail - (segmentsWidth(segments) - Bun.stringWidth(detail.text));
+  if (detailBudget <= 1) {
+    return fitBody(
+      segments.filter((_, index) => index !== detailIndex),
+      avail,
+    );
+  }
+  const content = detail.text.startsWith(" ") ? detail.text.slice(1) : detail.text;
+  const out = [...segments];
+  out[detailIndex] = { role: "detail", text: ` ${truncateMiddleToWidth(content, detailBudget - 1)}` };
+  return out;
+}
+
+/** Truncate a line's segments to fit `width` columns; `undefined` width leaves it untouched. */
+export function fitLine(line: LayoutLine, width?: number): LayoutLine {
+  if (width === undefined) return line;
+  const avail = Math.max(0, width - line.indent);
+  const segments = line.kind === "header" ? fitHeader(line.segments, avail) : fitBody(line.segments, avail);
+  return { ...line, segments };
+}

--- a/src/tool-output-render.ts
+++ b/src/tool-output-render.ts
@@ -1,122 +1,22 @@
-import { t, tDynamic } from "./i18n";
 import type { ToolOutputPart } from "./tool-output-contract";
-import { truncateToWidth } from "./truncate-text";
+import { fitLine, inlineSegments, type LayoutLine, layoutToolOutput, resolveHeader } from "./tool-output-layout";
 
-export type ResolvedHeader = { label: string; detail?: string; meta?: Record<string, unknown> };
-
-export function resolveHeader(content: ToolOutputPart): ResolvedHeader | null {
-  switch (content.kind) {
-    case "tool-header": {
-      const label = tDynamic(content.labelKey);
-      const detail = content.detail && content.detail !== "." ? content.detail : undefined;
-      return { label, detail };
-    }
-    case "file-header": {
-      const label = tDynamic(content.labelKey);
-      const detail =
-        content.count === 1 && content.targets.length === 1
-          ? content.targets[0]
-          : t("unit.file", { count: content.count });
-      return { label, detail };
-    }
-    case "scope-header": {
-      const label = tDynamic(content.labelKey);
-      const scopeSuffix = content.scope !== "workspace" ? ` in ${content.scope}` : "";
-      const detail =
-        content.patterns.length === 1
-          ? `${content.patterns[0]}${scopeSuffix}`
-          : `${t("unit.pattern", { count: content.patterns.length })}${scopeSuffix}`;
-      return { label, detail };
-    }
-    case "edit-header": {
-      const label = tDynamic(content.labelKey);
-      const path = content.path === "." ? undefined : content.path;
-      return { label, detail: path, meta: { added: content.added, removed: content.removed } };
-    }
-    default:
-      return null;
-  }
+function serializeLine(line: LayoutLine, width?: number): string {
+  const fitted = fitLine(line, width);
+  return " ".repeat(fitted.indent) + fitted.segments.map((segment) => segment.text).join("");
 }
 
-function formatMeta(meta: Record<string, unknown>): string {
-  if ("added" in meta && "removed" in meta) return `(+${meta.added} -${meta.removed})`;
-  return "";
-}
-
-function formatHeader(header: ResolvedHeader): string {
-  const parts = [header.label];
-  if (header.detail) parts.push(header.detail);
-  if (header.meta) parts.push(formatMeta(header.meta));
-  return parts.join(" ");
-}
-
-const TRUNCATED_UNIT_KEYS: Record<string, string> = {
-  lines: "unit.line",
-  matches: "unit.match",
-  files: "unit.file",
-};
-
-function formatTruncated(count: number | undefined, unit: string | undefined): string {
-  if (!count) return "…";
-  const text = tDynamic(TRUNCATED_UNIT_KEYS[unit ?? ""] ?? "unit.more", { count });
-  return `… +${text}`;
-}
-
-function renderPart(content: ToolOutputPart): string {
-  const header = resolveHeader(content);
-  if (header) return formatHeader(header);
-
-  switch (content.kind) {
-    case "text":
-      return content.text;
-    case "diff":
-      return `${content.lineNumber} ${content.marker === "add" ? "+" : content.marker === "remove" ? "-" : " "}${content.text}`;
-    case "shell-output":
-      return `${content.stream === "stdout" ? "out" : "err"} | ${content.text}`;
-    case "no-output":
-      return t("tool.content.no_output");
-    case "truncated":
-      return formatTruncated(content.count, content.unit);
-    default:
-      return "";
-  }
-}
-
-function renderDiffLine(item: Extract<ToolOutputPart, { kind: "diff" }>, numWidth: number): string {
-  const num = String(item.lineNumber).padStart(numWidth);
-  const prefix = item.marker === "add" ? "+" : item.marker === "remove" ? "-" : " ";
-  return `${num} ${prefix}${item.text}`;
-}
-
-function renderList(items: ToolOutputPart[], width?: number): string {
-  const first = items[0];
-  if (!first) return "";
-  const header = renderPart(first);
-  const body = items.slice(1);
-  if (body.length === 0) return header;
-  const numWidth = body.reduce(
-    (max, item) => (item.kind === "diff" ? Math.max(max, String(item.lineNumber).length) : max),
-    0,
-  );
-  const hasFileHeaders = numWidth > 0 && body.some((item) => item.kind === "text");
-  const diffIndent = hasFileHeaders ? "  " : "";
-  const lines = body.map((item) => {
-    if (item.kind === "diff") return `${diffIndent}${renderDiffLine(item, numWidth)}`;
-    if (item.kind === "truncated" && numWidth > 0) {
-      const suffix = renderPart(item).slice(2);
-      return suffix ? `${diffIndent}${"⋮".padStart(numWidth)} ${suffix}` : `${diffIndent}${"⋮".padStart(numWidth)}`;
-    }
-    return renderPart(item);
-  });
-  // Truncate each assembled body line (indent + gutter + content) at the display width so
-  // preview lines never wrap; the gutter sits at line start, so alignment is preserved.
-  // The header is left intact (long paths want middle-truncation, a separate concern).
-  const bodyLines = lines.map((line) => (width === undefined ? `  ${line}` : truncateToWidth(`  ${line}`, width)));
-  return `${header}\n${bodyLines.join("\n")}`;
+function serializePart(part: ToolOutputPart): string {
+  return inlineSegments(part)
+    .map((segment) => segment.text)
+    .join("");
 }
 
 export function renderToolOutput(content: ToolOutputPart | ToolOutputPart[], width?: number): string {
-  return Array.isArray(content) ? renderList(content, width) : renderPart(content);
+  if (!Array.isArray(content)) return serializePart(content);
+  return layoutToolOutput(content)
+    .map((line) => serializeLine(line, width))
+    .join("\n");
 }
 
 export type ToolOutputUpdate = {
@@ -134,7 +34,7 @@ export function createToolOutputState(): {
   return {
     push(entry) {
       const items = contentByCallId.get(entry.toolCallId) ?? [];
-      const incoming = renderPart(entry.content);
+      const incoming = serializePart(entry.content);
       if (lastRenderedByCallId.get(entry.toolCallId) === incoming) return null;
       lastRenderedByCallId.set(entry.toolCallId, incoming);
       items.push(entry.content);

--- a/src/tool-output-tui.tsx
+++ b/src/tool-output-tui.tsx
@@ -1,0 +1,90 @@
+import type React from "react";
+import { unreachable } from "./assert";
+import { palette } from "./palette";
+import type { ToolOutputPart } from "./tool-output-contract";
+import { fitLine, type LayoutLine, type LayoutSegment, layoutToolOutput, segmentsWidth } from "./tool-output-layout";
+import { Text } from "./tui";
+
+function styledSegment(segment: LayoutSegment, key: string): React.ReactNode {
+  switch (segment.role) {
+    case "label":
+      return (
+        <Text key={key} bold>
+          {segment.text}
+        </Text>
+      );
+    case "meta-add":
+      return (
+        <Text key={key} color={palette.diffAddText}>
+          {segment.text}
+        </Text>
+      );
+    case "meta-remove":
+      return (
+        <Text key={key} color={palette.diffRemoveText}>
+          {segment.text}
+        </Text>
+      );
+    case "diff-text":
+      return (
+        <Text key={key} color={palette.text}>
+          {segment.text}
+        </Text>
+      );
+    case "detail":
+    case "meta-punct":
+    case "dim":
+    case "diff-gutter":
+      return (
+        <Text key={key} dimColor>
+          {segment.text}
+        </Text>
+      );
+    case "stream-tag":
+      return null;
+    default:
+      return unreachable(segment.role);
+  }
+}
+
+function renderFilledLine(line: LayoutLine, index: number, width: number): React.ReactNode {
+  const fill = line.fill;
+  if (!fill) return null;
+  const bg = fill === "diff-add" ? palette.diffAdd : palette.diffRemove;
+  const fg = fill === "diff-add" ? palette.diffAddText : palette.diffRemoveText;
+  const pad = " ".repeat(Math.max(0, width - line.indent - segmentsWidth(line.segments)));
+  return (
+    <Text key={`tool-${index}`}>
+      {`\n${" ".repeat(line.indent)}`}
+      <Text backgroundColor={bg}>
+        {line.segments.map((segment) => (
+          <Text
+            key={`${index}-${segment.role}-${segment.text}`}
+            color={segment.role === "diff-gutter" ? fg : palette.text}
+          >
+            {segment.text}
+          </Text>
+        ))}
+        <Text color={palette.text}>{pad}</Text>
+      </Text>
+    </Text>
+  );
+}
+
+function renderLine(line: LayoutLine, index: number, width: number): React.ReactNode {
+  const visible = { ...line, segments: line.segments.filter((segment) => segment.role !== "stream-tag") };
+  const fitted = fitLine(visible, width);
+  if (fitted.fill) return renderFilledLine(fitted, index, width);
+  return (
+    <Text key={`tool-${index}`}>
+      {index === 0 ? "" : `\n${" ".repeat(fitted.indent)}`}
+      {fitted.segments.map((segment) => styledSegment(segment, `${index}-${segment.role}-${segment.text}`))}
+    </Text>
+  );
+}
+
+export function renderToolOutputTui(parts: ToolOutputPart[], width: number): React.ReactNode {
+  const lines = layoutToolOutput(parts);
+  if (lines.length === 0) return null;
+  return <>{lines.map((line, index) => renderLine(line, index, width))}</>;
+}

--- a/src/tool-output.tui.test.tsx
+++ b/src/tool-output.tui.test.tsx
@@ -14,12 +14,12 @@ function renderChat(toolOutput: ToolOutputPart[], columns = 96): string {
 
 /**
  * One case, two expected strings. The CLI (`renderToolOutput`) and chat
- * (`ChatTranscript`) blocks are intentionally different renderers of the same
- * `ToolOutputPart[]` — the CLI is markerless with `out |`/`err |` stream
- * prefixes, chat prepends a `• ` marker and re-implements the gutter math. This
- * shared table drives both from one input so a case can never be present in one
- * block and silently missing from the other; a new case that omits `cli` or
- * `chat` is a type error, not a coverage gap.
+ * (`ChatTranscript`) blocks are two serializers over the same shared layout
+ * (`tool-output-layout.ts`); they diverge only where intended — the CLI is
+ * markerless and keeps `out |`/`err |` stream prefixes, chat prepends a `• `
+ * marker and colors the diff band. This shared table drives both from one input
+ * so a case can never be present in one block and silently missing from the
+ * other; a new case that omits `cli` or `chat` is a type error, not a gap.
  */
 interface ToolCase {
   name: string;
@@ -135,9 +135,9 @@ const CASES: ToolCase[] = [
     ],
     cli: dedent(`
       Edit notes.ts (+1 -1)
-         9  const x = 1;
-        10 -const y = 2;
-        10 +const y = 3;
+          9  const x = 1;
+         10 -const y = 2;
+         10 +const y = 3;
     `),
     chat: dedent(`
       • Edit notes.ts (+1 -1)
@@ -158,11 +158,11 @@ const CASES: ToolCase[] = [
     ],
     cli: dedent(`
       Edit notes.ts (+1 -1)
-         1  const a = 1;
-         ⋮
-        10 -const y = 2;
-        10 +const y = 3;
-        11  const b = 4;
+          1  const a = 1;
+          ⋮
+         10 -const y = 2;
+         10 +const y = 3;
+         11  const b = 4;
     `),
     chat: dedent(`
       • Edit notes.ts (+1 -1)
@@ -171,6 +171,27 @@ const CASES: ToolCase[] = [
            10 -const y = 2;
            10 +const y = 3;
            11  const b = 4;
+    `),
+  },
+  {
+    name: "diff gap with a line count shows the count beside the ellipsis",
+    parts: [
+      { kind: "edit-header", labelKey: "tool.label.file_edit", path: "notes.ts", added: 1, removed: 1 },
+      { kind: "diff", lineNumber: 1, marker: "context", text: "const a = 1;" },
+      { kind: "truncated", count: 3, unit: "lines" },
+      { kind: "diff", lineNumber: 10, marker: "add", text: "const y = 3;" },
+    ],
+    cli: dedent(`
+      Edit notes.ts (+1 -1)
+          1  const a = 1;
+          ⋮  +3 lines
+         10 +const y = 3;
+    `),
+    chat: dedent(`
+      • Edit notes.ts (+1 -1)
+            1  const a = 1;
+            ⋮  +3 lines
+           10 +const y = 3;
     `),
   },
   {
@@ -187,11 +208,11 @@ const CASES: ToolCase[] = [
     cli: dedent(`
       Edit 14 files (+28 -28)
         src/short-id.ts (+1 -1)
-          2 -export function generateId(size = 8): string {
-          2 +export function generateId(size = 8): string {
+           2 -export function generateId(size = 8): string {
+           2 +export function generateId(size = 8): string {
         src/chat-contract.ts (+2 -2)
-          4 -import { generateId } from "./short-id";
-          4 +import { generateId } from "./short-id";
+           4 -import { generateId } from "./short-id";
+           4 +import { generateId } from "./short-id";
     `),
     chat: dedent(`
       • Edit 14 files (+28 -28)
@@ -212,8 +233,8 @@ const CASES: ToolCase[] = [
     ],
     cli: dedent(`
       Edit notes.ts (+1 -1)
-        2 -old
-        2 +new
+         2 -old
+         2 +new
     `),
     chat: dedent(`
       • Edit notes.ts (+1 -1)
@@ -540,15 +561,29 @@ describe("tool output TUI — CLI (renderToolOutput)", () => {
     expect(renderToolOutput([])).toBe("");
   });
 
-  test("truncates a long body line to the given width, leaving the header intact", () => {
+  test("truncates a long body line to the given width", () => {
     const items: ToolOutputPart[] = [
       { kind: "edit-header", labelKey: "tool.label.file_edit", path: "notes.ts", added: 1, removed: 0 },
       { kind: "diff", lineNumber: 1, marker: "add", text: "X".repeat(60) },
     ];
-    const [header, body] = renderToolOutput(items, 20).split("\n");
-    expect(header).toBe("Edit notes.ts (+1 -0)"); // header is never truncated
-    expect(body).toBe(`  1 +${"X".repeat(14)}…`);
+    const [, body] = renderToolOutput(items, 20).split("\n");
+    expect(body).toBe(`   1 +${"X".repeat(13)}…`);
     expect(Bun.stringWidth(body)).toBe(20);
+  });
+
+  test("middle-truncates a long header at width, keeping the tail filename (F8)", () => {
+    const items: ToolOutputPart[] = [
+      {
+        kind: "tool-header",
+        labelKey: "tool.label.shell_run",
+        detail: "bun test src/some/really/long/path/module.test.ts",
+      },
+    ];
+    const [header] = renderToolOutput(items, 40).split("\n");
+    expect(header.startsWith("Run ")).toBe(true);
+    expect(header.endsWith("module.test.ts")).toBe(true);
+    expect(header).toContain("…");
+    expect(Bun.stringWidth(header)).toBeLessThanOrEqual(40);
   });
 
   test("omitting the width leaves long lines unwrapped (default path unchanged)", () => {
@@ -556,7 +591,7 @@ describe("tool output TUI — CLI (renderToolOutput)", () => {
       { kind: "edit-header", labelKey: "tool.label.file_edit", path: "notes.ts", added: 1, removed: 0 },
       { kind: "diff", lineNumber: 1, marker: "add", text: "X".repeat(60) },
     ];
-    expect(renderToolOutput(items)).toBe(`Edit notes.ts (+1 -0)\n  1 +${"X".repeat(60)}`);
+    expect(renderToolOutput(items)).toBe(`Edit notes.ts (+1 -0)\n   1 +${"X".repeat(60)}`);
   });
 });
 

--- a/src/truncate-text.test.ts
+++ b/src/truncate-text.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { truncateMiddle, truncateText, truncateToWidth } from "./truncate-text";
+import { truncateMiddle, truncateMiddleToWidth, truncateText, truncateToWidth } from "./truncate-text";
 
 describe("truncateText", () => {
   test("returns input unchanged when within limit", () => {
@@ -110,5 +110,39 @@ describe("truncateToWidth", () => {
 
   test("handles empty string", () => {
     expect(truncateToWidth("", 10)).toBe("");
+  });
+});
+
+describe("truncateMiddleToWidth", () => {
+  test("returns input unchanged when within width", () => {
+    expect(truncateMiddleToWidth("module.ts", 20)).toBe("module.ts");
+  });
+
+  test("keeps head and tail around a single ellipsis", () => {
+    const out = truncateMiddleToWidth("abcdefghij", 7);
+    expect(out).toBe("abc…hij");
+    expect(Bun.stringWidth(out)).toBe(7);
+  });
+
+  test("favors the tail so trailing filenames survive", () => {
+    const out = truncateMiddleToWidth("bun test src/really/long/path/module.test.ts", 40);
+    expect(out).toContain("…");
+    expect(out.endsWith("module.test.ts")).toBe(true);
+    expect(Bun.stringWidth(out)).toBeLessThanOrEqual(40);
+  });
+
+  test("degrades to a bare ellipsis at width 1", () => {
+    expect(truncateMiddleToWidth("abc", 1)).toBe("…");
+  });
+
+  test("returns empty string for non-positive width", () => {
+    expect(truncateMiddleToWidth("abc", 0)).toBe("");
+  });
+
+  test("counts wide (CJK) characters by display width near the joint", () => {
+    const out = truncateMiddleToWidth("一二三四五六", 7);
+    expect(Bun.stringWidth(out)).toBeLessThanOrEqual(7);
+    expect(out).not.toContain("�");
+    expect(out).toContain("…");
   });
 });

--- a/src/truncate-text.ts
+++ b/src/truncate-text.ts
@@ -37,3 +37,35 @@ export function truncateToWidth(text: string, maxWidth: number): string {
   }
   return `${out}…`;
 }
+
+/**
+ * Single-line middle truncation: keeps head and tail around one `…` so the result fits
+ * `maxWidth` columns. The tail gets the surplus column so trailing identifiers (filenames
+ * at the end of a command) survive. Grapheme- and width-aware; plain text only.
+ */
+export function truncateMiddleToWidth(text: string, maxWidth: number): string {
+  if (maxWidth <= 0) return "";
+  if (Bun.stringWidth(text) <= maxWidth) return text;
+  if (maxWidth === 1) return "…";
+  const budget = maxWidth - 1;
+  const headBudget = Math.floor(budget / 2);
+  const tailBudget = budget - headBudget;
+  const segments = [...graphemeSegmenter.segment(text)].map(({ segment }) => segment);
+  let head = "";
+  let headWidth = 0;
+  for (const segment of segments) {
+    const width = Bun.stringWidth(segment);
+    if (headWidth + width > headBudget) break;
+    head += segment;
+    headWidth += width;
+  }
+  let tail = "";
+  let tailWidth = 0;
+  for (const segment of [...segments].reverse()) {
+    const width = Bun.stringWidth(segment);
+    if (tailWidth + width > tailBudget) break;
+    tail = segment + tail;
+    tailWidth += width;
+  }
+  return `${head}…${tail}`;
+}

--- a/src/web-toolkit.ts
+++ b/src/web-toolkit.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 import { createTool, type ToolkitInput } from "./tool-contract";
 import { runTool } from "./tool-execution";
 import { emitParts, webSearchSummaryParts } from "./tool-output-format";
-import { truncateText } from "./truncate-text";
 import { fetchWeb, searchWeb } from "./web-ops";
 
 const WEB_SEARCH_MAX_RESULTS = 5;
@@ -31,7 +30,7 @@ function createWebSearchTool(input: ToolkitInput) {
           content: {
             kind: "tool-header",
             labelKey: "tool.label.web_search",
-            detail: `"${truncateText(toolInput.query)}"`,
+            detail: `"${toolInput.query}"`,
           },
           toolCallId: callId,
         });


### PR DESCRIPTION
## Motivation

Tool-output previews were rendered by two duplicated paths — a string path for CLI/trace and a React path for the live TUI — that independently computed headers, gutters, and truncation. Both cut long commands mid-filename regardless of terminal width.

## Summary

- collapse the two paths into one width-free layout IR fed to thin string and TUI serializers
- truncate tool-row headers at render width, middle-truncating so the tail filename survives
- capture full commands by dropping the fixed 80-char source truncation in the shell, test, and web toolkits
- align run-mode diff-gutter geometry to the canonical TUI (run-mode diff lines shift one column right)