### PR TITLE
fix(cli): stop self-update overwriting runtime

### DIFF
--- a/src/cli-update.ts
+++ b/src/cli-update.ts
@@ -2,12 +2,11 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { stdout } from "node:process";
 import { resolveCliVersion } from "./cli-version";
-import { palette } from "./palette";
 import { stateDir } from "./paths";
 import { stopAllLocalServers } from "./server-daemon";
-import { ansi, colorToFg } from "./tui/styles";
-import { printOutput } from "./ui";
-import { installUpdate } from "./update-ops";
+import { ansi } from "./tui/styles";
+import { dimText, printDim, printError, printWarning } from "./ui";
+import { installUpdate, isSelfUpdatableBinary } from "./update-ops";
 
 const GITHUB_API = "https://api.github.com/repos/cniska/acolyte/releases/latest";
 const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000;
@@ -114,42 +113,40 @@ async function checkForUpdate(
   };
 }
 
-const BRAND = colorToFg(palette.brand);
-const GREEN = colorToFg(palette.green);
-const RED = colorToFg(palette.red);
 const BAR_FILL = "\u2588";
 const BAR_EMPTY = "\u2591";
 
 function progressBar(fraction: number, width: number): string {
   const filled = Math.round(fraction * width);
-  const empty = width - filled;
-  return `${BRAND}${BAR_FILL.repeat(filled)}${ansi.dim}${BAR_EMPTY.repeat(empty)}${ansi.reset}`;
+  return `${BAR_FILL.repeat(filled)}${BAR_EMPTY.repeat(width - filled)}`;
+}
+
+function progressLine(fraction: number): string {
+  const percent = Math.round(fraction * 100);
+  return dimText(`Downloading  ${progressBar(fraction, 20)}  ${String(percent).padStart(3)}%`);
 }
 
 function renderHeader(current: string, latest: string): void {
   stdout.write(ansi.cursorHide);
-  stdout.write(
-    `\n  ${BRAND}Acolyte${ansi.reset} ${ansi.dim}v${current}${ansi.reset} \u2192 ${ansi.dim}v${latest}${ansi.reset}\n\n`,
-  );
-  stdout.write(`  Downloading  ${progressBar(0, 20)}   0%\n`);
+  printDim(`Acolyte v${current} \u2192 v${latest}`);
+  stdout.write(`${progressLine(0)}\n`);
 }
 
 function renderProgress(received: number, total: number): void {
   const fraction = total > 0 ? Math.min(received / total, 1) : 0;
-  const percent = Math.round(fraction * 100);
   stdout.write(`${ansi.cursorUp(1)}${ansi.eraseLine}`);
-  stdout.write(`  Downloading  ${progressBar(fraction, 20)}  ${String(percent).padStart(3)}%\n`);
+  stdout.write(`${progressLine(fraction)}\n`);
 }
 
 function renderDone(latest: string): void {
   stdout.write(`${ansi.cursorUp(1)}${ansi.eraseLine}`);
-  stdout.write(`  ${GREEN}Updated to v${latest}${ansi.reset}\n\n`);
-  stdout.write(ansi.cursorShow);
+  printDim(`Updated to v${latest}`);
+  stdout.write(`\n${ansi.cursorShow}`);
 }
 
 function renderError(message: string): void {
   stdout.write(`${ansi.cursorUp(1)}${ansi.eraseLine}`);
-  stdout.write(`  ${RED}Update failed: ${message}${ansi.reset}\n\n`);
+  printError(`Update failed: ${message}`);
   stdout.write(ansi.cursorShow);
 }
 
@@ -179,17 +176,23 @@ async function performUpdate(currentVersion: string, update: UpdateInfo): Promis
   reexec();
 }
 
