### PR TITLE
fix(file-find): match patterns as globs

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -36,7 +36,7 @@ A second premise is that completion belongs to the model, not the host. The runt
 
 ### 2.3 Feature coverage — tools
 
-- **FR-11** — File tools: find, search, and read files; create, edit, and delete files. Read-only file tools are gitignore-aware in what they surface.
+- **FR-11** — File tools: find, search, and read files; create, edit, and delete files. Read-only file tools are gitignore-aware in what they surface. File find matches its pattern as a path glob against workspace-relative paths, and as a case-insensitive substring when the pattern contains no wildcard; when its result cap withholds matches it reports the full match count rather than presenting a truncated list as complete.
 - **FR-12** — Query file tools (find/search/read/scan) present a search-oriented contract; mutation file tools (edit/create/delete) present a targeting-oriented contract. The two are not unified merely because they share an engine.
 - **FR-13** — AST-based structural code scanning and editing across supported source files; an edit against an unsupported file surfaces a structured error rather than a silent no-op.
 - **FR-14** — Git tools: status, diff, log, show, add, commit.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -47,6 +47,8 @@ All tool calls run through the execution layer which ensures:
 
 Entries in `IGNORED_DIRS` take precedence and cannot be re-included by gitignore negation patterns.
 
+`file-find` matches a pattern against workspace-relative paths through `createPathMatcher` in `glob-match.ts` — a glob when the pattern has a wildcard, a substring when it does not. `gitignore.ts` shares the same glob compiler, so brace alternation is expanded outside it: git treats braces literally.
+
 ## Tool result cache
 
 Read-only and search tools (`file-read`, `file-find`, `file-search`, `code-scan`) are cached. Identical calls return the cached result without re-executing. Bounded `file-read` windows are keyed by `aroundLine` and `contextLines`, so full reads and windowed reads cache independently while still invalidating together by path.

--- a/src/file-ops.int.test.ts
+++ b/src/file-ops.int.test.ts
@@ -525,12 +525,19 @@ describe("findFiles", () => {
     expect(result.result.paths).toEqual(["./src/file-ops.ts"]);
   });
 
