### PR TITLE
fix(cli): bake version into compiled binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Build binary
-        run: bun build --compile src/cli.ts --outfile acolyte --external react-devtools-core
+        run: bash scripts/build-compiled.sh
 
       - name: Smoke test binary
         run: ACOLYTE_SMOKE_EXTENDED=1 bash scripts/smoke-compiled.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
         run: bun run verify
 
       - name: Build binary
-        run: bun build --compile src/cli.ts --outfile acolyte --external react-devtools-core
+        run: bash scripts/build-compiled.sh
 
       - name: Smoke test binary
         run: ACOLYTE_SMOKE_EXTENDED=1 bash scripts/smoke-compiled.sh

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Acolyte is an open-source, terminal-first AI coding agent with an opinionated ru
 curl -fsSL https://acolyte.sh/install | sh
 ```
 
-Installs the latest released binary for macOS and Linux. To run from source instead, see [Local development](#local-development).
+Installs the latest released binary for macOS and Linux. It keeps itself up to date automatically — see [Updates](docs/updates.md). To run from source instead, see [Local development](#local-development).
 
 ## Runtime model
 

--- a/scripts/build-compiled.sh
+++ b/scripts/build-compiled.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+outfile="${1:-acolyte}"
+version=$(bun -e 'console.log(require("./package.json").version)')
+
+bun build --compile src/cli.ts \
+  --outfile "$outfile" \
+  --external react-devtools-core \
+  --define "process.env.ACOLYTE_COMPILED_VERSION=\"${version}\""

--- a/scripts/smoke-compiled.sh
+++ b/scripts/smoke-compiled.sh
@@ -13,13 +13,25 @@ run_quiet() {
 }
 
 if [ ! -x "./acolyte" ]; then
-  echo "Missing ./acolyte (expected compiled binary). Run: bun build --compile src/cli.ts --outfile acolyte" >&2
+  echo "Missing ./acolyte (expected compiled binary). Run: bash scripts/build-compiled.sh" >&2
   exit 1
 fi
 
 # Minimal, deterministic checks to ensure the compiled CLI starts.
 run_quiet ./acolyte --help
 run_quiet ./acolyte auth --help
+
+# The compiled binary must report its baked version, not "dev" or the version
+# of whatever project it happens to run inside.
+expected="$(bun -e 'console.log(require("./package.json").version)')"
+reported="$(./acolyte --version)"
+case "$reported" in
+  "$expected" | "$expected "*) ;;
+  *)
+    echo "Version mismatch: expected '$expected', got '$reported'" >&2
+    exit 1
+    ;;
+esac
 
 # Optional stronger checks (still offline/deterministic).
 # This exercises tool registry wiring and the ast-grep native addon path.

--- a/src/cli-version.test.ts
+++ b/src/cli-version.test.ts
@@ -1,11 +1,32 @@
-import { describe, expect, test } from "bun:test";
-import { extractVersionFromPackageJsonText, formatVersionWithCommit } from "./cli-version";
+import { afterEach, describe, expect, test } from "bun:test";
+import { extractVersionFromPackageJsonText, formatVersionWithCommit, resolveCliVersion } from "./cli-version";
 
 describe("cli-version", () => {
+  const originalNpmVersion = process.env.npm_package_version;
+
+  afterEach(() => {
+    delete process.env.ACOLYTE_COMPILED_VERSION;
+    if (originalNpmVersion === undefined) delete process.env.npm_package_version;
+    else process.env.npm_package_version = originalNpmVersion;
+  });
+
   test("extractVersionFromPackageJsonText parses version safely", () => {
     expect(extractVersionFromPackageJsonText('{"name":"acolyte","version":"0.1.0"}')).toBe("0.1.0");
     expect(extractVersionFromPackageJsonText('{"name":"acolyte"}')).toBeNull();
     expect(extractVersionFromPackageJsonText("{bad json}")).toBeNull();
+  });
+
+  test("resolveCliVersion prefers the compiled-in version over npm_package_version and package.json", () => {
+    process.env.npm_package_version = "0.0.1-source";
+    process.env.ACOLYTE_COMPILED_VERSION = "1.2.3";
+    expect(resolveCliVersion()).toBe("1.2.3");
+  });
+
+  test("resolveCliVersion ignores a blank compiled-in version", () => {
+    delete process.env.ACOLYTE_COMPILED_VERSION;
+    const fallback = resolveCliVersion();
+    process.env.ACOLYTE_COMPILED_VERSION = "   ";
+    expect(resolveCliVersion()).toBe(fallback);
   });
 
   test("formatVersionWithCommit appends short commit when available", () => {

--- a/src/cli-version.ts
+++ b/src/cli-version.ts
@@ -12,6 +12,8 @@ export function extractVersionFromPackageJsonText(text: string): string | null {
 }
 
 export function resolveCliVersion(): string {
+  const compiled = process.env.ACOLYTE_COMPILED_VERSION;
+  if (compiled && compiled.trim().length > 0) return compiled.trim();
   if (process.env.npm_package_version && process.env.npm_package_version.trim().length > 0)
     return process.env.npm_package_version.trim();
   const candidates = [`${process.cwd()}/package.json`, `${import.meta.dir}/../package.json`];


### PR DESCRIPTION
## Summary

- resolve the CLI version from a value baked in at build time, keeping package.json lookups as source-run fallbacks only
- inject the version via a shared `build-compiled.sh` that both CI and release builds call
- assert the compiled binary reports its real version in the smoke test
- note automatic updates in the README install section, now that the binary reports a real version