### PR TITLE
fix(chat): smooth bursty stream rendering

### DIFF
--- a/src/chat-message-handler-stream.test.ts
+++ b/src/chat-message-handler-stream.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, jest, test } from "bun:test";
 import type { ChatRow } from "./chat-contract";
 import { isToolOutput } from "./chat-contract";
 import { createMessageStreamState } from "./chat-message-handler-stream";
 import { palette } from "./palette";
+
+// Larger than any drip horizon, so advancing by it fully reveals the backlog.
+const DRAIN_ALL_MS = 1000;
 
 function createRowsHarness(): {
   rows: ChatRow[];
@@ -16,6 +19,10 @@ function createRowsHarness(): {
 }
 
 describe("chat-message-handler-stream", () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   test("accumulates agent deltas and exposes via streamedText", () => {
     const { setRows } = createRowsHarness();
     const state = createMessageStreamState({ setRows });
@@ -185,14 +192,15 @@ describe("chat-message-handler-stream", () => {
     state.dispose();
   });
 
-  test("leading newlines are stripped when creating new assistant row", async () => {
+  test("leading newlines are stripped when creating new assistant row", () => {
+    jest.useFakeTimers();
     const { rows, setRows } = createRowsHarness();
     const state = createMessageStreamState({ setRows });
 
     // step-start emits "\n", then real text follows
     state.onDelta("\n");
     state.onDelta("Hello world");
-    await new Promise((resolve) => setTimeout(resolve, 60));
+    jest.advanceTimersByTime(DRAIN_ALL_MS);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.kind).toBe("assistant");
     expect(rows[0]?.content).toBe("Hello world");
@@ -239,7 +247,8 @@ describe("chat-message-handler-stream", () => {
     state.dispose();
   });
 
-  test("streamed text persists after finalize when status row is appended", async () => {
+  test("streamed text persists after finalize when status row is appended", () => {
+    jest.useFakeTimers();
     const { rows, setRows } = createRowsHarness();
     const state = createMessageStreamState({ setRows });
 
@@ -253,7 +262,7 @@ describe("chat-message-handler-stream", () => {
     state.onToolResult({ toolCallId: "call_1", toolName: "memory-search" });
 
     state.onDelta("Tell me what to build.");
-    await new Promise((resolve) => setTimeout(resolve, 60));
+    jest.advanceTimersByTime(DRAIN_ALL_MS);
     expect(rows.some((r) => r.kind === "assistant" && r.content === "Tell me what to build.")).toBe(true);
 
     state.finalize();
@@ -293,11 +302,12 @@ describe("chat-message-handler-stream", () => {
     return { rows, setRows, render };
   }
 
-  test("streamed answer survives StrictMode double-invocation of the flush updater", async () => {
+  test("streamed answer survives StrictMode double-invocation of the flush updater", () => {
+    jest.useFakeTimers();
     const h = createStrictHarness();
     const state = createMessageStreamState({ setRows: h.setRows });
     state.onDelta("The final answer.");
-    await new Promise((resolve) => setTimeout(resolve, 60)); // flush timer enqueues the updater
+    jest.advanceTimersByTime(DRAIN_ALL_MS); // ticks enqueue the updater
     h.render();
     expect(h.rows.filter((r) => r.kind === "assistant").map((r) => r.content)).toEqual(["The final answer."]);
     state.dispose();
@@ -334,6 +344,52 @@ describe("chat-message-handler-stream", () => {
     state.onProgressNotice({ message: "same", level: "warn" });
     state.onProgressNotice({ message: "same", level: "warn" });
     expect(rows).toHaveLength(1);
+    state.dispose();
+  });
+
+  test("drips a burst incrementally instead of publishing it in one jump", () => {
+    jest.useFakeTimers();
+    const { rows, setRows } = createRowsHarness();
+    const state = createMessageStreamState({ setRows });
+
+    // A whole paragraph arrives at once, as a rate-limited provider flushes a buffered burst.
+    const burst = "x".repeat(200);
+    state.onDelta(burst);
+
+    // A couple of ticks in — well under the drain horizon — only part is revealed.
+    jest.advanceTimersByTime(64);
+    const partial = typeof rows[0]?.content === "string" ? rows[0].content : "";
+    expect(partial.length).toBeGreaterThan(0);
+    expect(partial.length).toBeLessThan(burst.length);
+
+    // Draining reveals the rest, intact and in order.
+    jest.advanceTimersByTime(DRAIN_ALL_MS);
+    expect(rows[0]?.content).toBe(burst);
+    state.dispose();
+  });
+
+  test("a tool call mid-drip flushes the full backlog before the tool row", () => {
+    jest.useFakeTimers();
+    const { rows, setRows } = createRowsHarness();
+    const state = createMessageStreamState({ setRows });
+
+    const prose = "Reading the file to understand the failure before editing.";
+    state.onDelta(prose);
+    jest.advanceTimersByTime(64); // only a fragment has dripped in
+
+    // The tool call must drain the remaining backlog into the prose row, ordered before the
+    // tool row, with nothing dropped — the onOutput inline-seal bypass would otherwise lose it.
+    state.onOutput({
+      toolCallId: "call_1",
+      toolName: "file-read",
+      content: { kind: "tool-header", labelKey: "tool.label.file_read", detail: "a.ts" },
+    });
+
+    const assistantIdx = rows.findIndex((r) => r.kind === "assistant");
+    const toolIdx = rows.findIndex((r) => r.kind === "tool");
+    expect(assistantIdx).toBeGreaterThanOrEqual(0);
+    expect(toolIdx).toBeGreaterThan(assistantIdx);
+    expect(rows[assistantIdx]?.content).toBe(prose);
     state.dispose();
   });
 });

--- a/src/chat-message-handler-stream.ts
+++ b/src/chat-message-handler-stream.ts
@@ -30,7 +30,13 @@ export type MessageStreamState = {
   dispose: () => void;
 };
 
-const STREAM_FLUSH_MS = 50;
+// The live prose row is paced, not coalesced: a rate-limited provider delivers text in
+// bursts, so instead of publishing each burst in one jump we drip it into the row over a
+// bounded horizon. The tick cadence matches the renderer's paint throttle; a burst drains
+// over DRAIN_HORIZON_MS, and MIN_DRIP_CHARS keeps a trickle moving so short tails still flow.
+const STREAM_TICK_MS = 32;
+const DRAIN_HORIZON_MS = 250;
+const MIN_DRIP_CHARS = 8;
 
 export function createMessageStreamState(input: {
   setRows: (updater: (current: ChatRow[]) => ChatRow[]) => void;
@@ -39,7 +45,10 @@ export function createMessageStreamState(input: {
   // --- agent streaming state ---
   let activeRowId: string | null = null;
   let agentContent = "";
-  let flushTimer: ReturnType<typeof setTimeout> | null = null;
+  // Text received but not yet revealed. The tick drips it into `agentContent`; every path
+  // that reads `agentContent` as the authoritative prose must drain this first.
+  let pendingText = "";
+  let tickTimer: ReturnType<typeof setTimeout> | null = null;
   /** Every agent row ID we've created, so dispose() can remove them on the error path. */
   const agentRowIds: string[] = [];
 
@@ -58,11 +67,39 @@ export function createMessageStreamState(input: {
   // Cleared whenever any other row is appended, so only adjacent repeats collapse.
   let lastNoticeKey: string | null = null;
 
-  function cancelFlushTimer(): void {
-    if (flushTimer) {
-      clearTimeout(flushTimer);
-      flushTimer = null;
+  function cancelTick(): void {
+    if (tickTimer) {
+      clearTimeout(tickTimer);
+      tickTimer = null;
     }
+  }
+
+  // Reveal the whole backlog at once and stop pacing. The single chokepoint every seal/read
+  // path routes through, so dripped-but-unrevealed text can never render after a later row
+  // (reorder) or be lost when the closure resets.
+  function drainBacklog(): void {
+    if (pendingText.length > 0) {
+      agentContent += pendingText;
+      pendingText = "";
+    }
+    cancelTick();
+  }
+
+  function scheduleTick(): void {
+    if (!tickTimer) tickTimer = setTimeout(tick, STREAM_TICK_MS);
+  }
+
+  // Move one slice of the backlog into the live row and repaint. The slice is sized to drain
+  // any burst over DRAIN_HORIZON_MS; splitting on code points keeps surrogate pairs whole.
+  function tick(): void {
+    tickTimer = null;
+    if (pendingText.length === 0) return;
+    const codePoints = Array.from(pendingText);
+    const n = Math.max(MIN_DRIP_CHARS, Math.ceil((codePoints.length * STREAM_TICK_MS) / DRAIN_HORIZON_MS));
+    agentContent += codePoints.slice(0, n).join("");
+    pendingText = codePoints.slice(n).join("");
+    flush();
+    if (pendingText.length > 0) scheduleTick();
   }
 
   // Move the longest contiguous prefix of finalized rows into write-once scrollback.
@@ -84,7 +121,6 @@ export function createMessageStreamState(input: {
   }
 
   function flush(): void {
-    cancelFlushTimer();
     // Leading whitespace stripped every call so `content` is a pure function of
     // agentContent (no mutation), keeping the updater idempotent.
     const content = agentContent.replace(/^\s+/, "");
@@ -107,9 +143,9 @@ export function createMessageStreamState(input: {
     );
   }
 
-  /** Flush pending content and detach from the current agent row. */
+  /** Reveal any backlog, flush, and detach from the current agent row. */
   function sealAgentRow(): void {
-    cancelFlushTimer();
+    drainBacklog();
     flush();
     activeRowId = null;
     agentContent = "";
@@ -144,8 +180,8 @@ export function createMessageStreamState(input: {
 
     onDelta: (delta) => {
       if (delta.length === 0) return;
-      agentContent += delta;
-      if (!flushTimer) flushTimer = setTimeout(flush, STREAM_FLUSH_MS);
+      pendingText += delta;
+      scheduleTick();
     },
 
     onToolCall: () => {
@@ -160,7 +196,8 @@ export function createMessageStreamState(input: {
       const existingRowId = toolRowIdByCallId.get(entry.toolCallId);
       if (!existingRowId) {
         // New tool call: seal any in-progress agent row and append tool row in one atomic update.
-        cancelFlushTimer();
+        // Drain first so backlog folds into agentContent before it is read as the pending prose.
+        drainBacklog();
         const pendingContent = agentContent;
         const pendingRowId = activeRowId;
         activeRowId = null;
@@ -263,7 +300,7 @@ export function createMessageStreamState(input: {
       promoteFinalizedPrefix();
     },
 
-    streamedText: () => agentContent,
+    streamedText: () => agentContent + pendingText,
 
     finalize: () => {
       sealAgentRow();
@@ -276,13 +313,14 @@ export function createMessageStreamState(input: {
     },
 
     dispose: () => {
-      cancelFlushTimer();
+      cancelTick();
       const checklistIds = new Set(checklistRowIdByGroupId.values());
       checklistRowIdByGroupId.clear();
       const idsToRemove = [...agentRowIds];
       if (activeRowId && !idsToRemove.includes(activeRowId)) idsToRemove.push(activeRowId);
       activeRowId = null;
       agentContent = "";
+      pendingText = "";
       agentRowIds.length = 0;
       const removeSet = new Set([...idsToRemove, ...checklistIds]);
       if (removeSet.size > 0) {

--- a/src/chat-message-handler-stream.ts
+++ b/src/chat-message-handler-stream.ts
@@ -31,11 +31,14 @@ export type MessageStreamState = {
 };
 
 // The live prose row is paced, not coalesced: a rate-limited provider delivers text in
-// bursts, so instead of publishing each burst in one jump we drip it into the row over a
-// bounded horizon. The tick cadence matches the renderer's paint throttle; a burst drains
-// over DRAIN_HORIZON_MS, and MIN_DRIP_CHARS keeps a trickle moving so short tails still flow.
+// bursts, so instead of publishing each burst in one jump each tick reveals a fixed fraction
+// (STREAM_TICK_MS / DRIP_TIME_CONSTANT_MS) of the *remaining* backlog. That decays the burst
+// exponentially — fast while a lot is pending, gentle as it empties — which self-adjusts to
+// arrival rate (deltas keep appending mid-drain). The tick cadence matches the renderer's paint
+// throttle, so ~63% reveals within one time constant; MIN_DRIP_CHARS floors the per-tick reveal
+// so the short tail finishes promptly instead of trailing ever-smaller slices.
 const STREAM_TICK_MS = 32;
-const DRAIN_HORIZON_MS = 250;
+const DRIP_TIME_CONSTANT_MS = 250;
 const MIN_DRIP_CHARS = 8;
 
 export function createMessageStreamState(input: {
@@ -89,13 +92,13 @@ export function createMessageStreamState(input: {
     if (!tickTimer) tickTimer = setTimeout(tick, STREAM_TICK_MS);
   }
 
-  // Move one slice of the backlog into the live row and repaint. The slice is sized to drain
-  // any burst over DRAIN_HORIZON_MS; splitting on code points keeps surrogate pairs whole.
+  // Reveal one slice of the backlog and repaint. `Array.from` slices on code points, so a
+  // surrogate pair is never cut mid-character.
   function tick(): void {
     tickTimer = null;
     if (pendingText.length === 0) return;
     const codePoints = Array.from(pendingText);
-    const n = Math.max(MIN_DRIP_CHARS, Math.ceil((codePoints.length * STREAM_TICK_MS) / DRAIN_HORIZON_MS));
+    const n = Math.max(MIN_DRIP_CHARS, Math.ceil((codePoints.length * STREAM_TICK_MS) / DRIP_TIME_CONSTANT_MS));
     agentContent += codePoints.slice(0, n).join("");
     pendingText = codePoints.slice(n).join("");
     flush();


### PR DESCRIPTION
## Summary

- pace the live prose row with an adaptive drip instead of a one-shot flush, revealing an exponentially decaying fraction of the backlog each ~32ms tick
- drain the backlog through one chokepoint on every seal/read path so prose can't drop or reorder at a tool or notice boundary