### PR TITLE
feat(tui): render-layer line clipping

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -10,7 +10,7 @@ Ink is general-purpose and brings layout complexity (Yoga), dep weight, and beha
 
 Three components, intentionally minimal:
 
-- **`Box`** — flex container. Props: `flexDirection`, `justifyContent`, `flexWrap`, `width`.
+- **`Box`** — flex container. Props: `flexDirection`, `justifyContent`, `flexWrap`, `width`, `overflow` (`visible` default, or `truncate` to clip lines to the box width at render).
 - **`Text`** — styled text span. Props: `color`, `dimColor`, `backgroundColor`, `bold`, `underline`, `inverse`.
 - **`Static`** — write-once scrollback region. Rendered items are flushed to terminal scrollback and never re-rendered.
 
@@ -71,7 +71,7 @@ Use `@path` in chat input to attach file or directory context:
 - **Layout rules are a product contract.** Add tests before adding layout semantics.
 - **No "Ink, but homegrown."** If a feature doesn't materially help Acolyte's UX, don't add it.
 - **Centralized input handling.** Terminal key parsing gets fragile fast — keep it in one place.
-- **Terminal edge cases.** Wide glyphs, combining characters, ANSI length vs display width all need care. `stripAnsiLength` and `padLine` in `serialize.ts` handle width calculations.
+- **Terminal edge cases.** Wide glyphs, combining characters, ANSI length vs display width all need care. `stripAnsiLength`, `padLine`, and `clipLine` in `serialize.ts` handle width calculations.
 
 ## Testing
 

--- a/src/chat-checklist.tsx
+++ b/src/chat-checklist.tsx
@@ -38,7 +38,7 @@ export function ChatChecklist({ rows }: ChatChecklistProps): React.ReactNode {
             <Box width={2}>
               <Text>{"  "}</Text>
             </Box>
-            <Box width={contentWidth}>
+            <Box width={contentWidth} overflow="truncate">
               {isChecklistOutput(row.content) ? <Text>{renderChecklist(row.content)}</Text> : null}
             </Box>
           </Box>

--- a/src/chat-checklist.tui.test.tsx
+++ b/src/chat-checklist.tui.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { ChatChecklist } from "./chat-checklist";
+import { createRow } from "./chat-contract";
+import { renderToString } from "./tui/render-to-string";
+import { stripAnsiLength } from "./tui/serialize";
+import { withTerminalWidth } from "./tui/test-utils";
+
+describe("chat checklist clipping", () => {
+  test("clips long checklist items to the terminal width", () => {
+    const row = createRow("status", {
+      groupId: "g1",
+      groupTitle: "Implementation tasks",
+      items: [
+        {
+          id: "a",
+          label: "Wire the overflow prop end-to-end across the serialize pass and every box layout path",
+          status: "in_progress",
+          order: 0,
+        },
+        { id: "b", label: "Short one", status: "done", order: 1 },
+      ],
+    });
+    const raw = withTerminalWidth(40, () => renderToString(<ChatChecklist rows={[row]} />));
+    const widths = raw.split("\n").map((line) => stripAnsiLength(line));
+    for (const width of widths) {
+      expect(width).toBeLessThanOrEqual(40);
+    }
+    // The overflowing item is clipped up to the full width, not left short or wrapped.
+    expect(Math.max(...widths)).toBe(40);
+  });
+});

--- a/src/chat-input-panel.tsx
+++ b/src/chat-input-panel.tsx
@@ -160,7 +160,7 @@ export function ChatInputPanel(props: ChatInputPanelProps): React.ReactNode {
           <Text>{pickerLabel(picker)}</Text>
         )}
         <Text> </Text>
-        {renderPickerItems(picker, activeSessionId, brandColor)}
+        {renderPickerItems(picker, activeSessionId, brandColor, termWidth)}
         <Text> </Text>
         <Text dimColor>{pickerHint(picker)}</Text>
         <Text color={brandColor} dimColor>

