### PR TITLE
feat(tui): render user messages verbatim

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -156,6 +156,7 @@ A second premise is that completion belongs to the model, not the host. The runt
 - **TUI-8** — Slash commands cover session control (new, clear, resume, sessions), model change, status, usage, memory management, skill run and skills picker, and exit; the parallel-workspaces commands appear only when that flag is enabled.
 - **TUI-9** — Fuzzy autocomplete is offered for file paths, sessions, commands, and skills.
 - **TUI-10** — A queued message typed while a turn is running is handled cooperatively and processed in order rather than dropped or interleaved mid-step.
+- **TUI-11** — A user message renders verbatim in the transcript: leading indentation and internal whitespace runs are preserved (tabs expanded to fixed-width stops), and a wrapped line repeats its indentation on each continuation row.
 
 ## 8. Observability requirements (OBS)
 

--- a/src/chat-content.test.ts
+++ b/src/chat-content.test.ts
@@ -5,6 +5,7 @@ import {
   wrapAssistantContent,
   wrapCodeText,
   wrapText,
+  wrapUserText,
 } from "./chat-content";
 
 describe("chat-content helpers", () => {
@@ -107,5 +108,51 @@ describe("wrapCodeText", () => {
 
   test("clamps a non-positive budget to one column", () => {
     expect(wrapCodeText("ab", 0)).toEqual(["a", "b"]);
+  });
+});
+
+describe("wrapUserText", () => {
+  test("preserves leading indent verbatim", () => {
+    expect(wrapUserText("    indented", 80)).toEqual(["    indented"]);
+  });
+
+  test("preserves internal whitespace runs", () => {
+    expect(wrapUserText("foo    bar", 80)).toEqual(["foo    bar"]);
+  });
+
+  test("expands tabs to 4-column stops", () => {
+    expect(wrapUserText("\tx", 80)).toEqual(["    x"]);
+    expect(wrapUserText("ab\tc", 80)).toEqual(["ab  c"]);
+  });
+
+  test("normalizes CRLF and splits logical lines", () => {
+    expect(wrapUserText("a\r\nb", 80)).toEqual(["a", "b"]);
+  });
+
+  test("renders a blank line as an empty row", () => {
+    expect(wrapUserText("a\n\nb", 80)).toEqual(["a", "", "b"]);
+  });
+
+  test("renders a whitespace-only line as an empty row", () => {
+    expect(wrapUserText("   ", 80)).toEqual([""]);
+  });
+
+  test("word-wraps the body and repeats the indent as the continuation prefix", () => {
+    expect(wrapUserText("  alpha beta gamma delta", 20)).toEqual(["  alpha beta gamma", "  delta"]);
+  });
+
+  test("hard-breaks a single token wider than the budget", () => {
+    expect(wrapUserText("abcdefghij", 4)).toEqual(["abcd", "efgh", "ij"]);
+  });
+
+  test("does not emit a trailing empty row when overflowing whitespace ends a line", () => {
+    expect(wrapUserText("abcdefghij  ", 10)).toEqual(["abcdefghij"]);
+  });
+
+  test("clamps a deep indent so content always survives", () => {
+    const [first = "", second = ""] = wrapUserText(`${" ".repeat(40)}alpha beta`, 20);
+    expect(first.length).toBeLessThanOrEqual(20);
+    expect(`${first}${second}`).toContain("alpha");
+    expect(`${first}${second}`).toContain("beta");
   });
 });

--- a/src/chat-content.ts
+++ b/src/chat-content.ts
@@ -85,6 +85,86 @@ export function wrapCodeText(text: string, budget: number): string[] {
   return rows;
 }
 
+const TAB_WIDTH = 4;
+// Deepest indent that still leaves room for content; a deeper indent is clamped so text always survives.
+const MIN_USER_CONTENT = 16;
+
+function expandTabs(line: string): string {
+  let out = "";
+  let col = 0;
+  for (const ch of line) {
+    if (ch === "\t") {
+      const advance = TAB_WIDTH - (col % TAB_WIDTH);
+      out += " ".repeat(advance);
+      col += advance;
+    } else {
+      out += ch;
+      col += Bun.stringWidth(ch);
+    }
+  }
+  return out;
+}
+
+function wrapUserLine(line: string, limit: number): string[] {
+  const rawIndent = line.match(/^ */)?.[0].length ?? 0;
+  const body = line.slice(rawIndent);
+  if (body.length === 0) return [""];
+  const prefix = " ".repeat(Math.min(rawIndent, Math.max(0, limit - MIN_USER_CONTENT)));
+  const prefixWidth = prefix.length;
+  const rows: string[] = [];
+  let row = prefix;
+  let used = prefixWidth;
+  // Trailing whitespace is invisible and is stripped by formatters (so it would desync snapshots);
+  // a run between words on the same row is still preserved. A row that trims to empty came from
+  // boundary whitespace, not content — dropping it avoids a spurious blank band row (a truly blank
+  // logical line is handled above and never reaches here).
+  const pushRow = () => {
+    const trimmed = row.replace(/\s+$/, "");
+    if (trimmed.length > 0) rows.push(trimmed);
+    row = prefix;
+    used = prefixWidth;
+  };
+  for (const token of body.match(/\s+|\S+/g) ?? []) {
+    const cells = Bun.stringWidth(token);
+    if (used + cells <= limit) {
+      row += token;
+      used += cells;
+      continue;
+    }
+    if (/^\s/.test(token)) {
+      if (used > prefixWidth) pushRow();
+      continue;
+    }
+    if (used > prefixWidth) pushRow();
+    if (prefixWidth + cells <= limit) {
+      row += token;
+      used += cells;
+      continue;
+    }
+    for (const { segment } of codeGraphemes.segment(token)) {
+      const cell = Bun.stringWidth(segment);
+      if (used > prefixWidth && used + cell > limit) pushRow();
+      row += segment;
+      used += cell;
+    }
+  }
+  pushRow();
+  return rows;
+}
+
+// Whitespace-faithful wrap for a user message: unlike wrapTerminalProse it never trims indent or
+// collapses internal runs, so a pasted indented block reads as typed. Per logical line, tabs expand
+// to 4-column stops (a raw tab would break the band's width math), leading indent is preserved and
+// repeated as the continuation prefix, and the body word-wraps with a wrapCodeText-style grapheme
+// hard-break for a single token wider than the budget. Pure geometry — takes a display-width budget.
+export function wrapUserText(text: string, budget: number): string[] {
+  const limit = Math.max(1, budget);
+  return text
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .flatMap((logical) => wrapUserLine(expandTabs(logical), limit));
+}
+
 export function sanitizeAssistantContent(content: string): string {
   const cleaned = content
     .split("\n")

--- a/src/terminal-chat-layout.ts
+++ b/src/terminal-chat-layout.ts
@@ -7,6 +7,7 @@ import {
   segmentAssistantContent,
   tokenize,
   wrapAssistantContent,
+  wrapUserText,
 } from "./chat-content";
 import { alignCols, formatCommandOutput, formatCompactNumber } from "./chat-format";
 import { GLYPH_FILLED, GLYPH_FISHEYE, GLYPH_HOLLOW, GLYPH_USER } from "./chat-glyphs";
@@ -217,25 +218,37 @@ export function layoutTranscriptMessage(input: {
       })),
     };
   }
