### PR TITLE
fix(cli): width-aware truncation for list tables

### DIFF
--- a/src/cli-history.ts
+++ b/src/cli-history.ts
@@ -1,9 +1,8 @@
 import { hasBoolFlag, stripFlag } from "./cli-args";
-import { type CliOutput, createJsonOutput, createTextOutput } from "./cli-output";
+import { type CliOutput, createJsonOutput, createTextOutput, fitFlexColumn } from "./cli-output";
 import { formatRelativeTime } from "./datetime";
 import { t } from "./i18n";
 import type { SessionStore } from "./session-contract";
-import { truncateText } from "./truncate-text";
 
 type HistoryModeDeps = {
   hasHelpFlag: (args: string[]) => boolean;
@@ -33,13 +32,12 @@ export async function historyMode(args: string[], deps: HistoryModeDeps): Promis
   }
 
   const out: CliOutput = json ? createJsonOutput() : createTextOutput();
-  out.addTable(
-    sessions.map((session) => ({
-      id: session.id,
-      title: truncateText(session.title, 60),
-      time: formatRelativeTime(session.updatedAt),
-    })),
-  );
+  const tableRows = sessions.map((session) => ({
+    id: session.id,
+    title: session.title,
+    time: formatRelativeTime(session.updatedAt),
+  }));
+  out.addTable(json ? tableRows : fitFlexColumn(tableRows, "title"));
   const rendered = out.render();
   if (rendered) printDim(rendered);
 }

--- a/src/cli-memory.ts
+++ b/src/cli-memory.ts
@@ -1,10 +1,9 @@
 import { hasBoolFlag, stripFlag } from "./cli-args";
 import { formatUsage } from "./cli-help";
-import { type CliOutput, createJsonOutput, createTextOutput } from "./cli-output";
+import { type CliOutput, createJsonOutput, createTextOutput, fitFlexColumn } from "./cli-output";
 import { formatRelativeTime } from "./datetime";
 import { t } from "./i18n";
 import type { MemoryEntry, MemoryScope } from "./memory-contract";
-import { truncateText } from "./truncate-text";
 
 type MemoryOps = {
   list: (scope?: MemoryScope) => Promise<MemoryEntry[]>;
@@ -46,15 +45,14 @@ export async function memoryMode(args: string[], deps: MemoryModeDeps): Promise<
       return;
     }
     const out: CliOutput = json ? createJsonOutput() : createTextOutput();
-    out.addTable(
-      rows.slice(0, 50).map((row) => ({
-        id: row.id,
-        kind: row.kind,
-        content: truncateText(row.content, 80),
-        created: formatRelativeTime(row.createdAt),
-        recalled: row.lastRecalledAt ? formatRelativeTime(row.lastRecalledAt) : "never",
-      })),
-    );
+    const tableRows = rows.slice(0, 50).map((row) => ({
+      id: row.id,
+      kind: row.kind,
+      content: row.content,
+      created: formatRelativeTime(row.createdAt),
+      recalled: row.lastRecalledAt ? formatRelativeTime(row.lastRecalledAt) : "never",
+    }));
+    out.addTable(json ? tableRows : fitFlexColumn(tableRows, "content"));
     const rendered = out.render();
     if (rendered) printDim(rendered);
     return;

