### PR TITLE
feat(memory): dedup and skip re-distilling

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -50,7 +50,8 @@ The observation model is inspired by [Mastra's Observational Memory](https://mas
   - `"session"` — session-scoped facts (in-progress state, temporary constraints)
   - if a preference is project-scoped, use `"project"` not `"user"`
 - topic via the optional `topic` parameter — single-word label (e.g. testing, auth, config)
-- dedup: exact duplicate observations are skipped at write time
+- dedup: an observation matching any existing one in the same scope is skipped at write time; scopes dedup independently, so the same fact can be held at both project and session scope
+- the distiller sees only messages added since its last commit for that session, so a turn's work is never re-read
 
 ## Runtime guarantees
 

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -9,7 +9,7 @@ import { createLifecyclePolicy } from "./lifecycle-policy";
 import { phasePrepare } from "./lifecycle-prepare";
 import { resolveModel } from "./lifecycle-resolve";
 import { listMcpTools } from "./mcp-client";
-import type { MemoryCommitContext, MemoryCommitMetrics } from "./memory-contract";
+import { defaultMemoryPolicy, type MemoryCommitContext, type MemoryCommitMetrics } from "./memory-contract";
 import { commitDistiller, estimateDistillPromptTokens } from "./memory-distiller";
 import { createTaskActivity } from "./task-activity";
 import { createInMemoryTaskQueue } from "./task-queue";
@@ -159,7 +159,13 @@ function commitMemory(ctx: RunContext, input: LifecycleInput): void {
     { role: "user", content: ctx.request.message },
   ];
   const activity = createTaskActivity(scopedCallLog(ctx.session, ctx.taskId), WRITE_TOOL_SET, DISCOVERY_TOOL_SET);
-  const distillTokens = estimateDistillPromptTokens(messages, output, activity);
+  // Upper bound: the commit runs in the background, so the turn can only estimate. The distiller
+  // never sends more than one window and usually far less, having already seen the earlier turns.
+  const distillTokens = estimateDistillPromptTokens(
+    messages.slice(-defaultMemoryPolicy.contextMessageWindow),
+    output,
+    activity,
+  );
   ctx.promptUsage.memoryTokens += distillTokens;
   scheduleMemoryCommit(
     {

--- a/src/memory-distiller.test.ts
+++ b/src/memory-distiller.test.ts
@@ -103,7 +103,7 @@ describe("memoryDistiller", () => {
       expect(store.written).toHaveLength(0);
     });
 
-    test("skips consecutive duplicate observations", async () => {
+    test("skips a duplicate of any earlier observation, not just the latest", async () => {
       const store = createMockStore([
         {
           id: "mem_obs_prev",
@@ -111,6 +111,14 @@ describe("memoryDistiller", () => {
           kind: "observation",
           content: "prefers short answers",
           createdAt: "2026-03-04T10:00:00.000Z",
+          tokenEstimate: 6,
+        },
+        {
+          id: "mem_obs_newer",
+          scopeKey: "sess_test0001",
+          kind: "observation",
+          content: "the build runs on bun",
+          createdAt: "2026-03-04T11:00:00.000Z",
           tokenEstimate: 6,
         },
       ]);

--- a/src/memory-distiller.test.ts
+++ b/src/memory-distiller.test.ts
@@ -107,6 +107,33 @@ describe("high-water mark", () => {
     expect(seen[1]).not.toContain("turn one");
   });
 
+  test("a failed write leaves the messages re-readable next commit", async () => {
+    const seen: string[] = [];
+    const store = createMockStore();
+    let failWrite = true;
+    store.write = async () => {
+      if (failWrite) throw new Error("disk full");
+    };
+    const distiller = createMemoryDistiller({
+      store,
+      runner: async (_prompt, userContent) => {
+        seen.push(userContent);
+        return [{ scope: "session", content: "a durable fact", topic: null }];
+      },
+      policy: testPolicy,
+    });
+    await expect(
+      distiller.commit({ sessionId: "sess_test0001", messages: turnOne, output: "done one" }),
+    ).rejects.toThrow();
+    failWrite = false;
+    await distiller.commit({
+      sessionId: "sess_test0001",
+      messages: [...turnOne, { role: "user", content: "turn two" }],
+      output: "done two",
+    });
+    expect(seen[1]).toContain("turn one");
+  });
+
   test("each session keeps its own mark", async () => {
     const seen: string[] = [];
     const distiller = createMemoryDistiller({

--- a/src/memory-distiller.test.ts
+++ b/src/memory-distiller.test.ts
@@ -76,6 +76,70 @@ describe("createDistillInput", () => {
   });
 });
 
+describe("high-water mark", () => {
+  function captureRunner(seen: string[]) {
+    return async (_prompt: string, userContent: string): Promise<DistillObservation[]> => {
+      seen.push(userContent);
+      return [];
+    };
+  }
+
+  const turnOne = [
+    { role: "user", content: "turn one" },
+    { role: "assistant", content: "reply one" },
+  ];
+
+  test("a later commit re-sends nothing the distiller already saw", async () => {
+    const seen: string[] = [];
+    const distiller = createMemoryDistiller({
+      store: createMockStore(),
+      runner: captureRunner(seen),
+      policy: testPolicy,
+    });
+    await distiller.commit({ sessionId: "sess_test0001", messages: turnOne, output: "done one" });
+    await distiller.commit({
+      sessionId: "sess_test0001",
+      messages: [...turnOne, { role: "user", content: "turn two" }],
+      output: "done two",
+    });
+    expect(seen[0]).toContain("turn one");
+    expect(seen[1]).toContain("turn two");
+    expect(seen[1]).not.toContain("turn one");
+  });
+
+  test("each session keeps its own mark", async () => {
+    const seen: string[] = [];
+    const distiller = createMemoryDistiller({
+      store: createMockStore(),
+      runner: captureRunner(seen),
+      policy: testPolicy,
+    });
+    await distiller.commit({ sessionId: "sess_test0001", messages: turnOne, output: "done" });
+    await distiller.commit({ sessionId: "sess_test0002", messages: turnOne, output: "done" });
+    expect(seen[1]).toContain("turn one");
+  });
+
+  test("the context window still caps how far back a first commit reaches", async () => {
+    const seen: string[] = [];
+    const distiller = createMemoryDistiller({
+      store: createMockStore(),
+      runner: captureRunner(seen),
+      policy: createMemoryPolicy({ messageThreshold: 1, contextMessageWindow: 2 }),
+    });
+    await distiller.commit({
+      sessionId: "sess_test0001",
+      messages: [
+        { role: "user", content: "oldest" },
+        { role: "assistant", content: "middle" },
+        { role: "user", content: "newest" },
+      ],
+      output: "done",
+    });
+    expect(seen[0]).not.toContain("oldest");
+    expect(seen[0]).toContain("newest");
+  });
+});
+
 describe("memoryDistiller", () => {
   describe("commit", () => {
     test("skips when no sessionId", async () => {

--- a/src/memory-distiller.ts
+++ b/src/memory-distiller.ts
@@ -132,8 +132,12 @@ export function createMemoryDistiller(deps: Partial<DistillerDeps> = {}): Memory
   const runner = deps.runner ?? defaultRunner;
   const policy = deps.policy ?? defaultMemoryPolicy;
   const commitScope = deps.commitScope ?? "session";
-  // In-memory: with scope-wide dedup, a mark lost on restart costs one redundant distill, not a duplicate.
+  // In-memory: a mark lost on restart costs one redundant distill, whose facts are then mostly
+  // absorbed by scope dedup. Persisting it would buy little and outlive the history it indexes.
   const distilledThrough = new Map<string, number>();
+  const markDistilled = (sessionId: string | undefined, through: number): void => {
+    if (sessionId) distilledThrough.set(sessionId, through);
+  };
   return {
     async commit(ctx): Promise<MemoryCommitMetrics | undefined> {
       if (commitScope === "none") return;
@@ -141,16 +145,21 @@ export function createMemoryDistiller(deps: Partial<DistillerDeps> = {}): Memory
       if (ctx.messages.length < policy.messageThreshold) return;
 
       const ds = deps.store ?? (await getCachedStore());
-      const alreadyDistilled = ctx.sessionId ? (distilledThrough.get(ctx.sessionId) ?? 0) : 0;
+      const marked = ctx.sessionId ? (distilledThrough.get(ctx.sessionId) ?? 0) : 0;
+      // A mark past the end means history was rewritten under us (an aborted turn is spliced
+      // out), so it indexes messages that no longer exist — distrust it rather than skip the turn.
+      const alreadyDistilled = marked <= ctx.messages.length ? marked : 0;
       const start = Math.max(alreadyDistilled, ctx.messages.length - policy.contextMessageWindow, 0);
       const recentMessages = ctx.messages.slice(start);
       const distillInput = createDistillInput(recentMessages, ctx.output, ctx.activity);
       const observations = await runner(DISTILLER_PROMPT, distillInput);
-      if (ctx.sessionId) distilledThrough.set(ctx.sessionId, ctx.messages.length);
 
       const filtered =
         commitScope === "session" ? observations : observations.filter((obs) => obs.scope === commitScope);
-      if (filtered.length === 0) return;
+      if (filtered.length === 0) {
+        markDistilled(ctx.sessionId, ctx.messages.length);
+        return;
+      }
 
       const promptTokens = estimateDistillPromptTokens(recentMessages, ctx.output, ctx.activity);
       let totalTokens = promptTokens;
@@ -168,6 +177,8 @@ export function createMemoryDistiller(deps: Partial<DistillerDeps> = {}): Memory
         else if (obs.scope === "user") userCount++;
         else sessionCount++;
       }
+      // Only once the facts are persisted: a store failure must leave those messages re-readable.
+      markDistilled(ctx.sessionId, ctx.messages.length);
 
       log.debug("memory.distill.commit_done", {
         session: sessionCount,

--- a/src/memory-distiller.ts
+++ b/src/memory-distiller.ts
@@ -132,6 +132,8 @@ export function createMemoryDistiller(deps: Partial<DistillerDeps> = {}): Memory
   const runner = deps.runner ?? defaultRunner;
   const policy = deps.policy ?? defaultMemoryPolicy;
   const commitScope = deps.commitScope ?? "session";
+  // In-memory: with scope-wide dedup, a mark lost on restart costs one redundant distill, not a duplicate.
+  const distilledThrough = new Map<string, number>();
   return {
     async commit(ctx): Promise<MemoryCommitMetrics | undefined> {
       if (commitScope === "none") return;
@@ -139,9 +141,12 @@ export function createMemoryDistiller(deps: Partial<DistillerDeps> = {}): Memory
       if (ctx.messages.length < policy.messageThreshold) return;
 
       const ds = deps.store ?? (await getCachedStore());
-      const recentMessages = ctx.messages.slice(-policy.contextMessageWindow);
+      const alreadyDistilled = ctx.sessionId ? (distilledThrough.get(ctx.sessionId) ?? 0) : 0;
+      const start = Math.max(alreadyDistilled, ctx.messages.length - policy.contextMessageWindow, 0);
+      const recentMessages = ctx.messages.slice(start);
       const distillInput = createDistillInput(recentMessages, ctx.output, ctx.activity);
       const observations = await runner(DISTILLER_PROMPT, distillInput);
+      if (ctx.sessionId) distilledThrough.set(ctx.sessionId, ctx.messages.length);
 
       const filtered =
         commitScope === "session" ? observations : observations.filter((obs) => obs.scope === commitScope);

--- a/src/memory-ops.test.ts
+++ b/src/memory-ops.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { MemoryRecord } from "./memory-contract";
-import { listMemories, resolveScopeKey, visibleScopeKeys } from "./memory-ops";
+import { addObservation, listMemories, resolveScopeKey, visibleScopeKeys } from "./memory-ops";
 import { createSqliteMemoryStore } from "./memory-store";
 import { defaultUserResourceId, projectResourceIdFromWorkspace } from "./resource-id";
 
@@ -57,6 +57,23 @@ describe("visibleScopeKeys", () => {
     const keys = visibleScopeKeys({ sessionId: "sess_alpha" });
     expect(keys.has(projectResourceIdFromWorkspace(process.cwd()))).toBe(false);
     expect(keys).toEqual(new Set(["sess_alpha", defaultUserResourceId()]));
+  });
+});
+
+describe("addObservation", () => {
+  test("skips a repeat within a scope but keeps the same fact in a different scope", async () => {
+    const store = createSqliteMemoryStore(":memory:");
+    const fact = "the build runs on bun";
+    const userScope = defaultUserResourceId();
+    const projectScope = projectResourceIdFromWorkspace("/tmp/some-project");
+
+    expect(await addObservation(userScope, fact, { store })).not.toBeNull();
+    expect(await addObservation(userScope, fact, { store })).toBeNull();
+    expect(await addObservation(projectScope, fact, { store })).not.toBeNull();
+
+    expect((await store.list({ scopeKey: userScope })).length).toBe(1);
+    expect((await store.list({ scopeKey: projectScope })).length).toBe(1);
+    store.close();
   });
 });
 

--- a/src/memory-ops.ts
+++ b/src/memory-ops.ts
@@ -116,8 +116,9 @@ export async function addObservation(
 
   const store = options.store ?? (await getMemoryStore());
   const existing = await store.list({ scopeKey });
-  const latest = existing.filter((e) => e.kind === "observation").slice(-1)[0];
-  if (latest && normalizeMemoryText(latest.content) === normalizeMemoryText(trimmed)) return null;
+  const normalized = normalizeMemoryText(trimmed);
+  const duplicate = existing.some((e) => e.kind === "observation" && normalizeMemoryText(e.content) === normalized);
+  if (duplicate) return null;
 
   const record: MemoryRecord = {
     id: `mem_${createId()}`,


### PR DESCRIPTION
## Summary

- dedup observations against the whole scope, not just the most recent record — a fact re-derived turns later was stored again
- give the distiller a per-session mark so a turn's messages are sent once, not re-sent by every later turn
- advance that mark only after the facts are written, so a store failure leaves the messages re-readable
- reset the mark when history is spliced shorter than it, rather than silently skipping a turn

Dogfooded over three turns: the mark engaged, one fact correctly spanned two turns via the activity digest rather than thinning out, and a third turn on the same file added a new fact without re-storing the earlier one.