### PR TITLE
fix(benchmark): refresh competitor metrics

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -28,13 +28,13 @@ This methodology requires a comparable public source repository. Claude Code, Cu
 |---|---|---|---:|---:|---:|---:|---:|---:|
 | **Acolyte** | `8590335ddca0` | TypeScript | 31,068 | 27,336 | 795 | 2,937 | 257 | 10 + 6 |
 | OpenCode | `d36a2d8981ba` | TypeScript | 414,504 | 368,156 | 9,594 | 36,754 | 2,315 | 222 + 111 |
-| Codex | `b6de5b524cdc` | Rust | 895,926 | 761,912 | 59,750 | 74,264 | 2,256 | 331 + 84 |
+| Codex | `5c18cc0acc37` | Rust | 895,943 | 761,928 | 59,748 | 74,267 | 2,256 | 326 + 84 |
 | Goose | `36cb569e366f` | Rust | 200,974 | 164,705 | 13,913 | 22,356 | 428 | 162 + 20 |
-| Open Interpreter | `a4da0fc3cece` | Rust | 897,914 | 764,463 | 59,105 | 74,346 | 2,171 | 338 + 84 |
+| Open Interpreter | `a4da0fc3cece` | Rust | 897,914 | 764,463 | 59,105 | 74,346 | 2,171 | 333 + 84 |
 | Reasonix | `9eb9511f8b20` | Go | 205,633 | 168,750 | 20,886 | 15,997 | 641 | 45 + 0 |
 | Kimchi | `53a1d48a9521` | TypeScript | 115,150 | 87,314 | 15,187 | 12,649 | 595 | 25 + 19 |
 | Qwen Code | `9e822d6004d8` | TypeScript | 996,211 | 756,505 | 157,627 | 82,079 | 3,265 | 218 + 137 |
-| Grok Build | `ba76b0a683fa` | Rust | 1,229,473 | 932,162 | 206,652 | 90,659 | 1,926 | 311 + 71 |
+| Grok Build | `ba76b0a683fa` | Rust | 1,229,473 | 932,162 | 206,652 | 90,659 | 1,926 | 306 + 71 |
 
 ## Dependency surface area
 
@@ -94,7 +94,7 @@ Per 1k source lines.
 | Metric | Acolyte | OpenCode | Codex | Goose | Open Interpreter | Reasonix | Kimchi | Qwen Code | Grok Build |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
 | Test files | 216 | 700 | 405 | 26 | 397 | 596 | 440 | 1,838 | 343 |
-| Test lines | 29,636 | 167,792 | 253,174 | 14,638 | 237,596 | 180,152 | 127,960 | 1,018,902 | 132,351 |
+| Test lines | 29,636 | 167,792 | 253,205 | 14,638 | 237,596 | 180,152 | 127,960 | 1,018,902 | 132,351 |
 | Ratio | 0.95 | 0.40 | 0.28 | 0.07 | 0.26 | 0.88 | 1.11 | 1.02 | 0.11 |
 
 This ratio measures test volume, not executed coverage or test effectiveness.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -26,15 +26,15 @@ This methodology requires a comparable public source repository. Claude Code, Cu
 
 | Project | Revision | Language | Source lines | Code | Comments | Blank | Files | Dependencies |
 |---|---|---|---:|---:|---:|---:|---:|---:|
-| **Acolyte** | `65833b19d5c4` | TypeScript | 31,068 | 27,336 | 795 | 2,937 | 257 | 10 + 6 |
-| OpenCode | `b67fda133a18` | TypeScript | 414,444 | 368,100 | 9,594 | 36,750 | 2,315 | 222 + 111 |
-| Codex | `2244d11a1d9e` | Rust | 893,908 | 760,235 | 59,598 | 74,075 | 2,248 | 326 + 83 |
+| **Acolyte** | `8590335ddca0` | TypeScript | 31,068 | 27,336 | 795 | 2,937 | 257 | 10 + 6 |
+| OpenCode | `d36a2d8981ba` | TypeScript | 414,504 | 368,156 | 9,594 | 36,754 | 2,315 | 222 + 111 |
+| Codex | `28aacbb9d9e4` | Rust | 895,988 | 761,972 | 59,750 | 74,266 | 2,256 | 332 + 85 |
 | Goose | `36cb569e366f` | Rust | 200,974 | 164,705 | 13,913 | 22,356 | 428 | 165 + 22 |
-| Open Interpreter | `a4da0fc3cece` | Rust | 897,914 | 764,463 | 59,105 | 74,346 | 2,171 | 333 + 83 |
-| Reasonix | `77fd1a47be89` | Go | 205,633 | 168,750 | 20,886 | 15,997 | 641 | 45 + 0 |
+| Open Interpreter | `a4da0fc3cece` | Rust | 897,914 | 764,463 | 59,105 | 74,346 | 2,171 | 339 + 85 |
+| Reasonix | `9eb9511f8b20` | Go | 205,633 | 168,750 | 20,886 | 15,997 | 641 | 45 + 0 |
 | Kimchi | `53a1d48a9521` | TypeScript | 115,150 | 87,314 | 15,187 | 12,649 | 595 | 25 + 19 |
-| Qwen Code | `e27edf60b776` | TypeScript | 994,503 | 754,959 | 157,556 | 81,988 | 3,262 | 218 + 137 |
-| Grok Build | `ba76b0a683fa` | Rust | 1,229,473 | 932,162 | 206,652 | 90,659 | 1,926 | 313 + 70 |
+| Qwen Code | `9e822d6004d8` | TypeScript | 996,211 | 756,505 | 157,627 | 82,079 | 3,265 | 218 + 137 |
+| Grok Build | `ba76b0a683fa` | Rust | 1,229,473 | 932,162 | 206,652 | 90,659 | 1,926 | 319 + 71 |
 
 ## Dependency surface area
 
@@ -84,7 +84,7 @@ Per 1k source lines.
 |---|---:|---:|---:|---:|---:|
 | `unsafe` (Rust) | 0.2 | 0.8 | 0.8 | 0.8 | — |
 | `.unwrap()` (Rust) | 14.5 | 2.8 | 2.8 | 15.8 | — |
-| `.expect()` (Rust) | 2.1 | 13.1 | 13.8 | 3.7 | — |
+| `.expect()` (Rust) | 2.1 | 13.1 | 13.7 | 3.7 | — |
 | `any` / `interface{}` (Go) | — | — | — | — | 3.5 |
 | `panic()` (Go) | — | — | — | — | 0.2 |
 | `nolint` (Go) | — | — | — | — | 0.0 |
@@ -93,8 +93,8 @@ Per 1k source lines.
 
 | Metric | Acolyte | OpenCode | Codex | Goose | Open Interpreter | Reasonix | Kimchi | Qwen Code | Grok Build |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| Test files | 216 | 699 | 405 | 26 | 397 | 597 | 440 | 1,835 | 343 |
-| Test lines | 29,636 | 167,697 | 253,114 | 14,638 | 237,596 | 180,152 | 127,960 | 1,016,697 | 132,351 |
+| Test files | 216 | 700 | 405 | 26 | 397 | 596 | 440 | 1,838 | 343 |
+| Test lines | 29,636 | 167,792 | 253,176 | 14,638 | 237,596 | 180,152 | 127,960 | 1,018,902 | 132,351 |
 | Ratio | 0.95 | 0.40 | 0.28 | 0.07 | 0.26 | 0.88 | 1.11 | 1.02 | 0.11 |
 
 This ratio measures test volume, not executed coverage or test effectiveness.