--- a/src/chat-input-panel.tsx
+++ b/src/chat-input-panel.tsx
@@ -84,9 +84,9 @@ function renderInputPanelContent(input: {
   let suggestions: React.ReactNode = null;
   if (atQuery !== null && atSuggestions.length > 0) {
     suggestions = atSuggestions.map((item) => (
-      <Text key={`at-suggestion-${item}`} color={item === atSuggestions[atSuggestionIndex] ? brandColor : undefined}>
-        {`  ${item}`}
-      </Text>
+      <Box key={`at-suggestion-${item}`} width="terminal" overflow="truncate">
+        <Text color={item === atSuggestions[atSuggestionIndex] ? brandColor : undefined}>{`  ${item}`}</Text>
+      </Box>
     ));
   } else if (atQuery !== null) {
     suggestions = <Text dimColor> {t("chat.at_ref.no_matches")}</Text>;
@@ -97,7 +97,7 @@ function renderInputPanelContent(input: {
     suggestions = (
       <>
         {slashSuggestions.map((item, index) => (
-          <Box key={`slash-suggestion-${item}`}>
+          <Box key={`slash-suggestion-${item}`} width="terminal" overflow="truncate">
             <Text color={index === selectedIndex ? brandColor : undefined} dimColor={index !== selectedIndex}>
               {"  "}
             </Text>

--- a/src/chat-input-panel.tui.test.tsx
+++ b/src/chat-input-panel.tui.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { ChatInputPanel } from "./chat-input-panel";
+import { palette } from "./palette";
+import { renderToString } from "./tui/render-to-string";
+import { stripAnsiLength } from "./tui/serialize";
+import { withTerminalWidth } from "./tui/test-utils";
+
+function rowWidths(props: Record<string, unknown>, columns: number): number[] {
+  const raw = withTerminalWidth(columns, () =>
+    renderToString(<ChatInputPanel brandColor={palette.brand} onCursorLine={() => {}} {...props} />),
+  );
+  return raw.split("\n").map((line) => stripAnsiLength(line));
+}
+
+describe("chat input panel suggestion clipping", () => {
+  test("clips overflowing @-mention suggestions to the terminal width", () => {
+    const widths = rowWidths(
+      {
+        atQuery: "s",
+        atSuggestions: ["src/some/really/long/nested/path/to/a/file/that/overflows.tsx", "short.ts"],
+        atSuggestionIndex: 0,
+      },
+      40,
+    );
+    for (const width of widths) {
+      expect(width).toBeLessThanOrEqual(40);
+    }
+    expect(Math.max(...widths)).toBe(40);
+  });
+
+  test("clips overflowing slash-command suggestions to the terminal width", () => {
+    const widths = rowWidths(
+      {
+        slashSuggestions: ["/some-really-long-slash-command-name-that-overflows", "/help"],
+        slashSuggestionIndex: 0,
+      },
+      40,
+    );
+    for (const width of widths) {
+      expect(width).toBeLessThanOrEqual(40);
+    }
+  });
+});

--- a/src/chat-picker.tsx
+++ b/src/chat-picker.tsx
@@ -5,7 +5,7 @@ import { formatRelativeTime } from "./datetime";
 import { t } from "./i18n";
 import type { Session } from "./session-contract";
 import type { SkillMeta } from "./skill-contract";
-import { truncateText } from "./truncate-text";
+import { truncateToWidth } from "./truncate-text";
 import { Box, Text } from "./tui";
 
 export type ModelPickerItem = {
@@ -38,9 +38,9 @@ function renderPickerRows(
   return items.map((item, index) => {
     const selected = index === selectedIndex;
     return (
-      <Box key={item.key}>
+      <Box key={item.key} width="terminal" overflow="truncate">
         <Text>{selected ? "› " : "  "}</Text>
-        <Box width={labelWidth}>
+        <Box width={labelWidth} overflow="truncate">
           <Text color={selected ? brandColor : undefined}>{item.label}</Text>
         </Box>
         {item.detail ? (
@@ -93,14 +93,15 @@ export function renderPickerItems(
   picker: PickerState,
   activeSessionId: string | undefined,
   brandColor: string,
+  termWidth: number,
 ): React.ReactNode {
   switch (picker.kind) {
     case "skills": {
       return renderPickerRows(
         picker.items.map((skill) => ({
           key: skill.path,
-          label: truncateText(skill.name, PICKER_LABEL_WIDTH),
-          detail: truncateText(skill.description, 72),
+          label: skill.name,
+          detail: skill.description,
         })),
         picker.index,
         brandColor,
@@ -123,10 +124,17 @@ export function renderPickerItems(
       );
     }
     case "resume": {
-      const rows = picker.items.map((item) => [
-        `${item.id === activeSessionId ? "●" : " "} ${item.id}`,
-        truncateText(item.title || t("chat.session.default_title"), 40),
-        formatRelativeTime(item.updatedAt),
+      const idCells = picker.items.map((item) => `${item.id === activeSessionId ? "●" : " "} ${item.id}`);
+      const timeCells = picker.items.map((item) => formatRelativeTime(item.updatedAt));
+      const idWidth = Math.max(0, ...idCells.map((cell) => cell.length));
+      const timeWidth = Math.max(0, ...timeCells.map((cell) => cell.length));
+      const gap = 2;
+      const prefixWidth = 2;
+      const titleBudget = Math.max(1, termWidth - prefixWidth - idWidth - gap - timeWidth - gap);
+      const rows = picker.items.map((item, i) => [
+        idCells[i] ?? "",
+        truncateToWidth(item.title || t("chat.session.default_title"), titleBudget),
+        timeCells[i] ?? "",
       ]);
       const formattedRows = alignCols(rows);
       const visible = formattedRows.slice(picker.scrollOffset, picker.scrollOffset + PICKER_PAGE_SIZE);
@@ -134,10 +142,10 @@ export function renderPickerItems(
       return visible.map((line, index) => {
         const selected = index === picker.index - picker.scrollOffset;
         return (
-          <Text key={visibleItems[index]?.id ?? `${index}`}>
-            {selected ? "› " : "  "}
+          <Box key={visibleItems[index]?.id ?? `${index}`} width="terminal" overflow="truncate">
+            <Text>{selected ? "› " : "  "}</Text>
             <Text color={selected ? brandColor : undefined}>{line}</Text>
-          </Text>
+          </Box>
         );
       });
     }

--- a/src/chat-picker.tui.test.tsx
+++ b/src/chat-picker.tui.test.tsx
@@ -47,6 +47,79 @@ describe("chat picker visual regression", () => {
     );
   });
 
+  test("clips skill label and description to terminal width", () => {
+    const out = renderInputPanelWithPicker(
+      {
+        kind: "skills",
+        items: [
+          {
+            name: "improve-codebase-architecture",
+            description: "Find deepening opportunities in a codebase, informed by domain language and ADRs",
+            path: "bundled://improve",
+            source: "bundled" as const,
+          },
+          {
+            name: "build",
+            description: "Implement features incrementally through vertical slices",
+            path: "bundled://build",
+            source: "bundled" as const,
+          },
+        ],
+        index: 0,
+      },
+      40,
+    );
+    expect(out).toBe(
+      dedent(`
+      ────────────────────────────────────────
+      Skills
+
+      › improve-codebase-ar… Find deepening o…
+        build                Implement featur…
+
+      Enter to select · Esc to close
+      ────────────────────────────────────────
+    `),
+    );
+  });
+
+  test("clips resume title but keeps the timestamp at narrow width", () => {
+    const realNow = Date.now;
+    Date.now = () => new Date("2026-03-02T00:00:00.000Z").getTime();
+    try {
+      const out = renderInputPanelWithPicker(
+        {
+          kind: "resume",
+          items: [
+            createSession({
+              id: "sess_active",
+              title: "A very long session title that needs clipping at narrow widths for sure",
+              updatedAt: "2026-03-02T00:00:00.000Z",
+            }),
+            createSession({ id: "sess_prev", title: "Short", updatedAt: "2026-03-02T00:00:00.000Z" }),
+          ],
+          index: 1,
+          scrollOffset: 0,
+        },
+        40,
+      );
+      expect(out).toBe(
+        dedent(`
+        ────────────────────────────────────────
+        Resume Session
+
+          ● sess_active  A very long …  just now
+        ›   sess_prev    Short          just now
+
+        Enter to resume · Esc to close
+        ────────────────────────────────────────
+      `),
+      );
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
   test("renders resume picker", () => {
     const realNow = Date.now;
     Date.now = () => new Date("2026-03-02T00:00:00.000Z").getTime();

--- a/src/chat-picker.tui.test.tsx
+++ b/src/chat-picker.tui.test.tsx
@@ -4,13 +4,29 @@ import type { PickerState } from "./chat-picker";
 import { palette } from "./palette";
 import { createSession, dedent } from "./test-utils";
 import { DEFAULT_TERMINAL_WIDTH } from "./tui/constants";
-import { renderPlain } from "./tui/test-utils";
+import { renderToString } from "./tui/render-to-string";
+import { stripAnsiLength } from "./tui/serialize";
+import { renderPlain, withTerminalWidth } from "./tui/test-utils";
 
 function renderInputPanelWithPicker(picker: PickerState, columns = DEFAULT_TERMINAL_WIDTH): string {
   return renderPlain(
     <ChatInputPanel picker={picker} activeSessionId="sess_active" brandColor={palette.brand} onCursorLine={() => {}} />,
     columns,
   );
+}
+
+function pickerRowWidths(picker: PickerState, columns: number): number[] {
+  const raw = withTerminalWidth(columns, () =>
+    renderToString(
+      <ChatInputPanel
+        picker={picker}
+        activeSessionId="sess_active"
+        brandColor={palette.brand}
+        onCursorLine={() => {}}
+      />,
+    ),
+  );
+  return raw.split("\n").map((line) => stripAnsiLength(line));
 }
 
 describe("chat picker visual regression", () => {
@@ -149,5 +165,28 @@ describe("chat picker visual regression", () => {
     } finally {
       Date.now = realNow;
     }
+  });
+
+  test("clips overflowing picker rows to exactly the terminal width", () => {
+    const widths = pickerRowWidths(
+      {
+        kind: "skills",
+        items: [
+          {
+            name: "improve-codebase-architecture",
+            description: "Find deepening opportunities in a codebase, informed by domain language and ADRs",
+            path: "bundled://improve",
+            source: "bundled" as const,
+          },
+        ],
+        index: 0,
+      },
+      40,
+    );
+    for (const width of widths) {
+      expect(width).toBeLessThanOrEqual(40);
+    }
+    // The overflowing skill row is clipped up to the full terminal width, not left short.
+    expect(Math.max(...widths)).toBe(40);
   });
 });

--- a/src/checklist-contract.test.ts
+++ b/src/checklist-contract.test.ts
@@ -4,7 +4,7 @@ import { checklistMarker, checklistProgress } from "./checklist-contract";
 describe("checklistMarker", () => {
   test("returns correct markers", () => {
     expect(checklistMarker("pending")).toBe("○");
-    expect(checklistMarker("in_progress")).toBe("◐");
+    expect(checklistMarker("in_progress")).toBe("⊙");
     expect(checklistMarker("done")).toBe("●");
     expect(checklistMarker("failed")).toBe("◉");
   });

--- a/src/checklist-contract.ts
+++ b/src/checklist-contract.ts
@@ -22,7 +22,7 @@ export type ChecklistOutput = z.infer<typeof checklistOutputSchema>;
 
 const STATUS_MARKERS: Record<ChecklistItemStatus, string> = {
   pending: "○",
-  in_progress: "◐",
+  in_progress: "⊙",
   done: "●",
   failed: "◉",
 };

--- a/src/checklist-format.test.ts
+++ b/src/checklist-format.test.ts
@@ -15,7 +15,7 @@ describe("formatChecklist", () => {
     expect(result.header).toBe("Build (1/3)");
     expect(result.items).toEqual([
       { id: "s1", marker: "●", label: "lint" },
-      { id: "s2", marker: "◐", label: "test" },
+      { id: "s2", marker: "⊙", label: "test" },
       { id: "s3", marker: "○", label: "deploy" },
     ]);
   });

--- a/src/checklist.tui.test.tsx
+++ b/src/checklist.tui.test.tsx
@@ -37,7 +37,7 @@ describe("checklist TUI rendering", () => {
       expected(`
         Build pipeline (1/3)
           ● lint
-          ◐ test
+          ⊙ test
           ○ deploy
       `),
     );
@@ -61,7 +61,7 @@ describe("checklist TUI rendering", () => {
       expected(`
         Steps (1/4)
           ● done step
-          ◐ active step
+          ⊙ active step
           ○ waiting step
           ◉ broken step
       `),
@@ -85,7 +85,7 @@ describe("checklist TUI rendering", () => {
       expected(`
         Steps (1/3)
           ● first
-          ◐ second
+          ⊙ second
           ○ third
       `),
     );

--- a/src/tui/components.tsx
+++ b/src/tui/components.tsx
@@ -5,6 +5,7 @@ type BoxProps = {
   justifyContent?: "flex-start" | "flex-end" | "space-between";
   flexWrap?: "nowrap" | "wrap";
   width?: number | "terminal";
+  overflow?: "visible" | "truncate";
   children?: React.ReactNode;
   key?: React.Key;
 };
@@ -32,6 +33,7 @@ export function Box(props: BoxProps): React.ReactElement {
       justifyContent={props.justifyContent}
       flexWrap={props.flexWrap}
       width={props.width}
+      overflow={props.overflow}
     >
       {props.children}
     </tui-box>

--- a/src/tui/dom.ts
+++ b/src/tui/dom.ts
@@ -6,6 +6,7 @@ export interface TuiProps {
   justifyContent?: "flex-start" | "flex-end" | "space-between";
   flexWrap?: "nowrap" | "wrap";
   width?: number | "terminal";
+  overflow?: "visible" | "truncate";
   // Text
   color?: string;
   dimColor?: boolean;

--- a/src/tui/serialize.test.tsx
+++ b/src/tui/serialize.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { Box, Text } from "./components";
 import { renderToString } from "./render-to-string";
-import { stripAnsiLength } from "./serialize";
+import { clipLine, stripAnsi, stripAnsiLength } from "./serialize";
 import { renderPlain } from "./test-utils";
 
 describe("serialize", () => {
@@ -190,6 +190,154 @@ describe("serialize", () => {
 
     test("counts CJK with ANSI codes correctly", () => {
       expect(stripAnsiLength("\x1b[1mこんにちは\x1b[0m")).toBe(10);
+    });
+  });
+
+  describe("clipLine", () => {
+    const RESET = "\x1b[0m";
+
+    test("leaves lines that fit unchanged", () => {
+      expect(clipLine("hello", 5)).toBe("hello");
+      expect(clipLine("hi", 10)).toBe("hi");
+      expect(clipLine("\x1b[1mhello\x1b[0m", 5)).toBe("\x1b[1mhello\x1b[0m");
+    });
+
+    test("clips over-width plain text and appends an ellipsis", () => {
+      expect(clipLine("hello world", 5)).toBe(`hell…${RESET}`);
+    });
+
+    test("reserves exactly one column for the ellipsis", () => {
+      expect(stripAnsiLength(clipLine("abcdefgh", 4))).toBe(4);
+      expect(clipLine("abcdefgh", 4)).toBe(`abc…${RESET}`);
+    });
+
+    test("returns empty for non-positive width", () => {
+      expect(clipLine("hello", 0)).toBe("");
+      expect(clipLine("hello", -3)).toBe("");
+    });
+
+    test("width of one yields just the ellipsis", () => {
+      expect(clipLine("hello", 1)).toBe(`…${RESET}`);
+    });
+
+    test("preserves escape sequences before the cut and closes with reset", () => {
+      const out = clipLine("\x1b[31mred text here\x1b[0m", 5);
+      expect(out.startsWith("\x1b[31m")).toBe(true);
+      expect(out.endsWith(RESET)).toBe(true);
+      expect(stripAnsiLength(out)).toBe(5);
+    });
+
+    test("does not split a wide grapheme across the boundary", () => {
+      expect(stripAnsiLength(clipLine("aあ", 2))).toBeLessThanOrEqual(2);
+      expect(clipLine("aあ", 2)).toBe(`a…${RESET}`);
+      expect(stripAnsiLength(clipLine("ああ", 3))).toBeLessThanOrEqual(3);
+    });
+
+    // Property tests: invariants must hold across many generated inputs.
+    const alphabet = ["a", "z", " ", "あ", "😀", "\x1b[1m", "\x1b[0m", "\x1b[31m", "\t"];
+    function nextSeed(s: number): number {
+      return (s * 1664525 + 1013904223) >>> 0;
+    }
+    function generate(seed: number): { line: string; width: number } {
+      let s = nextSeed(seed);
+      const len = s % 24;
+      let line = "";
+      for (let i = 0; i < len; i++) {
+        s = nextSeed(s);
+        line += alphabet[s % alphabet.length];
+      }
+      s = nextSeed(s);
+      return { line, width: s % 20 };
+    }
+
+    test("visible width never exceeds the target", () => {
+      for (let seed = 0; seed < 500; seed++) {
+        const { line, width } = generate(seed);
+        expect(stripAnsiLength(clipLine(line, width))).toBeLessThanOrEqual(Math.max(0, width));
+      }
+    });
+
+    test("clipped output always closes any open style with a reset", () => {
+      for (let seed = 0; seed < 500; seed++) {
+        const { line, width } = generate(seed);
+        const out = clipLine(line, width);
+        if (width > 0 && stripAnsiLength(line) > width) {
+          expect(out.endsWith(RESET)).toBe(true);
+        }
+      }
+    });
+
+    test("stripped output never contains a partial escape (ESC byte)", () => {
+      for (let seed = 0; seed < 500; seed++) {
+        const { line, width } = generate(seed);
+        expect(stripAnsi(clipLine(line, width))).not.toContain("\x1b");
+      }
+    });
+  });
+
+  describe("box overflow", () => {
+    test("truncate clips a column line to the box width", () => {
+      const out = renderPlain(
+        <Box flexDirection="column" width={6} overflow="truncate">
+          <Text>hello world</Text>
+        </Box>,
+      );
+      expect(out).toBe("hello…");
+    });
+
+    test("visible default keeps the full line", () => {
+      const out = renderPlain(
+        <Box flexDirection="column" width={6}>
+          <Text>hello world</Text>
+        </Box>,
+      );
+      expect(out).toBe("hello world");
+    });
+
+    test("truncate still pads a short line to the box width", () => {
+      const out = renderToString(
+        <Box flexDirection="column" width={6} overflow="truncate">
+          <Text>hi</Text>
+        </Box>,
+      );
+      expect(out).toBe("hi    ");
+    });
+
+    test("truncate clips a row line to the box width", () => {
+      const out = renderPlain(
+        <Box width={4} overflow="truncate">
+          <Text>abcdef</Text>
+        </Box>,
+      );
+      expect(out).toBe("abc…");
+    });
+
+    test("truncate clips space-between rows to the box width", () => {
+      const raw = renderToString(
+        <Box justifyContent="space-between" width={8} overflow="truncate">
+          <Text>aaaaa</Text>
+          <Text>bbbbb</Text>
+        </Box>,
+      );
+      expect(stripAnsiLength(raw)).toBe(8);
+    });
+
+    test("truncate clips flex-end rows to the box width", () => {
+      const raw = renderToString(
+        <Box justifyContent="flex-end" width={6} overflow="truncate">
+          <Text>abcdefghij</Text>
+        </Box>,
+      );
+      expect(stripAnsiLength(raw)).toBe(6);
+    });
+
+    test("truncate re-pads a wide-grapheme cut to full box width", () => {
+      const raw = renderToString(
+        <Box flexDirection="column" width={4} overflow="truncate">
+          <Text>ab漢漢</Text>
+        </Box>,
+      );
+      expect(stripAnsiLength(raw)).toBe(4);
     });
   });
 

--- a/src/tui/serialize.ts
+++ b/src/tui/serialize.ts
@@ -113,6 +113,41 @@ function padLine(line: string, width: number): string {
   return line;
 }
 
+const clipSegmenter = new Intl.Segmenter();
+
+/**
+ * ANSI-safe end-clip: cut a single line so its visible width never exceeds `width`
+ * columns, preserving escape sequences (zero width) and re-emitting `ansi.reset` so no
+ * open style leaks past the cut. Reserves one column for the `…` marker. End-clip only —
+ * middle-truncation stays a layout concern where the IR knows which span is elastic.
+ */
+export function clipLine(line: string, width: number): string {
+  if (width <= 0) return "";
+  if (stripAnsiLength(line) <= width) return line;
+  const budget = width - 1;
+  let out = "";
+  let used = 0;
+  let i = 0;
+  while (i < line.length) {
+    if (line[i] === "\x1b") {
+      const end = skipEscapeSequence(line, i + 1);
+      out += line.slice(i, end);
+      i = end;
+      continue;
+    }
+    let j = i;
+    while (j < line.length && line[j] !== "\x1b") j++;
+    for (const { segment } of clipSegmenter.segment(line.slice(i, j))) {
+      const w = Bun.stringWidth(segment);
+      if (used + w > budget) return `${out}…${ansi.reset}`;
+      out += segment;
+      used += w;
+    }
+    i = j;
+  }
+  return `${out}…${ansi.reset}`;
+}
+
 /**
  * Serialize a node to string. When `staticAcc` is provided, `tui-static`
  * children are collected into it instead of rendered inline — this lets
@@ -154,68 +189,17 @@ function serializeNode(node: TuiNode, inherited: StyleStack, terminalWidth: numb
 
   if (el.type === "tui-box") {
     const style = mergeStyle(inherited, el.props);
-    const isColumn = el.props.flexDirection === "column";
-
-    if (isColumn) {
-      const parts = el.children
-        .map((child) => serializeNode(child, style, terminalWidth, staticAcc))
-        .filter((p) => p.length > 0);
-      let joined = parts.join("\n");
-      if (el.props.width !== undefined) {
-        const w = el.props.width === "terminal" ? terminalWidth : el.props.width;
-        joined = joined
+    const content = serializeBox(el, style, terminalWidth, staticAcc);
+    if (el.props.overflow === "truncate") {
+      const boxWidth = el.props.width === "terminal" ? terminalWidth : el.props.width;
+      if (boxWidth !== undefined) {
+        return content
           .split("\n")
-          .map((line) => padLine(line, w))
+          .map((line) => padLine(clipLine(line, boxWidth), boxWidth))
           .join("\n");
       }
-      return joined;
     }
-
-    // Row direction: concatenate children horizontally.
-    const childOutputs = el.children.map((child) => serializeNode(child, style, terminalWidth, staticAcc));
-    const boxWidth = el.props.width === "terminal" ? terminalWidth : el.props.width;
-    const justify = el.props.justifyContent;
-    const wrap = el.props.flexWrap === "wrap";
-
-    if (wrap && boxWidth !== undefined) {
-      const childWidths = childOutputs.map((o) => stripAnsiLength(o.split("\n")[0] ?? ""));
-      const totalWidth = childWidths.reduce((a, b) => a + b, 0);
-      if (totalWidth > boxWidth) {
-        // Group children into rows that fit within boxWidth.
-        const rows: string[][] = [[]];
-        let rowWidth = 0;
-        for (let i = 0; i < childOutputs.length; i++) {
-          const w = childWidths[i] ?? 0;
-          if ((rows[rows.length - 1]?.length ?? 0) > 0 && rowWidth + w > boxWidth) {
-            rows.push([]);
-            rowWidth = 0;
-          }
-          rows[rows.length - 1]?.push(childOutputs[i] ?? "");
-          rowWidth += w;
-        }
-        // Apply justifyContent to each row, fall back to joinRow for single-item rows.
-        const renderedRows = rows.map((row) => {
-          if (justify === "space-between" && row.length >= 2) {
-            return joinRowSpaceBetween(row, boxWidth);
-          }
-          return joinRow(row, boxWidth);
-        });
-        return renderedRows.join("\n");
-      }
-    }
-
-    if (justify === "space-between" && boxWidth !== undefined && childOutputs.length >= 2) {
-      return joinRowSpaceBetween(childOutputs, boxWidth);
-    }
-
-    if (justify === "flex-end" && boxWidth !== undefined) {
-      const content = childOutputs.join("");
-      const visible = stripAnsiLength(content);
-      if (visible < boxWidth) return " ".repeat(boxWidth - visible) + content;
-      return content;
-    }
-
-    return joinRow(childOutputs, boxWidth);
+    return content;
   }
 
   // Root — render children as column
@@ -223,6 +207,68 @@ function serializeNode(node: TuiNode, inherited: StyleStack, terminalWidth: numb
     .map((child) => serializeNode(child, inherited, terminalWidth, staticAcc))
     .filter((p) => p.length > 0)
     .join("\n");
+}
+
+function serializeBox(el: TuiElement, style: StyleStack, terminalWidth: number, staticAcc?: string[]): string {
+  const isColumn = el.props.flexDirection === "column";
+
+  if (isColumn) {
+    const parts = el.children
+      .map((child) => serializeNode(child, style, terminalWidth, staticAcc))
+      .filter((p) => p.length > 0);
+    let joined = parts.join("\n");
+    if (el.props.width !== undefined) {
+      const w = el.props.width === "terminal" ? terminalWidth : el.props.width;
+      joined = joined
+        .split("\n")
+        .map((line) => padLine(line, w))
+        .join("\n");
+    }
+    return joined;
+  }
+
+  const childOutputs = el.children.map((child) => serializeNode(child, style, terminalWidth, staticAcc));
+  const boxWidth = el.props.width === "terminal" ? terminalWidth : el.props.width;
+  const justify = el.props.justifyContent;
+  const wrap = el.props.flexWrap === "wrap";
+
+  if (wrap && boxWidth !== undefined) {
+    const childWidths = childOutputs.map((o) => stripAnsiLength(o.split("\n")[0] ?? ""));
+    const totalWidth = childWidths.reduce((a, b) => a + b, 0);
+    if (totalWidth > boxWidth) {
+      const rows: string[][] = [[]];
+      let rowWidth = 0;
+      for (let i = 0; i < childOutputs.length; i++) {
+        const w = childWidths[i] ?? 0;
+        if ((rows[rows.length - 1]?.length ?? 0) > 0 && rowWidth + w > boxWidth) {
+          rows.push([]);
+          rowWidth = 0;
+        }
+        rows[rows.length - 1]?.push(childOutputs[i] ?? "");
+        rowWidth += w;
+      }
+      const renderedRows = rows.map((row) => {
+        if (justify === "space-between" && row.length >= 2) {
+          return joinRowSpaceBetween(row, boxWidth);
+        }
+        return joinRow(row, boxWidth);
+      });
+      return renderedRows.join("\n");
+    }
+  }
+
+  if (justify === "space-between" && boxWidth !== undefined && childOutputs.length >= 2) {
+    return joinRowSpaceBetween(childOutputs, boxWidth);
+  }
+
+  if (justify === "flex-end" && boxWidth !== undefined) {
+    const content = childOutputs.join("");
+    const visible = stripAnsiLength(content);
+    if (visible < boxWidth) return " ".repeat(boxWidth - visible) + content;
+    return content;
+  }
+
+  return joinRow(childOutputs, boxWidth);
 }
 
 /** Join children with space distributed evenly between them. */


### PR DESCRIPTION
## Motivation

Width truncation was hand-rolled per call site (tool rows) or hardcoded as magic char caps (picker, checklist), so it was wrong on narrow and wide terminals and could emit over-width lines that break resize/scrollback geometry.

## Summary

- add `clipLine` and an `overflow: "visible" | "truncate"` prop on `Box`, honored as a unified post-pass so any box layout path clips to its width
- migrate the picker off the magic 72/40/20 caps: labels and descriptions clip at render width, the resume title is width-derived so the timestamp survives
- clip input-panel `@`-mention and slash-command dropdown rows at terminal width
- clip long checklist items instead of overflowing the content box
- change the in-progress checklist marker from `◐` to `⊙`

Known limitation: the resume-title budget measures columns while `alignCols` pads by char count, so a wide-glyph title mixed with a near-budget ASCII title can clip the timestamp — graceful (the row backstop prevents any overflow); a proper fix needs a width-aware `alignCols`, tracked as a follow-up.