### PR TITLE
fix(lifecycle): order tool output through fullStream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ acolyte
 *.bun-build
 scripts/data/memory-bench/
 docs/notes/
+.opencode/
+opencode.json
+.pi

--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ bun run dev
 
 `bun run dev` starts a watch-mode daemon and opens the CLI client. It restarts any local daemon already using the development port, then stops the daemon it started when the client exits.
 
+For daily dogfooding, link the checkout CLI into your PATH:
+
+```bash
+mkdir -p ~/.local/bin
+ln -sf "$PWD/src/cli.ts" ~/.local/bin/acolyte
+```
+
+Use `scripts/install.sh` only when you want the latest released binary instead of the local source checkout.
+
 Provider credentials are not needed to run the test suites. To use the agent against a provider while developing, configure one once for your user account:
 
 ```bash

--- a/src/agent-contract.ts
+++ b/src/agent-contract.ts
@@ -4,8 +4,11 @@ import type {
   LanguageModelV4Message,
   SharedV4ProviderOptions,
 } from "@ai-sdk/provider";
+import type { ChecklistItem } from "./checklist-contract";
 import type { ReasoningLevel } from "./config-contract";
+import type { ActiveSkill } from "./skill-contract";
 import type { ToolDefinition } from "./tool-contract";
+import type { ToolOutputPart } from "./tool-output-contract";
 
 export type ToolCallEntry = {
   toolCallId: string;
@@ -51,7 +54,20 @@ export type StreamChunk =
   | { type: "tool-call"; payload: ToolCallPayload }
   | { type: "tool-result"; payload: ToolResultPayload }
   | { type: "tool-error"; payload: ToolErrorPayload }
-  | { type: "model-usage"; payload: ModelUsagePayload };
+  | { type: "model-usage"; payload: ModelUsagePayload }
+  | SideEffectChunk;
+
+// Effects a tool raises mid-execute (output rows, checklists, skill lifecycle). They ride the
+// same ordered `fullStream` as text and tool calls so the transcript order is structurally
+// faithful — a tool can only emit them from inside its `execute`, between its tool-call and
+// tool-result chunks.
+export type SideEffectChunk =
+  | { type: "tool-output"; toolName: string; content: ToolOutputPart; toolCallId?: string }
+  | { type: "checklist"; groupId: string; groupTitle: string; items: ChecklistItem[] }
+  | { type: "skill-activated"; skill: ActiveSkill }
+  | { type: "skill-deactivated"; name: string };
+
+export type SideEffectSink = (chunk: SideEffectChunk) => void;
 
 export type Agent = {
   readonly id: string;
@@ -69,6 +85,9 @@ export type StreamOptions = {
   reasoning?: ReasoningLevel;
   providerOptions?: SharedV4ProviderOptions;
   preCallInputTokenLimit?: number;
+  // Installed for the lifetime of one stream so tool-raised effects enqueue onto `fullStream`;
+  // the streamer calls it with `null` once the stream closes.
+  installSideEffectSink?: (sink: SideEffectSink | null) => void;
   onBeforeNextCall?: (messages: readonly LanguageModelV4Message[]) => LanguageModelV4Message[];
   onBeforeFinish?: (attempt: {
     messages: readonly LanguageModelV4Message[];

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -62,212 +62,217 @@ export function createAgentStream(
         streamController = controller;
       },
     });
+    options.installSideEffectSink?.((chunk) => streamController.enqueue(chunk));
 
     const resultPromise = (async (): Promise<GenerateResult> => {
       let finishReason: LanguageModelV4FinishReason | undefined;
-      while (true) {
-        loopIteration++;
-        if (loopIteration > 1) streamController.enqueue({ type: "step-start" });
-        log.debug("agent-stream.loop.start", { iteration: loopIteration, pending_messages: messages.length });
-
-        const preCallLimit = options.preCallInputTokenLimit;
-        if (typeof preCallLimit === "number" && preCallLimit > 0) {
-          const size = estimatePromptSize(messages, functionTools);
-          const message = promptBudgetError(size, preCallLimit);
-          if (message) {
-            log.debug("agent-stream.precall.overflow", {
-              iteration: loopIteration,
-              limit: preCallLimit,
-              total: size.total,
-              system: size.system,
-              tools: size.tools,
-              messages: size.messages,
-              message_count: messages.length,
-            });
-            const err = new Error(message) as Error & { code: string; kind: string };
-            err.code = LIFECYCLE_ERROR_CODES.budgetExhausted;
-            err.kind = ERROR_KINDS.budgetExhausted;
-            throw err;
-          }
-        }
-
-        await rateLimiter.beforeCall();
-        let streamResult: Awaited<ReturnType<typeof model.doStream>>;
-        try {
-          streamResult = await model.doStream({
-            prompt: messages,
-            temperature: options.temperature,
-            tools: functionTools.length > 0 ? functionTools : undefined,
-            toolChoice: functionTools.length > 0 ? { type: "auto" } : undefined,
-            ...(options.reasoning ? { reasoning: options.reasoning } : {}),
-            ...(options.providerOptions ? { providerOptions: options.providerOptions } : {}),
-          });
-          rateLimiter.reset();
-        } catch (error) {
-          const recovery = rateLimiter.onError(error);
-          if (recovery.shouldRetry) {
-            log.debug("agent-stream.rate_limit.retry", { delay_ms: recovery.delayMs, iteration: loopIteration });
-            await new Promise((resolve) => setTimeout(resolve, recovery.delayMs));
-            continue;
-          }
-          throw error;
-        }
-
-        const pendingToolCalls: Array<{
-          toolCallId: string;
-          toolName: string;
-          input: string;
-        }> = [];
-        finishReason = undefined;
-        const stepTextParts: string[] = [];
-        const reasoningBlocks = new Map<string, ReasoningBlock>();
-
-        const reader = streamResult.stream.getReader();
+      try {
         while (true) {
-          const { done, value: part } = await reader.read();
-          if (done) break;
-          emitStreamPart(part, streamController, stepTextParts, pendingToolCalls, reasoningBlocks);
-          if (part.type === "finish") {
-            finishReason = part.finishReason;
-            streamController.enqueue({
-              type: "model-usage",
-              payload: {
-                inputTokens: part.usage?.inputTokens?.total,
-                outputTokens: part.usage?.outputTokens?.total,
-                cacheReadTokens: part.usage?.inputTokens?.cacheRead,
-                cacheWriteTokens: part.usage?.inputTokens?.cacheWrite,
-                reasoningTokens: part.usage?.outputTokens?.reasoning,
-              },
-            });
+          loopIteration++;
+          if (loopIteration > 1) streamController.enqueue({ type: "step-start" });
+          log.debug("agent-stream.loop.start", { iteration: loopIteration, pending_messages: messages.length });
+
+          const preCallLimit = options.preCallInputTokenLimit;
+          if (typeof preCallLimit === "number" && preCallLimit > 0) {
+            const size = estimatePromptSize(messages, functionTools);
+            const message = promptBudgetError(size, preCallLimit);
+            if (message) {
+              log.debug("agent-stream.precall.overflow", {
+                iteration: loopIteration,
+                limit: preCallLimit,
+                total: size.total,
+                system: size.system,
+                tools: size.tools,
+                messages: size.messages,
+                message_count: messages.length,
+              });
+              const err = new Error(message) as Error & { code: string; kind: string };
+              err.code = LIFECYCLE_ERROR_CODES.budgetExhausted;
+              err.kind = ERROR_KINDS.budgetExhausted;
+              throw err;
+            }
           }
-        }
 
-        const stepText = stepTextParts.join("");
-        // Text alongside tool calls is narration, not the final response. Only a pure
-        // no-tool-call step carries the answer; prepend any prefix carried from a truncation.
-        if (pendingToolCalls.length === 0) answerText = truncatedPrefix + stepText;
-
-        if (pendingToolCalls.length > 0) {
-          const assistantContent: Array<
-            LanguageModelV4ReasoningPart | LanguageModelV4TextPart | LanguageModelV4ToolCallPart
-          > = [
-            ...reasoningContentParts(reasoningBlocks),
-            ...(stepText.length > 0 ? [{ type: "text" as const, text: stepText }] : []),
-            ...pendingToolCalls.map((tc) => ({
-              type: "tool-call" as const,
-              toolCallId: tc.toolCallId,
-              toolName: tc.toolName,
-              input: safeParseJSON(tc.input),
-            })),
-          ];
-
-          const toolResultParts: LanguageModelV4ToolResultPart[] = [];
-          for (const tc of pendingToolCalls) {
-            allToolCalls.push({ toolCallId: tc.toolCallId, toolName: tc.toolName, args: tc.input });
-            const tool = toolsByName.get(tc.toolName);
-            if (!tool) {
-              const error = `Unknown tool: ${tc.toolName}`;
-              streamController.enqueue({
-                type: "tool-error",
-                payload: { error, message: error, toolName: tc.toolName, toolCallId: tc.toolCallId },
-              });
-              toolResultParts.push({
-                type: "tool-result",
-                toolCallId: tc.toolCallId,
-                toolName: tc.toolName,
-                output: { type: "text", value: JSON.stringify({ error }) },
-              });
+          await rateLimiter.beforeCall();
+          let streamResult: Awaited<ReturnType<typeof model.doStream>>;
+          try {
+            streamResult = await model.doStream({
+              prompt: messages,
+              temperature: options.temperature,
+              tools: functionTools.length > 0 ? functionTools : undefined,
+              toolChoice: functionTools.length > 0 ? { type: "auto" } : undefined,
+              ...(options.reasoning ? { reasoning: options.reasoning } : {}),
+              ...(options.providerOptions ? { providerOptions: options.providerOptions } : {}),
+            });
+            rateLimiter.reset();
+          } catch (error) {
+            const recovery = rateLimiter.onError(error);
+            if (recovery.shouldRetry) {
+              log.debug("agent-stream.rate_limit.retry", { delay_ms: recovery.delayMs, iteration: loopIteration });
+              await new Promise((resolve) => setTimeout(resolve, recovery.delayMs));
               continue;
             }
+            throw error;
+          }
 
-            try {
-              const args = JSON.parse(tc.input);
-              const { result, effectOutput } = await tool.execute(args, tc.toolCallId);
+          const pendingToolCalls: Array<{
+            toolCallId: string;
+            toolName: string;
+            input: string;
+          }> = [];
+          finishReason = undefined;
+          const stepTextParts: string[] = [];
+          const reasoningBlocks = new Map<string, ReasoningBlock>();
+
+          const reader = streamResult.stream.getReader();
+          while (true) {
+            const { done, value: part } = await reader.read();
+            if (done) break;
+            emitStreamPart(part, streamController, stepTextParts, pendingToolCalls, reasoningBlocks);
+            if (part.type === "finish") {
+              finishReason = part.finishReason;
               streamController.enqueue({
-                type: "tool-result",
-                payload: { toolCallId: tc.toolCallId, toolName: tc.toolName, result },
-              });
-              const raw = effectOutput ? `${JSON.stringify(result)}\n${effectOutput}` : JSON.stringify(result);
-              const outputValue = truncateMiddle(raw, MAX_TOOL_RESULT_CHARS);
-              toolResultParts.push({
-                type: "tool-result",
-                toolCallId: tc.toolCallId,
-                toolName: tc.toolName,
-                output: { type: "text", value: outputValue },
-              });
-            } catch (error) {
-              const serializedError = serializeToolError(error);
-              const message = serializedError.error.message;
-              const code = serializedError.error.code;
-              const kind = serializedError.error.kind;
-              streamController.enqueue({
-                type: "tool-error",
+                type: "model-usage",
                 payload: {
-                  error: serializedError.error,
-                  message,
-                  code,
-                  kind,
-                  toolName: tc.toolName,
-                  toolCallId: tc.toolCallId,
+                  inputTokens: part.usage?.inputTokens?.total,
+                  outputTokens: part.usage?.outputTokens?.total,
+                  cacheReadTokens: part.usage?.inputTokens?.cacheRead,
+                  cacheWriteTokens: part.usage?.inputTokens?.cacheWrite,
+                  reasoningTokens: part.usage?.outputTokens?.reasoning,
                 },
               });
-              toolResultParts.push({
-                type: "tool-result",
+            }
+          }
+
+          const stepText = stepTextParts.join("");
+          // Text alongside tool calls is narration, not the final response. Only a pure
+          // no-tool-call step carries the answer; prepend any prefix carried from a truncation.
+          if (pendingToolCalls.length === 0) answerText = truncatedPrefix + stepText;
+
+          if (pendingToolCalls.length > 0) {
+            const assistantContent: Array<
+              LanguageModelV4ReasoningPart | LanguageModelV4TextPart | LanguageModelV4ToolCallPart
+            > = [
+              ...reasoningContentParts(reasoningBlocks),
+              ...(stepText.length > 0 ? [{ type: "text" as const, text: stepText }] : []),
+              ...pendingToolCalls.map((tc) => ({
+                type: "tool-call" as const,
                 toolCallId: tc.toolCallId,
                 toolName: tc.toolName,
-                output: { type: "text", value: JSON.stringify(serializedError) },
-              });
+                input: safeParseJSON(tc.input),
+              })),
+            ];
+
+            const toolResultParts: LanguageModelV4ToolResultPart[] = [];
+            for (const tc of pendingToolCalls) {
+              allToolCalls.push({ toolCallId: tc.toolCallId, toolName: tc.toolName, args: tc.input });
+              const tool = toolsByName.get(tc.toolName);
+              if (!tool) {
+                const error = `Unknown tool: ${tc.toolName}`;
+                streamController.enqueue({
+                  type: "tool-error",
+                  payload: { error, message: error, toolName: tc.toolName, toolCallId: tc.toolCallId },
+                });
+                toolResultParts.push({
+                  type: "tool-result",
+                  toolCallId: tc.toolCallId,
+                  toolName: tc.toolName,
+                  output: { type: "text", value: JSON.stringify({ error }) },
+                });
+                continue;
+              }
+
+              try {
+                const args = JSON.parse(tc.input);
+                const { result, effectOutput } = await tool.execute(args, tc.toolCallId);
+                streamController.enqueue({
+                  type: "tool-result",
+                  payload: { toolCallId: tc.toolCallId, toolName: tc.toolName, result },
+                });
+                const raw = effectOutput ? `${JSON.stringify(result)}\n${effectOutput}` : JSON.stringify(result);
+                const outputValue = truncateMiddle(raw, MAX_TOOL_RESULT_CHARS);
+                toolResultParts.push({
+                  type: "tool-result",
+                  toolCallId: tc.toolCallId,
+                  toolName: tc.toolName,
+                  output: { type: "text", value: outputValue },
+                });
+              } catch (error) {
+                const serializedError = serializeToolError(error);
+                const message = serializedError.error.message;
+                const code = serializedError.error.code;
+                const kind = serializedError.error.kind;
+                streamController.enqueue({
+                  type: "tool-error",
+                  payload: {
+                    error: serializedError.error,
+                    message,
+                    code,
+                    kind,
+                    toolName: tc.toolName,
+                    toolCallId: tc.toolCallId,
+                  },
+                });
+                toolResultParts.push({
+                  type: "tool-result",
+                  toolCallId: tc.toolCallId,
+                  toolName: tc.toolName,
+                  output: { type: "text", value: JSON.stringify(serializedError) },
+                });
+              }
             }
+
+            messages.push({ role: "assistant", content: assistantContent });
+            messages.push({ role: "tool", content: toolResultParts });
           }
 
-          messages.push({ role: "assistant", content: assistantContent });
-          messages.push({ role: "tool", content: toolResultParts });
-        }
+          // A step is terminal when the model emitted no tool calls (native end_turn) OR it
+          // emitted tool calls but finished with a non-tool-calls reason (degenerate; terminate
+          // rather than loop).
+          const isTerminalStep =
+            pendingToolCalls.length === 0 || (finishReason !== undefined && finishReason.unified !== "tool-calls");
 
-        // A step is terminal when the model emitted no tool calls (native end_turn) OR it
-        // emitted tool calls but finished with a non-tool-calls reason (degenerate; terminate
-        // rather than loop).
-        const isTerminalStep =
-          pendingToolCalls.length === 0 || (finishReason !== undefined && finishReason.unified !== "tool-calls");
-
-        if (isTerminalStep) {
-          const extras =
-            options.onBeforeFinish?.({ messages, text: stepText, answerText, finishReason: finishReason?.unified }) ??
-            [];
-          if (extras.length > 0) {
-            // On a no-tool-call step the assistant text has not been pushed yet; push it so the
-            // reopen nudge has context. On a tool step, assistant+tool messages are already pushed.
-            // An empty-answer reopen has blank stepText; skip the empty text block (providers
-            // reject it) so the completion backstop can actually retry.
-            if (pendingToolCalls.length === 0 && stepText.length > 0) {
-              messages.push({ role: "assistant", content: [{ type: "text", text: stepText }] });
+          if (isTerminalStep) {
+            const extras =
+              options.onBeforeFinish?.({ messages, text: stepText, answerText, finishReason: finishReason?.unified }) ??
+              [];
+            if (extras.length > 0) {
+              // On a no-tool-call step the assistant text has not been pushed yet; push it so the
+              // reopen nudge has context. On a tool step, assistant+tool messages are already pushed.
+              // An empty-answer reopen has blank stepText; skip the empty text block (providers
+              // reject it) so the completion backstop can actually retry.
+              if (pendingToolCalls.length === 0 && stepText.length > 0) {
+                messages.push({ role: "assistant", content: [{ type: "text", text: stepText }] });
+              }
+              // A truncated no-tool-call step is a fragment of the answer; carry it so the
+              // continuation appends to it rather than the assembled answer losing the prefix.
+              if (pendingToolCalls.length === 0 && finishReason?.unified === "length") truncatedPrefix += stepText;
+              for (const msg of extras) messages.push(msg);
+              continue;
             }
-            // A truncated no-tool-call step is a fragment of the answer; carry it so the
-            // continuation appends to it rather than the assembled answer losing the prefix.
-            if (pendingToolCalls.length === 0 && finishReason?.unified === "length") truncatedPrefix += stepText;
-            for (const msg of extras) messages.push(msg);
-            continue;
+            break;
           }
-          break;
+
+          const extras = options.onBeforeNextCall?.(messages) ?? [];
+          for (const msg of extras) messages.push(msg);
         }
 
-        const extras = options.onBeforeNextCall?.(messages) ?? [];
-        for (const msg of extras) messages.push(msg);
+        log.debug("agent-stream.complete", {
+          iterations: loopIteration,
+          total_tool_calls: allToolCalls.length,
+          text_length: answerText.length,
+          finish_reason: finishReason?.unified ?? "unknown",
+        });
+        streamController.close();
+        return {
+          text: answerText,
+          textStreamed: answerText.trim().length > 0,
+          toolCalls: allToolCalls,
+          ...(finishReason ? { finishReason: finishReason.unified } : {}),
+        };
+      } finally {
+        options.installSideEffectSink?.(null);
       }
-
-      log.debug("agent-stream.complete", {
-        iterations: loopIteration,
-        total_tool_calls: allToolCalls.length,
-        text_length: answerText.length,
-        finish_reason: finishReason?.unified ?? "unknown",
-      });
-      streamController.close();
-      return {
-        text: answerText,
-        textStreamed: answerText.trim().length > 0,
-        toolCalls: allToolCalls,
-        ...(finishReason ? { finishReason: finishReason.unified } : {}),
-      };
     })().catch((error) => {
       try {
         streamController.error(error);

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -1,4 +1,4 @@
-import type { Agent, GenerateResult } from "./agent-contract";
+import type { Agent, GenerateResult, SideEffectSink } from "./agent-contract";
 import type { ChatRequest } from "./api";
 import type { StreamEvent } from "./client-contract";
 import type { ReasoningLevel } from "./config-contract";
@@ -149,7 +149,7 @@ export type RunContext = {
   errorStats: Record<ErrorCategory, number>;
   result?: GenerateResult;
   toolCallStartedAt: Map<string, ToolCallStart>;
-  toolOutputHandler: ((event: ToolOutputEvent) => void) | null;
+  sideEffectSink: SideEffectSink | null;
   reasoning?: ReasoningLevel;
   temperature?: number;
   readonly authRoute?: AuthRoute;

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -34,6 +34,7 @@ import { providerFromModel } from "./provider-config";
 import type { StreamError } from "./stream-error";
 import type { ToolDefinition } from "./tool-contract";
 import { extractToolErrorCode } from "./tool-error";
+import { renderToolOutput } from "./tool-output-render";
 import type { Toolset } from "./tool-registry";
 
 function budgetNotice(ctx: RunContext): LanguageModelV4Message | undefined {
@@ -207,6 +208,9 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
     const temperature = reasoning ? undefined : ctx.temperature;
     const streamOutput = await ctx.agent.stream(prompt, {
       preCallInputTokenLimit: ctx.policy.contextMaxTokens,
+      installSideEffectSink: (sink) => {
+        ctx.sideEffectSink = sink;
+      },
       onBeforeNextCall: () => {
         const notice = budgetNotice(ctx);
         if (!notice) return [];
@@ -437,6 +441,37 @@ const CHUNK_HANDLERS: Record<StreamChunk["type"], ChunkHandler> = {
       completeToolCall(ctx, p.toolCallId, p.toolName, true);
       emitToolResult(ctx, p.toolCallId, p.toolName, error);
     }
+  },
+
+  "tool-output"(ctx, chunk) {
+    if (chunk.type !== "tool-output") return;
+    const rendered = renderToolOutput(chunk.content);
+    if (!rendered.trim()) return;
+    ctx.debug("lifecycle.tool.output", {
+      tool: chunk.toolName,
+      preview: rendered.length > 120 ? `${rendered.slice(0, 119)}…` : rendered,
+    });
+    ctx.emit({
+      type: "tool-output",
+      toolCallId: chunk.toolCallId ?? chunk.toolName,
+      toolName: chunk.toolName,
+      content: chunk.content,
+    });
+  },
+
+  checklist(ctx, chunk) {
+    if (chunk.type !== "checklist") return;
+    ctx.emit({ type: "checklist", groupId: chunk.groupId, groupTitle: chunk.groupTitle, items: chunk.items });
+  },
+
+  "skill-activated"(ctx, chunk) {
+    if (chunk.type !== "skill-activated") return;
+    ctx.emit({ type: "skill-activated", skill: chunk.skill });
+  },
+
+  "skill-deactivated"(ctx, chunk) {
+    if (chunk.type !== "skill-deactivated") return;
+    ctx.emit({ type: "skill-deactivated", name: chunk.name });
   },
 
   "model-usage"(ctx, chunk) {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -13,7 +13,6 @@ import { listMcpTools } from "./mcp-client";
 import type { MemoryCommitContext, MemoryCommitMetrics } from "./memory-contract";
 import { commitDistiller, estimateDistillPromptTokens } from "./memory-distiller";
 import { createInMemoryTaskQueue } from "./task-queue";
-import { renderToolOutput } from "./tool-output-render";
 import { WRITE_TOOL_SET } from "./tool-registry";
 import { attachUndoCheckpointSideEffects } from "./undo-checkpoints-effects";
 import { formatWorkspaceCommand, resolveWorkspaceProfile } from "./workspace-profile";
@@ -120,7 +119,7 @@ function createRunContext(
     lastUsageEmitChars: 0,
     errorStats: createErrorStats(),
     toolCallStartedAt: new Map(),
-    toolOutputHandler: null,
+    sideEffectSink: null,
     reasoning: input.reasoning,
     temperature: input.temperature,
     authRoute: input.authRoute,
@@ -189,25 +188,6 @@ function acceptResult(ctx: RunContext): void {
   }
 }
 
-function attachToolOutputHandler(ctx: RunContext) {
-  ctx.toolOutputHandler = (event) => {
-    const rendered = renderToolOutput(event.content);
-    if (!rendered.trim()) return;
-    const toolName = event.toolName;
-    const resolvedToolCallId = event.toolCallId ?? toolName;
-    ctx.debug("lifecycle.tool.output", {
-      tool: toolName,
-      preview: rendered.length > 120 ? `${rendered.slice(0, 119)}…` : rendered,
-    });
-    ctx.emit({
-      type: "tool-output",
-      toolCallId: resolvedToolCallId,
-      toolName,
-      content: event.content,
-    });
-  };
-}
-
 export async function runLifecycle(input: LifecycleInput, deps: LifecycleDeps = defaultLifecycleDeps) {
   const emit = input.onEvent ?? (() => {});
 
@@ -268,16 +248,21 @@ export async function runLifecycle(input: LifecycleInput, deps: LifecycleDeps = 
     policy,
     debug,
     onOutput: (event: ToolOutputEvent) => {
-      ctxRef?.toolOutputHandler?.(event);
+      ctxRef?.sideEffectSink?.({ type: "tool-output", ...event });
     },
     onChecklist: (event) => {
-      emit({ type: "checklist", groupId: event.groupId, groupTitle: event.groupTitle, items: event.items });
+      ctxRef?.sideEffectSink?.({
+        type: "checklist",
+        groupId: event.groupId,
+        groupTitle: event.groupTitle,
+        items: event.items,
+      });
     },
     onSkillActivated: (skill) => {
-      emit({ type: "skill-activated", skill });
+      ctxRef?.sideEffectSink?.({ type: "skill-activated", skill });
     },
     onSkillDeactivated: (name) => {
-      emit({ type: "skill-deactivated", name });
+      ctxRef?.sideEffectSink?.({ type: "skill-deactivated", name });
     },
     mcpListings,
   });
@@ -291,7 +276,6 @@ export async function runLifecycle(input: LifecycleInput, deps: LifecycleDeps = 
     createRunAgent: deps.createRunAgent,
   });
   ctxRef = ctx;
-  attachToolOutputHandler(ctx);
   ctx.session.maxToolCallsPerRequest = policy.maxToolCallsPerRequest;
   if (profile.ecosystem) ctx.session.workspaceProfile = profile;
 

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -561,7 +561,7 @@ export function createRunContext(overrides: Partial<RunContext> = {}): RunContex
     lastUsageEmitChars: 0,
     errorStats: createErrorStats(),
     toolCallStartedAt: new Map(),
-    toolOutputHandler: null,
+    sideEffectSink: null,
     ...overrides,
   };
 }

--- a/src/tool-output-emit-order.int.test.ts
+++ b/src/tool-output-emit-order.int.test.ts
@@ -67,6 +67,8 @@ describe("real emit order (single ordered channel)", () => {
     // channel that jumps the ordered fullStream.
     let ctxRef: RunContext | undefined;
     const onOutput: ToolOutputListener = (event) => ctxRef?.sideEffectSink?.({ type: "tool-output", ...event });
+    // skill-activate raises an output row then a skill-activated event, both mid-execute — the
+    // same shape real toolkits use. Every one must ride the ordered stream.
     const tool: ToolDefinition = {
       id: "skill-activate",
       description: "d",
@@ -77,6 +79,7 @@ describe("real emit order (single ordered channel)", () => {
           content: { kind: "tool-header", labelKey: "tool.label.skill_activate", detail: "acolyte", state: "on" },
           toolCallId,
         });
+        ctxRef?.sideEffectSink?.({ type: "skill-activated", skill: { name: "acolyte", instructions: "x" } });
         return { result: { kind: "skill-activate", activated: [] } };
       },
     } as unknown as ToolDefinition;
@@ -111,15 +114,20 @@ describe("real emit order (single ordered channel)", () => {
     const seq = events.map((e) => e.type);
     const toolCall = seq.indexOf("tool-call");
     const toolOutput = seq.indexOf("tool-output");
+    const skillActivated = seq.indexOf("skill-activated");
     const toolResult = seq.indexOf("tool-result");
     const narrationBeforeToolCall = seq.slice(0, toolCall).filter((t) => t === "text-delta").length;
 
     expect(toolCall).toBeGreaterThan(-1);
     expect(toolOutput).toBeGreaterThan(-1);
+    expect(skillActivated).toBeGreaterThan(-1);
     expect(toolResult).toBeGreaterThan(-1);
-    // The row belongs to its tool call: after the tool-call that spawned it, before its result.
+    // Every event raised mid-execute belongs to its tool call: after the tool-call that spawned
+    // it, before its result. It holds for output rows and skill lifecycle events alike.
     expect(toolOutput).toBeGreaterThan(toolCall);
     expect(toolOutput).toBeLessThan(toolResult);
+    expect(skillActivated).toBeGreaterThan(toolCall);
+    expect(skillActivated).toBeLessThan(toolResult);
     // Step-1 narration lands whole before the tool-call, so no output row splits the prose.
     expect(narrationBeforeToolCall).toBe(narration.length);
   });

--- a/src/tool-output-emit-order.int.test.ts
+++ b/src/tool-output-emit-order.int.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import type { LanguageModelV4, LanguageModelV4StreamPart } from "@ai-sdk/provider";
+import { createAgentStream } from "./agent-stream";
+import type { StreamEvent } from "./client-contract";
+import type { RunContext } from "./lifecycle-contract";
+import type { RateLimiter } from "./rate-limiter";
+import { createRunContext } from "./test-utils";
+import type { ToolDefinition } from "./tool-contract";
+import type { ToolOutputListener } from "./tool-output-format";
+
+const noopRateLimiter: RateLimiter = {
+  async beforeCall() {},
+  onResponse() {},
+  onError() {
+    return { shouldRetry: false, delayMs: 0 };
+  },
+  reset() {},
+  state() {
+    return {
+      requestsRemaining: undefined,
+      tokensRemaining: undefined,
+      requestsResetMs: undefined,
+      tokensResetMs: undefined,
+    };
+  },
+};
+
+function scriptedModel(turns: LanguageModelV4StreamPart[][]): LanguageModelV4 {
+  let call = 0;
+  return {
+    specificationVersion: "v3",
+    provider: "test",
+    modelId: "test-model",
+    supportedUrls: {},
+    async doStream() {
+      const parts = turns[call] ?? [];
+      call += 1;
+      return {
+        stream: new ReadableStream<LanguageModelV4StreamPart>({
+          start(controller) {
+            for (const part of parts) controller.enqueue(part);
+            controller.close();
+          },
+        }),
+      };
+    },
+  } as unknown as LanguageModelV4;
+}
+
+const finish = (reason: "tool-calls" | "stop"): LanguageModelV4StreamPart => ({
+  type: "finish",
+  finishReason: { unified: reason, raw: reason },
+  usage: {
+    inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+    outputTokens: { total: 1, text: 1, reasoning: 0 },
+  },
+});
+const delta = (text: string): LanguageModelV4StreamPart => ({ type: "text-delta", id: "t", delta: text }) as never;
+
+describe("real emit order (single ordered channel)", () => {
+  test("a tool-output raised during execute is ordered against its tool-call and tool-result", async () => {
+    const events: StreamEvent[] = [];
+    const emit = (e: StreamEvent) => events.push(e);
+
+    // The tool raises output the way a real toolkit does: through the injected onOutput sink,
+    // which lifecycle wires to `ctx.sideEffectSink`. It must never reach the client via a side
+    // channel that jumps the ordered fullStream.
+    let ctxRef: RunContext | undefined;
+    const onOutput: ToolOutputListener = (event) => ctxRef?.sideEffectSink?.({ type: "tool-output", ...event });
+    const tool: ToolDefinition = {
+      id: "skill-activate",
+      description: "d",
+      parameters: { type: "object", properties: {} },
+      execute: async (_args: unknown, toolCallId: string) => {
+        onOutput({
+          toolName: "skill-activate",
+          content: { kind: "tool-header", labelKey: "tool.label.skill_activate", detail: "acolyte", state: "on" },
+          toolCallId,
+        });
+        return { result: { kind: "skill-activate", activated: [] } };
+      },
+    } as unknown as ToolDefinition;
+
+    const narration = Array.from({ length: 12 }, (_, i) => delta(`word${i} `));
+    const agent = {
+      id: "a",
+      name: "a",
+      instructions: "",
+      model: {} as never,
+      tools: {},
+      stream: createAgentStream(
+        scriptedModel([
+          [
+            ...narration,
+            { type: "tool-call", toolCallId: "tc1", toolName: "skill-activate", input: "{}" } as never,
+            finish("tool-calls"),
+          ],
+          [delta("The answer prose."), finish("stop")],
+        ]),
+        "instructions",
+        { "skill-activate": tool },
+        noopRateLimiter,
+      ),
+    } as never;
+
+    const { phaseGenerate } = await import("./lifecycle-generate");
+    const ctx = createRunContext({ emit, agent, session: (await import("./tool-session")).createSessionContext() });
+    ctxRef = ctx;
+    await phaseGenerate(ctx, { timeoutMs: 2000 });
+
+    const seq = events.map((e) => e.type);
+    const toolCall = seq.indexOf("tool-call");
+    const toolOutput = seq.indexOf("tool-output");
+    const toolResult = seq.indexOf("tool-result");
+    const narrationBeforeToolCall = seq.slice(0, toolCall).filter((t) => t === "text-delta").length;
+
+    expect(toolCall).toBeGreaterThan(-1);
+    expect(toolOutput).toBeGreaterThan(-1);
+    expect(toolResult).toBeGreaterThan(-1);
+    // The row belongs to its tool call: after the tool-call that spawned it, before its result.
+    expect(toolOutput).toBeGreaterThan(toolCall);
+    expect(toolOutput).toBeLessThan(toolResult);
+    // Step-1 narration lands whole before the tool-call, so no output row splits the prose.
+    expect(narrationBeforeToolCall).toBe(narration.length);
+  });
+});


### PR DESCRIPTION
## Summary
- route tool-output, checklist, and skill activate/deactivate events through the ordered agent stream instead of a side channel that could reach the client before the tool-call they belong to
- install a per-stream side-effect sink in the streamer, drained by the lifecycle chunk handlers, so transcript order is structurally faithful
- add a regression test asserting a tool-raised output row lands after its tool-call and before its tool-result