-  // The band bleeds the full terminal width while the text sits at the content column, mirroring the
-  // demo's negative-margin trick. Leading whitespace carries the user-fill role so its own background
-  // paints the left gutter — the renderer's `fill` only reaches from the first non-blank span rightward.
-  const bandLine = (): TerminalLine => ({ spans: [{ text: " ".repeat(input.columns), role: "user-fill" as const }] });
-  const textLines: TerminalLine[] = wrapTerminalProse(
+  // The gray band insets one column from each terminal edge and fills solid across every row. Leading
+  // pad carries the user-fill role so its own background paints up to the marker; each row stops one
+  // column short of the right edge, so the terminal ground shows through as the matching right gutter.
+  const inner = Math.max(1, input.columns - 2 * GUTTER);
+  const gutterSpan = { text: " ".repeat(GUTTER), role: "plain" as const };
+  const bandLine = (): TerminalLine => ({
+    spans: [gutterSpan, { text: " ".repeat(inner), role: "user-fill" as const }],
+  });
+  const textLines: TerminalLine[] = wrapUserText(
     input.text,
     Math.max(1, contentWidth(input.columns) - width(marker)),
   ).map((text, index) => {
+    // A blank interior row has no marker to anchor the fill, so render it as a solid band row —
+    // otherwise the renderer paints no background and the band shows a hole.
+    if (index > 0 && !/\S/.test(text)) return bandLine();
     const lead =
       index === 0
         ? [
-            { text: " ".repeat(CONTENT_COLUMN), role: "user-fill" as const },
+            { text: " ".repeat(CONTENT_COLUMN - GUTTER), role: "user-fill" as const },
             { text: marker, role },
           ]
-        : [{ text: " ".repeat(CONTENT_COLUMN + width(marker)), role: "user-fill" as const }];
-    const pad = Math.max(0, input.columns - CONTENT_COLUMN - width(marker) - width(text));
+        : [{ text: " ".repeat(CONTENT_COLUMN - GUTTER + width(marker)), role: "user-fill" as const }];
+    const pad = Math.max(0, inner - (CONTENT_COLUMN - GUTTER) - width(marker) - width(text));
     return {
       fill: "user-fill" as const,
-      spans: [...lead, { text, role }, ...(pad ? [{ text: " ".repeat(pad), role: "plain" as const }] : [])],
+      spans: [
+        gutterSpan,
+        ...lead,
+        { text, role },
+        ...(pad ? [{ text: " ".repeat(pad), role: "user-fill" as const }] : []),
+      ],
     };
   });
   return { lines: [bandLine(), ...textLines, bandLine()] };

--- a/src/terminal-scene-render.test.tsx
+++ b/src/terminal-scene-render.test.tsx
@@ -117,3 +117,21 @@ test("assistant layout represents inline markup as semantic spans", () => {
     { text: "src/chat.ts:42.", role: "assistant-path" },
   ]);
 });
+
+test("user layout preserves leading indent and internal whitespace runs", () => {
+  const scene = layoutTranscriptMessage({ text: "    def f():\nreturn    x", kind: "user", columns: 40 });
+  const userText = scene.lines.flatMap((line) => line.spans).filter((span) => span.role === "user");
+  expect(userText.map((span) => span.text)).toEqual(["❯ ", "    def f():", "return    x"]);
+});
+
+test("user layout renders a blank interior line as a solid band row with no hole", () => {
+  const scene = layoutTranscriptMessage({ text: "first\n\nlast", kind: "user", columns: 30 });
+  const blank = scene.lines[2];
+  expect(blank?.spans.some((span) => span.role === "user")).toBe(false);
+  expect(blank).toEqual({
+    spans: [
+      { text: " ", role: "plain" },
+      { text: " ".repeat(28), role: "user-fill" },
+    ],
+  });
+});


### PR DESCRIPTION
## Summary

- render user messages whitespace-faithfully: preserve leading indent and internal spacing, tabs expanded to 4-column stops
- repeat indentation on wrapped continuation rows
- inset the user-message band with symmetric one-column gutters
- render blank interior lines as solid band rows so the fill shows no hole