-  test("rejects an absolute pattern outside the workspace", async () => {
+  test("anchors a leading-slash pattern at the workspace root", async () => {
     const workspace = await workspaceWithToolkits();
     const { tools } = toolsForAgent({ workspace });
-    await expect(tools.findFiles.execute({ pattern: "/etc/*.conf" }, "call_find_outside")).rejects.toThrow(
-      "outside the workspace",
-    );
+    const result = await tools.findFiles.execute({ pattern: "/src/*-toolkit.ts" }, "call_find_root_anchored");
+    expect(result.result.paths.sort()).toEqual(["./src/agent-toolkit.ts", "./src/file-toolkit.ts"]);
+  });
+
+  test("matches nothing for an absolute pattern outside the workspace", async () => {
+    const workspace = await workspaceWithToolkits();
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.findFiles.execute({ pattern: "/etc/*.conf" }, "call_find_outside");
+    expect(result.result.paths).toEqual([]);
+    expect(result.result.matches).toBe(0);
   });
 
   test("reports how many matches were withheld when results are capped", async () => {

--- a/src/file-ops.int.test.ts
+++ b/src/file-ops.int.test.ts
@@ -515,6 +515,16 @@ describe("findFiles", () => {
     expect(result.result.paths.sort()).toEqual(["./src/agent-toolkit.ts", "./src/file-toolkit.ts"]);
   });
 
+  test("resolves an absolute path with no wildcard to that one file", async () => {
+    const workspace = await workspaceWithToolkits();
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.findFiles.execute(
+      { pattern: join(workspace, "src", "file-ops.ts") },
+      "call_find_absolute_exact",
+    );
+    expect(result.result.paths).toEqual(["./src/file-ops.ts"]);
+  });
+
   test("rejects an absolute pattern outside the workspace", async () => {
     const workspace = await workspaceWithToolkits();
     const { tools } = toolsForAgent({ workspace });

--- a/src/file-ops.int.test.ts
+++ b/src/file-ops.int.test.ts
@@ -554,6 +554,24 @@ describe("findFiles", () => {
     expect(result.result.output).toContain("45 files matched, showing the first 40");
   });
 
+  test("says so rather than returning nothing for a blank pattern", async () => {
+    const workspace = await workspaceWithToolkits();
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.findFiles.execute({ pattern: "   " }, "call_find_blank");
+    expect(result.result.output).toBe("No matches.");
+    expect(result.result.matches).toBe(0);
+  });
+
+  test("ranks an exact path above the same name nested deeper", async () => {
+    const workspace = dirs.createDir("acolyte-find-rank-");
+    await mkdir(join(workspace, "sub"), { recursive: true });
+    await writeFile(join(workspace, "package.json"), "{}\n", "utf8");
+    await writeFile(join(workspace, "sub", "package.json"), "{}\n", "utf8");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.findFiles.execute({ pattern: "package.json" }, "call_find_rank");
+    expect(result.result.paths[0]).toBe("./package.json");
+  });
+
   test("reports an uncapped result as complete", async () => {
     const workspace = await workspaceWithToolkits();
     const { tools } = toolsForAgent({ workspace });

--- a/src/file-ops.int.test.ts
+++ b/src/file-ops.int.test.ts
@@ -442,6 +442,100 @@ describe("searchFiles", () => {
   });
 });
 
+describe("findFiles", () => {
+  async function workspaceWithToolkits(): Promise<string> {
+    const workspace = dirs.createDir("acolyte-find-glob-");
+    await mkdir(join(workspace, "src", "tui"), { recursive: true });
+    for (const rel of [
+      "src/agent-toolkit.ts",
+      "src/file-toolkit.ts",
+      "src/file-ops.ts",
+      "src/cli-tool.ts",
+      "src/tui/tool-render.tsx",
+      "docs.md",
+    ]) {
+      await writeFile(join(workspace, rel), "export const x = 1;\n", "utf8");
+    }
+    return workspace;
+  }
+
+  test("matches a path prefix combined with a mid-segment wildcard", async () => {
+    const workspace = await workspaceWithToolkits();
+    const { tools, session } = toolsForAgent({ workspace });
+    const result = await tools.findFiles.execute({ pattern: "src/*-toolkit.ts" }, "call_find_prefixed_glob");
+    expect(result.result.paths.sort()).toEqual(["./src/agent-toolkit.ts", "./src/file-toolkit.ts"]);
+    expect(session.callLog[0]?.toolName).toBe("file-find");
+  });
+
+  test("matches a bare wildcard pattern at any depth", async () => {
+    const workspace = await workspaceWithToolkits();
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.findFiles.execute({ pattern: "*-toolkit.ts" }, "call_find_bare_glob");
+    expect(result.result.paths.sort()).toEqual(["./src/agent-toolkit.ts", "./src/file-toolkit.ts"]);
+  });
+
+  test("keeps a wildcard within one path segment", async () => {
+    const workspace = await workspaceWithToolkits();
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.findFiles.execute({ pattern: "src/*tool*" }, "call_find_fragment_glob");
+    expect(result.result.paths.sort()).toEqual([
+      "./src/agent-toolkit.ts",
+      "./src/cli-tool.ts",
+      "./src/file-toolkit.ts",
+    ]);
+  });
+
+  test("matches a wildcard-free pattern as a substring", async () => {
+    const workspace = await workspaceWithToolkits();
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.findFiles.execute({ pattern: "toolkit" }, "call_find_substring");
+    expect(result.result.paths.sort()).toEqual(["./src/agent-toolkit.ts", "./src/file-toolkit.ts"]);
+  });
+
+  test("expands brace alternation", async () => {
+    const workspace = await workspaceWithToolkits();
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.findFiles.execute({ pattern: "src/**/*.{ts,tsx}" }, "call_find_braces");
+    expect(result.result.paths.sort()).toEqual([
+      "./src/agent-toolkit.ts",
+      "./src/cli-tool.ts",
+      "./src/file-ops.ts",
+      "./src/file-toolkit.ts",
+      "./src/tui/tool-render.tsx",
+    ]);
+  });
+
+  test("resolves an absolute pattern against the workspace root", async () => {
+    const workspace = await workspaceWithToolkits();
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.findFiles.execute(
+      { pattern: join(workspace, "src", "*-toolkit.ts") },
+      "call_find_absolute",
+    );
+    expect(result.result.paths.sort()).toEqual(["./src/agent-toolkit.ts", "./src/file-toolkit.ts"]);
+  });
+
+  test("rejects an absolute pattern outside the workspace", async () => {
+    const workspace = await workspaceWithToolkits();
+    const { tools } = toolsForAgent({ workspace });
+    await expect(tools.findFiles.execute({ pattern: "/etc/*.conf" }, "call_find_outside")).rejects.toThrow(
+      "outside the workspace",
+    );
+  });
+
+  test("reports how many matches were withheld when results are capped", async () => {
+    const workspace = dirs.createDir("acolyte-find-truncate-");
+    await mkdir(join(workspace, "src"), { recursive: true });
+    for (let i = 0; i < 45; i++) {
+      await writeFile(join(workspace, "src", `mod-${String(i).padStart(2, "0")}.ts`), "export const x = 1;\n", "utf8");
+    }
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.findFiles.execute({ pattern: "src/*.ts" }, "call_find_truncated");
+    expect(result.result.paths).toHaveLength(40);
+    expect(result.result.output).toContain("45 files matched, showing the first 40");
+  });
+});
+
 describe("createFile", () => {
   test("creates workspace files", async () => {
     const workspace = dirs.createDir("acolyte-create-ws-");

--- a/src/file-ops.int.test.ts
+++ b/src/file-ops.int.test.ts
@@ -542,7 +542,18 @@ describe("findFiles", () => {
     const { tools } = toolsForAgent({ workspace });
     const result = await tools.findFiles.execute({ pattern: "src/*.ts" }, "call_find_truncated");
     expect(result.result.paths).toHaveLength(40);
+    expect(result.result.matches).toBe(45);
+    expect(result.result.truncated).toBe(true);
     expect(result.result.output).toContain("45 files matched, showing the first 40");
+  });
+
+  test("reports an uncapped result as complete", async () => {
+    const workspace = await workspaceWithToolkits();
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.findFiles.execute({ pattern: "src/*-toolkit.ts" }, "call_find_untruncated");
+    expect(result.result.matches).toBe(2);
+    expect(result.result.truncated).toBe(false);
+    expect(result.result.output).not.toContain("Narrow the pattern");
   });
 });
 

--- a/src/file-ops.test.ts
+++ b/src/file-ops.test.ts
@@ -50,7 +50,7 @@ describe("searchFiles", () => {
 describe("findFiles", () => {
   test("finds files by pattern in workspace", async () => {
     const result = await findFiles(WORKSPACE, ["package.json"]);
-    expect(result).toContain("package.json");
+    expect(result.output).toContain("package.json");
   });
 
   test("rejects empty patterns", async () => {

--- a/src/file-ops.ts
+++ b/src/file-ops.ts
@@ -51,14 +51,13 @@ export async function findFiles(workspace: string, patterns: string[], maxResult
     const needle = relativePattern.replace(/^\.\/+/, "").toLowerCase();
     const matches = createPathMatcher(relativePattern);
 
-    const matched = allFiles.filter(matches).sort((a, b) => {
-      const aLower = a.toLowerCase();
-      const bLower = b.toLowerCase();
-      const aScore = aLower === needle ? 0 : aLower.endsWith(`/${needle}`) ? 1 : 2;
-      const bScore = bLower === needle ? 0 : bLower.endsWith(`/${needle}`) ? 1 : 2;
-      if (aScore !== bScore) return aScore - bScore;
-      return a.length - b.length;
-    });
+    const rank = (path: string) => {
+      const lower = path.toLowerCase();
+      if (lower === needle) return 0;
+      if (lower.endsWith(`/${needle}`)) return 1;
+      return 2;
+    };
+    const matched = allFiles.filter(matches).sort((a, b) => rank(a) - rank(b) || a.length - b.length);
     const ranked = matched.slice(0, maxResults).map((path) => `./${path}`);
     totalMatches += matched.length;
 
@@ -71,14 +70,11 @@ export async function findFiles(workspace: string, patterns: string[], maxResult
     }
   }
 
+  if (sections.length === 0) sections.push("No matches."); // every pattern was blank
   return { output: sections.join("\n"), totalMatches };
 }
 
-/**
- * An absolute pattern inside the workspace becomes root-anchored; every other leading slash already
- * means "anchored at the workspace root", so it passes through. Nothing needs rejecting here — the
- * candidates are already confined to the workspace, so a pattern can only ever match inside it.
- */
+/** Nothing is rejected here: the candidates are already confined to the workspace. */
 function toWorkspaceRelativePattern(pattern: string, workspace: string): string {
   const prefix = workspace.endsWith("/") ? workspace : `${workspace}/`;
   return pattern.startsWith(prefix) ? `/${pattern.slice(prefix.length)}` : pattern;

--- a/src/file-ops.ts
+++ b/src/file-ops.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 import { TOOL_ERROR_CODES } from "./error-contract";
+import { createPathMatcher } from "./glob-match";
 import { createToolError } from "./tool-error";
 
 /** Owner-only read/write. Use for files containing secrets or sensitive metadata. */
@@ -43,29 +44,39 @@ export async function findFiles(workspace: string, patterns: string[], maxResult
   for (const pattern of patterns) {
     const trimmed = pattern.trim();
     if (!trimmed) continue;
-    const needle = trimmed
-      .replace(/^\.\/+/, "")
-      .replace(/[*?]+/g, "")
-      .toLowerCase();
+    const relativePattern = toWorkspaceRelativePattern(trimmed, workspace);
+    const needle = relativePattern.replace(/^\.\/+/, "").toLowerCase();
+    const matches = createPathMatcher(relativePattern);
 
-    const ranked = allFiles
-      .filter((path) => path.toLowerCase().includes(needle))
-      .sort((a, b) => {
-        const aLower = a.toLowerCase();
-        const bLower = b.toLowerCase();
-        const aScore = aLower === needle ? 0 : aLower.endsWith(`/${needle}`) ? 1 : 2;
-        const bScore = bLower === needle ? 0 : bLower.endsWith(`/${needle}`) ? 1 : 2;
-        if (aScore !== bScore) return aScore - bScore;
-        return a.length - b.length;
-      })
-      .slice(0, maxResults)
-      .map((path) => `./${path}`);
+    const matched = allFiles.filter(matches).sort((a, b) => {
+      const aLower = a.toLowerCase();
+      const bLower = b.toLowerCase();
+      const aScore = aLower === needle ? 0 : aLower.endsWith(`/${needle}`) ? 1 : 2;
+      const bScore = bLower === needle ? 0 : bLower.endsWith(`/${needle}`) ? 1 : 2;
+      if (aScore !== bScore) return aScore - bScore;
+      return a.length - b.length;
+    });
+    const ranked = matched.slice(0, maxResults).map((path) => `./${path}`);
 
     if (multi) sections.push(`--- ${trimmed} ---`);
     sections.push(ranked.length > 0 ? ranked.join("\n") : "No matches.");
+    if (matched.length > ranked.length) {
+      sections.push(
+        `(${matched.length} files matched, showing the first ${ranked.length}. Narrow the pattern to see the rest.)`,
+      );
+    }
   }
 
   return sections.join("\n");
+}
+
+function toWorkspaceRelativePattern(pattern: string, workspace: string): string {
+  if (!isAbsolute(pattern)) return pattern;
+  const prefix = workspace.endsWith("/") ? workspace : `${workspace}/`;
+  if (pattern === workspace || !pattern.startsWith(prefix)) {
+    throw new Error(`Pattern is outside the workspace: ${pattern}`);
+  }
+  return `/${pattern.slice(prefix.length)}`; // leading slash anchors the remainder at the workspace root
 }
 
 export async function searchFiles(

--- a/src/file-ops.ts
+++ b/src/file-ops.ts
@@ -35,11 +35,14 @@ const MAX_BATCH_EDIT_LINES = 32;
 const MAX_BATCH_EDIT_CHARS = 2400;
 export const DEFAULT_READ_CONTEXT_LINES = 20;
 
-export async function findFiles(workspace: string, patterns: string[], maxResults = 40): Promise<string> {
+export type FindFilesResult = { output: string; totalMatches: number };
+
+export async function findFiles(workspace: string, patterns: string[], maxResults = 40): Promise<FindFilesResult> {
   if (patterns.length === 0) throw new Error("At least one pattern is required");
   const allFiles = await collectWorkspaceFiles(workspace);
   const multi = patterns.length > 1;
   const sections: string[] = [];
+  let totalMatches = 0;
 
   for (const pattern of patterns) {
     const trimmed = pattern.trim();
@@ -57,6 +60,7 @@ export async function findFiles(workspace: string, patterns: string[], maxResult
       return a.length - b.length;
     });
     const ranked = matched.slice(0, maxResults).map((path) => `./${path}`);
+    totalMatches += matched.length;
 
     if (multi) sections.push(`--- ${trimmed} ---`);
     sections.push(ranked.length > 0 ? ranked.join("\n") : "No matches.");
@@ -67,7 +71,7 @@ export async function findFiles(workspace: string, patterns: string[], maxResult
     }
   }
 
-  return sections.join("\n");
+  return { output: sections.join("\n"), totalMatches };
 }
 
 function toWorkspaceRelativePattern(pattern: string, workspace: string): string {

--- a/src/file-ops.ts
+++ b/src/file-ops.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
-import { dirname, isAbsolute, join } from "node:path";
+import { dirname, join } from "node:path";
 import { TOOL_ERROR_CODES } from "./error-contract";
 import { createPathMatcher } from "./glob-match";
 import { createToolError } from "./tool-error";
@@ -74,13 +74,14 @@ export async function findFiles(workspace: string, patterns: string[], maxResult
   return { output: sections.join("\n"), totalMatches };
 }
 
+/**
+ * An absolute pattern inside the workspace becomes root-anchored; every other leading slash already
+ * means "anchored at the workspace root", so it passes through. Nothing needs rejecting here — the
+ * candidates are already confined to the workspace, so a pattern can only ever match inside it.
+ */
 function toWorkspaceRelativePattern(pattern: string, workspace: string): string {
-  if (!isAbsolute(pattern)) return pattern;
   const prefix = workspace.endsWith("/") ? workspace : `${workspace}/`;
-  if (pattern === workspace || !pattern.startsWith(prefix)) {
-    throw new Error(`Pattern is outside the workspace: ${pattern}`);
-  }
-  return `/${pattern.slice(prefix.length)}`; // leading slash anchors the remainder at the workspace root
+  return pattern.startsWith(prefix) ? `/${pattern.slice(prefix.length)}` : pattern;
 }
 
 export async function searchFiles(

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -33,7 +33,8 @@ function createFindFilesTool(input: ToolkitInput) {
     id: "file-find",
     toolkit: "file",
     category: "search",
-    description: "Find files by name or path pattern. To search file contents use `file-search` instead.",
+    description:
+      "Find files by name or path pattern. The pattern is a glob (`*`, `?`, `**`, `[abc]`, `{a,b}`) matched against workspace-relative paths, or a case-insensitive substring when it has no wildcard. A leading `/` anchors at the workspace root. Results are capped, and a cap notice reports the full match count. To search file contents use `file-search` instead.",
     instruction: "Use `file-find` to locate files by name/path pattern.",
     inputSchema: z.object({
       pattern: z.string().min(1),

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -43,21 +43,23 @@ function createFindFilesTool(input: ToolkitInput) {
       kind: z.literal("file-find"),
       pattern: z.string().min(1),
       matches: z.number().int().nonnegative(),
+      truncated: z.boolean(),
       paths: z.array(z.string().min(1)),
       output: z.string(),
     }),
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "file-find", toolCallId, toolInput, async (callId) => {
         const patterns = [toolInput.pattern];
-        const raw = await findFiles(input.workspace, patterns);
-        const paths = findResultPaths(raw);
+        const { output, totalMatches } = await findFiles(input.workspace, patterns);
+        const paths = findResultPaths(output);
         emitParts(findSummaryParts(paths, patterns, "tool.label.file_find"), "file-find", input.onOutput, callId);
         return {
           kind: "file-find" as const,
           pattern: toolInput.pattern,
-          matches: paths.length,
+          matches: totalMatches,
+          truncated: paths.length < totalMatches,
           paths,
-          output: raw,
+          output,
         };
       });
     },

--- a/src/gitignore.test.ts
+++ b/src/gitignore.test.ts
@@ -90,6 +90,12 @@ describe("double star **", () => {
     expect(ignored(["a/**/b"], "a/x/b")).toBe(true);
     expect(ignored(["a/**/b"], "a/x/y/b")).toBe(true);
   });
+
+  test("internal /**/ spans whole directories, not part of a segment", () => {
+    expect(ignored(["a/**/b"], "a/xb")).toBe(false);
+    expect(ignored(["src/**/test"], "src/latest")).toBe(false);
+    expect(ignored(["src/**/test"], "src/test")).toBe(true);
+  });
 });
 
 describe("anchored patterns", () => {

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { globToRegex } from "./glob-match";
 
 type CompiledPattern = {
   regex: RegExp;
@@ -11,44 +12,6 @@ export type GitignoreContext = {
   patterns: CompiledPattern[];
   dir: string;
 };
-
-function escapeRegex(s: string): string {
-  return s.replace(/[.+^${}()|[\]\\]/g, "\\$&");
-}
-
-function globToRegex(glob: string, anchored: boolean): string {
-  let re = anchored ? "^" : "(^|/)";
-
-  if (glob.startsWith("**/")) {
-    re += "(.+/)?"; // leading **/ — any number of leading directories
-    glob = glob.slice(3);
-  }
-
-  for (const [token] of glob.matchAll(/\/\*\*\/|\/\*\*|\*\*|\*|\?|\[[^\]]*\]|\[|[^*?[/]+|\//g)) {
-    switch (token) {
-      case "/**/":
-        re += "/(.+/)?";
-        break; // zero or more intermediate directories
-      case "/**":
-        re += "/.*";
-        break; // slash + anything
-      case "**":
-        re += ".*";
-        break; // anything including slashes
-      case "*":
-        re += "[^/]*";
-        break; // anything within one segment
-      case "?":
-        re += "[^/]";
-        break; // exactly one non-separator character
-      default:
-        re += token.startsWith("[") && token.endsWith("]") ? token.replace(/^\[!/, "[^") : escapeRegex(token);
-    }
-  }
-
-  re += "(/|$)";
-  return re;
-}
 
 type ParsedPattern = {
   glob: string;

--- a/src/gitignore.ts
+++ b/src/gitignore.ts
@@ -1,9 +1,9 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { globToRegex } from "./glob-match";
+import { createGlobMatcher } from "./glob-match";
 
 type CompiledPattern = {
-  regex: RegExp;
+  matches: (path: string) => boolean;
   negated: boolean;
   dirOnly: boolean;
 };
@@ -44,8 +44,8 @@ function compileGitignorePattern(raw: string): CompiledPattern | null {
   const parsed = parseGitignorePattern(raw);
   if (!parsed) return null;
   try {
-    const regex = new RegExp(globToRegex(parsed.glob, parsed.anchored));
-    return { regex, negated: parsed.negated, dirOnly: parsed.dirOnly };
+    const matches = createGlobMatcher(parsed.glob, parsed.anchored);
+    return { matches, negated: parsed.negated, dirOnly: parsed.dirOnly };
   } catch {
     return null;
   }
@@ -72,7 +72,7 @@ export function isIgnoredByPatterns(contexts: GitignoreContext[], absPath: strin
 
     for (const pattern of ctx.patterns) {
       if (pattern.dirOnly && !isDir) continue;
-      if (pattern.regex.test(rel)) {
+      if (pattern.matches(rel)) {
         ignored = !pattern.negated;
       }
     }

--- a/src/glob-match.test.ts
+++ b/src/glob-match.test.ts
@@ -102,4 +102,15 @@ describe("createPathMatcher", () => {
     const exploded = `${"{a,b}".repeat(7)}*`;
     expect(() => createPathMatcher(exploded)).toThrow("more than 64 alternatives");
   });
+
+  test("caps the work done, not just the result, for a combinatorial pattern", () => {
+    // 2^30 expansions: eager cross-product exhausts memory before any cap can reject it.
+    expect(() => createPathMatcher(`${"{a,b}".repeat(30)}*`)).toThrow("more than 64 alternatives");
+  });
+
+  test("reports the original pattern when rejecting an expansion", () => {
+    expect(() => createPathMatcher("src/{a,b}{c,d}{e,f}{g,h}{i,j}{k,l}{m,n}*")).toThrow(
+      "src/{a,b}{c,d}{e,f}{g,h}{i,j}{k,l}{m,n}*",
+    );
+  });
 });

--- a/src/glob-match.test.ts
+++ b/src/glob-match.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import { createPathMatcher } from "./glob-match";
+
+const PATHS = [
+  "src/agent-toolkit.ts",
+  "src/file-toolkit.ts",
+  "src/file-ops.ts",
+  "src/cli-tool.ts",
+  "src/tui/tool-render.tsx",
+  "src/tui/components.tsx",
+  "docs/tooling.md",
+  "package.json",
+];
+
+function matched(pattern: string): string[] {
+  const matches = createPathMatcher(pattern);
+  return PATHS.filter(matches);
+}
+
+describe("createPathMatcher", () => {
+  test("matches a path prefix combined with a mid-segment wildcard", () => {
+    expect(matched("src/*-toolkit.ts")).toEqual(["src/agent-toolkit.ts", "src/file-toolkit.ts"]);
+  });
+
+  test("matches a bare wildcard pattern at any depth", () => {
+    expect(matched("*-toolkit.ts")).toEqual(["src/agent-toolkit.ts", "src/file-toolkit.ts"]);
+  });
+
+  test("matches wildcards on both sides of a fragment within one segment", () => {
+    expect(matched("src/*tool*")).toEqual(["src/agent-toolkit.ts", "src/file-toolkit.ts", "src/cli-tool.ts"]);
+  });
+
+  test("a single wildcard does not cross a path separator", () => {
+    expect(matched("src/*.tsx")).toEqual([]);
+  });
+
+  test("double wildcard crosses path separators", () => {
+    expect(matched("src/**/*.tsx")).toEqual(["src/tui/tool-render.tsx", "src/tui/components.tsx"]);
+  });
+
+  test("an unanchored directory prefix matches nested directories", () => {
+    expect(matched("tui/*.tsx")).toEqual(["src/tui/tool-render.tsx", "src/tui/components.tsx"]);
+  });
+
+  test("a leading slash anchors the pattern at the workspace root", () => {
+    expect(matched("/tui/*.tsx")).toEqual([]);
+    expect(matched("/src/*-toolkit.ts")).toEqual(["src/agent-toolkit.ts", "src/file-toolkit.ts"]);
+  });
+
+  test("a wildcard-free pattern matches as a substring", () => {
+    expect(matched("toolkit")).toEqual(["src/agent-toolkit.ts", "src/file-toolkit.ts"]);
+    expect(matched("tool")).toContain("docs/tooling.md");
+  });
+
+  test("a wildcard-free path matches exactly one file", () => {
+    expect(matched("package.json")).toEqual(["package.json"]);
+  });
+
+  test("ignores a leading ./ on the pattern", () => {
+    expect(matched("./src/*-toolkit.ts")).toEqual(["src/agent-toolkit.ts", "src/file-toolkit.ts"]);
+  });
+
+  test("matches case-insensitively", () => {
+    expect(matched("SRC/*-TOOLKIT.TS")).toEqual(["src/agent-toolkit.ts", "src/file-toolkit.ts"]);
+    expect(matched("TOOLKIT")).toEqual(["src/agent-toolkit.ts", "src/file-toolkit.ts"]);
+  });
+
+  test("matches a character class", () => {
+    expect(matched("src/[cf]*.ts")).toEqual(["src/file-toolkit.ts", "src/file-ops.ts", "src/cli-tool.ts"]);
+  });
+
+  test("rejects an uncompilable glob", () => {
+    expect(() => createPathMatcher("src/[z-a].ts")).toThrow("Invalid glob pattern");
+  });
+
+  test("expands brace alternation", () => {
+    expect(matched("src/*.{ts,tsx}")).toEqual([
+      "src/agent-toolkit.ts",
+      "src/file-toolkit.ts",
+      "src/file-ops.ts",
+      "src/cli-tool.ts",
+    ]);
+  });
+
+  test("treats a braced pattern without a wildcard as a glob", () => {
+    expect(matched("{package,docs}.json")).toEqual(["package.json"]);
+  });
+
+  test("expands nested braces", () => {
+    expect(matched("{src/{cli,file}-*,docs/*}.ts")).toEqual([
+      "src/file-toolkit.ts",
+      "src/file-ops.ts",
+      "src/cli-tool.ts",
+    ]);
+  });
+
+  test("leaves an unbalanced brace literal", () => {
+    expect(matched("src/{ts*")).toEqual([]);
+  });
+
+  test("rejects a pattern with too many brace alternatives", () => {
+    const exploded = `${"{a,b}".repeat(7)}*`;
+    expect(() => createPathMatcher(exploded)).toThrow("more than 64 alternatives");
+  });
+});

--- a/src/glob-match.test.ts
+++ b/src/glob-match.test.ts
@@ -47,6 +47,14 @@ describe("createPathMatcher", () => {
     expect(matched("/src/*-toolkit.ts")).toEqual(["src/agent-toolkit.ts", "src/file-toolkit.ts"]);
   });
 
+  test("an anchored wildcard-free pattern matches that exact path", () => {
+    expect(matched("/src/file-ops.ts")).toEqual(["src/file-ops.ts"]);
+  });
+
+  test("a leading slash inside a brace alternative still anchors", () => {
+    expect(matched("{/src,/docs}/*.md")).toEqual(["docs/tooling.md"]);
+  });
+
   test("a wildcard-free pattern matches as a substring", () => {
     expect(matched("toolkit")).toEqual(["src/agent-toolkit.ts", "src/file-toolkit.ts"]);
     expect(matched("tool")).toContain("docs/tooling.md");

--- a/src/glob-match.test.ts
+++ b/src/glob-match.test.ts
@@ -34,6 +34,11 @@ describe("createPathMatcher", () => {
     expect(matched("src/*.tsx")).toEqual([]);
   });
 
+  test("a middle double wildcard spans whole directories, never part of a segment", () => {
+    const paths = ["a/b", "a/x/b", "a/x/y/b", "a/xb", "a/bx"];
+    expect(paths.filter(createPathMatcher("/a/**/b"))).toEqual(["a/b", "a/x/b", "a/x/y/b"]);
+  });
+
   test("double wildcard crosses path separators", () => {
     expect(matched("src/**/*.tsx")).toEqual(["src/tui/tool-render.tsx", "src/tui/components.tsx"]);
   });

--- a/src/glob-match.test.ts
+++ b/src/glob-match.test.ts
@@ -111,6 +111,18 @@ describe("createPathMatcher", () => {
     expect(() => createPathMatcher(exploded)).toThrow("more than 64 alternatives");
   });
 
+  test("collapses redundant star runs instead of backtracking on them", () => {
+    // Each extra adjacent `.*` multiplied match time ~7x: 8 of them took 7.45s on one path.
+    const start = Date.now();
+    expect(matched(`${"**".repeat(40)}Z`)).toEqual([]);
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+
+  test("a collapsed star run still matches like a single one", () => {
+    expect(matched("src/****/*.tsx")).toEqual(matched("src/**/*.tsx"));
+    expect(matched("src/**/**/*.tsx")).toEqual(matched("src/**/*.tsx"));
+  });
+
   test("caps the work done, not just the result, for a combinatorial pattern", () => {
     // 2^30 expansions: eager cross-product exhausts memory before any cap can reject it.
     expect(() => createPathMatcher(`${"{a,b}".repeat(30)}*`)).toThrow("more than 64 alternatives");

--- a/src/glob-match.test.ts
+++ b/src/glob-match.test.ts
@@ -111,16 +111,22 @@ describe("createPathMatcher", () => {
     expect(() => createPathMatcher(exploded)).toThrow("more than 64 alternatives");
   });
 
-  test("collapses redundant star runs instead of backtracking on them", () => {
-    // Each extra adjacent `.*` multiplied match time ~7x: 8 of them took 7.45s on one path.
+  test("does not backtrack on adjacent wildcards", () => {
     const start = Date.now();
     expect(matched(`${"**".repeat(40)}Z`)).toEqual([]);
     expect(Date.now() - start).toBeLessThan(500);
   });
 
-  test("a collapsed star run still matches like a single one", () => {
+  test("does not backtrack on wildcards separated by literals", () => {
+    // As a regex this backtracked superexponentially: 9 of these took 7.8s against one path.
+    const subject = [`src/${"a".repeat(50)}b.ts`];
+    const start = Date.now();
+    expect(subject.filter(createPathMatcher(`${"*a".repeat(12)}Z`))).toEqual([]);
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+
+  test("repeated star runs still match like a single one", () => {
     expect(matched("src/****/*.tsx")).toEqual(matched("src/**/*.tsx"));
-    expect(matched("src/**/**/*.tsx")).toEqual(matched("src/**/*.tsx"));
   });
 
   test("caps the work done, not just the result, for a combinatorial pattern", () => {

--- a/src/glob-match.ts
+++ b/src/glob-match.ts
@@ -2,6 +2,7 @@ import { escapeRegex } from "./string-utils";
 
 export function globToRegex(glob: string, anchored: boolean): string {
   let re = anchored ? "^" : "(^|/)";
+  glob = collapseStars(glob);
 
   if (glob.startsWith("**/")) {
     re += "(.+/)?"; // leading **/ — any number of leading directories
@@ -32,6 +33,15 @@ export function globToRegex(glob: string, anchored: boolean): string {
 
   re += "(/|$)";
   return re;
+}
+
+/**
+ * Redundant star runs mean the same thing as one `**` but each extra one compiles to another
+ * adjacent `.*`, and adjacent `.*` backtrack catastrophically: `**` eight times took 7s on a single
+ * path before this collapse. Patterns are model-supplied, so the cost has to be bounded here.
+ */
+function collapseStars(glob: string): string {
+  return glob.replace(/\*{2,}/g, "**").replace(/\*\*(?:\/\*\*)+/g, "**");
 }
 
 const WILDCARD = /[*?[{]/;

--- a/src/glob-match.ts
+++ b/src/glob-match.ts
@@ -43,18 +43,19 @@ const MAX_BRACE_ALTERNATIVES = 64;
  */
 export function createPathMatcher(pattern: string): (path: string) => boolean {
   const normalized = pattern.replace(/^\.\/+/, "");
-  if (!WILDCARD.test(normalized)) {
+  if (!normalized.startsWith("/") && !WILDCARD.test(normalized)) {
     const needle = normalized.toLowerCase();
     return (path) => path.toLowerCase().includes(needle);
   }
-  const anchored = normalized.startsWith("/");
-  const regexes = expandBraces(anchored ? normalized.slice(1) : normalized).map((glob) => compileGlob(glob, anchored));
+  const regexes = expandBraces(normalized).map(compileGlob);
   return (path) => regexes.some((regex) => regex.test(path));
 }
 
-function compileGlob(glob: string, anchored: boolean): RegExp {
+/** Anchoring is decided per expansion so a leading slash inside a brace alternative still anchors. */
+function compileGlob(glob: string): RegExp {
+  const anchored = glob.startsWith("/");
   try {
-    return new RegExp(globToRegex(glob, anchored), "i");
+    return new RegExp(globToRegex(anchored ? glob.slice(1) : glob, anchored), "i");
   } catch {
     throw new Error(`Invalid glob pattern: ${glob}`);
   }

--- a/src/glob-match.ts
+++ b/src/glob-match.ts
@@ -35,11 +35,7 @@ export function globToRegex(glob: string, anchored: boolean): string {
   return re;
 }
 
-/**
- * Redundant star runs mean the same thing as one `**` but each extra one compiles to another
- * adjacent `.*`, and adjacent `.*` backtrack catastrophically: `**` eight times took 7s on a single
- * path before this collapse. Patterns are model-supplied, so the cost has to be bounded here.
- */
+/** Adjacent `.*` backtrack catastrophically — eight of them took 7s on one path. */
 function collapseStars(glob: string): string {
   return glob.replace(/\*{2,}/g, "**").replace(/\*\*(?:\/\*\*)+/g, "**");
 }

--- a/src/glob-match.ts
+++ b/src/glob-match.ts
@@ -65,23 +65,27 @@ function compileGlob(glob: string, anchored: boolean): RegExp {
  * compiler and git treats braces literally.
  */
 export function expandBraces(pattern: string): string[] {
-  const expanded = expandFirstBrace(pattern);
-  if (expanded.length > MAX_BRACE_ALTERNATIVES) {
-    throw new Error(`Glob pattern expands to more than ${MAX_BRACE_ALTERNATIVES} alternatives: ${pattern}`);
-  }
-  return expanded;
+  const expansions: string[] = [];
+  expandInto(pattern, pattern, expansions);
+  return expansions;
 }
 
-function expandFirstBrace(pattern: string): string[] {
+/** Depth-first so the cap bounds the work done, not merely the result returned. */
+function expandInto(pattern: string, original: string, expansions: string[]): void {
+  if (expansions.length >= MAX_BRACE_ALTERNATIVES) {
+    throw new Error(`Glob pattern expands to more than ${MAX_BRACE_ALTERNATIVES} alternatives: ${original}`);
+  }
   const open = pattern.indexOf("{");
-  if (open === -1) return [pattern];
-  const close = matchingBrace(pattern, open);
-  if (close === -1) return [pattern]; // unbalanced — the brace stays a literal
+  const close = open === -1 ? -1 : matchingBrace(pattern, open);
+  if (close === -1) {
+    expansions.push(pattern); // no brace, or an unbalanced one that stays literal
+    return;
+  }
   const prefix = pattern.slice(0, open);
   const suffix = pattern.slice(close + 1);
-  return splitAlternatives(pattern.slice(open + 1, close)).flatMap((alternative) =>
-    expandFirstBrace(`${prefix}${alternative}${suffix}`),
-  );
+  for (const alternative of splitAlternatives(pattern.slice(open + 1, close))) {
+    expandInto(`${prefix}${alternative}${suffix}`, original, expansions);
+  }
 }
 
 function matchingBrace(pattern: string, open: number): number {

--- a/src/glob-match.ts
+++ b/src/glob-match.ts
@@ -1,0 +1,111 @@
+import { escapeRegex } from "./string-utils";
+
+export function globToRegex(glob: string, anchored: boolean): string {
+  let re = anchored ? "^" : "(^|/)";
+
+  if (glob.startsWith("**/")) {
+    re += "(.+/)?"; // leading **/ — any number of leading directories
+    glob = glob.slice(3);
+  }
+
+  for (const [token] of glob.matchAll(/\/\*\*\/|\/\*\*|\*\*|\*|\?|\[[^\]]*\]|\[|[^*?[/]+|\//g)) {
+    switch (token) {
+      case "/**/":
+        re += "/(.+/)?";
+        break; // zero or more intermediate directories
+      case "/**":
+        re += "/.*";
+        break; // slash + anything
+      case "**":
+        re += ".*";
+        break; // anything including slashes
+      case "*":
+        re += "[^/]*";
+        break; // anything within one segment
+      case "?":
+        re += "[^/]";
+        break; // exactly one non-separator character
+      default:
+        re += token.startsWith("[") && token.endsWith("]") ? token.replace(/^\[!/, "[^") : escapeRegex(token);
+    }
+  }
+
+  re += "(/|$)";
+  return re;
+}
+
+const WILDCARD = /[*?[{]/;
+const MAX_BRACE_ALTERNATIVES = 64;
+
+/**
+ * A wildcard-free pattern matches as a substring so a bare fragment still locates files; anything
+ * else matches as a glob. Only a leading slash anchors — `tui/*.tsx` is meant to find nested files.
+ */
+export function createPathMatcher(pattern: string): (path: string) => boolean {
+  const normalized = pattern.replace(/^\.\/+/, "");
+  if (!WILDCARD.test(normalized)) {
+    const needle = normalized.toLowerCase();
+    return (path) => path.toLowerCase().includes(needle);
+  }
+  const anchored = normalized.startsWith("/");
+  const regexes = expandBraces(anchored ? normalized.slice(1) : normalized).map((glob) => compileGlob(glob, anchored));
+  return (path) => regexes.some((regex) => regex.test(path));
+}
+
+function compileGlob(glob: string, anchored: boolean): RegExp {
+  try {
+    return new RegExp(globToRegex(glob, anchored), "i");
+  } catch {
+    throw new Error(`Invalid glob pattern: ${glob}`);
+  }
+}
+
+/**
+ * Brace alternation is expanded here rather than in `globToRegex` because gitignore shares that
+ * compiler and git treats braces literally.
+ */
+export function expandBraces(pattern: string): string[] {
+  const expanded = expandFirstBrace(pattern);
+  if (expanded.length > MAX_BRACE_ALTERNATIVES) {
+    throw new Error(`Glob pattern expands to more than ${MAX_BRACE_ALTERNATIVES} alternatives: ${pattern}`);
+  }
+  return expanded;
+}
+
+function expandFirstBrace(pattern: string): string[] {
+  const open = pattern.indexOf("{");
+  if (open === -1) return [pattern];
+  const close = matchingBrace(pattern, open);
+  if (close === -1) return [pattern]; // unbalanced — the brace stays a literal
+  const prefix = pattern.slice(0, open);
+  const suffix = pattern.slice(close + 1);
+  return splitAlternatives(pattern.slice(open + 1, close)).flatMap((alternative) =>
+    expandFirstBrace(`${prefix}${alternative}${suffix}`),
+  );
+}
+
+function matchingBrace(pattern: string, open: number): number {
+  let depth = 0;
+  for (let i = open; i < pattern.length; i++) {
+    if (pattern[i] === "{") depth++;
+    else if (pattern[i] === "}" && --depth === 0) return i;
+  }
+  return -1;
+}
+
+function splitAlternatives(body: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < body.length; i++) {
+    const char = body[i];
+    if (char === "{") depth++;
+    else if (char === "}") depth--;
+    else if (char === "," && depth === 0) {
+      parts.push(body.slice(start, i));
+      start = i + 1;
+    }
+  }
+  parts.push(body.slice(start));
+  return parts;
+}

--- a/src/glob-match.ts
+++ b/src/glob-match.ts
@@ -92,10 +92,11 @@ function matchFrom(tokens: Token[], ti: number, path: string, si: number, visite
     case "globstar":
       return matchRun(tokens, ti, path, si, visited, true);
     case "globstarSlash": {
+      // Directories only: the tail may resume right after this separator, or after a later one — never mid-segment.
       if (path[si] !== "/") return false;
-      for (let j = si + 1; j <= path.length; j++) {
-        if (matchFrom(tokens, ti + 1, path, j, visited)) return true;
-        if (j < path.length && path[j] === "/" && matchFrom(tokens, ti + 1, path, j + 1, visited)) return true;
+      if (matchFrom(tokens, ti + 1, path, si + 1, visited)) return true;
+      for (let j = si + 1; j < path.length; j++) {
+        if (path[j] === "/" && matchFrom(tokens, ti + 1, path, j + 1, visited)) return true;
       }
       return false;
     }

--- a/src/glob-match.ts
+++ b/src/glob-match.ts
@@ -1,43 +1,138 @@
-import { escapeRegex } from "./string-utils";
+type Token =
+  | { kind: "literal"; text: string }
+  | { kind: "class"; negated: boolean; source: string }
+  | { kind: "any" } // ? — one character, never a separator
+  | { kind: "star" } // * — any run within one segment
+  | { kind: "globstar" } // ** — any run, separators included
+  | { kind: "globstarSlash" }; // /**/ — a separator, then zero or more directories
 
-export function globToRegex(glob: string, anchored: boolean): string {
-  let re = anchored ? "^" : "(^|/)";
-  glob = collapseStars(glob);
+const TOKEN_PATTERN = /\/\*\*\/|\/\*\*|\*\*|\*|\?|\[[^\]]*\]|\[|[^*?[/]+|\//g;
 
-  if (glob.startsWith("**/")) {
-    re += "(.+/)?"; // leading **/ — any number of leading directories
-    glob = glob.slice(3);
+export function tokenizeGlob(glob: string): Token[] {
+  const tokens: Token[] = [];
+  for (const [token] of glob.matchAll(TOKEN_PATTERN)) {
+    if (token === "/**/") tokens.push({ kind: "globstarSlash" });
+    else if (token === "/**") tokens.push({ kind: "literal", text: "/" }, { kind: "globstar" });
+    else if (token === "**") tokens.push({ kind: "globstar" });
+    else if (token === "*") tokens.push({ kind: "star" });
+    else if (token === "?") tokens.push({ kind: "any" });
+    else if (token.startsWith("[") && token.endsWith("]") && token.length > 2) {
+      const negated = token[1] === "!" || token[1] === "^";
+      const source = token.slice(negated ? 2 : 1, -1);
+      assertClassRanges(source, token);
+      tokens.push({ kind: "class", negated, source });
+    } else tokens.push({ kind: "literal", text: token });
   }
-
-  for (const [token] of glob.matchAll(/\/\*\*\/|\/\*\*|\*\*|\*|\?|\[[^\]]*\]|\[|[^*?[/]+|\//g)) {
-    switch (token) {
-      case "/**/":
-        re += "/(.+/)?";
-        break; // zero or more intermediate directories
-      case "/**":
-        re += "/.*";
-        break; // slash + anything
-      case "**":
-        re += ".*";
-        break; // anything including slashes
-      case "*":
-        re += "[^/]*";
-        break; // anything within one segment
-      case "?":
-        re += "[^/]";
-        break; // exactly one non-separator character
-      default:
-        re += token.startsWith("[") && token.endsWith("]") ? token.replace(/^\[!/, "[^") : escapeRegex(token);
-    }
-  }
-
-  re += "(/|$)";
-  return re;
+  return tokens;
 }
 
-/** Adjacent `.*` backtrack catastrophically — eight of them took 7s on one path. */
-function collapseStars(glob: string): string {
-  return glob.replace(/\*{2,}/g, "**").replace(/\*\*(?:\/\*\*)+/g, "**");
+/** An out-of-order range is rejected rather than silently never matching, as the old compile step did. */
+function assertClassRanges(source: string, token: string): void {
+  for (let i = 0; i + 2 < source.length; i++) {
+    if (source[i + 1] !== "-") continue;
+    if ((source[i] ?? "") > (source[i + 2] ?? "")) throw new Error(`Invalid character class: ${token}`);
+    i += 2;
+  }
+}
+
+/**
+ * Matched by walking tokens with a visited set rather than by compiling to a regex: glob wildcards
+ * translate to adjacent `.*`/`[^/]*` groups, which backtrack catastrophically on a model-supplied
+ * pattern — `*a` nine times took 7.8s against one path. The visited set makes the work O(tokens x path).
+ */
+export function createGlobMatcher(glob: string, anchored: boolean, caseInsensitive = false): (path: string) => boolean {
+  // A leading `**/` means zero or more directories, which is exactly where an unanchored match may start.
+  const leadingGlobstar = glob.startsWith("**/");
+  const startAnywhere = leadingGlobstar || !anchored;
+  const fold = (value: string) => (caseInsensitive ? value.toLowerCase() : value);
+  const tokens = tokenizeGlob(leadingGlobstar ? glob.slice(3) : glob).map((token) => {
+    if (token.kind === "literal") return { ...token, text: fold(token.text) };
+    if (token.kind === "class") return { ...token, source: fold(token.source) };
+    return token;
+  });
+  return (path) => {
+    const subject = fold(path);
+    const visited = new Set<number>();
+    for (const start of startPositions(subject, !startAnywhere)) {
+      if (matchFrom(tokens, 0, subject, start, visited)) return true;
+    }
+    return false;
+  };
+}
+
+/** An unanchored pattern may start at the path root or after any separator. */
+function startPositions(path: string, anchored: boolean): number[] {
+  if (anchored) return [0];
+  const positions = [0];
+  for (let i = 0; i < path.length; i++) {
+    if (path[i] === "/") positions.push(i + 1);
+  }
+  return positions;
+}
+
+function matchFrom(tokens: Token[], ti: number, path: string, si: number, visited: Set<number>): boolean {
+  const key = ti * (path.length + 1) + si;
+  if (visited.has(key)) return false;
+  visited.add(key);
+
+  const token = tokens[ti];
+  if (!token) return si === path.length || path[si] === "/"; // trailing (/|$) — a match may end at a segment edge
+
+  switch (token.kind) {
+    case "literal":
+      return path.startsWith(token.text, si) && matchFrom(tokens, ti + 1, path, si + token.text.length, visited);
+    case "any":
+      return si < path.length && path[si] !== "/" && matchFrom(tokens, ti + 1, path, si + 1, visited);
+    case "class":
+      return (
+        si < path.length && matchesClass(token, path[si] ?? "") && matchFrom(tokens, ti + 1, path, si + 1, visited)
+      );
+    case "star":
+      return matchRun(tokens, ti, path, si, visited, false);
+    case "globstar":
+      return matchRun(tokens, ti, path, si, visited, true);
+    case "globstarSlash": {
+      if (path[si] !== "/") return false;
+      for (let j = si + 1; j <= path.length; j++) {
+        if (matchFrom(tokens, ti + 1, path, j, visited)) return true;
+        if (j < path.length && path[j] === "/" && matchFrom(tokens, ti + 1, path, j + 1, visited)) return true;
+      }
+      return false;
+    }
+    default:
+      return false;
+  }
+}
+
+function matchRun(
+  tokens: Token[],
+  ti: number,
+  path: string,
+  si: number,
+  visited: Set<number>,
+  crossSeparators: boolean,
+): boolean {
+  for (let j = si; j <= path.length; j++) {
+    if (matchFrom(tokens, ti + 1, path, j, visited)) return true;
+    if (j < path.length && !crossSeparators && path[j] === "/") break;
+  }
+  return false;
+}
+
+function matchesClass(token: { negated: boolean; source: string }, char: string): boolean {
+  if (char === "/") return false;
+  let inClass = false;
+  for (let i = 0; i < token.source.length; i++) {
+    const from = token.source[i] ?? "";
+    if (token.source[i + 1] === "-" && i + 2 < token.source.length) {
+      const to = token.source[i + 2] ?? "";
+      if (char >= from && char <= to) inClass = true;
+      i += 2;
+      continue;
+    }
+    if (char === from) inClass = true;
+  }
+  return token.negated ? !inClass : inClass;
 }
 
 const WILDCARD = /[*?[{]/;
@@ -53,23 +148,23 @@ export function createPathMatcher(pattern: string): (path: string) => boolean {
     const needle = normalized.toLowerCase();
     return (path) => path.toLowerCase().includes(needle);
   }
-  const regexes = expandBraces(normalized).map(compileGlob);
-  return (path) => regexes.some((regex) => regex.test(path));
+  const matchers = expandBraces(normalized).map(compileGlob);
+  return (path) => matchers.some((matches) => matches(path));
 }
 
 /** Anchoring is decided per expansion so a leading slash inside a brace alternative still anchors. */
-function compileGlob(glob: string): RegExp {
+function compileGlob(glob: string): (path: string) => boolean {
   const anchored = glob.startsWith("/");
   try {
-    return new RegExp(globToRegex(anchored ? glob.slice(1) : glob, anchored), "i");
+    return createGlobMatcher(anchored ? glob.slice(1) : glob, anchored, true);
   } catch {
     throw new Error(`Invalid glob pattern: ${glob}`);
   }
 }
 
 /**
- * Brace alternation is expanded here rather than in `globToRegex` because gitignore shares that
- * compiler and git treats braces literally.
+ * Brace alternation is expanded here rather than in the tokenizer because gitignore shares that
+ * and git treats braces literally.
  */
 export function expandBraces(pattern: string): string[] {
   const expansions: string[] = [];


### PR DESCRIPTION
## Summary

- match patterns as globs through a shared `glob-match` module, reused by gitignore
- support `**`, character classes and `{a,b}` alternation; keep a wildcard-free pattern as a substring match
- anchor a leading `/` at the workspace root, and resolve an absolute in-workspace path to it
- report the full match count when the result cap withholds files, instead of presenting 40 of 516 as complete
- bound glob and brace expansion against patterns that backtrack catastrophically or expand combinatorially
- answer a blank pattern with `No matches.` instead of an empty string