### PR TITLE
docs(skills): sharpen skill descriptions

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -60,6 +60,7 @@ This glossary defines the naming conventions and runtime terms used across Acoly
 | SessionState | Aggregate session state (`sessions[]`, `activeSessionId`) |
 | SessionStore | Read/write/create interface for session persistence |
 | Skill | Declarative prompt extension defined in a `SKILL.md` file with metadata and compatibility constraints |
+| Skill Roster | Ambient per-turn line listing the activatable (non-active) skills and their descriptions, from which the model selects via `skill-activate`; the selection surface, distinct from the loaded-skill store |
 | Step Budget | Per-turn tool-call limit inlined into tool execution to prevent runaway loops |
 | Storage | The persistence mechanism a `*Store` uses for memory and session records — `sqlite` (local) or `cloud` |
 | Task | Lifecycle work request moving through accept, queue, run, and terminal states |

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -10,6 +10,10 @@ These are specialized for Acolyte from the tool-agnostic set at [cniska/skills](
 
 Multiple skills can be active in one session. The agent can load one or more in a single call, and the active set is shown in the status line.
 
+## Descriptions
+
+The agent selects a skill from the roster — the per-turn line of names and `description`s — with nothing else to match on, so the `description` is the whole selection signal. Each follows one shape: `<imperative capability>. Use when <precise, observable trigger>.` The first sentence says what the skill does; the second gives a trigger phrased to fire exactly when the skill applies and stay quiet otherwise, naming the boundary against neighboring skills (build vs tdd, plan vs design, style-review vs the other review dimensions). Keep it under the roster's 250-character cap.
+
 ## Skills
 
 | Phase | Skill | Description |

--- a/docs/skills/architecture-review.md
+++ b/docs/skills/architecture-review.md
@@ -1,6 +1,6 @@
 ---
 name: architecture-review
-description: Review architecture, boundaries, and design consistency. Use when reviewing module boundaries, extension seams, or contract drift.
+description: Review boundaries, indirection pressure, and contract integrity. Use when reviewing module structure, extension seams, or unnecessary layers.
 ---
 
 # Architecture Review

--- a/docs/skills/build.md
+++ b/docs/skills/build.md
@@ -1,6 +1,6 @@
 ---
 name: build
-description: Implement features incrementally through vertical slices. Use when building features, adding functionality, or implementing tasks that touch multiple files.
+description: Implement a feature or change in thin vertical slices, verifying each before starting the next. Use when building or extending functionality and not driving it test-first.
 ---
 
 # Build

--- a/docs/skills/design.md
+++ b/docs/skills/design.md
@@ -1,6 +1,6 @@
 ---
 name: design
-description: Design stable interfaces that are hard to misuse. Use when defining contracts, module boundaries, or public APIs.
+description: Design interfaces that are hard to misuse and stable under change. Use when defining a contract, module boundary, public API, or schema.
 ---
 
 # Design

--- a/docs/skills/doc-review.md
+++ b/docs/skills/doc-review.md
@@ -1,6 +1,6 @@
 ---
 name: doc-review
-description: Review docs for drift, missing updates, and terminology changes. Use when code changes should be reflected in documentation.
+description: Review docs the change touched for drift — stale terms, contracts, and behavior. Use when a diff may have made documentation inaccurate.
 ---
 
 # Documentation Review

--- a/docs/skills/git.md
+++ b/docs/skills/git.md
@@ -1,6 +1,6 @@
 ---
 name: git
-description: Manage commits, branches, and change history. Use when committing, branching, or managing version control.
+description: Manage commits, branches, and history — atomic commits, clean history. Use when committing, branching, or rewriting history before a push.
 ---
 
 # Git

--- a/docs/skills/plan.md
+++ b/docs/skills/plan.md
@@ -1,6 +1,6 @@
 ---
 name: plan
-description: Design a feature or behavior change through dialogue. Use when asked to plan, scope, design, or break down work before coding.
+description: Scope and break down a feature or change through dialogue before coding. Use when a task is ambiguous or large enough to need a shared plan first.
 ---
 
 # Plan

--- a/docs/skills/style-review.md
+++ b/docs/skills/style-review.md
@@ -1,6 +1,6 @@
 ---
 name: style-review
-description: Review code style, naming, patterns, and consistency. Use when reviewing code quality or style drift.
+description: Review naming, patterns, and convention consistency against the codebase. Use when the concern is style and readability, not logic or structure.
 ---
 
 # Style Review

--- a/docs/skills/tdd.md
+++ b/docs/skills/tdd.md
@@ -1,6 +1,6 @@
 ---
 name: tdd
-description: Drive implementation with red-green-refactor. Use when building features or fixing bugs test-first.
+description: Drive implementation test-first through red-green-refactor. Use when you want a failing test to specify each change before you write it.
 ---
 
 # TDD


### PR DESCRIPTION
## Summary

- sharpen eight bundled-skill descriptions to a precise "use when" trigger, separating overlapping pairs (build/tdd, plan/design, style-review vs the other review dimensions)
- pin the description convention in the skills README so future skills follow it
- add a `Skill Roster` glossary term, distinguishing the model-facing selection line from the loaded-skill store