@@ -110,9 +110,9 @@ Test types include:
 
 | Metric | Acolyte | OpenCode | Codex | Goose | Open Interpreter | Reasonix | Kimchi | Qwen Code | Grok Build |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| Avg lines / file | 121 | 179 | 398 | 470 | 414 | 321 | 194 | 305 | 638 |
-| Files > 500 lines | 3 (1%) | 194 (8%) | 503 (22%) | 128 (30%) | 504 (23%) | 101 (16%) | 46 (8%) | 468 (14%) | 692 (36%) |
-| Largest file | 619 | 7,220 | 7,302 | 4,428 | 6,352 | 10,000 | 4,664 | 9,799 | 9,768 |
+| Avg lines / file | 121 | 179 | 397 | 470 | 414 | 321 | 194 | 305 | 638 |
+| Files > 500 lines | 3 (1%) | 194 (8%) | 503 (22%) | 128 (30%) | 504 (23%) | 101 (16%) | 46 (8%) | 469 (14%) | 692 (36%) |
+| Largest file | 619 | 7,220 | 7,349 | 4,428 | 6,352 | 10,000 | 4,664 | 9,799 | 9,768 |
 | Barrel / index files | 1 | 70 | 77 | 50 | 73 | 2 | 36 | 161 | 190 |
 
 Acolyte has the smallest average module size and fewest large files in this snapshot.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,6 +1,6 @@
 # Benchmarks
 
-These benchmarks compare Acolyte with eight current open-source terminal coding agents using static source counts and normalized pattern counts.
+Static code quality benchmarks compare Acolyte with eight current open-source terminal coding agents using source, dependency, test, and type-safety metrics.
 
 For feature and architecture comparisons, see [Comparison](./comparison.md). Both documents use the same competitor set.
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -24,17 +24,17 @@ This methodology requires a comparable public source repository. Claude Code, Cu
 
 ## Projects compared
 
-| Project | Revision | Snapshot date | Language | Source lines | Code | Comments | Blank | Files | Dependencies |
-|---|---|---|---|---:|---:|---:|---:|---:|---:|
-| **Acolyte** | `65833b19d5c4` | 20 Jul 2026 | TypeScript | 31,068 | 27,336 | 795 | 2,937 | 257 | 10 + 6 |
-| OpenCode | `b67fda133a18` | 20 Jul 2026 | TypeScript | 414,444 | 368,100 | 9,594 | 36,750 | 2,315 | 222 + 111 |
-| Codex | `2deed3fb9c00` | 20 Jul 2026 | Rust | 894,488 | 760,715 | 59,645 | 74,128 | 2,250 | 290 + 82 |
-| Goose | `36cb569e366f` | 20 Jul 2026 | Rust | 200,974 | 164,705 | 13,913 | 22,356 | 428 | 157 + 22 |
-| Open Interpreter | `a4da0fc3cece` | 18 Jul 2026 | Rust | 897,914 | 764,463 | 59,105 | 74,346 | 2,171 | 297 + 82 |
-| Reasonix | `8b44e4cee53f` | 20 Jul 2026 | Go | 206,116 | 169,191 | 20,894 | 16,031 | 643 | 45 + 0 |
-| Kimchi | `53a1d48a9521` | 17 Jul 2026 | TypeScript | 115,150 | 87,314 | 15,187 | 12,649 | 595 | 25 + 19 |
-| Qwen Code | `17cb5f609123` | 20 Jul 2026 | TypeScript | 994,503 | 754,959 | 157,556 | 81,988 | 3,262 | 218 + 137 |
-| Grok Build | `ba76b0a683fa` | 19 Jul 2026 | Rust | 1,229,473 | 932,162 | 206,652 | 90,659 | 1,926 | 279 + 68 |
+| Project | Revision | Language | Source lines | Code | Comments | Blank | Files | Dependencies |
+|---|---|---|---:|---:|---:|---:|---:|---:|
+| **Acolyte** | `65833b19d5c4` | TypeScript | 31,068 | 27,336 | 795 | 2,937 | 257 | 10 + 6 |
+| OpenCode | `b67fda133a18` | TypeScript | 414,444 | 368,100 | 9,594 | 36,750 | 2,315 | 222 + 111 |
+| Codex | `2244d11a1d9e` | Rust | 893,908 | 760,235 | 59,598 | 74,075 | 2,248 | 326 + 83 |
+| Goose | `36cb569e366f` | Rust | 200,974 | 164,705 | 13,913 | 22,356 | 428 | 165 + 22 |
+| Open Interpreter | `a4da0fc3cece` | Rust | 897,914 | 764,463 | 59,105 | 74,346 | 2,171 | 333 + 83 |
+| Reasonix | `77fd1a47be89` | Go | 205,633 | 168,750 | 20,886 | 15,997 | 641 | 45 + 0 |
+| Kimchi | `53a1d48a9521` | TypeScript | 115,150 | 87,314 | 15,187 | 12,649 | 595 | 25 + 19 |
+| Qwen Code | `e27edf60b776` | TypeScript | 994,503 | 754,959 | 157,556 | 81,988 | 3,262 | 218 + 137 |
+| Grok Build | `ba76b0a683fa` | Rust | 1,229,473 | 932,162 | 206,652 | 90,659 | 1,926 | 313 + 70 |
 
 ## Dependency surface area
 
@@ -84,7 +84,7 @@ Per 1k source lines.
 |---|---:|---:|---:|---:|---:|
 | `unsafe` (Rust) | 0.2 | 0.8 | 0.8 | 0.8 | — |
 | `.unwrap()` (Rust) | 14.5 | 2.8 | 2.8 | 15.8 | — |
-| `.expect()` (Rust) | 2.1 | 13.1 | 13.7 | 3.7 | — |
+| `.expect()` (Rust) | 2.1 | 13.1 | 13.8 | 3.7 | — |
 | `any` / `interface{}` (Go) | — | — | — | — | 3.5 |
 | `panic()` (Go) | — | — | — | — | 0.2 |
 | `nolint` (Go) | — | — | — | — | 0.0 |
@@ -94,7 +94,7 @@ Per 1k source lines.
 | Metric | Acolyte | OpenCode | Codex | Goose | Open Interpreter | Reasonix | Kimchi | Qwen Code | Grok Build |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
 | Test files | 216 | 699 | 405 | 26 | 397 | 597 | 440 | 1,835 | 343 |
-| Test lines | 29,636 | 167,697 | 253,262 | 14,638 | 237,596 | 180,811 | 127,960 | 1,016,695 | 132,351 |
+| Test lines | 29,636 | 167,697 | 253,114 | 14,638 | 237,596 | 180,152 | 127,960 | 1,016,697 | 132,351 |
 | Ratio | 0.95 | 0.40 | 0.28 | 0.07 | 0.26 | 0.88 | 1.11 | 1.02 | 0.11 |
 
 This ratio measures test volume, not executed coverage or test effectiveness.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -14,7 +14,7 @@ All metrics are extracted with [`scripts/benchmark.ts`](../scripts/benchmark.ts)
 - Metrics normalized **per 1k source lines** where applicable
 - Dependencies are direct declarations detected in the included project manifests and shown as **runtime + development**; Go modules do not distinguish development dependencies
 - Each project is measured from a fresh shallow clone of its origin's default branch
