### PR TITLE
fix(memory): stream distillation requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,13 +41,14 @@ Format: `type(scope): description` — types: `feat`, `fix`, `refactor`, `docs`,
 
 ## Pull requests
 
+- Open a `/pr` for anything behavior-affecting, release-gating, or touching a load-bearing subsystem (memory, lifecycle, renderer, transcript); push direct to `main` only for releases and changes that alter no behavior (typos, comments, dead-code removal, pure refactors that keep `verify` green). Size is a tiebreaker, not the test.
 - Gate: run `/review` (multi-dimension, not `/code-review`) before opening, and fix all findings first.
 - Title: `type(scope): description`, under 50 characters, no trailing period.
 - Body follows `.github/pull_request_template.md`: brief motivation (omit when obvious), then a flat summary bullet list. Cut anything a reviewer would infer from the diff.
 - End with `Fixes #N` when an issue matches the work.
 - Fold related changes into one PR; keep unrelated work separate.
 - Never push or open a PR without explicit approval.
-- Merges are squash-only; the PR title becomes the squash commit subject, so it must satisfy the commit format above. `main` allows direct pushes for small fixes and releases; it is protected against force-pushes and deletions, requires linear history and signed commits, and the pre-push hook enforces commit format.
+- Merges are squash-only; the PR title becomes the squash commit subject, so it must satisfy the commit format above. `main` is protected against force-pushes and deletions, requires linear history and signed commits, and the pre-push hook enforces commit format.
 
 ## Code
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -67,7 +67,7 @@ A second premise is that completion belongs to the model, not the host. The runt
 
 ### 2.5 Options / configuration
 
-- **FR-36** — Configuration merges a user-scoped source and a project-scoped source, with project overriding user; the resolved surface includes model, temperature, reasoning level, provider base URLs, locale, log format, embedding and distill models, reply timeout, daemon port, and feature flags. The full settable-key set is fixed by the configuration reference, and an unknown key is rejected.
+- **FR-36** — Configuration merges a user-scoped source and a project-scoped source, with project overriding user; the resolved surface includes model, reasoning level, provider base URLs, locale, log format, embedding and distill models, reply timeout, daemon port, and feature flags. The full settable-key set is fixed by the configuration reference, and an unknown key is rejected.
 - **FR-37** — Feature flags are opt-in and default off: syncing AGENTS.md into project memory, undo checkpoints, parallel workspaces, cloud sync, and MCP. A disabled flag's surface (commands, tools, behavior) is absent, not merely inert.
 - **FR-38** — Reasoning level (`low`/`medium`/`high`) is accepted and mapped to the selected provider's native reasoning control.
 - **FR-39** — Locale selects the UI language; an unset locale defaults to English, and an unavailable locale falls back rather than failing.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -166,7 +166,6 @@ acolyte config set features.syncAgents true
 | `port` | daemon server port (default: 6767) |
 | `locale` | UI language (default: `en`) |
 | `model` | model |
-| `temperature` | generation temperature (`0.0` to `2.0`) |
 | `reasoning` | reasoning level for supported models (`low`, `medium`, `high`) |
 | `openaiBaseUrl` | OpenAI API base URL |
 | `anthropicBaseUrl` | Anthropic API base URL |

