### PR TITLE
fix(chat): dedupe queued command

### DIFF
--- a/src/chat-state.ts
+++ b/src/chat-state.ts
@@ -15,7 +15,7 @@ import { resumeActiveTranscript, useScenePromotion } from "./chat-promotion";
 import { createMessage } from "./chat-session";
 import { createSkillActivator } from "./chat-skill-activator";
 import { statusTokenTotals } from "./chat-status-line";
-import { enqueueQueuedMessage, resolveQueueSubmit } from "./chat-submit";
+import { drainQueueOnTurnEnd, enqueueQueuedMessage, resolveQueueSubmit } from "./chat-submit";
 import { projectActiveTranscript, type TranscriptRow } from "./chat-transcript-contract";
 import { createTranscriptPublisher } from "./chat-transcript-publisher";
 import type { ChatViewportPresentationInput } from "./chat-viewport-contract";
@@ -194,6 +194,8 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
 
   const interruptRef = useRef<(() => void) | null>(null);
   const handleSubmitRef = useRef<((text: string) => Promise<void>) | null>(null);
+  const queuedMessagesRef = useRef<string[]>([]);
+  queuedMessagesRef.current = queuedMessages;
 
   const tokenTotals = statusTokenTotals(tokenUsage, runningUsage);
   const statusLine: FooterStatus = {
@@ -322,11 +324,10 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
     onStopPending: () => {
       setPendingState(null);
       setRunningUsage(null);
-      setQueuedMessages((current) => {
-        if (current.length === 0) return current;
-        const [next, ...rest] = current;
-        if (next) queueMicrotask(() => void handleSubmitRef.current?.(next));
-        return rest;
+      drainQueueOnTurnEnd({
+        queue: queuedMessagesRef.current,
+        submit: (message) => queueMicrotask(() => void handleSubmitRef.current?.(message)),
+        setQueue: setQueuedMessages,
       });
     },
     setPendingState,

--- a/src/chat-submit.test.ts
+++ b/src/chat-submit.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { enqueueQueuedMessage, resolveQueueSubmit, resolveSubmitInput } from "./chat-submit";
+import {
+  dequeueQueuedMessage,
+  drainQueueOnTurnEnd,
+  enqueueQueuedMessage,
+  resolveQueueSubmit,
+  resolveSubmitInput,
+} from "./chat-submit";
 
 describe("chat submit helpers", () => {
   test("autocompletes unresolved @path on submit", () => {
@@ -66,5 +72,42 @@ describe("chat submit helpers", () => {
 
   test("enqueueQueuedMessage appends in all mode", () => {
     expect(enqueueQueuedMessage(["first", "second"], "latest", "all")).toEqual(["first", "second", "latest"]);
+  });
+
+  test("dequeueQueuedMessage splits head from rest", () => {
+    expect(dequeueQueuedMessage(["one", "two"])).toEqual({ next: "one", rest: ["two"] });
+    expect(dequeueQueuedMessage([])).toEqual({ next: undefined, rest: [] });
+  });
+
+  // A queued slash command must reach the transcript once. The original bug scheduled
+  // the resubmit inside the queue state updater, so React's StrictMode double-invoke of
+  // that updater submitted the command twice. This harness double-invokes the updater
+  // (discarding the first result, like StrictMode) and asserts a single submit.
+  test("drainQueueOnTurnEnd submits the head once under a double-invoked updater", () => {
+    const submitted: string[] = [];
+    let queue = ["/model"];
+    const setQueue = (updater: (current: string[]) => string[]): void => {
+      updater([...queue]); // StrictMode extra invocation — result discarded
+      queue = updater(queue); // real invocation — committed
+    };
+
+    drainQueueOnTurnEnd({ queue, submit: (message) => submitted.push(message), setQueue });
+
+    expect(submitted).toEqual(["/model"]);
+    expect(queue).toEqual([]);
+  });
+
+  test("drainQueueOnTurnEnd does nothing on an empty queue", () => {
+    const submitted: string[] = [];
+    let queue: string[] = [];
+    drainQueueOnTurnEnd({
+      queue,
+      submit: (message) => submitted.push(message),
+      setQueue: (updater) => {
+        queue = updater(queue);
+      },
+    });
+    expect(submitted).toEqual([]);
+    expect(queue).toEqual([]);
   });
 });

--- a/src/chat-submit.ts
+++ b/src/chat-submit.ts
@@ -60,3 +60,23 @@ export function enqueueQueuedMessage(current: string[], next: string, policy: Qu
   if (policy === "all") return [...current, next];
   return [next];
 }
+
+export function dequeueQueuedMessage(current: string[]): { next: string | undefined; rest: string[] } {
+  const [next, ...rest] = current;
+  return { next, rest };
+}
+
+// The submit runs once, outside the setQueue updater, so a StrictMode double-invoke of the
+// updater cannot resubmit the queued command. Read the head from the caller's snapshot; the
+// updater only drains it. submit and setQueue must stay synchronous and adjacent — an await
+// between them would let a message queued in the gap be dropped by one-at-a-time replace.
+export function drainQueueOnTurnEnd(params: {
+  queue: string[];
+  submit: (message: string) => void;
+  setQueue: (updater: (current: string[]) => string[]) => void;
+}): void {
+  const { next } = dequeueQueuedMessage(params.queue);
+  if (next === undefined) return;
+  params.submit(next);
+  params.setQueue((current) => dequeueQueuedMessage(current).rest);
+}


### PR DESCRIPTION
## Summary

- fix a slash command queued mid-turn (e.g. `/model`) committing to the transcript twice
- move the queued-message resubmit outside the `setQueuedMessages` updater so React's StrictMode double-invoke can't fire it twice; the updater is now a pure drain
- add a StrictMode double-invoke regression test