-- Snapshot revisions and commit dates tie each result to the exact source measured
+- Snapshot revisions tie each result to the exact source measured
 
 These are structural signals, not measures of model quality, runtime correctness, or task success. Repository-wide counts are especially difficult to compare when a project includes multiple clients, products, or bundled applications.
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -28,13 +28,13 @@ This methodology requires a comparable public source repository. Claude Code, Cu
 |---|---|---|---:|---:|---:|---:|---:|---:|
 | **Acolyte** | `8590335ddca0` | TypeScript | 31,068 | 27,336 | 795 | 2,937 | 257 | 10 + 6 |
 | OpenCode | `d36a2d8981ba` | TypeScript | 414,504 | 368,156 | 9,594 | 36,754 | 2,315 | 222 + 111 |
-| Codex | `28aacbb9d9e4` | Rust | 895,988 | 761,972 | 59,750 | 74,266 | 2,256 | 332 + 85 |
-| Goose | `36cb569e366f` | Rust | 200,974 | 164,705 | 13,913 | 22,356 | 428 | 165 + 22 |
-| Open Interpreter | `a4da0fc3cece` | Rust | 897,914 | 764,463 | 59,105 | 74,346 | 2,171 | 339 + 85 |
+| Codex | `b6de5b524cdc` | Rust | 895,926 | 761,912 | 59,750 | 74,264 | 2,256 | 331 + 84 |
+| Goose | `36cb569e366f` | Rust | 200,974 | 164,705 | 13,913 | 22,356 | 428 | 162 + 20 |
+| Open Interpreter | `a4da0fc3cece` | Rust | 897,914 | 764,463 | 59,105 | 74,346 | 2,171 | 338 + 84 |
 | Reasonix | `9eb9511f8b20` | Go | 205,633 | 168,750 | 20,886 | 15,997 | 641 | 45 + 0 |
 | Kimchi | `53a1d48a9521` | TypeScript | 115,150 | 87,314 | 15,187 | 12,649 | 595 | 25 + 19 |
 | Qwen Code | `9e822d6004d8` | TypeScript | 996,211 | 756,505 | 157,627 | 82,079 | 3,265 | 218 + 137 |
-| Grok Build | `ba76b0a683fa` | Rust | 1,229,473 | 932,162 | 206,652 | 90,659 | 1,926 | 319 + 71 |
+| Grok Build | `ba76b0a683fa` | Rust | 1,229,473 | 932,162 | 206,652 | 90,659 | 1,926 | 311 + 71 |
 
 ## Dependency surface area
 
@@ -94,7 +94,7 @@ Per 1k source lines.
 | Metric | Acolyte | OpenCode | Codex | Goose | Open Interpreter | Reasonix | Kimchi | Qwen Code | Grok Build |
 |---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
 | Test files | 216 | 700 | 405 | 26 | 397 | 596 | 440 | 1,838 | 343 |
-| Test lines | 29,636 | 167,792 | 253,176 | 14,638 | 237,596 | 180,152 | 127,960 | 1,018,902 | 132,351 |
+| Test lines | 29,636 | 167,792 | 253,174 | 14,638 | 237,596 | 180,152 | 127,960 | 1,018,902 | 132,351 |
 | Ratio | 0.95 | 0.40 | 0.28 | 0.07 | 0.26 | 0.88 | 1.11 | 1.02 | 0.11 |
 
 This ratio measures test volume, not executed coverage or test effectiveness.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,105 +1,103 @@
 # Benchmarks
 
-These benchmarks compare Acolyte with eight open-source coding agents using static source counts and normalized pattern counts.
+These benchmarks compare Acolyte with eight current open-source terminal coding agents using static source counts and normalized pattern counts.
 
-For feature and architecture comparisons, see [Comparison](./comparison.md).
+For feature and architecture comparisons, see [Comparison](./comparison.md). Both documents use the same competitor set.
 
-All metrics extracted with [`scripts/benchmark.ts`](../scripts/benchmark.ts).
+All metrics are extracted with [`scripts/benchmark.ts`](../scripts/benchmark.ts).
 
 ## Methodology
 
-- **Source lines** = total lines of source code (including blanks and comments)
+- **Source lines** = total lines in included source files, including code, comments, and blanks
+- Code, comment, and blank line counts are reported separately; comment classification is based on leading comment markers
 - Test files, known generated directories, and source files over **10k lines** are excluded
 - Metrics normalized **per 1k source lines** where applicable
-- Dependencies are direct declarations detected in each ecosystem's manifests and shown as **runtime + development**; Go modules do not distinguish development dependencies
+- Dependencies are direct declarations detected in the included project manifests and shown as **runtime + development**; Go modules do not distinguish development dependencies
 - Each project is measured from a fresh shallow clone of its origin's default branch
-- Snapshot revisions tie each result to the exact source measured, even after those branches move
+- Snapshot revisions and commit dates tie each result to the exact source measured
+
+These are structural signals, not measures of model quality, runtime correctness, or task success. Repository-wide counts are especially difficult to compare when a project includes multiple clients, products, or bundled applications.
 
 ## Closed systems
 
-This methodology requires a comparable public source repository. Claude Code, Cursor, and Copilot are excluded from the source analysis.
+This methodology requires a comparable public source repository. Claude Code, Cursor, and GitHub Copilot are excluded from the source analysis.
 
 ## Projects compared
 
-| Project | Revision | Language | Description | Source lines | Files | Dependencies |
-|---|---|---|---|---|---|---|
-| **Acolyte** | `178136ee6418` | TypeScript | Terminal coding agent with transparent execution and memory | 30,294 | 249 | 10 + 6 |
-| OpenCode | `cb8be9ba1217` | TypeScript | Open-source coding agent with TUI, web, and desktop clients | 409,049 | 2,287 | 222 + 110 |
-| Codex | `325cf161940c` | Rust | Terminal coding agent from OpenAI | 867,770 | 2,144 | 289 + 81 |
-| Crush | `4721e53c30a0` | Go | Terminal coding agent from Charm with Bubble Tea TUI | 83,525 | 334 | 72 + 0 |
-| Aider | `5dc9490bb35f` | Python | Pair-programming agent for the terminal | 25,958 | 105 | 35 + 17 |
-| Goose | `2ecb8c089487` | Rust | Extensible coding agent from Block with MCP integration | 196,264 | 425 | 157 + 22 |
-| Qwen Code | `515a83110af5` | TypeScript | Terminal coding agent from Alibaba | 953,849 | 3,193 | 219 + 134 |
-| Plandex | `e2d772072efa` | Go | Terminal coding agent for large multi-file tasks | 74,573 | 333 | 54 + 0 |
-| Mistral Vibe | `30792a4cac2c` | Python | Terminal coding agent from Mistral | 64,104 | 378 | 96 + 16 |
+| Project | Revision | Snapshot date | Language | Source lines | Code | Comments | Blank | Files | Dependencies |
+|---|---|---|---|---:|---:|---:|---:|---:|---:|
+| **Acolyte** | `65833b19d5c4` | 20 Jul 2026 | TypeScript | 31,068 | 27,336 | 795 | 2,937 | 257 | 10 + 6 |
+| OpenCode | `b67fda133a18` | 20 Jul 2026 | TypeScript | 414,444 | 368,100 | 9,594 | 36,750 | 2,315 | 222 + 111 |
+| Codex | `2deed3fb9c00` | 20 Jul 2026 | Rust | 894,488 | 760,715 | 59,645 | 74,128 | 2,250 | 290 + 82 |
+| Goose | `36cb569e366f` | 20 Jul 2026 | Rust | 200,974 | 164,705 | 13,913 | 22,356 | 428 | 157 + 22 |
+| Open Interpreter | `a4da0fc3cece` | 18 Jul 2026 | Rust | 897,914 | 764,463 | 59,105 | 74,346 | 2,171 | 297 + 82 |
+| Reasonix | `8b44e4cee53f` | 20 Jul 2026 | Go | 206,116 | 169,191 | 20,894 | 16,031 | 643 | 45 + 0 |
+| Kimchi | `53a1d48a9521` | 17 Jul 2026 | TypeScript | 115,150 | 87,314 | 15,187 | 12,649 | 595 | 25 + 19 |
+| Qwen Code | `17cb5f609123` | 20 Jul 2026 | TypeScript | 994,503 | 754,959 | 157,556 | 81,988 | 3,262 | 218 + 137 |
+| Grok Build | `ba76b0a683fa` | 19 Jul 2026 | Rust | 1,229,473 | 932,162 | 206,652 | 90,659 | 1,926 | 279 + 68 |
 
 ## Dependency surface area
 
 Measures how much of a codebase depends on external packages.
 