--- a/src/cli-output.test.ts
+++ b/src/cli-output.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { createJsonOutput, createTextOutput } from "./cli-output";
+import { createJsonOutput, createTextOutput, fitFlexColumn } from "./cli-output";
 
 describe("createTextOutput", () => {
   test("renders row as key=value pairs", () => {
@@ -68,6 +68,34 @@ describe("createTextOutput", () => {
 
   test("verbose can be set via options", () => {
     expect(createTextOutput({ verbose: true }).verbose).toBe(true);
+  });
+});
+
+describe("fitFlexColumn", () => {
+  test("truncates the flex column so the widest row fits the width", () => {
+    const rows = [{ id: "sess_abc", title: "x".repeat(200), time: "2 hours ago" }];
+    const [fitted] = fitFlexColumn(rows, "title", 40);
+    // id(8) + gap(2) + title + gap(2) + time(11) must fit 40 columns
+    const rowWidth = fitted.id.length + 2 + fitted.title.length + 2 + fitted.time.length;
+    expect(rowWidth).toBeLessThanOrEqual(40);
+    expect(fitted.title.endsWith("…")).toBe(true);
+  });
+
+  test("adapts to the available width instead of a fixed cap", () => {
+    const rows = [{ id: "a", title: "y".repeat(300), time: "now" }];
+    const wide = fitFlexColumn(rows, "title", 200)[0].title.length;
+    const narrow = fitFlexColumn(rows, "title", 60)[0].title.length;
+    expect(wide).toBeGreaterThan(narrow);
+  });
+
+  test("leaves rows that already fit untouched", () => {
+    const rows = [{ id: "a", title: "short", time: "now" }];
+    expect(fitFlexColumn(rows, "title", 120)[0].title).toBe("short");
+  });
+
+  test("keeps a minimum flex width on a very narrow terminal", () => {
+    const rows = [{ id: "sess_long_id", title: "z".repeat(80), time: "yesterday" }];
+    expect(fitFlexColumn(rows, "title", 10)[0].title.length).toBeGreaterThan(0);
   });
 });
 

--- a/src/cli-output.ts
+++ b/src/cli-output.ts
@@ -1,4 +1,33 @@
 import { alignCols } from "./chat-format";
+import { truncateToWidth } from "./truncate-text";
+
+const TABLE_GAP = 2;
+const MIN_FLEX_COLUMN = 16;
+
+function terminalColumns(fallback = 80): number {
+  const columns = process.stdout.columns;
+  return typeof columns === "number" && columns > 0 ? columns : fallback;
+}
+
+/**
+ * Truncate one flexible column so the widest assembled row fits the terminal width,
+ * reserving the measured width of the sibling columns. Text tables only — callers skip
+ * this for --json so machine-readable output stays whole.
+ */
+export function fitFlexColumn<T extends Record<string, string | undefined>>(
+  rows: T[],
+  flexKey: keyof T & string,
+  width = terminalColumns(),
+): T[] {
+  if (rows.length === 0) return rows;
+  const otherKeys = Object.keys(rows[0]).filter((key) => key !== flexKey);
+  const reserved = otherKeys.reduce(
+    (sum, key) => sum + Math.max(0, ...rows.map((row) => Bun.stringWidth(row[key] ?? ""))) + TABLE_GAP,
+    0,
+  );
+  const budget = Math.max(MIN_FLEX_COLUMN, width - reserved - TABLE_GAP);
+  return rows.map((row) => ({ ...row, [flexKey]: truncateToWidth(row[flexKey] ?? "", budget) }) as T);
+}
 
 export type CliOutputOptions = {
   verbose?: boolean;

--- a/src/cli-visual.int.test.ts
+++ b/src/cli-visual.int.test.ts
@@ -187,7 +187,7 @@ describe("cli visual regression", () => {
       const out = await run(["history"]);
       expect(out).toBe(
         dedent(`
-        sess_long  This title is intentionally made very long so we can verify…  just now
+        sess_long  This title is intentionally made very long so we can ver…  just now
       `),
       );
     });

--- a/src/truncate-text.test.ts
+++ b/src/truncate-text.test.ts
@@ -1,31 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { truncateMiddle, truncateMiddleToWidth, truncateText, truncateToWidth } from "./truncate-text";
-
-describe("truncateText", () => {
-  test("returns input unchanged when within limit", () => {
-    expect(truncateText("short")).toBe("short");
-    expect(truncateText("ab", 4)).toBe("ab");
-  });
-
-  test("truncates with ellipsis when over limit", () => {
-    expect(truncateText("abcdef", 4)).toBe("abc…");
-  });
-
-  test("uses default max of 80 chars", () => {
-    const input = "a".repeat(100);
-    const result = truncateText(input);
-    expect(result.length).toBe(80);
-    expect(result.endsWith("…")).toBe(true);
-  });
-
-  test("handles edge case of maxChars 1", () => {
-    expect(truncateText("abc", 1)).toBe("…");
-  });
-
-  test("handles empty string", () => {
-    expect(truncateText("")).toBe("");
-  });
-});
+import { truncateMiddle, truncateMiddleToWidth, truncateToWidth } from "./truncate-text";
 
 describe("truncateMiddle", () => {
   test("returns input unchanged when under limit", () => {

--- a/src/truncate-text.ts
+++ b/src/truncate-text.ts
@@ -1,10 +1,3 @@
-const DEFAULT_MAX_DISPLAY_CHARS = 80;
-
-export function truncateText(input: string, maxChars = DEFAULT_MAX_DISPLAY_CHARS): string {
-  if (input.length <= maxChars) return input;
-  return `${input.slice(0, Math.max(0, maxChars - 1))}…`;
-}
-
 export function truncateMiddle(text: string, maxChars: number): string {
   if (text.length <= maxChars) return text;
   const dropped = text.length - maxChars;


### PR DESCRIPTION
## Summary
- `acolyte history`/`memory list` tables truncate width-aware against the terminal (reserving sibling columns) instead of fixed 60/80-char caps
- `--json` output is no longer truncated (it was being capped too)
- drop the now-unused `truncateText`