### PR TITLE
fix(chat): append queued messages

### DIFF
--- a/scripts/memory-bench-scenarios.ts
+++ b/scripts/memory-bench-scenarios.ts
@@ -531,18 +531,21 @@ const locomoDistilledAdapter: DatasetAdapter = {
     const runner = async (systemPrompt: string, userContent: string): Promise<string> => {
       const qualifiedModel = normalizeModel(appConfig.distillModel);
       const model = createModel(qualifiedModel, sharedRateLimiter(providerFromModel(qualifiedModel)));
-      const result = await model.doGenerate({
+      const { stream } = await model.doStream({
         prompt: [
           { role: "system", content: systemPrompt },
           { role: "user", content: [{ type: "text", text: userContent }] },
         ],
-        temperature: 0,
       });
-      return result.content
-        .filter((part): part is { type: "text"; text: string } => part.type === "text")
-        .map((part) => part.text)
-        .join("")
-        .trim();
+      const reader = stream.getReader();
+      let text = "";
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value.type === "error") throw value.error instanceof Error ? value.error : new Error(String(value.error));
+        if (value.type === "text-delta") text += value.delta;
+      }
+      return text.trim();
     };
 
     const cacheDir = join(dir, "distilled");

--- a/src/chat-state.ts
+++ b/src/chat-state.ts
@@ -33,8 +33,6 @@ import { loadSkills } from "./skill-ops";
 import { useAsyncEffect, useMountEffect, useSyncEffect } from "./tui/effects";
 import type { PromotedSceneSlice } from "./tui/scene-viewport";
 
-const QUEUE_DELIVERY_POLICY = "one-at-a-time" as const;
-
 /** Debounce for the git-status refresh; coalesces rapid pending-state churn. */
 const GIT_REFRESH_DEBOUNCE_MS = 300;
 
@@ -427,7 +425,7 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
       const queueDecision = resolveQueueSubmit({ value: resolved.value, isPending });
       if (queueDecision.kind === "ignore") return;
       if (isPending) {
-        setQueuedMessages((current) => enqueueQueuedMessage(current, queueDecision.value, QUEUE_DELIVERY_POLICY));
+        setQueuedMessages((current) => enqueueQueuedMessage(current, queueDecision.value));
         setValue("");
         return;
       }

--- a/src/chat-submit.test.ts
+++ b/src/chat-submit.test.ts
@@ -66,12 +66,28 @@ describe("chat submit helpers", () => {
     });
   });
 
-  test("enqueueQueuedMessage keeps only latest prompt in one-at-a-time mode", () => {
-    expect(enqueueQueuedMessage(["first", "second"], "latest", "one-at-a-time")).toEqual(["latest"]);
+  test("enqueueQueuedMessage appends without dropping earlier messages", () => {
+    expect(enqueueQueuedMessage(["first", "second"], "latest")).toEqual(["first", "second", "latest"]);
   });
 
-  test("enqueueQueuedMessage appends in all mode", () => {
-    expect(enqueueQueuedMessage(["first", "second"], "latest", "all")).toEqual(["first", "second", "latest"]);
+  test("messages queued over multiple sends drain one-per-turn in order until empty", () => {
+    let queue = enqueueQueuedMessage([], "first");
+    queue = enqueueQueuedMessage(queue, "second");
+    queue = enqueueQueuedMessage(queue, "third");
+
+    const submitted: string[] = [];
+    // Each turn end drains one head; the resubmit would end another turn, re-firing the drain.
+    while (queue.length > 0) {
+      drainQueueOnTurnEnd({
+        queue,
+        submit: (message) => submitted.push(message),
+        setQueue: (updater) => {
+          queue = updater(queue);
+        },
+      });
+    }
+
+    expect(submitted).toEqual(["first", "second", "third"]);
   });
 
   test("dequeueQueuedMessage splits head from rest", () => {

--- a/src/chat-submit.ts
+++ b/src/chat-submit.ts
@@ -21,8 +21,6 @@ export type QueueSubmitResolution =
       value: string;
     };
 
-export type QueueDeliveryPolicy = "one-at-a-time" | "all";
-
 type ResolveSubmitInput = {
   value: string;
   cursor?: number;
@@ -56,9 +54,8 @@ export function resolveQueueSubmit(input: { value: string; isPending: boolean })
   return { kind: "submit", value: input.value };
 }
 
-export function enqueueQueuedMessage(current: string[], next: string, policy: QueueDeliveryPolicy): string[] {
-  if (policy === "all") return [...current, next];
-  return [next];
+export function enqueueQueuedMessage(current: string[], next: string): string[] {
+  return [...current, next];
 }
 
 export function dequeueQueuedMessage(current: string[]): { next: string | undefined; rest: string[] } {
@@ -68,8 +65,7 @@ export function dequeueQueuedMessage(current: string[]): { next: string | undefi
 
 // The submit runs once, outside the setQueue updater, so a StrictMode double-invoke of the
 // updater cannot resubmit the queued command. Read the head from the caller's snapshot; the
-// updater only drains it. submit and setQueue must stay synchronous and adjacent — an await
-// between them would let a message queued in the gap be dropped by one-at-a-time replace.
+// updater only drains it.
 export function drainQueueOnTurnEnd(params: {
   queue: string[];
   submit: (message: string) => void;


### PR DESCRIPTION
## Summary
- queuing a message while one is already queued now appends instead of dropping the earlier one, so all queued messages run in order (SPEC-TUI-10)
- drop the unused one-at-a-time delivery policy in favor of a single append behavior