-| Metric | Acolyte | OpenCode | Qwen Code |
-|---|---|---|---|
-| External imports / 1k LOC | 6.9 | 18.9 | 7.0 |
-| Runtime dependencies | 10 | 222 | 219 |
+| Metric | Acolyte | OpenCode | Kimchi | Qwen Code |
+|---|---:|---:|---:|---:|
+| External imports / 1k LOC | 7.0 | 18.9 | 7.4 | 6.9 |
+| Runtime dependencies | 10 | 222 | 25 | 218 |
 
 _TypeScript projects only._
 
-Acolyte has the lowest external import density and fewest runtime dependencies among TypeScript projects.
+Acolyte has the fewest runtime dependencies and lowest external-import density among the TypeScript projects except Qwen Code's slightly lower import count.
 
 ## Input validation density
 
 Counts `.parse()`, `.safeParse()`, and `.validate()` call sites per 1k source lines. This measures validation patterns, not runtime path coverage.
 
-| Metric | Acolyte | OpenCode | Qwen Code |
-|---|---|---|---|
-| Parse and validation calls / 1k LOC | 2.7 | 0.5 | 0.5 |
-| `.safeParse()` calls / 1k | 1.0 | 0.0 | 0.0 |
+| Metric | Acolyte | OpenCode | Kimchi | Qwen Code |
+|---|---:|---:|---:|---:|
+| Parse and validation calls / 1k LOC | 3.1 | 0.5 | 1.2 | 0.5 |
+| `.safeParse()` calls / 1k | 1.3 | 0.0 | 0.0 | 0.0 |
 
 _TypeScript projects only._
 
-Acolyte has the highest combined parse and validation call density, as well as the highest `.safeParse()` call density, among the TypeScript projects.
+Acolyte has the highest measured validation-call density in this TypeScript comparison.
 
 ## TypeScript type safety signals
 
 Per 1k source lines.
 
-| Metric | Acolyte | OpenCode | Qwen Code |
-|---|---|---|---|
-| `as any` | 0.0 | 1.0 | 0.2 |
-| `: any` annotations | 0.0 | 0.6 | 0.3 |
-| `@ts-ignore` / `@ts-expect-error` | 0.0 | 0.2 | 0.0 |
-| Lint ignores | 0.2 | 0.0 | 0.2 |
-| `: unknown` usage | 3.1 | 2.5 | 2.9 |
+| Metric | Acolyte | OpenCode | Kimchi | Qwen Code |
+|---|---:|---:|---:|---:|
+| `as any` | 0.0 | 0.9 | 0.4 | 0.2 |
+| `: any` annotations | 0.0 | 0.6 | 0.2 | 0.2 |
+| `@ts-ignore` / `@ts-expect-error` | 0.0 | 0.2 | 0.0 | 0.0 |
+| Lint ignores | 0.2 | 0.0 | 0.8 | 0.2 |
+| `: unknown` usage | 3.2 | 2.5 | 4.8 | 3.0 |
 
-Acolyte has one measured `as any` occurrence and no `: any` annotations or TypeScript suppression comments.
+Acolyte has the lowest measured TypeScript escape-hatch density in this comparison. These counts do not establish correctness.
 
 ## Language-specific type safety signals
 
 Per 1k source lines.
 
-| Metric | Aider | Mistral Vibe | Goose | Codex | Crush | Plandex |
-|---|---|---|---|---|---|---|
-| `type: ignore` (Python) | 0.0 | 0.1 | — | — | — | — |
-| `Any` usage (Python) | 0.1 | 11.2 | — | — | — | — |
-| `cast()` calls (Python) | 0.0 | 0.6 | — | — | — | — |
-| `unsafe` (Rust) | — | — | 0.1 | 0.8 | — | — |
-| `.unwrap()` (Rust) | — | — | 14.2 | 2.8 | — | — |
-| `.expect()` (Rust) | — | — | 2.0 | 13.5 | — | — |
-| `any` / `interface{}` (Go) | — | — | — | — | 4.6 | 4.4 |
-| `panic()` (Go) | — | — | — | — | 0.2 | 0.3 |
-| `nolint` (Go) | — | — | — | — | 0.2 | 0.0 |
-
-Aider has the lowest measured Python type-escape density. Mistral Vibe has the highest `Any` density. Codex has lower `.unwrap()` density than Goose but substantially higher `.expect()` density.
+| Metric | Goose | Open Interpreter | Codex | Grok Build | Reasonix |
+|---|---:|---:|---:|---:|---:|
+| `unsafe` (Rust) | 0.2 | 0.8 | 0.8 | 0.8 | — |
+| `.unwrap()` (Rust) | 14.5 | 2.8 | 2.8 | 15.8 | — |
+| `.expect()` (Rust) | 2.1 | 13.1 | 13.7 | 3.7 | — |
+| `any` / `interface{}` (Go) | — | — | — | — | 3.5 |
+| `panic()` (Go) | — | — | — | — | 0.2 |
+| `nolint` (Go) | — | — | — | — | 0.0 |
 
 ## Test density
 
-| Metric | Acolyte | OpenCode | Codex | Crush | Aider | Goose | Qwen Code | Plandex | Mistral Vibe |
-|---|---|---|---|---|---|---|---|---|---|
-| Test files | 204 | 689 | 391 | 167 | 42 | 25 | 1,752 | 6 | 424 |
-| Test lines | 28,367 | 166,129 | 241,050 | 39,521 | 12,470 | 13,974 | 943,051 | 2,517 | 98,214 |
-| Ratio | 0.94 | 0.41 | 0.28 | 0.47 | 0.48 | 0.07 | 0.99 | 0.03 | 1.53 |
+| Metric | Acolyte | OpenCode | Codex | Goose | Open Interpreter | Reasonix | Kimchi | Qwen Code | Grok Build |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| Test files | 216 | 699 | 405 | 26 | 397 | 597 | 440 | 1,835 | 343 |
+| Test lines | 29,636 | 167,697 | 253,262 | 14,638 | 237,596 | 180,811 | 127,960 | 1,016,695 | 132,351 |
+| Ratio | 0.95 | 0.40 | 0.28 | 0.07 | 0.26 | 0.88 | 1.11 | 1.02 | 0.11 |
 
-Acolyte has 0.94 test lines per source line. This ratio measures test volume, not executed coverage or test effectiveness.
+This ratio measures test volume, not executed coverage or test effectiveness.
 
 Test types include:
 
@@ -110,24 +108,24 @@ Test types include:
 
 ## Module size
 
