### PR TITLE
feat(tui): highlight code in user messages

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -156,7 +156,7 @@ A second premise is that completion belongs to the model, not the host. The runt
 - **TUI-8** — Slash commands cover session control (new, clear, resume, sessions), model change, status, usage, memory management, skill run and skills picker, and exit; the parallel-workspaces commands appear only when that flag is enabled.
 - **TUI-9** — Fuzzy autocomplete is offered for file paths, sessions, commands, and skills.
 - **TUI-10** — A queued message typed while a turn is running is handled cooperatively and processed in order rather than dropped or interleaved mid-step.
-- **TUI-11** — A user message renders verbatim in the transcript: leading indentation and internal whitespace runs are preserved (tabs expanded to fixed-width stops), and a wrapped line repeats its indentation on each continuation row.
+- **TUI-11** — A user message preserves its whitespace in the transcript: leading indentation and internal whitespace runs are kept (tabs expanded to fixed-width stops), and a wrapped line repeats its indentation on each continuation row. Inline markup — backtick `code`, bold, and file paths — renders styled, with its delimiters interpreted.
 
 ## 8. Observability requirements (OBS)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -156,7 +156,7 @@ A second premise is that completion belongs to the model, not the host. The runt
 - **TUI-8** — Slash commands cover session control (new, clear, resume, sessions), model change, status, usage, memory management, skill run and skills picker, and exit; the parallel-workspaces commands appear only when that flag is enabled.
 - **TUI-9** — Fuzzy autocomplete is offered for file paths, sessions, commands, and skills.
 - **TUI-10** — A queued message typed while a turn is running is handled cooperatively and processed in order rather than dropped or interleaved mid-step.
-- **TUI-11** — A user message preserves its whitespace in the transcript: leading indentation and internal whitespace runs are kept (tabs expanded to fixed-width stops), and a wrapped line repeats its indentation on each continuation row. Inline markup — backtick `code`, bold, and file paths — renders styled, with its delimiters interpreted.
+- **TUI-11** — A user message preserves its whitespace in the transcript: leading indentation and internal whitespace runs are kept (tabs expanded to fixed-width stops), and a wrapped line repeats its indentation on each continuation row. Inline markup — backtick `code`, bold, and file paths — renders styled, with its delimiters interpreted. A fenced code block renders syntax-highlighted like assistant output, its fence interpreted; unfenced text stays verbatim.
 
 ## 8. Observability requirements (OBS)
 

--- a/src/chat-tokenizer.test.ts
+++ b/src/chat-tokenizer.test.ts
@@ -100,8 +100,14 @@ describe("tokenize", () => {
       expect(tokens.find((t) => t.kind === "path")?.text).toBe("src/foo.ts:42");
     });
 