--- a/src/agent-contract.ts
+++ b/src/agent-contract.ts
@@ -81,7 +81,6 @@ export type Agent = {
 export type OnBeforeFinishResult = LanguageModelV4Message[];
 
 export type StreamOptions = {
-  temperature?: number;
   reasoning?: ReasoningLevel;
   providerOptions?: SharedV4ProviderOptions;
   preCallInputTokenLimit?: number;

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -98,7 +98,6 @@ export function createAgentStream(
           try {
             streamResult = await model.doStream({
               prompt: messages,
-              temperature: options.temperature,
               tools: functionTools.length > 0 ? functionTools : undefined,
               toolChoice: functionTools.length > 0 ? { type: "auto" } : undefined,
               ...(options.reasoning ? { reasoning: options.reasoning } : {}),

--- a/src/app-config.ts
+++ b/src/app-config.ts
@@ -33,7 +33,6 @@ export const appConfig = {
     baseUrl: fileConfig.vercelBaseUrl,
   },
   model: fileConfig.model,
-  temperature: fileConfig.temperature,
   reasoning: fileConfig.reasoning,
   distillModel: fileConfig.distillModel,
   embeddingModel: fileConfig.embeddingModel,

--- a/src/cli-config.test.ts
+++ b/src/cli-config.test.ts
@@ -34,12 +34,12 @@ describe("cli config", () => {
     expect(dimLines).toContain("locale:  en");
   });
 
-  test("list renders temperature scalar key", async () => {
+  test("list renders replyTimeoutMs scalar key", async () => {
     const { deps, dimLines } = createDeps({
-      readConfig: async () => ({ temperature: 0.2 }),
+      readConfig: async () => ({ replyTimeoutMs: 30000 }),
     });
     await configMode(["list"], deps);
-    expect(dimLines).toContain("temperature:  0.2");
+    expect(dimLines).toContain("replyTimeoutMs:  30000");
   });
 
   test("unset forwards key", async () => {
@@ -49,8 +49,8 @@ describe("cli config", () => {
         calls.push({ key, scope: options?.scope ?? "user" });
       },
     });
-    await configMode(["unset", "temperature"], deps);
-    expect(calls).toEqual([{ key: "temperature", scope: "user" }]);
+    await configMode(["unset", "reasoning"], deps);
+    expect(calls).toEqual([{ key: "reasoning", scope: "user" }]);
   });
 
   test("unset accepts trailing scope flag", async () => {
@@ -60,8 +60,8 @@ describe("cli config", () => {
         calls.push({ key, scope: options?.scope ?? "user" });
       },
     });
-    await configMode(["unset", "temperature", "--project"], deps);
-    expect(calls).toEqual([{ key: "temperature", scope: "project" }]);
+    await configMode(["unset", "reasoning", "--project"], deps);
+    expect(calls).toEqual([{ key: "reasoning", scope: "project" }]);
   });
 
   test("set accepts trailing scope flag", async () => {
@@ -71,7 +71,7 @@ describe("cli config", () => {
         calls.push({ key, value, scope: options?.scope ?? "user" });
       },
     });
-    await configMode(["set", "temperature", "0.3", "--project"], deps);
-    expect(calls).toEqual([{ key: "temperature", value: "0.3", scope: "project" }]);
+    await configMode(["set", "reasoning", "high", "--project"], deps);
+    expect(calls).toEqual([{ key: "reasoning", value: "high", scope: "project" }]);
   });
 });

--- a/src/config-contract.ts
+++ b/src/config-contract.ts
@@ -9,7 +9,6 @@ export const scopeSchema = z.enum(["user", "project"]);
 export type ConfigScope = z.infer<typeof scopeSchema>;
 
 const MAX_RUN_REPLY_TIMEOUT_MS = 600_000;
-const MAX_TEMPERATURE = 2;
 
 export const reasoningLevelSchema = z.enum(["low", "medium", "high"]);
 export type ReasoningLevel = z.infer<typeof reasoningLevelSchema>;
@@ -20,16 +19,11 @@ const parseIntegerSchema = (min: number, max: number): z.ZodType<number> =>
     (value) => (typeof value === "string" && value.trim().length > 0 ? Number(value) : value),
     z.number().int().min(min).max(max),
   );
-const parseTemperatureSchema = z.preprocess(
-  (value) => (typeof value === "string" && value.trim().length > 0 ? Number(value) : value),
-  z.number().min(0).max(MAX_TEMPERATURE),
-);
 
 export interface Config {
   port?: number;
   locale?: TranslationLocale;
   model?: string;
-  temperature?: number;
   distillModel?: string;
   openaiBaseUrl?: string;
   anthropicBaseUrl?: string;
@@ -46,7 +40,6 @@ export interface ResolvedConfig {
   port: number;
   locale: TranslationLocale;
   model: string;
-  temperature?: number;
   distillModel: string;
   openaiBaseUrl: string;
   anthropicBaseUrl: string;
@@ -63,7 +56,6 @@ export const CONFIG_SET_SCHEMAS: Partial<Record<keyof Config, z.ZodTypeAny>> = {
   port: parseIntegerSchema(1, 65535),
   locale: translationLocaleSchema,
   model: nonEmptyStringSchema,
-  temperature: parseTemperatureSchema,
   openaiBaseUrl: nonEmptyStringSchema,
   anthropicBaseUrl: nonEmptyStringSchema,
   googleBaseUrl: nonEmptyStringSchema,
@@ -86,7 +78,6 @@ export function toConfig(input: Record<string, unknown>): Config {
     port: parseField(parseIntegerSchema(1, 65535), input.port),
     locale: parseField(translationLocaleSchema, input.locale),
     model: parseField(nonEmptyStringSchema, input.model),
-    temperature: parseField(parseTemperatureSchema, input.temperature),
     distillModel: parseField(nonEmptyStringSchema, input.distillModel),
     openaiBaseUrl: parseField(nonEmptyStringSchema, input.openaiBaseUrl),
     anthropicBaseUrl: parseField(nonEmptyStringSchema, input.anthropicBaseUrl),

--- a/src/config.int.test.ts
+++ b/src/config.int.test.ts
@@ -178,7 +178,6 @@ describe("config store", () => {
         'googleBaseUrl = "https://google.example.com"',
 
         'logFormat = "json"',
-        "temperature = 0.3",
         "replyTimeoutMs = 220000",
       ].join("\n"),
       "utf8",
@@ -190,7 +189,6 @@ describe("config store", () => {
     expect(loaded.model).toBe("openai/gpt-5-mini");
 
     expect(loaded.logFormat).toBe("json");
-    expect(loaded.temperature).toBe(0.3);
     expect(loaded.replyTimeoutMs).toBe(220000);
   });
 
@@ -217,35 +215,11 @@ describe("config store", () => {
     expect(resolved.port).toBe(6767);
     expect(resolved.locale).toBe("en");
     expect(resolved.model).toBe("anthropic/claude-sonnet-4");
-    expect(resolved.temperature).toBeUndefined();
     expect(resolved.distillModel).toBe("anthropic/claude-sonnet-4");
     expect(resolved.anthropicBaseUrl).toBe("https://api.anthropic.com/v1");
 
     expect(resolved.logFormat).toBe("logfmt");
     expect(resolved.replyTimeoutMs).toBe(180000);
-  });
-
-  test("readResolvedConfigSync uses top-level temperature when set", () => {
-    const home = createDir("acolyte-config-home-");
-    const dataDir = configDir({ HOME: home });
-    mkdirSync(dataDir, { recursive: true });
-    writeFileSync(join(dataDir, "config.toml"), 'model = "anthropic/claude-sonnet-4"\n\ntemperature = 0.2\n', "utf8");
-
-    const resolved = readResolvedConfigSync({ env: { HOME: home }, cwd: home });
-    expect(resolved.model).toBe("anthropic/claude-sonnet-4");
-    expect(resolved.temperature).toBe(0.2);
-    expect(resolved.distillModel).toBe("anthropic/claude-sonnet-4");
-  });
-
-  test("readResolvedConfigSync uses top-level temperature from config", () => {
-    const home = createDir("acolyte-config-home-");
-    const dataDir = configDir({ HOME: home });
-    mkdirSync(dataDir, { recursive: true });
-    writeFileSync(join(dataDir, "config.toml"), 'model = "anthropic/claude-sonnet-4"\n\ntemperature = 0.1\n', "utf8");
-
-    const resolved = readResolvedConfigSync({ env: { HOME: home }, cwd: home });
-    expect(resolved.model).toBe("anthropic/claude-sonnet-4");
-    expect(resolved.temperature).toBe(0.1);
   });
 
   test("setConfigValue rejects internal config keys", async () => {
@@ -379,37 +353,37 @@ describe("config store", () => {
       "Invalid value for port",
     );
 
-    await expect(setConfigValue("temperature", "3", { env: { HOME: home }, cwd: project })).rejects.toThrow(
-      "Invalid value for temperature",
+    await expect(setConfigValue("reasoning", "extreme", { env: { HOME: home }, cwd: project })).rejects.toThrow(
+      "Invalid value for reasoning",
     );
     await expect(setConfigValue("locale", "xx", { env: { HOME: home }, cwd: project })).rejects.toThrow(
       "Invalid value for locale",
     );
   });
 
-  test("setConfigValue supports top-level temperature", async () => {
+  test("setConfigValue supports top-level reasoning", async () => {
     const home = createDir("acolyte-config-home-");
     const project = createDir("acolyte-config-project-");
     const projectDataDir = join(project, ".acolyte");
     mkdirSync(projectDataDir, { recursive: true });
 
-    await setConfigValue("temperature", "0.2", { env: { HOME: home }, cwd: project, scope: "project" });
+    await setConfigValue("reasoning", "high", { env: { HOME: home }, cwd: project, scope: "project" });
 
     const loaded = await readConfigForScope("project", { env: { HOME: home }, cwd: project });
-    expect(loaded.temperature).toBe(0.2);
+    expect(loaded.reasoning).toBe("high");
   });
 
-  test("unsetConfigValue removes temperature key", async () => {
+  test("unsetConfigValue removes reasoning key", async () => {
     const home = createDir("acolyte-config-home-");
     const project = createDir("acolyte-config-project-");
     const projectDataDir = join(project, ".acolyte");
     mkdirSync(projectDataDir, { recursive: true });
 
-    await setConfigValue("temperature", "0.4", { env: { HOME: home }, cwd: project, scope: "project" });
-    await unsetConfigValue("temperature", { env: { HOME: home }, cwd: project, scope: "project" });
+    await setConfigValue("reasoning", "medium", { env: { HOME: home }, cwd: project, scope: "project" });
+    await unsetConfigValue("reasoning", { env: { HOME: home }, cwd: project, scope: "project" });
 
     const loaded = await readConfigForScope("project", { env: { HOME: home }, cwd: project });
-    expect(loaded.temperature).toBeUndefined();
+    expect(loaded.reasoning).toBeUndefined();
   });
 
   test("unsetConfigValue removes key only from targeted project scope", async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -124,7 +124,6 @@ function serializeToml(config: Config): string {
   if (typeof config.port === "number") lines.push(`port = ${config.port}`);
   if (config.locale) lines.push(`locale = ${JSON.stringify(config.locale)}`);
   if (config.model) lines.push(`model = ${JSON.stringify(config.model)}`);
-  if (typeof config.temperature === "number") lines.push(`temperature = ${config.temperature}`);
   if (config.distillModel) lines.push(`distillModel = ${JSON.stringify(config.distillModel)}`);
   if (config.openaiBaseUrl) lines.push(`openaiBaseUrl = ${JSON.stringify(config.openaiBaseUrl)}`);
   if (config.anthropicBaseUrl) lines.push(`anthropicBaseUrl = ${JSON.stringify(config.anthropicBaseUrl)}`);
@@ -158,7 +157,6 @@ function resolveConfig(config: Config): ResolvedConfig {
     port,
     locale: config.locale ?? defaults.locale,
     model,
-    temperature: config.temperature,
     distillModel: config.distillModel ?? model,
     openaiBaseUrl: config.openaiBaseUrl ?? defaults.openaiBaseUrl,
     anthropicBaseUrl: config.anthropicBaseUrl ?? defaults.anthropicBaseUrl,

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -114,7 +114,6 @@ export type LifecycleInput = {
   taskId?: string;
   features: ResolvedFeatureFlags;
   reasoning?: ReasoningLevel;
-  temperature?: number;
   authRoute?: AuthRoute;
   lifecyclePolicy?: Partial<LifecyclePolicy>;
   runControl?: RunControl;
@@ -151,6 +150,5 @@ export type RunContext = {
   toolCallStartedAt: Map<string, ToolCallStart>;
   sideEffectSink: SideEffectSink | null;
   reasoning?: ReasoningLevel;
-  temperature?: number;
   readonly authRoute?: AuthRoute;
 };

--- a/src/lifecycle-generate.test.ts
+++ b/src/lifecycle-generate.test.ts
@@ -68,12 +68,11 @@ function finishPart(reason: "tool-calls" | "stop"): LanguageModelV4StreamPart {
 }
 
 describe("phaseGenerate", () => {
-  test("prompt cache options do not suppress temperature without reasoning", async () => {
+  test("forwards prompt cache options", async () => {
     let capturedOptions: StreamOptions | undefined;
     const ctx = createRunContext({
       model: "openai/gpt-5-mini",
       reasoning: undefined,
-      temperature: 0.42,
       agent: {
         id: "test-agent",
         name: "test-agent",
@@ -98,7 +97,6 @@ describe("phaseGenerate", () => {
 
     await phaseGenerate(ctx, { timeoutMs: 1000 });
 
-    expect(capturedOptions?.temperature).toBe(0.42);
     expect(capturedOptions?.providerOptions?.openai?.promptCacheKey).toBeString();
   });
 
@@ -152,12 +150,11 @@ describe("phaseGenerate", () => {
     expect(start?.fields).not.toHaveProperty("auth_route");
   });
 
-  test("forwards the reasoning level as a call option and suppresses temperature", async () => {
+  test("forwards the reasoning level as a call option", async () => {
     let capturedOptions: StreamOptions | undefined;
     const ctx = createRunContext({
       model: "anthropic/claude-opus-4-8",
       reasoning: "high",
-      temperature: 0.42,
       agent: {
         id: "test-agent",
         name: "test-agent",
@@ -183,9 +180,7 @@ describe("phaseGenerate", () => {
     await phaseGenerate(ctx, { timeoutMs: 1000 });
 
     expect(capturedOptions?.reasoning).toBe("high");
-    // Reasoning models reject an explicit temperature, and the deprecated thinking
-    // budget must never be assembled by hand.
-    expect(capturedOptions?.temperature).toBeUndefined();
+    // The deprecated thinking budget must never be assembled by hand.
     expect(capturedOptions?.providerOptions?.anthropic).toBeUndefined();
   });
 

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -205,7 +205,6 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
     });
     const providerOptions = promptCacheProviderOptions(provider, cacheKey);
     const reasoning = ctx.reasoning;
-    const temperature = reasoning ? undefined : ctx.temperature;
     const streamOutput = await ctx.agent.stream(prompt, {
       preCallInputTokenLimit: ctx.policy.contextMaxTokens,
       installSideEffectSink: (sink) => {
@@ -242,7 +241,6 @@ async function streamWithTimeout(ctx: RunContext, prompt: string, timeoutMs: num
         }
         return renderReopenMessages(decision);
       },
-      ...(typeof temperature === "number" ? { temperature } : {}),
       ...(reasoning ? { reasoning } : {}),
       ...(providerOptions ? { providerOptions } : {}),
     });

--- a/src/lifecycle.test.ts
+++ b/src/lifecycle.test.ts
@@ -20,19 +20,18 @@ describe("runLifecycle", () => {
     expect(response).toEqual({ model: "gpt-5-mini", outputStreamed: true, output: "Generated output" });
   });
 
-  test("threads reasoning and temperature from input into the run context", async () => {
-    let captured: { reasoning?: string; temperature?: number } | undefined;
+  test("threads reasoning from input into the run context", async () => {
+    let captured: { reasoning?: string } | undefined;
     const deps = createLifecycleDeps({
-      phaseGenerate: mock(async (ctx: { reasoning?: string; temperature?: number; result?: unknown }) => {
-        captured = { reasoning: ctx.reasoning, temperature: ctx.temperature };
+      phaseGenerate: mock(async (ctx: { reasoning?: string; result?: unknown }) => {
+        captured = { reasoning: ctx.reasoning };
         ctx.result = { text: "ok", toolCalls: [] };
       }),
     });
 
-    await runLifecycle(createLifecycleInput({ reasoning: "high", temperature: 0.3, workspace: process.cwd() }), deps);
+    await runLifecycle(createLifecycleInput({ reasoning: "high", workspace: process.cwd() }), deps);
 
     expect(captured?.reasoning).toBe("high");
-    expect(captured?.temperature).toBe(0.3);
   });
 
   test("accounts memory tokens when distilling", async () => {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -121,7 +121,6 @@ function createRunContext(
     toolCallStartedAt: new Map(),
     sideEffectSink: null,
     reasoning: input.reasoning,
-    temperature: input.temperature,
     authRoute: input.authRoute,
   };
 

--- a/src/memory-distiller.int.test.ts
+++ b/src/memory-distiller.int.test.ts
@@ -19,14 +19,16 @@ let fake: FakeProviderServer;
 let savedBaseUrl: string;
 let savedApiKey: string | undefined;
 let savedDistillModel: string;
+let lastRequestBody: Record<string, unknown> | undefined;
 
 beforeAll(() => {
   savedBaseUrl = appConfig.openai.baseUrl;
   savedApiKey = appConfig.openai.apiKey;
   savedDistillModel = appConfig.distillModel;
   fake = startFakeProviderServer({
-    handleRequest: (ctx) =>
-      createToolCallsPayload(ctx.model, ctx.responseCounter, [
+    handleRequest: (ctx) => {
+      lastRequestBody = ctx.body as Record<string, unknown>;
+      return createToolCallsPayload(ctx.model, ctx.responseCounter, [
         {
           id: `fc_proj_${ctx.responseCounter}`,
           callId: `call_proj_${ctx.responseCounter}`,
@@ -45,7 +47,8 @@ beforeAll(() => {
           name: "memory-observe",
           args: JSON.stringify({ scope: "session", content: "fixing memory search bug" }),
         },
-      ]),
+      ]);
+    },
   });
   (appConfig.openai as { baseUrl: string }).baseUrl = fake.baseUrl;
   (appConfig.openai as { apiKey: string | undefined }).apiKey = "fake-key";
@@ -112,5 +115,20 @@ describe("memoryDistiller integration", () => {
     expect(contents).toContain("project uses Bun as runtime");
     expect(contents).toContain("prefers concise responses");
     expect(contents).not.toContain("fixing memory search bug");
+  });
+
+  test("sends no explicit temperature so reasoning-model routes do not reject the commit", async () => {
+    const store = createStore();
+    const distiller = createMemoryDistiller({ store, policy: testPolicy });
+
+    await distiller.commit({
+      sessionId: "sess_inttest003",
+      resourceId: "proj_inttest003",
+      messages: [{ role: "user", content: "hello" }],
+      output: "hi",
+    });
+
+    expect(lastRequestBody).toBeDefined();
+    expect(lastRequestBody).not.toHaveProperty("temperature");
   });
 });

--- a/src/memory-distiller.int.test.ts
+++ b/src/memory-distiller.int.test.ts
@@ -117,7 +117,7 @@ describe("memoryDistiller integration", () => {
     expect(contents).not.toContain("fixing memory search bug");
   });
 
-  test("sends no explicit temperature so reasoning-model routes do not reject the commit", async () => {
+  test("streams the distill request so the subscription backend accepts it", async () => {
     const store = createStore();
     const distiller = createMemoryDistiller({ store, policy: testPolicy });
 
@@ -129,6 +129,6 @@ describe("memoryDistiller integration", () => {
     });
 
     expect(lastRequestBody).toBeDefined();
-    expect(lastRequestBody).not.toHaveProperty("temperature");
+    expect(lastRequestBody?.stream).toBe(true);
   });
 });

--- a/src/memory-distiller.ts
+++ b/src/memory-distiller.ts
@@ -83,7 +83,8 @@ function parseToolCall(call: LanguageModelV4ToolCall): DistillObservation | null
 async function defaultRunner(systemPrompt: string, userContent: string): Promise<DistillObservation[]> {
   const qualifiedModel = normalizeModel(appConfig.distillModel);
   const model = createModel(qualifiedModel, sharedRateLimiter(providerFromModel(qualifiedModel)));
-  const result = await model.doGenerate({
+  // The subscription backend rejects non-streaming requests ("Stream must be set to true"), so distill over doStream.
+  const { stream } = await model.doStream({
     prompt: [
       { role: "system", content: systemPrompt },
       { role: "user", content: [{ type: "text", text: userContent }] },
@@ -91,10 +92,17 @@ async function defaultRunner(systemPrompt: string, userContent: string): Promise
     tools: [MEMORY_OBSERVE_TOOL],
     toolChoice: { type: "auto" },
   });
-  return result.content
-    .filter((part): part is LanguageModelV4ToolCall => part.type === "tool-call" && part.toolName === "memory-observe")
-    .map(parseToolCall)
-    .filter((obs): obs is DistillObservation => obs !== null);
+  const observations: DistillObservation[] = [];
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value.type === "error") throw value.error instanceof Error ? value.error : new Error(String(value.error));
+    if (value.type !== "tool-call" || value.toolName !== "memory-observe") continue;
+    const obs = parseToolCall(value);
+    if (obs) observations.push(obs);
+  }
+  return observations;
 }
 
 async function commitFact(ds: MemoryStore, key: string, content: string, topic: string | null): Promise<number> {

--- a/src/memory-distiller.ts
+++ b/src/memory-distiller.ts
@@ -90,7 +90,6 @@ async function defaultRunner(systemPrompt: string, userContent: string): Promise
     ],
     tools: [MEMORY_OBSERVE_TOOL],
     toolChoice: { type: "auto" },
-    temperature: 0,
   });
   return result.content
     .filter((part): part is LanguageModelV4ToolCall => part.type === "tool-call" && part.toolName === "memory-observe")

--- a/src/server-chat-runtime.ts
+++ b/src/server-chat-runtime.ts
@@ -283,7 +283,6 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
       workspace: workspaceResolution.workspacePath,
       features: config.features,
       reasoning: config.reasoning,
-      temperature: config.temperature,
       authRoute: authRouteForModel(chatRequest.model, providerCredentials),
       taskId: handlers.taskId,
       runControl,

--- a/src/task-queue.test.ts
+++ b/src/task-queue.test.ts
@@ -29,6 +29,38 @@ describe("task queue", () => {
     expect(events).toEqual(["start-1", "end-1", "start-2", "end-2"]);
   });
 
+  test("does not surface a failed job as an unhandled rejection", async () => {
+    const queue = createInMemoryTaskQueue();
+    const rejections: unknown[] = [];
+    const onUnhandled = (reason: unknown) => rejections.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      await queue
+        .enqueue("sess_fail0001", async () => {
+          throw new Error("boom");
+        })
+        .catch(() => {});
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(rejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+    }
+  });
+
+  test("recovers for the same key after a job fails", async () => {
+    const queue = createInMemoryTaskQueue();
+    let ran = false;
+    await queue
+      .enqueue("sess_recover01", async () => {
+        throw new Error("boom");
+      })
+      .catch(() => {});
+    await queue.enqueue("sess_recover01", async () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+  });
+
   test("allows different keys to run independently", async () => {
     const queue = createInMemoryTaskQueue();
     const events: string[] = [];

--- a/src/task-queue.ts
+++ b/src/task-queue.ts
@@ -9,9 +9,11 @@ export function createInMemoryTaskQueue(): TaskQueue {
       const previous = queueByKey.get(key) ?? Promise.resolve();
       const next = previous.catch(() => {}).then(job);
       queueByKey.set(key, next);
-      void next.finally(() => {
-        if (queueByKey.get(key) === next) queueByKey.delete(key);
-      });
+      void next
+        .catch(() => {})
+        .finally(() => {
+          if (queueByKey.get(key) === next) queueByKey.delete(key);
+        });
       return next;
     },
   };


### PR DESCRIPTION
## Summary

- distill over `doStream` — the subscription backend rejects non-streaming `doGenerate` (`"Stream must be set to true"`), which is what emptied the corpus
- throw on a stream `error` part so a failed distill still surfaces as `commit_failed`, never a silent empty commit
- catch the commit-queue cleanup promise so a failed commit no longer leaks an unhandled rejection
- drop the unused `temperature` config knob — unrelated cleanup bundled here; reasoning models reject it and it was never the cause