-| Metric | Acolyte | OpenCode | Codex | Crush | Aider | Goose | Qwen Code | Plandex | Mistral Vibe |
-|---|---|---|---|---|---|---|---|---|---|
-| Avg lines / file | 122 | 179 | 405 | 250 | 247 | 462 | 299 | 224 | 170 |
-| Files > 500 lines | 3 (1%) | 190 (8%) | 491 (23%) | 35 (10%) | 14 (13%) | 124 (29%) | 446 (14%) | 36 (11%) | 20 (5%) |
-| Largest file | 656 | 7,220 | 6,352 | 4,578 | 2,486 | 4,246 | 8,944 | 2,455 | 4,244 |
-| Barrel / index files | 1 | 70 | 74 | 2 | 5 | 50 | 161 | 0 | 56 |
+| Metric | Acolyte | OpenCode | Codex | Goose | Open Interpreter | Reasonix | Kimchi | Qwen Code | Grok Build |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| Avg lines / file | 121 | 179 | 398 | 470 | 414 | 321 | 194 | 305 | 638 |
+| Files > 500 lines | 3 (1%) | 194 (8%) | 503 (22%) | 128 (30%) | 504 (23%) | 101 (16%) | 46 (8%) | 468 (14%) | 692 (36%) |
+| Largest file | 619 | 7,220 | 7,302 | 4,428 | 6,352 | 10,000 | 4,664 | 9,799 | 9,768 |
+| Barrel / index files | 1 | 70 | 77 | 50 | 73 | 2 | 36 | 161 | 190 |
 
-Acolyte maintains the smallest average module size and fewest large files.
+Acolyte has the smallest average module size and fewest large files in this snapshot.
 
 ## Error-handling patterns
 
 Per 1k source lines.
 
-| Metric | Acolyte | OpenCode | Qwen Code |
-|---|---|---|---|
-| `.safeParse()` calls | 1.0 | 0.0 | 0.0 |
-| `try { ... }` blocks | 5.8 | 1.2 | 5.5 |
-| `.catch()` calls | 0.5 | 1.7 | 0.9 |
+| Metric | Acolyte | OpenCode | Kimchi | Qwen Code |
+|---|---:|---:|---:|---:|
+| `.safeParse()` calls | 1.3 | 0.0 | 0.0 | 0.0 |
+| `try { ... }` blocks | 6.1 | 1.2 | 6.8 | 5.6 |
+| `.catch()` calls | 0.4 | 1.6 | 0.9 | 0.9 |
 
 _TypeScript projects only._
 
@@ -137,16 +135,12 @@ Acolyte has the highest `.safeParse()` call density among the TypeScript project
 
 At this snapshot, Acolyte has:
 
-- The lowest measured `any` escape density among the TypeScript projects
+- The lowest measured TypeScript escape-hatch density
 - The smallest average module size and lowest large-file density
-- The lowest counted dependency total
-- The highest combined parse and validation call density among the TypeScript projects
-- A 0.94 test-to-source line ratio
+- The fewest runtime dependencies
+- The highest measured TypeScript validation-call density
+- A 0.95 test-to-source line ratio
 
-These are static source metrics. They describe code structure and validation patterns, not runtime correctness, model quality, or task performance.
+These signals describe source structure and engineering patterns. They do not rank model quality or user-visible reliability.
 
-## Summary
-
-Acolyte remains the smallest TypeScript codebase in the benchmark. It has the lowest counted dependency total and smallest average module size across all projects. Qwen Code has a slightly higher test-to-source ratio, while Mistral Vibe has the highest ratio overall.
-
-Updated 14 July 2026.
+Updated 20 July 2026.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,23 +1,21 @@
 # Comparison
 
