### PR TITLE
refactor(paths): unify global xdg layout

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -19,7 +19,7 @@ Acolyte combines a terminal-first client, headless daemon, lifecycle effects, pe
 - live status line with location, model, token, skill, and PR segments
 - auto-update on startup with progress UI
 - update flags to force or skip auto-update (`--update`, `--no-update`)
-- XDG Base Directory support on Linux
+- XDG-style global directories
 - one-line install script
 
 ## Agent execution

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -1,21 +1,6 @@
 # Paths
 
-Acolyte resolves config, data, and state directories per-platform.
-
-## macOS
-
-Everything lives under `~/.acolyte/`:
-
-| Category | Path |
-|---|---|
-| Config | `~/.acolyte/config.toml`, `~/.acolyte/credentials` |
-| Data | `~/.acolyte/memory.db`, `~/.acolyte/sessions.json`, `~/.acolyte/trace.db`, `~/.acolyte/tool.db`, `~/.acolyte/projects/` |
-| State | `~/.acolyte/daemons/`, `~/.acolyte/locks/`, `~/.acolyte/client.log`, `~/.acolyte/update-check.json` |
-| Binary | `~/.acolyte/bin/acolyte` |
-
-## Linux
-
-Follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/). Environment variables override the defaults. Relative paths in XDG variables are ignored per spec.
+Acolyte uses one XDG-style global layout on macOS and Linux. Environment variables override the defaults. Relative paths in XDG variables are ignored per spec.
 
 | Category | Default | Env override |
 |---|---|---|
@@ -24,15 +9,15 @@ Follows the [XDG Base Directory Specification](https://specifications.freedeskto
 | State | `~/.local/state/acolyte/` | `$XDG_STATE_HOME/acolyte/` |
 | Binary | `~/.local/bin/acolyte` | — |
 
-### What goes where
+## What goes where
 
-- **Config** — user-edited settings and credentials: `config.toml`, `credentials`
+- **Config** — user-edited settings and credentials: `config.toml`, `credentials`, `oauth.json`
 - **Data** — persistent application data: `memory.db`, `sessions.json`, `trace.db`, `tool.db`, `projects/`
 - **State** — runtime state that can be regenerated: `daemons/`, `locks/`, `client.log`, `update-check.json`
 
 ## Project scope
 
-Project-scoped config is always at `<cwd>/.acolyte/config.toml`, regardless of platform.
+Project-scoped config is always at `<cwd>/.acolyte/config.toml`, regardless of platform. Project `.acolyte/` is workspace metadata, not global state.
 
 ## Key files
 

--- a/scripts/data/acolyte-facts.json
+++ b/scripts/data/acolyte-facts.json
@@ -34,6 +34,6 @@
   "Protocol events: status, reasoning, tool-call, tool-output, tool-result, text-delta, error, done. Every request has exactly one terminal event (done or error).",
   "RPC: WebSocket JSON envelopes with transport request id (rpc_*) and domain task id (task_*). Auth via Bearer token in sec-websocket-protocol.",
 
-  "Config scopes: user (~/.acolyte/config.toml) and project (<cwd>/.acolyte/config.toml). Project overrides user.",
+  "Config scopes: user (~/.config/acolyte/config.toml by default) and project (<cwd>/.acolyte/config.toml). Project overrides user.",
   "Provider support: OpenAI, Anthropic, Google with configurable base URLs. Local models via OpenAI-compatible endpoints (Ollama, vLLM)."
 ]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -24,11 +24,7 @@ main() {
     *) echo "No prebuilt binary for ${platform}-${arch}. Build from source with Bun (see README)." >&2; exit 1 ;;
   esac
 
-  if [ "$platform" = "linux" ]; then
-    INSTALL_DIR="${HOME}/.local/bin"
-  else
-    INSTALL_DIR="${HOME}/.acolyte/bin"
-  fi
+  INSTALL_DIR="${HOME}/.local/bin"
 
   asset="acolyte-${platform}-${arch}.tar.gz"
 