-    test("@ prefix is not a path", () => {
+    test("@ prefix is a ref, not a path", () => {
+      const tokens = tokenize("use @src/file.ts");
+      expect(tokens.find((t) => t.kind === "ref")?.text).toBe("@src/file.ts");
       expect(kinds("use @src/file.ts")).not.toContain("path");
+    });
+
+    test("@ without a path-like target stays plain", () => {
+      expect(kinds("ping @here now")).not.toContain("ref");
     });
 
     test("path inside parentheses", () => {

--- a/src/chat-tokenizer.ts
+++ b/src/chat-tokenizer.ts
@@ -1,4 +1,4 @@
-type MarkupTokenKind = "plain" | "code" | "bold" | "path";
+type MarkupTokenKind = "plain" | "code" | "bold" | "path" | "ref";
 
 export type MarkupToken = {
   text: string;
@@ -6,7 +6,7 @@ export type MarkupToken = {
 };
 
 type TokenRule = {
-  kind: Exclude<MarkupTokenKind, "plain" | "path">;
+  kind: Exclude<MarkupTokenKind, "plain" | "path" | "ref">;
   pattern: RegExp;
 };
 
@@ -87,6 +87,10 @@ function tokenizePlainSegment(text: string): MarkupToken[] {
   for (const chunk of chunks) {
     if (/^\s+$/.test(chunk)) {
       tokens.push({ text: chunk, kind: "plain" });
+      continue;
+    }
+    if (chunk.startsWith("@") && looksLikePathRef(chunk.slice(1).replace(/[)",.;!?]+$/g, ""))) {
+      tokens.push({ text: chunk, kind: "ref" });
       continue;
     }
     const core = chunk.replace(/^[("'`]+|[)",.;!?]+$/g, "");

--- a/src/code-highlight.test.ts
+++ b/src/code-highlight.test.ts
@@ -23,6 +23,13 @@ describe("highlightCode", () => {
     expect(flat).toContainEqual({ text: "@Component", role: "syntax-meta" });
   });
 
+  test("colors diff add and delete lines with foreground-only roles", () => {
+    const flat = spans(highlightCode("@@ -1,2 +1,2 @@\n-old line\n+new line\n context", "diff"));
+    expect(flat).toContainEqual({ text: "-old line", role: "syntax-deletion" });
+    expect(flat).toContainEqual({ text: "+new line", role: "syntax-addition" });
+    expect(flat).toContainEqual({ text: "@@ -1,2 +1,2 @@", role: "syntax-meta" });
+  });
+
   // The upgrade tripwire: token text must reconstruct the source byte-for-byte, or a highlight.js /
   // lowlight bump silently rewrote token boundaries.
   test.each([
@@ -33,6 +40,7 @@ describe("highlightCode", () => {
     ["bash", 'set -e\nfor f in *.ts; do\n  echo "$f"\ndone'],
     ["css", ".a {\n  color: #fff;\n  margin: 0 auto;\n}"],
     ["yaml", "name: acolyte\nlist:\n  - one\n  - two"],
+    ["diff", "@@ -1,2 +1,2 @@\n-old\n+new\n ctx"],
   ])("reconstructs %s source losslessly", (lang, source) => {
     expect(reconstruct(highlightCode(source, lang))).toBe(source);
   });
@@ -74,6 +82,7 @@ describe("resolveLanguage", () => {
     expect(resolveLanguage("ts")).toBe("typescript");
     expect(resolveLanguage("  TS ")).toBe("typescript");
     expect(resolveLanguage("py")).toBe("python");
+    expect(resolveLanguage("patch")).toBe("diff");
   });
 
   test("returns null for an unknown token", () => {

--- a/src/code-highlight.ts
+++ b/src/code-highlight.ts
@@ -3,6 +3,7 @@ import bash from "highlight.js/lib/languages/bash";
 import c from "highlight.js/lib/languages/c";
 import cpp from "highlight.js/lib/languages/cpp";
 import css from "highlight.js/lib/languages/css";
+import diff from "highlight.js/lib/languages/diff";
 import dockerfile from "highlight.js/lib/languages/dockerfile";
 import go from "highlight.js/lib/languages/go";
 import ini from "highlight.js/lib/languages/ini";
@@ -32,6 +33,7 @@ const lowlight = createLowlight({
   c,
   cpp,
   css,
+  diff,
   dockerfile,
   go,
   ini,
@@ -107,6 +109,8 @@ const LANGUAGE_ALIASES: Record<string, string> = {
   rb: "ruby",
   ruby: "ruby",
   php: "php",
+  diff: "diff",
+  patch: "diff",
 };
 
 // hljs scope (dotted, with `hljs-` prefix and sub-scope `_` suffix stripped) -> our bounded role.
@@ -145,6 +149,8 @@ const SCOPE_ROLES: Record<string, TerminalStyleRole> = {
   meta: "syntax-meta",
   "meta.keyword": "syntax-meta",
   "meta.prompt": "syntax-meta",
+  addition: "syntax-addition",
+  deletion: "syntax-deletion",
 };
 
 // null (not a plain fallback) lets a caller keep its own rendering for an unknown token.

--- a/src/terminal-chat-layout.test.ts
+++ b/src/terminal-chat-layout.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { wrapCodeText } from "./chat-content";
-import { layoutTranscriptTool, wrapSpans } from "./terminal-chat-layout";
+import { layoutTranscriptMessage, layoutTranscriptTool, wrapSpans } from "./terminal-chat-layout";
 import type { TerminalSpan } from "./terminal-scene-contract";
 import type { ToolOutputPart } from "./tool-output-contract";
 
@@ -115,5 +115,44 @@ describe("layoutTranscriptTool diff highlighting", () => {
     const roles = rolesOf(line.spans);
     expect(roles).not.toContain("syntax-keyword");
     expect(roles).toContain("diff-added");
+  });
+});
+
+describe("layoutTranscriptMessage user messages", () => {
+  const rolesOf = (spans: TerminalSpan[]): string[] => spans.map((span) => span.role);
+
+  test("renders an unfenced paste verbatim with no syntax roles", () => {
+    const scene = layoutTranscriptMessage({ text: "  const x = 1", kind: "user", columns: 80 });
+    const body = scene.lines.map((line) => rowText(line.spans)).join("\n");
+    expect(body).toContain("  const x = 1");
+    for (const line of scene.lines) {
+      for (const role of rolesOf(line.spans)) expect(role.startsWith("syntax-")).toBe(false);
+    }
+  });
+
+  test("highlights a fenced code block and keeps the band whole behind indentation", () => {
+    const scene = layoutTranscriptMessage({
+      text: "look:\n```ts\n  const x = 1\n```",
+      kind: "user",
+      columns: 80,
+    });
+    const allSpans = scene.lines.flatMap((line) => line.spans);
+    expect(allSpans).toContainEqual({ text: "const", role: "syntax-keyword" });
+    // Indentation inside the code takes the fill role, never a foreground-only syntax role, which
+    // would paint no background and leave a hole in the band.
+    for (const span of allSpans) {
+      if (!/\S/.test(span.text)) expect(span.role.startsWith("syntax-")).toBe(false);
+    }
+  });
+
+  test("colors a fenced diff block with foreground-only add/delete roles", () => {
+    const scene = layoutTranscriptMessage({
+      text: "```diff\n-old\n+new\n```",
+      kind: "user",
+      columns: 80,
+    });
+    const roles = scene.lines.flatMap((line) => rolesOf(line.spans));
+    expect(roles).toContain("syntax-addition");
+    expect(roles).toContain("syntax-deletion");
   });
 });

--- a/src/terminal-chat-layout.ts
+++ b/src/terminal-chat-layout.ts
@@ -224,17 +224,41 @@ export function layoutTranscriptMessage(input: {
   // pad carries the user-fill role so its own background paints up to the marker; each row stops one
   // column short of the right edge, so the terminal ground shows through as the matching right gutter.
   const inner = Math.max(1, input.columns - 2 * GUTTER);
+  const budget = Math.max(1, contentWidth(input.columns) - width(marker));
   const gutterSpan = { text: " ".repeat(GUTTER), role: "plain" as const };
   const bandLine = (): TerminalLine => ({
     spans: [gutterSpan, { text: " ".repeat(inner), role: "user-fill" as const }],
   });
-  const textLines: TerminalLine[] = wrapUserText(
-    input.text,
-    Math.max(1, contentWidth(input.columns) - width(marker)),
-  ).map((text, index) => {
-    // A blank interior row has no marker to anchor the fill, so render it as a solid band row —
-    // otherwise the renderer paints no background and the band shows a hole.
-    if (index > 0 && !/\S/.test(text)) return bandLine();
+  // Fenced code highlights like the assistant path; unfenced text stays one prose segment and renders
+  // verbatim (whitespace-faithful). An empty row array is a blank band row. Whitespace spans take the
+  // fill role because the renderer extends `fill` only rightward from the first non-blank span, so a
+  // leading indent would otherwise leave a hole in the band.
+  const rows: TerminalSpan[][] = [];
+  segmentAssistantContent(input.text).forEach((segment, index) => {
+    if (index > 0) rows.push([]);
+    if (segment.kind === "prose") {
+      for (const line of wrapUserText(segment.text, budget)) {
+        if (!/\S/.test(line)) {
+          rows.push([]);
+          continue;
+        }
+        rows.push(
+          tokenize(line).map((token) =>
+            /\S/.test(token.text) ? assistantTokenSpan(token, role) : { text: token.text, role: "user-fill" as const },
+          ),
+        );
+      }
+    } else {
+      for (const codeLine of highlightCode(segment.text, segment.lang)) {
+        for (const wrapped of wrapSpans(codeLine, budget)) {
+          rows.push(wrapped.map((span) => (/\S/.test(span.text) ? span : { text: span.text, role: "user-fill" })));
+        }
+      }
+    }
+  });
+  const textLines: TerminalLine[] = rows.map((spans, index) => {
+    // A blank interior row has no marker to anchor the fill, so render it as a solid band row.
+    if (index > 0 && spans.length === 0) return bandLine();
     const lead =
       index === 0
         ? [
@@ -242,22 +266,12 @@ export function layoutTranscriptMessage(input: {
             { text: marker, role },
           ]
         : [{ text: " ".repeat(CONTENT_COLUMN - GUTTER + width(marker)), role: "user-fill" as const }];
-    // Whitespace takes the fill role, not plain: the renderer extends `fill` only rightward from the
-    // first non-blank span, so a leading indent would otherwise leave a hole in the band.
-    const tokenSpans = tokenize(text).map((token) =>
-      /\S/.test(token.text) ? assistantTokenSpan(token, role) : { text: token.text, role: "user-fill" as const },
-    );
     // Measured post-strip: the markup mapper drops delimiters, so the rendered width is below the raw line.
-    const rendered = tokenSpans.reduce((total, span) => total + width(span.text), 0);
+    const rendered = spans.reduce((total, span) => total + width(span.text), 0);
     const pad = Math.max(0, inner - (CONTENT_COLUMN - GUTTER) - width(marker) - rendered);
     return {
       fill: "user-fill" as const,
-      spans: [
-        gutterSpan,
-        ...lead,
-        ...tokenSpans,
-        ...(pad ? [{ text: " ".repeat(pad), role: "user-fill" as const }] : []),
-      ],
+      spans: [gutterSpan, ...lead, ...spans, ...(pad ? [{ text: " ".repeat(pad), role: "user-fill" as const }] : [])],
     };
   });
   return { lines: [bandLine(), ...textLines, bandLine()] };

--- a/src/terminal-chat-layout.ts
+++ b/src/terminal-chat-layout.ts
@@ -117,6 +117,8 @@ function assistantTokenSpan(token: MarkupToken, role: TerminalStyleRole): Termin
   switch (token.kind) {
     case "code":
       return { text: token.text.slice(1, -1), role: "assistant-code" };
+    case "ref":
+      return { text: token.text, role: "assistant-code" };
     case "bold":
       return { text: token.text.slice(2, -2), role: "assistant-bold" };
     case "path":
@@ -240,13 +242,20 @@ export function layoutTranscriptMessage(input: {
             { text: marker, role },
           ]
         : [{ text: " ".repeat(CONTENT_COLUMN - GUTTER + width(marker)), role: "user-fill" as const }];
-    const pad = Math.max(0, inner - (CONTENT_COLUMN - GUTTER) - width(marker) - width(text));
+    // Whitespace takes the fill role, not plain: the renderer extends `fill` only rightward from the
+    // first non-blank span, so a leading indent would otherwise leave a hole in the band.
+    const tokenSpans = tokenize(text).map((token) =>
+      /\S/.test(token.text) ? assistantTokenSpan(token, role) : { text: token.text, role: "user-fill" as const },
+    );
+    // Measured post-strip: the markup mapper drops delimiters, so the rendered width is below the raw line.
+    const rendered = tokenSpans.reduce((total, span) => total + width(span.text), 0);
+    const pad = Math.max(0, inner - (CONTENT_COLUMN - GUTTER) - width(marker) - rendered);
     return {
       fill: "user-fill" as const,
       spans: [
         gutterSpan,
         ...lead,
-        { text, role },
+        ...tokenSpans,
         ...(pad ? [{ text: " ".repeat(pad), role: "user-fill" as const }] : []),
       ],
     };

--- a/src/terminal-scene-render.test.tsx
+++ b/src/terminal-scene-render.test.tsx
@@ -120,8 +120,34 @@ test("assistant layout represents inline markup as semantic spans", () => {
 
 test("user layout preserves leading indent and internal whitespace runs", () => {
   const scene = layoutTranscriptMessage({ text: "    def f():\nreturn    x", kind: "user", columns: 40 });
-  const userText = scene.lines.flatMap((line) => line.spans).filter((span) => span.role === "user");
-  expect(userText.map((span) => span.text)).toEqual(["❯ ", "    def f():", "return    x"]);
+  const rows = scene.lines.map((line) => line.spans.map((span) => span.text).join(""));
+  expect(rows.some((row) => row.includes("    def f():"))).toBe(true);
+  expect(rows.some((row) => row.includes("return    x"))).toBe(true);
+});
+
+test("user layout gives whitespace the band fill so an indented line has no hole", () => {
+  const scene = layoutTranscriptMessage({ text: "  indented", kind: "user", columns: 40 });
+  const blankUserSpans = scene.lines
+    .flatMap((line) => line.spans)
+    .filter((span) => span.role === "user" && !/\S/.test(span.text));
+  expect(blankUserSpans).toEqual([]);
+});
+
+test("user layout styles inline code, bold, path, and @-ref markup", () => {
+  const scene = layoutTranscriptMessage({
+    text: "run `build` on **main** in src/foo.ts see @lib/x.ts",
+    kind: "user",
+    columns: 60,
+  });
+  const spans = scene.lines.flatMap((line) => line.spans);
+  expect(spans).toEqual(
+    expect.arrayContaining([
+      { text: "build", role: "assistant-code" },
+      { text: "main", role: "assistant-bold" },
+      { text: "src/foo.ts", role: "assistant-path" },
+      { text: "@lib/x.ts", role: "assistant-code" },
+    ]),
+  );
 });
 
 test("user layout renders a blank interior line as a solid band row with no hole", () => {

--- a/src/terminal-theme.ts
+++ b/src/terminal-theme.ts
@@ -19,6 +19,8 @@ export const terminalStyleRoleSchema = z.enum([
   "syntax-function",
   "syntax-property",
   "syntax-meta",
+  "syntax-addition",
+  "syntax-deletion",
   "tool",
   "skill-on",
   "skill-off",
@@ -91,6 +93,10 @@ export const terminalTheme: TerminalTheme = Object.freeze({
     "syntax-function": { foreground: "#4DA3FF" },
     "syntax-property": { foreground: "#9EE86B" },
     "syntax-meta": { foreground: "#E07BD0" },
+    // Fenced ```diff blocks only: foreground-only add/delete, neon siblings of the vivid palette.
+    // Distinct from the band-carrying diff-added/diff-removed the edit tool uses.
+    "syntax-addition": { foreground: "#5CF08A" },
+    "syntax-deletion": { foreground: "#FF5C7A" },
     tool: { foreground: "#aaaaaa" },
     "skill-on": { foreground: "#A56EFF" },
     "skill-off": { dim: true },


### PR DESCRIPTION
## Summary

- highlight fenced code blocks in user messages like assistant output; unfenced text stays verbatim
- style inline backtick code, bold, and file paths in user messages
- add `diff`/`patch` as a fenced highlight language with foreground-only add/delete roles