-Compare Acolyte with eight open-source terminal coding agents across architecture, lifecycle behavior, tooling, observability, and extensibility.
+Compare Acolyte with the same eight current open-source terminal coding agents used in [Benchmarks](./benchmarks.md): [OpenCode](https://github.com/anomalyco/opencode), [Codex](https://github.com/openai/codex), [Goose](https://github.com/aaif-goose/goose), [Open Interpreter](https://github.com/openinterpreter/openinterpreter), [Reasonix](https://github.com/esengine/DeepSeek-Reasonix), [Kimchi](https://github.com/getkimchi/kimchi), [Qwen Code](https://github.com/QwenLM/qwen-code), and [Grok Build](https://github.com/xai-org/grok-build).
 
 See [Why Acolyte](./why-acolyte.md) for a summary.
-
-Projects compared: [OpenCode](https://github.com/anomalyco/opencode), [Codex](https://github.com/openai/codex), [Crush](https://github.com/charmbracelet/crush), [Aider](https://github.com/Aider-AI/aider), [Goose](https://github.com/block/goose), [Qwen Code](https://github.com/QwenLM/qwen-code), [Plandex](https://github.com/plandex-ai/plandex), [Mistral Vibe](https://github.com/mistralai/mistral-vibe).
 
 The overview covers documented, shipped capabilities. “Partial” means the capability is optional, experimental, or narrower in scope. An em dash means the capability was not documented in the reviewed source; it does not prove absence.
 
 ## Feature overview
 
-| Capability | Acolyte | OpenCode | Codex | Crush | Aider | Goose | Qwen Code | Plandex | Mistral Vibe |
+| Capability | Acolyte | OpenCode | Codex | Goose | Open Interpreter | Reasonix | Kimchi | Qwen Code | Grok Build |
 |---|---|---|---|---|---|---|---|---|---|
-| Multi-provider | ✓ | ✓ | partial | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| Client/server mode | ✓ | ✓ | partial | ✓ | — | ✓ | ✓ | ✓ | partial |
-| Workspace boundary or sandbox | ✓ | partial | ✓ | partial | — | partial | ✓ | ✓ | partial |
-| Agent Skills (`SKILL.md`) | ✓ | ✓ | ✓ | ✓ | — | ✓ | ✓ | — | ✓ |
+| Multi-provider | ✓ | ✓ | partial | ✓ | ✓ | ✓ | ✓ | ✓ | — |
+| Client/server or editor protocol | ✓ | ✓ | partial | ✓ | ✓ | ✓ | ✓ | ✓ | — |
+| Workspace boundary or sandbox | ✓ | partial | ✓ | partial | ✓ | ✓ | partial | ✓ | — |
+| Agent skills | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
-Workspace controls are not equivalent security models. The row groups path boundaries, operating-system sandboxes, and permission gates so their presence can be compared without claiming identical isolation.
+Workspace controls are not equivalent security models. The row groups path boundaries, operating-system sandboxes, permission gates, and editor protocols so their presence can be compared without claiming identical isolation. A dash means the reviewed source did not establish the capability.
 
 ## Architecture
 
@@ -25,13 +23,13 @@ Workspace controls are not equivalent security models. The row groups path bound
 |---|---|---|
 | **Acolyte** | Headless daemon + typed RPC clients | persistent local daemon |
 | OpenCode | HTTP/WebSocket server + TUI, web, and desktop clients | client/server |
-| Codex | Rust CLI, SDKs, app-server, and experimental app-server daemon | CLI + optional server |
-| Crush | Go CLI with Bubble Tea TUI and shared workspace server | CLI + client/server |
-| Aider | Python CLI | single process |
+| Codex | Rust CLI, SDKs, app-server, and app-server daemon | CLI + optional server |
 | Goose | ACP agent server with TUI, desktop, and editor clients | CLI + client/server |
+| Open Interpreter | Rust terminal agent with ACP and Codex-compatible protocols | CLI + ACP |
+| Reasonix | Go CLI with desktop client, plugins, and ACP integration | local CLI + desktop |
+| Kimchi | TypeScript CLI with subagents, ACP, LSP, and remote sessions | CLI + remote sessions |
 | Qwen Code | CLI with daemon SDK/UI and IDE integrations | CLI + client/server |
-| Plandex | CLI with self-hostable or cloud server | client/server |
-| Mistral Vibe | Python CLI with ACP integration | CLI + ACP |
+| Grok Build | Rust terminal harness and TUI | local CLI |
 
 Acolyte runs as a headless daemon. The CLI and third-party clients connect over the same typed RPC protocol. Editor integrations can use that protocol without embedding a separate agent runtime.
 
@@ -41,7 +39,7 @@ The TUI is a custom React terminal renderer built on `react-reconciler`.
 
 ## Lifecycle pipeline
 
-Every request flows through four phases, each implemented as its own module with its own tests:
+Every Acolyte request flows through four phases, each implemented as its own module with its own tests:
 
 ```
 resolve → prepare → generate → finalize
@@ -49,28 +47,28 @@ resolve → prepare → generate → finalize
 
 - **resolve**: pick model and policy
 - **prepare**: wire tools and session context
-- **generate**: run the model with tool calls, effects apply per-tool-result
-- **finalize**: accept the terminal step, persist results, emit the response
+- **generate**: run the model with tool calls; effects apply per tool result
+- **finalize**: accept the terminal step, persist results, and emit the response
 
 The lifecycle trusts the model to make good decisions. Format and lint effects run automatically after writes, and lint errors surface in the tool result for the model to decide on. A step budget inlined into tool execution enforces one per-turn tool-call limit to prevent runaway loops.
 
-The distinction is not that other agents lack a loop. Acolyte makes its lifecycle phases, native completion, and post-tool effects explicit contracts with independent tests.
+The distinction is not that other agents lack a loop. Acolyte makes its lifecycle phases, native completion, and post-tool effects explicit contracts with independent tests. The benchmark and comparison do not claim that this architecture produces better model outcomes by itself.
 
 ## Workspace detection
 
 Acolyte auto-detects project tooling from workspace config files at lifecycle start. The detected profile includes ecosystem, package manager, lint command, format command, and test command. Detection is cached per workspace and feeds into the lifecycle policy and agent instructions.
 
-Aider supports user-configured per-language lint commands through `--lint-cmd`. Other projects expose different project-context and command-discovery mechanisms, so the comparison is not a binary capability test.
+The other projects expose different project-context and command-discovery mechanisms, so the comparison is not a binary capability test.
 
 ## Workspace sandboxing
 
 Acolyte enforces a workspace sandbox that prevents tool operations outside the resolved workspace root. All file paths are validated against the sandbox boundary using `realpath`-based resolution before any read, write, or delete operation.
 
-Codex provides operating-system sandbox policies with writable-directory restrictions. Qwen Code supports container sandboxes. Plandex stages changes in a cumulative diff sandbox, while several other projects use approval or trust gates. These approaches cover different threats and should not be read as equivalent to Acolyte's path boundary.
+Codex provides operating-system sandbox policies with writable-directory restrictions. Qwen Code supports container sandboxes. Reasonix documents workspace permissions and sandbox controls, while Open Interpreter documents native sandboxing. These approaches cover different threats and should not be read as equivalent to Acolyte's path boundary.
 
 ## Observability
 
-Each request emits ordered, task-scoped events for task state, workspace resolution, lifecycle phases, tool calls and results, cache decisions, budget blocks, effects, memory commits, and its final summary.
+Each Acolyte request emits ordered, task-scoped events for task state, workspace resolution, lifecycle phases, tool calls and results, cache decisions, budget blocks, effects, memory commits, and its final summary.
 
 Events are written locally to logfmt and SQLite. The `acolyte trace` command queries SQLite to list recent tasks or render one task's compact tool timeline and summary:
 
@@ -87,7 +85,7 @@ timestamp=... task_id=task_abc123 event=lifecycle.summary model_calls=1 read=3 s
 
 Acolyte supports the [SKILL.md standard](https://agentskills.io) for declarative prompt extensions. Skills live in `.agents/skills/` and can be activated by the agent or through slash commands. Multiple skills can remain active in the same session.
 
-OpenCode, Codex, Crush, Goose, Qwen Code, and Mistral Vibe also support Agent Skills. Goose loads skills through its Summon extension and continues to use MCP for executable extensions.
+OpenCode, Codex, Goose, Open Interpreter, Reasonix, Kimchi, Qwen Code, and Grok Build also document skills or equivalent skill/plugin extensions. The extension models differ: some treat skills as prompt resources, while others also expose executable plugins or MCP servers.
 
 Core systems expose minimal, well-defined extension points: lifecycle policies, tool registration, memory strategies, skill metadata, and configuration layers. The surface is intentionally narrow; Acolyte is an opinionated product, not a general-purpose agent framework.
 
@@ -97,7 +95,7 @@ How each agent retains knowledge across sessions.
 
 Acolyte stores memory in three scopes: session, project, and user. Memory is recalled on demand rather than injected into every prompt. A post-generation distiller can extract observations automatically, while explicit tools let the agent search, add, and remove entries. Retrieval combines semantic similarity with token overlap.
 
-Goose offers a memory extension, Aider combines repository maps with chat restore, and Plandex retains plan and conversation state. These mechanisms solve different context problems and are not direct substitutes for Acolyte's scoped memory.
+The other projects use different combinations of session persistence, project files, repository maps, compaction, plans, and memory extensions. These mechanisms solve different context problems and are not direct substitutes for Acolyte's scoped memory.
 
 ## Context budgeting
 
@@ -105,12 +103,14 @@ How each agent manages the token window when context grows large.
 
 Acolyte budgets context **before assembly** and maintains a bounded running context window. It reserves known prompt costs, keeps recent conversation within the remaining budget, and caps tool results individually. When earlier conversation falls outside the window, the model receives an explicit gap notice and can retrieve it with `session-search`. Durable session, project, and user context remains available through on-demand `memory-search`, not upfront prompt injection.
 
-OpenCode and Mistral Vibe support compaction, Aider ranks repository-map context, and Plandex summarizes long-running conversations. Acolyte keeps its live window bounded and retrieves earlier or durable context on demand rather than compacting the conversation into a replacement summary. Each completed request also reports input, output, total, and prompt-breakdown token counts. See [Context Budgeting](./context-budgeting.md) for the runtime behavior.
+The other projects use different approaches to compaction, repository-map context, planning, and session persistence. Acolyte keeps its live window bounded and retrieves earlier or durable context on demand rather than compacting the conversation into a replacement summary. Each completed request also reports input, output, total, and prompt-breakdown token counts. See [Context Budgeting](./context-budgeting.md) for the runtime behavior.
 
 ## Code quality
 
-See [Benchmarks](./benchmarks.md) for the measured source comparison. At the recorded snapshot, Acolyte has the lowest counted dependency total and smallest average module size. It also has the lowest measured `any` escape density among the TypeScript projects.
+See [Benchmarks](./benchmarks.md) for the measured source comparison. At the recorded snapshot, Acolyte has the smallest repository, smallest average module size, fewest runtime dependencies, and highest measured TypeScript validation-call density in the selected peer set.
+
+These are static engineering signals. They do not establish task success, model quality, security equivalence, or overall product superiority.
 
 Reviewed against the revisions recorded in [Benchmarks](./benchmarks.md).
 
-Updated 14 July 2026.
+Updated 20 July 2026.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -10,7 +10,7 @@ The overview covers documented, shipped capabilities. “Partial” means the ca
 
 | Capability | Acolyte | OpenCode | Codex | Goose | Open Interpreter | Reasonix | Kimchi | Qwen Code | Grok Build |
 |---|---|---|---|---|---|---|---|---|---|
-| Multi-provider | ✓ | ✓ | partial | ✓ | ✓ | ✓ | ✓ | ✓ | — |
+| Multi-provider | ✓ | ✓ | partial | ✓ | ✓ | ✓ | ✓ | ✓ | partial |
 | Client/server or editor protocol | ✓ | ✓ | partial | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Workspace boundary or sandbox | ✓ | partial | ✓ | partial | ✓ | ✓ | partial | ✓ | ✓ |
 | Agent skills | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -4,6 +4,8 @@ Compare Acolyte with eight current open-source terminal coding agents across arc
 
 See [Why Acolyte](./why-acolyte.md) for a summary.
 
+Projects compared: [OpenCode](https://github.com/anomalyco/opencode), [Codex](https://github.com/openai/codex), [Goose](https://github.com/aaif-goose/goose), [Open Interpreter](https://github.com/openinterpreter/openinterpreter), [Reasonix](https://github.com/esengine/DeepSeek-Reasonix), [Kimchi](https://github.com/getkimchi/kimchi), [Qwen Code](https://github.com/QwenLM/qwen-code), and [Grok Build](https://github.com/xai-org/grok-build).
+
 The overview covers documented, shipped capabilities. “Partial” means the capability is optional, experimental, or narrower in scope. An em dash means the capability was not documented in the reviewed source; it does not prove absence.
 
 ## Feature overview

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,6 +1,6 @@
 # Comparison
 
-Compare Acolyte with the same eight current open-source terminal coding agents used in the Benchmarks document.
+Compare Acolyte with eight current open-source terminal coding agents across architecture, lifecycle behavior, sandboxing, observability, memory, and extensibility.
 
 See [Why Acolyte](./why-acolyte.md) for a summary.
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -1,6 +1,6 @@
 # Comparison
 
-Compare Acolyte with the same eight current open-source terminal coding agents used in [Benchmarks](./benchmarks.md): [OpenCode](https://github.com/anomalyco/opencode), [Codex](https://github.com/openai/codex), [Goose](https://github.com/aaif-goose/goose), [Open Interpreter](https://github.com/openinterpreter/openinterpreter), [Reasonix](https://github.com/esengine/DeepSeek-Reasonix), [Kimchi](https://github.com/getkimchi/kimchi), [Qwen Code](https://github.com/QwenLM/qwen-code), and [Grok Build](https://github.com/xai-org/grok-build).
+Compare Acolyte with the same eight current open-source terminal coding agents used in the Benchmarks document.
 
 See [Why Acolyte](./why-acolyte.md) for a summary.
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -11,8 +11,8 @@ The overview covers documented, shipped capabilities. “Partial” means the ca
 | Capability | Acolyte | OpenCode | Codex | Goose | Open Interpreter | Reasonix | Kimchi | Qwen Code | Grok Build |
 |---|---|---|---|---|---|---|---|---|---|
 | Multi-provider | ✓ | ✓ | partial | ✓ | ✓ | ✓ | ✓ | ✓ | — |
-| Client/server or editor protocol | ✓ | ✓ | partial | ✓ | ✓ | ✓ | ✓ | ✓ | — |
-| Workspace boundary or sandbox | ✓ | partial | ✓ | partial | ✓ | ✓ | partial | ✓ | — |
+| Client/server or editor protocol | ✓ | ✓ | partial | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Workspace boundary or sandbox | ✓ | partial | ✓ | partial | ✓ | ✓ | partial | ✓ | ✓ |
 | Agent skills | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 
 Workspace controls are not equivalent security models. The row groups path boundaries, operating-system sandboxes, permission gates, and editor protocols so their presence can be compared without claiming identical isolation. A dash means the reviewed source did not establish the capability.
@@ -29,7 +29,7 @@ Workspace controls are not equivalent security models. The row groups path bound
 | Reasonix | Go CLI with desktop client, plugins, and ACP integration | local CLI + desktop |
 | Kimchi | TypeScript CLI with subagents, ACP, LSP, and remote sessions | CLI + remote sessions |
 | Qwen Code | CLI with daemon SDK/UI and IDE integrations | CLI + client/server |
-| Grok Build | Rust terminal harness and TUI | local CLI |
+| Grok Build | Rust terminal harness and TUI with ACP and sandboxing | local CLI + ACP |
 
 Acolyte runs as a headless daemon. The CLI and third-party clients connect over the same typed RPC protocol. Editor integrations can use that protocol without embedding a separate agent runtime.
 
@@ -107,7 +107,7 @@ The other projects use different approaches to compaction, repository-map contex
 
 ## Code quality
 
-See [Benchmarks](./benchmarks.md) for the measured source comparison. At the recorded snapshot, Acolyte has the smallest repository, smallest average module size, fewest runtime dependencies, and highest measured TypeScript validation-call density in the selected peer set.
+See [Benchmarks](./benchmarks.md) for the measured source comparison. At the recorded snapshot, Acolyte has the smallest measured source set, smallest average module size, fewest runtime dependencies, and highest measured TypeScript validation-call density in the selected peer set.
 
 These are static engineering signals. They do not establish task success, model quality, security equivalence, or overall product superiority.
 

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -277,7 +277,7 @@ function countDepsRust(dir: string): { runtime: number; dev: number } {
       }
 
       const dependency = dependencySection(section);
-      if (dependency && /^[a-z_-]/.test(line)) {
+      if (dependency && !dependency.name && /^[a-z_-]/.test(line)) {
         const name = line.split(/[\s=]/)[0].replace(/\.workspace$/, "");
         (dependency.kind === "runtime" ? runtime : dev).add(name);
       }

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -278,7 +278,8 @@ function countDepsRust(dir: string): { runtime: number; dev: number } {
 
       const dependency = dependencySection(section);
       if (dependency && /^[a-z_-]/.test(line)) {
-        (dependency.kind === "runtime" ? runtime : dev).add(line.split(/[\s=]/)[0]);
+        const name = line.split(/[\s=]/)[0].replace(/\.workspace$/, "");
+        (dependency.kind === "runtime" ? runtime : dev).add(name);
       }
     }
   }

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -255,9 +255,17 @@ function countDepsRust(dir: string): { runtime: number; dev: number } {
     let section = "";
     for (const line of text.split("\n")) {
       if (line.startsWith("[")) section = line;
-      else if (section === "[dependencies]" && /^[a-z_-]/.test(line)) {
+      else if (
+        (section === "[dependencies]" ||
+          section === "[workspace.dependencies]" ||
+          /^\[target\..+\.dependencies\]$/.test(section)) &&
+        /^[a-z_-]/.test(line)
+      ) {
         runtime.add(line.split(/[\s=]/)[0]);
-      } else if (section === "[dev-dependencies]" && /^[a-z_-]/.test(line)) {
+      } else if (
+        (section === "[dev-dependencies]" || /^\[target\..+\.dev-dependencies\]$/.test(section)) &&
+        /^[a-z_-]/.test(line)
+      ) {
         dev.add(line.split(/[\s=]/)[0]);
       }
     }

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -17,12 +17,12 @@ const PROJECTS: Project[] = [
   { name: "acolyte", url: "https://github.com/cniska/acolyte.git", lang: "typescript" },
   { name: "opencode", url: "https://github.com/anomalyco/opencode.git", lang: "typescript" },
   { name: "codex", url: "https://github.com/openai/codex.git", lang: "rust" },
-  { name: "crush", url: "https://github.com/charmbracelet/crush.git", lang: "go" },
-  { name: "aider", url: "https://github.com/Aider-AI/aider.git", lang: "python" },
-  { name: "goose", url: "https://github.com/block/goose.git", lang: "rust" },
+  { name: "goose", url: "https://github.com/aaif-goose/goose.git", lang: "rust" },
+  { name: "open-interpreter", url: "https://github.com/openinterpreter/openinterpreter.git", lang: "rust" },
+  { name: "reasonix", url: "https://github.com/esengine/DeepSeek-Reasonix.git", lang: "go" },
+  { name: "kimchi", url: "https://github.com/getkimchi/kimchi.git", lang: "typescript" },
   { name: "qwen-code", url: "https://github.com/QwenLM/qwen-code.git", lang: "typescript" },
-  { name: "plandex", url: "https://github.com/plandex-ai/plandex.git", lang: "go" },
-  { name: "mistral-vibe", url: "https://github.com/mistralai/mistral-vibe.git", lang: "python" },
+  { name: "grok-build", url: "https://github.com/xai-org/grok-build.git", lang: "rust" },
 ];
 
 // --- file collection ---
@@ -96,18 +96,48 @@ interface FileStats {
   files: string[];
   lines: string[];
   lineCount: number;
+  codeLineCount: number;
+  commentLineCount: number;
+  blankLineCount: number;
   fileCounts: { file: string; lines: number }[];
 }
 
+function classifyLines(lines: string[]): Pick<FileStats, "codeLineCount" | "commentLineCount" | "blankLineCount"> {
+  let codeLineCount = 0;
+  let commentLineCount = 0;
+  let blankLineCount = 0;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) blankLineCount++;
+    else if (/^(?:\/\/|#|\/\*|\*|\*\/|<!--|-->)\s?/.test(trimmed)) commentLineCount++;
+    else codeLineCount++;
+  }
+
+  return { codeLineCount, commentLineCount, blankLineCount };
+}
+
 function readFiles(files: string[]): FileStats {
-  const result: FileStats = { files: [], lines: [], lineCount: 0, fileCounts: [] };
+  const result: FileStats = {
+    files: [],
+    lines: [],
+    lineCount: 0,
+    codeLineCount: 0,
+    commentLineCount: 0,
+    blankLineCount: 0,
+    fileCounts: [],
+  };
   for (const file of files) {
     const content = readFileSync(file, "utf8");
     const fileLines = content.split("\n");
     if (fileLines.length > MAX_FILE_LINES) continue;
+    const lineKinds = classifyLines(fileLines);
     result.files.push(file);
     result.lines.push(...fileLines);
     result.lineCount += fileLines.length;
+    result.codeLineCount += lineKinds.codeLineCount;
+    result.commentLineCount += lineKinds.commentLineCount;
+    result.blankLineCount += lineKinds.blankLineCount;
     result.fileCounts.push({ file, lines: fileLines.length });
   }
   return result;
@@ -273,17 +303,12 @@ function cloneSnapshot(name: string, url: string): void {
   execSync(`git clone --depth 1 --quiet ${url} ${dir}`, { stdio: "ignore" });
 }
 
-function getCreatedDate(repoPath: string): string {
-  try {
-    const out = execSync(`gh api repos/${repoPath} --jq '.created_at'`, { encoding: "utf8" }).trim();
-    return out.split("T")[0];
-  } catch {
-    return "unknown";
-  }
+function getRevision(dir: string): string {
+  return execSync("git rev-parse --short=12 HEAD", { cwd: dir, encoding: "utf8" }).trim();
 }
 
-function getRevision(dir: string): string {
-  return execSync(`git -C ${dir} rev-parse --short=12 HEAD`, { encoding: "utf8" }).trim();
+function getSnapshotDate(dir: string): string {
+  return execSync("git log -1 --format=%cI", { cwd: dir, encoding: "utf8" }).trim();
 }
 
 // --- main ---
@@ -357,17 +382,17 @@ for (const p of PROJECTS) {
   else if (p.lang === "rust") barrelFiles = src.files.filter((f) => f.endsWith("/mod.rs")).length;
   else if (p.lang === "go") barrelFiles = src.files.filter((f) => f.endsWith("/doc.go")).length;
 
-  const repoPath = p.url.replace("https://github.com/", "").replace(".git", "");
-  const initialCommit = getCreatedDate(repoPath);
-
   console.log(`  Source lines:     ${src.lineCount}`);
+  console.log(`  Code lines:       ${src.codeLineCount}`);
+  console.log(`  Comment lines:    ${src.commentLineCount}`);
+  console.log(`  Blank lines:      ${src.blankLineCount}`);
   console.log(`  Source files:     ${src.files.length}`);
   console.log(`  Avg lines/file:   ${avgLines}`);
   console.log(`  Files > 500:      ${filesOver500} (${filesOver500Pct}%)`);
   console.log(`  Largest file:     ${largestFile.lines}`);
   console.log(`  Barrel files:     ${barrelFiles}`);
   console.log(`  Revision:         ${getRevision(dir)}`);
-  console.log(`  Initial commit:   ${initialCommit}`);
+  console.log(`  Snapshot date:    ${getSnapshotDate(dir)}`);
   console.log(`  Dependencies:     ${deps.runtime} runtime + ${deps.dev} dev = ${deps.runtime + deps.dev} total`);
   console.log(`  Test files:       ${test.fileCount}`);
   console.log(`  Test lines:       ${test.count}`);

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -250,23 +250,35 @@ function countDepsRust(dir: string): { runtime: number; dev: number } {
   const cargoFiles = walk(dir).filter((f) => f.endsWith("/Cargo.toml") && !f.includes("/target/"));
   const runtime = new Set<string>();
   const dev = new Set<string>();
+
+  function dependencySection(section: string): { kind: "runtime" | "dev"; name?: string } | undefined {
+    const header = section.slice(1, -1);
+    const match = header.match(
+      /^(?:(?:target\..+|workspace)\.)?(dependencies|dev-dependencies|build-dependencies)(?:\.(.+))?$/,
+    );
+    if (!match) return undefined;
+    return {
+      kind: match[1] === "dependencies" ? "runtime" : "dev",
+      name: match[2],
+    };
+  }
+
   for (const f of cargoFiles) {
     const text = readFileSync(f, "utf8");
     let section = "";
     for (const line of text.split("\n")) {
-      if (line.startsWith("[")) section = line;
-      else if (
-        (section === "[dependencies]" ||
-          section === "[workspace.dependencies]" ||
-          /^\[target\..+\.dependencies\]$/.test(section)) &&
-        /^[a-z_-]/.test(line)
-      ) {
-        runtime.add(line.split(/[\s=]/)[0]);
-      } else if (
-        (section === "[dev-dependencies]" || /^\[target\..+\.dev-dependencies\]$/.test(section)) &&
-        /^[a-z_-]/.test(line)
-      ) {
-        dev.add(line.split(/[\s=]/)[0]);
+      if (line.startsWith("[")) {
+        section = line;
+        const dependency = dependencySection(section);
+        if (dependency?.name) {
+          (dependency.kind === "runtime" ? runtime : dev).add(dependency.name);
+        }
+        continue;
+      }
+
+      const dependency = dependencySection(section);
+      if (dependency && /^[a-z_-]/.test(line)) {
+        (dependency.kind === "runtime" ? runtime : dev).add(line.split(/[\s=]/)[0]);
       }
     }
   }


### PR DESCRIPTION
## Summary

- refresh benchmark and comparison docs for the current eight-project competitor set
- update benchmark tables with exact fresh metrics and revisions
- count dotted, target-specific, workspace, and build Cargo dependencies correctly