--- a/scripts/migrate-macos-xdg.sh
+++ b/scripts/migrate-macos-xdg.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+home="${HOME:?HOME is required}"
+legacy_dir="${ACOLYTE_LEGACY_DIR:-$home/.acolyte}"
+if [[ "${XDG_CONFIG_HOME:-}" = /* ]]; then
+  config_home="$XDG_CONFIG_HOME"
+else
+  config_home="$home/.config"
+fi
+if [[ "${XDG_DATA_HOME:-}" = /* ]]; then
+  data_home="$XDG_DATA_HOME"
+else
+  data_home="$home/.local/share"
+fi
+if [[ "${XDG_STATE_HOME:-}" = /* ]]; then
+  state_home="$XDG_STATE_HOME"
+else
+  state_home="$home/.local/state"
+fi
+
+config_dir="$config_home/acolyte"
+data_dir="$data_home/acolyte"
+state_dir="$state_home/acolyte"
+bin_dir="$home/.local/bin"
+
+if [[ ! -d "$legacy_dir" ]]; then
+  echo "No legacy Acolyte directory found at $legacy_dir"
+  exit 0
+fi
+
+move_path() {
+  local source="$1"
+  local target="$2"
+
+  if [[ ! -e "$source" ]]; then
+    return
+  fi
+  if [[ -e "$target" ]]; then
+    echo "Refusing to overwrite existing target: $target" >&2
+    exit 1
+  fi
+
+  mkdir -p "$(dirname "$target")"
+  mv "$source" "$target"
+  echo "moved $source -> $target"
+}
+
+move_path "$legacy_dir/config.toml" "$config_dir/config.toml"
+move_path "$legacy_dir/config.json" "$config_dir/config.json"
+move_path "$legacy_dir/credentials" "$config_dir/credentials"
+move_path "$legacy_dir/oauth.json" "$config_dir/oauth.json"
+
+move_path "$legacy_dir/memory.db" "$data_dir/memory.db"
+move_path "$legacy_dir/memory.db-shm" "$data_dir/memory.db-shm"
+move_path "$legacy_dir/memory.db-wal" "$data_dir/memory.db-wal"
+move_path "$legacy_dir/memory.json" "$data_dir/memory.json"
+move_path "$legacy_dir/memory" "$data_dir/memory"
+move_path "$legacy_dir/sessions.json" "$data_dir/sessions.json"
+move_path "$legacy_dir/trace.db" "$data_dir/trace.db"
+move_path "$legacy_dir/trace.db-shm" "$data_dir/trace.db-shm"
+move_path "$legacy_dir/trace.db-wal" "$data_dir/trace.db-wal"
+move_path "$legacy_dir/tool.db" "$data_dir/tool.db"
+move_path "$legacy_dir/tool.db-shm" "$data_dir/tool.db-shm"
+move_path "$legacy_dir/tool.db-wal" "$data_dir/tool.db-wal"
+move_path "$legacy_dir/projects" "$data_dir/projects"
+
+move_path "$legacy_dir/daemons" "$state_dir/daemons"
+move_path "$legacy_dir/locks" "$state_dir/locks"
+move_path "$legacy_dir/client.log" "$state_dir/client.log"
+move_path "$legacy_dir/server.log" "$state_dir/server.log"
+move_path "$legacy_dir/prompt.log" "$state_dir/prompt.log"
+move_path "$legacy_dir/update-check.json" "$state_dir/update-check.json"
+move_path "$legacy_dir/dogfood-gate-history.json" "$state_dir/dogfood-gate-history.json"
+
+move_path "$legacy_dir/bin/acolyte" "$bin_dir/acolyte"
+rmdir "$legacy_dir/bin" 2>/dev/null || true
+
+if find "$legacy_dir" -mindepth 1 -print -quit | grep -q .; then
+  echo "Legacy directory still contains unmigrated files:" >&2
+  find "$legacy_dir" -mindepth 1 -maxdepth 2 -print >&2
+  exit 1
+fi
+
+rmdir "$legacy_dir" 2>/dev/null || true
+
+echo "Acolyte macOS XDG migration complete."

--- a/scripts/run-behavior.ts
+++ b/scripts/run-behavior.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { z } from "zod";
+import { stateDir } from "../src/paths";
 import {
   BEHAVIOR_SCENARIO_BY_ID,
   BEHAVIOR_SCENARIO_LIST,
@@ -338,7 +339,7 @@ async function createBehaviorEnvironment(): Promise<BehaviorEnvironment> {
     homeDir: home.homeDir,
     port: home.port,
     env: home.env,
-    daemonLogPath: join(home.homeDir, ".acolyte", "daemons", `${home.port}.log`),
+    daemonLogPath: join(stateDir(home.env), "daemons", `${home.port}.log`),
   };
 }
 

--- a/scripts/with-server.sh
+++ b/scripts/with-server.sh
@@ -9,7 +9,12 @@ fi
 serve_script="$1"
 shift
 
-log_path="${ACOLYTE_SERVER_LOG:-$HOME/.acolyte/daemons/server.log}"
+if [[ "${XDG_STATE_HOME:-}" = /* ]]; then
+  state_home="$XDG_STATE_HOME"
+else
+  state_home="$HOME/.local/state"
+fi
+log_path="${ACOLYTE_SERVER_LOG:-$state_home/acolyte/daemons/server.log}"
 wait_url="${ACOLYTE_SERVER_WAIT_URL:-http://localhost:6767/v1/status}"
 wait_timeout_ms="${ACOLYTE_SERVER_WAIT_TIMEOUT_MS:-10000}"
 restart_server="${ACOLYTE_SERVER_RESTART:-0}"

--- a/src/cli-auth.test.ts
+++ b/src/cli-auth.test.ts
@@ -33,7 +33,7 @@ function createDeps(overrides: Partial<Parameters<typeof authMode>[1]> = {}) {
     removeProviderApiKey: mock(async (envKey: ProviderApiEnvKey) => {
       removes.push(envKey);
     }),
-    credentialsPath: () => "/home/user/.acolyte/credentials",
+    credentialsPath: () => "/home/user/.config/acolyte/credentials",
     commandError: mock((_: string, __?: string) => {}),
     commandHelp: mock((_: string) => {}),
   };

--- a/src/paths.test.ts
+++ b/src/paths.test.ts
@@ -12,45 +12,35 @@ describe("resolveHomeDir", () => {
   });
 });
 
-describe("macOS paths", () => {
-  const env = { HOME: "/Users/me" };
-
-  test("configDir uses .acolyte", () => {
-    expect(configDir(env, "darwin")).toBe("/Users/me/.acolyte");
+describe("XDG paths", () => {
+  test("macOS and Linux share the same default configDir", () => {
+    const env = { HOME: "/Users/me" };
+    expect(configDir(env, "darwin")).toBe("/Users/me/.config/acolyte");
+    expect(configDir(env, "linux")).toBe("/Users/me/.config/acolyte");
   });
 
-  test("dataDir uses .acolyte", () => {
-    expect(dataDir(env, "darwin")).toBe("/Users/me/.acolyte");
+  test("macOS and Linux share the same default dataDir", () => {
+    const env = { HOME: "/Users/me" };
+    expect(dataDir(env, "darwin")).toBe("/Users/me/.local/share/acolyte");
+    expect(dataDir(env, "linux")).toBe("/Users/me/.local/share/acolyte");
   });
 
-  test("stateDir uses .acolyte", () => {
-    expect(stateDir(env, "darwin")).toBe("/Users/me/.acolyte");
+  test("macOS and Linux share the same default stateDir", () => {
+    const env = { HOME: "/Users/me" };
+    expect(stateDir(env, "darwin")).toBe("/Users/me/.local/state/acolyte");
+    expect(stateDir(env, "linux")).toBe("/Users/me/.local/state/acolyte");
   });
-});
 
-describe("Linux paths", () => {
   test("configDir respects XDG_CONFIG_HOME", () => {
-    expect(configDir({ HOME: "/home/me", XDG_CONFIG_HOME: "/custom/config" }, "linux")).toBe("/custom/config/acolyte");
-  });
-
-  test("configDir defaults to ~/.config/acolyte", () => {
-    expect(configDir({ HOME: "/home/me" }, "linux")).toBe("/home/me/.config/acolyte");
+    expect(configDir({ HOME: "/home/me", XDG_CONFIG_HOME: "/custom/config" }, "darwin")).toBe("/custom/config/acolyte");
   });
 
   test("dataDir respects XDG_DATA_HOME", () => {
-    expect(dataDir({ HOME: "/home/me", XDG_DATA_HOME: "/custom/data" }, "linux")).toBe("/custom/data/acolyte");
-  });
-
-  test("dataDir defaults to ~/.local/share/acolyte", () => {
-    expect(dataDir({ HOME: "/home/me" }, "linux")).toBe("/home/me/.local/share/acolyte");
+    expect(dataDir({ HOME: "/home/me", XDG_DATA_HOME: "/custom/data" }, "darwin")).toBe("/custom/data/acolyte");
   });
 
   test("stateDir respects XDG_STATE_HOME", () => {
-    expect(stateDir({ HOME: "/home/me", XDG_STATE_HOME: "/custom/state" }, "linux")).toBe("/custom/state/acolyte");
-  });
-
-  test("stateDir defaults to ~/.local/state/acolyte", () => {
-    expect(stateDir({ HOME: "/home/me" }, "linux")).toBe("/home/me/.local/state/acolyte");
+    expect(stateDir({ HOME: "/home/me", XDG_STATE_HOME: "/custom/state" }, "darwin")).toBe("/custom/state/acolyte");
   });
 
   test("ignores relative XDG_CONFIG_HOME per spec", () => {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -21,23 +21,14 @@ function xdgDir(env: Env, key: string, fallback: string): string {
   return join(fallback, "acolyte");
 }
 
-export function configDir(env: Env = process.env, platform: Platform = resolvePlatform()): string {
-  if (platform === "linux") {
-    return xdgDir(env, "XDG_CONFIG_HOME", join(resolveHomeDir(env), ".config"));
-  }
-  return join(resolveHomeDir(env), ".acolyte");
+export function configDir(env: Env = process.env, _platform: Platform = resolvePlatform()): string {
+  return xdgDir(env, "XDG_CONFIG_HOME", join(resolveHomeDir(env), ".config"));
 }
 
-export function dataDir(env: Env = process.env, platform: Platform = resolvePlatform()): string {
-  if (platform === "linux") {
-    return xdgDir(env, "XDG_DATA_HOME", join(resolveHomeDir(env), ".local", "share"));
-  }
-  return join(resolveHomeDir(env), ".acolyte");
+export function dataDir(env: Env = process.env, _platform: Platform = resolvePlatform()): string {
+  return xdgDir(env, "XDG_DATA_HOME", join(resolveHomeDir(env), ".local", "share"));
 }
 
-export function stateDir(env: Env = process.env, platform: Platform = resolvePlatform()): string {
-  if (platform === "linux") {
-    return xdgDir(env, "XDG_STATE_HOME", join(resolveHomeDir(env), ".local", "state"));
-  }
-  return join(resolveHomeDir(env), ".acolyte");
+export function stateDir(env: Env = process.env, _platform: Platform = resolvePlatform()): string {
+  return xdgDir(env, "XDG_STATE_HOME", join(resolveHomeDir(env), ".local", "state"));
 }


### PR DESCRIPTION
## Summary

- use XDG-style config, data, and state directories on every supported platform
- install the binary to `~/.local/bin` on macOS and Linux
- update docs, facts, scripts, and tests for the unified layout
- add a one-off macOS migration script for legacy local files