-export async function updateMode(): Promise<void> {
+export async function updateMode(execPath: string = process.execPath): Promise<void> {
+  if (!isSelfUpdatableBinary(execPath)) {
+    printDim(
+      "Self-update applies only to the installed acolyte binary. Running from source; update via your package manager or a fresh install.",
+    );
+    return;
+  }
   const currentVersion = resolveCliVersion();
   const update = await checkForUpdate(currentVersion, { force: true });
 
   if (!update) {
-    printOutput("Could not check for updates. Check your network connection.");
+    printWarning("Could not check for updates. Check your network connection.");
     return;
   }
 
   if (!update.available) {
-    printOutput(`Already up to date (${currentVersion}).`);
+    printDim(`Already up to date (${currentVersion}).`);
     return;
   }
 
@@ -200,10 +203,9 @@ export async function checkAndUpdateOnStartup(options?: { skip?: boolean }): Pro
   if (options?.skip) return false;
   if (process.env.ACOLYTE_SKIP_UPDATE === "1") return false;
   if (process.argv.includes("--no-update")) return false;
+  if (!isSelfUpdatableBinary()) return false;
 
   const currentVersion = resolveCliVersion();
-  if (currentVersion === "dev") return false;
-
   const update = await checkForUpdate(currentVersion);
   if (!update?.available) return false;
 

--- a/src/cli-visual.harness.test.ts
+++ b/src/cli-visual.harness.test.ts
@@ -9,11 +9,18 @@ describe("cli visual regression (harness)", () => {
       new Response("no", { status: 503 })) as unknown as typeof fetch;
     try {
       const out = await captureCliOutput(async () => {
-        await updateMode();
+        await updateMode("/Users/me/.acolyte/bin/acolyte");
       });
       expect(out).toBe("Could not check for updates. Check your network connection.");
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+
+  test("update command refuses when running from a non-acolyte runtime", async () => {
+    const out = await captureCliOutput(async () => {
+      await updateMode("/opt/homebrew/Cellar/bun/1.3.14/bin/bun");
+    });
+    expect(out).toContain("Self-update applies only to the installed acolyte binary");
   });
 });

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -20,8 +20,10 @@ function hexToAnsi(hex: string): string {
   return `\x1b[38;2;${(n >> 16) & 255};${(n >> 8) & 255};${n & 255}m`;
 }
 
+export const dimText = (value: string): string => `\x1b[2m${value}\x1b[22m`;
+
 const color = {
-  dim: (value: string): string => `\x1b[2m${value}\x1b[22m`,
+  dim: dimText,
   brand: (value: string): string => `${hexToAnsi(palette.brand)}${value}\x1b[39m`,
   white: (value: string): string => `\x1b[37m${value}\x1b[39m`,
   green: (value: string): string => `\x1b[32m${value}\x1b[39m`,

--- a/src/update-ops.test.ts
+++ b/src/update-ops.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseChecksumFile } from "./update-ops";
+import { installUpdate, isSelfUpdatableBinary, parseChecksumFile } from "./update-ops";
 
 describe("parseChecksumFile", () => {
   test("extracts hash from standard checksum format", () => {
@@ -16,5 +16,26 @@ describe("parseChecksumFile", () => {
 
   test("throws on whitespace-only content", () => {
     expect(() => parseChecksumFile("   \n  ")).toThrow(/empty or malformed/);
+  });
+});
+
+describe("isSelfUpdatableBinary", () => {
+  test("accepts a binary named acolyte", () => {
+    expect(isSelfUpdatableBinary("/Users/me/.acolyte/bin/acolyte")).toBe(true);
+    expect(isSelfUpdatableBinary("acolyte")).toBe(true);
+  });
+
+  test("rejects a runtime it must never overwrite", () => {
+    expect(isSelfUpdatableBinary("/opt/homebrew/Cellar/bun/1.3.14/bin/bun")).toBe(false);
+    expect(isSelfUpdatableBinary("/usr/local/bin/node")).toBe(false);
+  });
+});
+
+describe("installUpdate", () => {
+  test("refuses to overwrite the runtime when not the acolyte binary", async () => {
+    expect(isSelfUpdatableBinary(process.execPath)).toBe(false);
+    const result = await installUpdate("https://invalid.example/acolyte.tar.gz", null);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("refusing to overwrite");
   });
 });

--- a/src/update-ops.ts
+++ b/src/update-ops.ts
@@ -1,9 +1,13 @@
 import { access, chmod, copyFile, lstat, mkdir, readdir, rename, rm, unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { errorMessage } from "./error-contract";
 
 const FETCH_TIMEOUT_MS = 5_000;
+
+export function isSelfUpdatableBinary(execPath: string = process.execPath): boolean {
+  return basename(execPath) === "acolyte";
+}
 
 export type ProgressCallback = (received: number, total: number) => void;
 export type InstallResult = { success: boolean; error?: string };
@@ -99,6 +103,8 @@ export async function installUpdate(
   onProgress?: ProgressCallback,
 ): Promise<InstallResult> {
   const binaryPath = process.execPath;
+  if (!isSelfUpdatableBinary(binaryPath))
+    return { success: false, error: `refusing to overwrite ${binaryPath}: not the installed acolyte binary` };
   const tmp = tmpdir();
   const tarPath = join(tmp, `acolyte-update-${Date.now()}.tar.gz`);
   const extractDir = join(tmp, `acolyte-extract-${Date.now()}`);


### PR DESCRIPTION
## Summary

- refuse self-update unless the running binary is the installed `acolyte` — never overwrite the runtime
- skip startup auto-update and forced `--update` when running from source
- restyle the update output to Acolyte's minimal dim style, errors stay red