### PR TITLE
refactor(code): drop multi-file code-edit

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -42,7 +42,7 @@ Acolyte combines a terminal-first client, headless daemon, lifecycle effects, pe
 
 - find/search/read files with gitignore awareness
 - edit/create/delete files
-- AST-based structural code editing with workspace-wide scope
+- AST-based structural code editing
 - git status/diff/log/show/add/commit
 - GitHub CLI integration for PR and issue management (view/create/edit), auto-enabled when `gh` is installed
 - on-demand session search across conversation history

--- a/src/code-contract.ts
+++ b/src/code-contract.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 const editCodeScopeSchema = {
   within: z.string().min(1).optional(),
   withinSymbol: z.string().min(1).optional(),
-  scope: z.literal("workspace").optional(),
 };
 
 export const editCodeRenameTargetSchema = z.enum(["local", "member"]);

--- a/src/code-ops.int.test.ts
+++ b/src/code-ops.int.test.ts
@@ -674,61 +674,13 @@ describe("editCode", () => {
     });
   });
 
-  test("applies edits across directory", async () => {
-    const workspace = dirs.createDir("acolyte-test-ast-dir-");
+  test("rejects a directory path", async () => {
+    const workspace = dirs.createDir("acolyte-test-ast-dir-reject-");
     await writeFile(join(workspace, "a.ts"), "const x = oldName();\n", "utf8");
-    await writeFile(join(workspace, "b.ts"), "const y = oldName();\n", "utf8");
     const { tools } = toolsForAgent({ workspace });
-    const result = await tools.editCode.execute(
-      { path: workspace, edits: [{ op: "rename", from: "oldName", to: "newName" }] },
-      "call_22",
-    );
-    expect(result.result.matches).toBe(2);
-    expect(result.result.output).toContain("a.ts");
-    expect(result.result.output).toContain("b.ts");
-    const aContent = await readFile(join(workspace, "a.ts"), "utf8");
-    const bContent = await readFile(join(workspace, "b.ts"), "utf8");
-    expect(aContent).toContain("newName");
-    expect(bContent).toContain("newName");
-  });
-
-  test("workspace scope renames across all project files", async () => {
-    const workspace = dirs.createDir("acolyte-test-ast-ws-");
-    await writeFile(join(workspace, "lib.ts"), "export function oldName() { return 1; }\n", "utf8");
-    await writeFile(join(workspace, "main.ts"), "import { oldName } from './lib';\noldName();\n", "utf8");
-    const { tools } = toolsForAgent({ workspace });
-    const result = await tools.editCode.execute(
-      {
-        path: join(workspace, "lib.ts"),
-        edits: [{ op: "rename", from: "oldName", to: "newName", scope: "workspace" }],
-      },
-      "call_23",
-    );
-    expect(result.result.matches).toBeGreaterThanOrEqual(3);
-    const libContent = await readFile(join(workspace, "lib.ts"), "utf8");
-    const mainContent = await readFile(join(workspace, "main.ts"), "utf8");
-    expect(libContent).toContain("newName");
-    expect(mainContent).toContain("newName");
-    expect(mainContent).not.toContain("oldName");
-  });
-
-  test("workspace scope replaces across all project files", async () => {
-    const workspace = dirs.createDir("acolyte-test-ast-ws-replace-");
-    await writeFile(join(workspace, "a.ts"), "console.log('hello');\n", "utf8");
-    await writeFile(join(workspace, "b.ts"), "console.log('world');\n", "utf8");
-    const { tools } = toolsForAgent({ workspace });
-    const result = await tools.editCode.execute(
-      {
-        path: join(workspace, "a.ts"),
-        edits: [{ op: "replace", rule: "console.log($ARG)", replacement: "logger.info($ARG)", scope: "workspace" }],
-      },
-      "call_24",
-    );
-    expect(result.result.matches).toBe(2);
-    const aContent = await readFile(join(workspace, "a.ts"), "utf8");
-    const bContent = await readFile(join(workspace, "b.ts"), "utf8");
-    expect(aContent).toContain("logger.info");
-    expect(bContent).toContain("logger.info");
+    await expect(
+      tools.editCode.execute({ path: workspace, edits: [{ op: "rename", from: "oldName", to: "newName" }] }, "call_22"),
+    ).rejects.toThrow(/requires a file/);
   });
 
   test("rejects unsupported non-code files", async () => {

--- a/src/code-ops.ts
+++ b/src/code-ops.ts
@@ -324,48 +324,15 @@ export type ScanCodeResult = {
   patterns: ScanCodePatternResult[];
 };
 
-async function collectParseableFiles(dirPath: string, maxFiles = 500): Promise<string[]> {
-  const files: string[] = [];
-  const stack = [dirPath];
-  while (stack.length > 0 && files.length < maxFiles) {
-    const dir = stack.pop();
-    if (!dir) break;
-    let entries: Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean }>;
-    try {
-      entries = await readdir(dir, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    entries.sort((a, b) => a.name.localeCompare(b.name));
-    for (const entry of entries) {
-      if (entry.name.startsWith(".") && entry.isDirectory()) continue;
-      if (entry.isDirectory() && IGNORED_DIRS.has(entry.name)) continue;
-      const abs = join(dir, entry.name);
-      if (entry.isDirectory()) {
-        stack.push(abs);
-        continue;
-      }
-      if (entry.isFile() && isParseable(abs)) files.push(abs);
-      if (files.length >= maxFiles) break;
-    }
-  }
-  return files;
-}
-
 type EditCodeFileResult = {
   matches: number;
   affectedSymbols: string[];
   diff: string;
-} | null;
+};
 
-async function editCodeFile(
-  absPath: string,
-  workspace: string,
-  edits: EditCodeEdit[],
-  throwOnNoMatch: boolean,
-): Promise<EditCodeFileResult> {
+async function editCodeFile(absPath: string, workspace: string, edits: EditCodeEdit[]): Promise<EditCodeFileResult> {
   const langName = languageFromPath(absPath);
-  if (!langName) return null;
+  invariant(langName, "editCodeFile requires a parseable file; callers must gate on isParseable");
   const langEnum = napi.Lang[langName as keyof typeof napi.Lang];
   const original = await readFile(absPath, "utf8");
   let current = original;
@@ -395,34 +362,25 @@ async function editCodeFile(
       matches = matches.filter((match) => matchIsWithinSymbol(match, symbol));
     }
     if (matches.length === 0) {
-      if (throwOnNoMatch) {
-        throw createToolError(
-          TOOL_ERROR_CODES.editCodeNoMatch,
-          `No AST matches found for ${isRenameEdit(edit) ? "rename target" : "rule"}: ${pattern}${edit.within ? ` within: ${edit.within}` : ""}${edit.withinSymbol ? ` withinSymbol: ${edit.withinSymbol}` : ""}`,
-        );
-      }
-      continue;
+      throw createToolError(
+        TOOL_ERROR_CODES.editCodeNoMatch,
+        `No AST matches found for ${isRenameEdit(edit) ? "rename target" : "rule"}: ${pattern}${edit.within ? ` within: ${edit.within}` : ""}${edit.withinSymbol ? ` withinSymbol: ${edit.withinSymbol}` : ""}`,
+      );
     }
     if (isRenameEdit(edit) && !edit.target && hasRenameModeConflict(matches)) {
-      if (throwOnNoMatch) {
-        throw createToolError(
-          TOOL_ERROR_CODES.editCodeNoMatch,
-          `Scoped rename target is ambiguous for ${edit.from}; retry with target: "local" or target: "member"${edit.withinSymbol ? ` withinSymbol: ${edit.withinSymbol}` : ""}`,
-        );
-      }
-      continue;
+      throw createToolError(
+        TOOL_ERROR_CODES.editCodeNoMatch,
+        `Scoped rename target is ambiguous for ${edit.from}; retry with target: "local" or target: "member"${edit.withinSymbol ? ` withinSymbol: ${edit.withinSymbol}` : ""}`,
+      );
     }
     const renameMode = isRenameEdit(edit) ? (requestedRenameMode(edit) ?? resolveRenameMode(matches)) : null;
     if (renameMode === "local") matches = matches.filter(isLocalRenameTarget);
     if (renameMode === "member") matches = matches.filter(isMemberRenameTarget);
     if (matches.length === 0) {
-      if (throwOnNoMatch) {
-        throw createToolError(
-          TOOL_ERROR_CODES.editCodeNoMatch,
-          `No AST matches found for ${isRenameEdit(edit) ? "rename target" : "rule"}: ${pattern}${edit.within ? ` within: ${edit.within}` : ""}${edit.withinSymbol ? ` withinSymbol: ${edit.withinSymbol}` : ""}${isRenameEdit(edit) && edit.target ? ` target: ${edit.target}` : ""}`,
-        );
-      }
-      continue;
+      throw createToolError(
+        TOOL_ERROR_CODES.editCodeNoMatch,
+        `No AST matches found for ${isRenameEdit(edit) ? "rename target" : "rule"}: ${pattern}${edit.within ? ` within: ${edit.within}` : ""}${edit.withinSymbol ? ` withinSymbol: ${edit.withinSymbol}` : ""}${isRenameEdit(edit) && edit.target ? ` target: ${edit.target}` : ""}`,
+      );
     }
     totalMatches += matches.length;
     for (const match of matches) {
@@ -463,15 +421,9 @@ async function editCodeFile(
     }
   }
 
-  if (totalMatches === 0) return null;
-
   await writeFile(absPath, current, "utf8");
   const diff = createDiff(displayPathForDiff(absPath, workspace), original, current);
   return { matches: totalMatches, affectedSymbols: Array.from(affectedSymbols), diff };
-}
-
-function hasWorkspaceScope(edits: EditCodeEdit[]): boolean {
-  return edits.some((edit) => edit.scope === "workspace");
 }
 
 export async function editCode(input: {
@@ -479,18 +431,10 @@ export async function editCode(input: {
   path: string;
   edits: EditCodeEdit[];
 }): Promise<EditCodeResult> {
-  if (hasWorkspaceScope(input.edits)) {
-    return editCodeDirectory(input.workspace, input.workspace, input.edits);
-  }
-
   const absPath = ensurePathWithinSandbox(input.path, input.workspace);
   const pathStats = await stat(absPath);
 
-  if (pathStats.isDirectory()) {
-    return editCodeDirectory(input.workspace, absPath, input.edits);
-  }
-
-  if (!pathStats.isFile()) throw new Error(`code-edit requires a file or directory path, got: ${input.path}`);
+  if (!pathStats.isFile()) throw new Error(`code-edit requires a file path, got: ${input.path}`);
   if (!isParseable(absPath)) {
     throw createToolError(
       TOOL_ERROR_CODES.editCodeUnsupportedFile,
@@ -498,10 +442,7 @@ export async function editCode(input: {
     );
   }
 
-  const result = await editCodeFile(absPath, input.workspace, input.edits, true);
-  if (!result) {
-    throw createToolError(TOOL_ERROR_CODES.editCodeNoMatch, `No AST matches found in ${input.path}`);
-  }
+  const result = await editCodeFile(absPath, input.workspace, input.edits);
 
   const outputParts = [`path=${absPath}`, `edits=${input.edits.length}`, `matches=${result.matches}`];
   if (result.affectedSymbols.length > 0) outputParts.push(`symbols=${result.affectedSymbols.join(", ")}`);
@@ -514,30 +455,6 @@ export async function editCode(input: {
     output: outputParts.join("\n"),
     affectedSymbols: result.affectedSymbols,
   };
-}
-
-async function editCodeDirectory(workspace: string, dirPath: string, edits: EditCodeEdit[]): Promise<EditCodeResult> {
-  const files = await collectParseableFiles(dirPath);
-  const diffs: string[] = [];
-  let totalMatches = 0;
-  const allAffectedSymbols: string[] = [];
-
-  for (const absFile of files) {
-    const result = await editCodeFile(absFile, workspace, edits, false);
-    if (!result) continue;
-    totalMatches += result.matches;
-    allAffectedSymbols.push(...result.affectedSymbols);
-    diffs.push(result.diff);
-  }
-
-  if (totalMatches === 0) {
-    throw createToolError(TOOL_ERROR_CODES.editCodeNoMatch, `No AST matches found in directory: ${dirPath}`);
-  }
-
-  const diff = diffs.join("\n");
-  const affectedSymbols = Array.from(new Set(allAffectedSymbols));
-  const output = [`path=${dirPath}`, `edits=${edits.length}`, `matches=${totalMatches}`, "", diff].join("\n");
-  return { path: dirPath, edits: edits.length, matches: totalMatches, diff, output, affectedSymbols };
 }
 
 export async function scanCode(input: {

--- a/src/code-toolkit.ts
+++ b/src/code-toolkit.ts
@@ -94,7 +94,6 @@ function createEditCodeTool(input: ToolkitInput) {
   const outputSchema = z.object({
     kind: z.literal("code-edit"),
     path: z.string().min(1),
-    files: z.number().int().nonnegative(),
     added: z.number().int().nonnegative(),
     removed: z.number().int().nonnegative(),
     matches: z.number().int().nonnegative(),
@@ -107,13 +106,12 @@ function createEditCodeTool(input: ToolkitInput) {
     toolkit: "code",
     category: "write",
     description:
-      'Edit code structurally with AST-aware operations. Pass `edits` as operation objects like {op:"rename", from, to, withinSymbol?, target?} or {op:"replace", rule, replacement, within?, withinSymbol?}. For `replace`, `rule` may be a string/pattern object shorthand or a recursive ast-grep rule object. `path` may be a file or directory (`.` for workspace-wide). For non-code files use `file-edit`.',
+      'Edit code structurally with AST-aware operations. Pass `edits` as operation objects like {op:"rename", from, to, withinSymbol?, target?} or {op:"replace", rule, replacement, within?, withinSymbol?}. For `replace`, `rule` may be a string/pattern object shorthand or a recursive ast-grep rule object. `path` is a single code file. For non-code files use `file-edit`.',
     instruction: [
       "Use `code-edit` for AST-aware refactors; use `file-edit` for plain text edits.",
       "Prefer explicit `rename` or `replace` operations.",
       "For ambiguous local/member renames, set `target` to `local` or `member`.",
       "Use `withinSymbol` to keep edits scoped.",
-      "Set `scope` to `workspace` to apply edits across all project files.",
       "Read the target file directly before editing.",
       "If `code-edit` reports no matches, refine scope/rule from current file evidence instead of broadening blindly.",
       "Use the diff preview to confirm bounded changes and stop.",
@@ -138,7 +136,6 @@ function createEditCodeTool(input: ToolkitInput) {
         return {
           kind: "code-edit" as const,
           path: toolInput.path,
-          files: totals.files > 0 ? totals.files : 1,
           added: totals.added,
           removed: totals.removed,
           matches: editResult.matches,

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -172,7 +172,6 @@ function createEditFileTool(input: ToolkitInput) {
   const outputSchema = z.object({
     kind: z.literal("file-edit"),
     path: z.string().min(1),
-    files: z.number().int().nonnegative(),
     added: z.number().int().nonnegative(),
     removed: z.number().int().nonnegative(),
     output: z.string(),
@@ -222,7 +221,6 @@ function createEditFileTool(input: ToolkitInput) {
         return {
           kind: "file-edit" as const,
           path: toolInput.path,
-          files: totals.files > 0 ? totals.files : 1,
           added: totals.added,
           removed: totals.removed,
           output: rawResult,
@@ -247,7 +245,6 @@ function createCreateFileTool(input: ToolkitInput) {
     outputSchema: z.object({
       kind: z.literal("file-create"),
       path: z.string().min(1),
-      files: z.number().int().nonnegative(),
       added: z.number().int().nonnegative(),
       removed: z.number().int().nonnegative(),
       output: z.string(),
@@ -268,7 +265,6 @@ function createCreateFileTool(input: ToolkitInput) {
         return {
           kind: "file-create" as const,
           path: toolInput.path,
-          files: totals.files > 0 ? totals.files : 1,
           added: totals.added,
           removed: totals.removed,
           output: rawResult,

--- a/src/tool-output-format.ts
+++ b/src/tool-output-format.ts
@@ -50,10 +50,8 @@ export function emitParts(
 }
 
 export function diffSummaryParts(path: string, rawResult: string, labelKey: string): ToolOutputPart[] {
-  const { files, added, removed } = summarizeUnifiedDiff(rawResult);
-  const touchedFiles = files > 0 ? files : 1;
-  const displayPath = touchedFiles > 1 ? t("unit.file", { count: touchedFiles }) : path;
-  return [{ kind: "edit-header", labelKey, path: displayPath, added, removed }];
+  const { added, removed } = summarizeUnifiedDiff(rawResult);
+  return [{ kind: "edit-header", labelKey, path, added, removed }];
 }
 
 function mapHeadTailParts<T>(

--- a/src/tool-output-parse.ts
+++ b/src/tool-output-parse.ts
@@ -1,20 +1,14 @@
 import type { ToolOutputPart } from "./tool-output-contract";
 
 export type UnifiedDiffSummary = {
-  files: number;
   added: number;
   removed: number;
 };
 
 export function summarizeUnifiedDiff(rawResult: string): UnifiedDiffSummary {
-  let files = 0;
   let added = 0;
   let removed = 0;
   for (const line of rawResult.split("\n")) {
-    if (line.startsWith("diff --git ")) {
-      files += 1;
-      continue;
-    }
     if (line.startsWith("+++ ") || line.startsWith("--- ")) continue;
     if (line.startsWith("+")) {
       added += 1;
@@ -22,7 +16,7 @@ export function summarizeUnifiedDiff(rawResult: string): UnifiedDiffSummary {
     }
     if (line.startsWith("-")) removed += 1;
   }
-  return { files, added, removed };
+  return { added, removed };
 }
 
 export function findResultPaths(result: string): string[] {


### PR DESCRIPTION
## Summary

- `code-edit` is single-file only: drops `scope:"workspace"` and directory-path fan-out, and now rejects a directory path
- removes the orphaned `files` count from `code-edit` / `file-edit` / `file-create` output
- leaves the multi-file diff renderer (#296) intact although no tool now produces it — removing that is a separate call