### PR TITLE
fix(file-find): disclose incomplete discovery

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -36,7 +36,7 @@ A second premise is that completion belongs to the model, not the host. The runt
 
 ### 2.3 Feature coverage — tools
 
-- **FR-11** — File tools: find, search, and read files; create, edit, and delete files. Read-only file tools are gitignore-aware in what they surface. File find matches its pattern as a path glob against workspace-relative paths, and as a case-insensitive substring when the pattern contains no wildcard; when its result cap withholds matches it reports the full match count rather than presenting a truncated list as complete.
+- **FR-11** — File tools: find, search, and read files; create, edit, and delete files. Read-only file tools are gitignore-aware in what they surface. File find matches its pattern as a path glob against workspace-relative paths, and as a case-insensitive substring when the pattern contains no wildcard; when its result cap withholds matches it reports the full match count, and when its workspace-discovery cap withholds matches it reports the shown count as a lower bound rather than presenting a truncated list as complete.
 - **FR-12** — Query file tools (find/search/read/scan) present a search-oriented contract; mutation file tools (edit/create/delete) present a targeting-oriented contract. The two are not unified merely because they share an engine.
 - **FR-13** — AST-based structural code scanning and editing across supported source files; an edit against an unsupported file surfaces a structured error rather than a silent no-op.
 - **FR-14** — Git tools: status, diff, log, show, add, commit.

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -47,7 +47,7 @@ All tool calls run through the execution layer which ensures:
 
 Entries in `IGNORED_DIRS` take precedence and cannot be re-included by gitignore negation patterns.
 
-`file-find` matches a pattern against workspace-relative paths through `createPathMatcher` in `glob-match.ts` — a glob when the pattern has a wildcard, a substring when it does not. A trailing slash searches beneath matching directories. `gitignore.ts` shares the same glob compiler, so brace alternation is expanded outside it: git treats braces literally. File discovery retains at most 5,000 paths; when that cap or the result cap withholds matches, `file-find` reports the shown count as a lower bound.
+`file-find` matches a pattern against workspace-relative paths through `createPathMatcher` in `glob-match.ts` — a glob when the pattern has a wildcard, a substring when it does not. A trailing slash searches beneath matching directories. `gitignore.ts` shares the same glob compiler, so brace alternation is expanded outside it: git treats braces literally. File discovery retains at most 5,000 paths; when that cap withholds matches, `file-find` reports the shown count as a lower bound. Its result cap reports the full match count.
 
 ## Tool result cache
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -47,7 +47,7 @@ All tool calls run through the execution layer which ensures:
 
 Entries in `IGNORED_DIRS` take precedence and cannot be re-included by gitignore negation patterns.
 
-`file-find` matches a pattern against workspace-relative paths through `createPathMatcher` in `glob-match.ts` — a glob when the pattern has a wildcard, a substring when it does not. `gitignore.ts` shares the same glob compiler, so brace alternation is expanded outside it: git treats braces literally.
+`file-find` matches a pattern against workspace-relative paths through `createPathMatcher` in `glob-match.ts` — a glob when the pattern has a wildcard, a substring when it does not. A trailing slash searches beneath matching directories. `gitignore.ts` shares the same glob compiler, so brace alternation is expanded outside it: git treats braces literally. File discovery retains at most 5,000 paths; when that cap or the result cap withholds matches, `file-find` reports the shown count as a lower bound.
 
 ## Tool result cache
 

--- a/src/file-ops.int.test.ts
+++ b/src/file-ops.int.test.ts
@@ -554,6 +554,38 @@ describe("findFiles", () => {
     expect(result.result.output).toContain("45 files matched, showing the first 40");
   });
 
+  test("reports when the workspace scan withholds matches", async () => {
+    const workspace = dirs.createDir("acolyte-find-scan-cap-");
+    await mkdir(join(workspace, "src"), { recursive: true });
+    await Promise.all(
+      Array.from({ length: 5001 }, (_, i) =>
+        writeFile(join(workspace, "src", `mod-${String(i).padStart(4, "0")}.ts`), "export const x = 1;\n", "utf8"),
+      ),
+    );
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.findFiles.execute({ pattern: "src/*.ts" }, "call_find_scan_capped");
+    expect(result.result.paths).toHaveLength(40);
+    expect(result.result.matches).toBe(5000);
+    expect(result.result.truncated).toBe(true);
+    expect(result.result.output).toContain("At least 5000 files matched, showing the first 40");
+  });
+
+  test("does not report no matches as complete when the workspace scan is capped", async () => {
+    const workspace = dirs.createDir("acolyte-find-scan-no-match-");
+    await mkdir(join(workspace, "src"), { recursive: true });
+    await Promise.all(
+      Array.from({ length: 5000 }, (_, i) =>
+        writeFile(join(workspace, "src", `mod-${String(i).padStart(4, "0")}.ts`), "export const x = 1;\n", "utf8"),
+      ),
+    );
+    await writeFile(join(workspace, "src", "target.ts"), "export const target = 1;\n", "utf8");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.findFiles.execute({ pattern: "target.ts" }, "call_find_scan_no_match");
+    expect(result.result.matches).toBe(0);
+    expect(result.result.truncated).toBe(true);
+    expect(result.result.output).toContain("No matches in the scanned workspace files");
+  });
+
   test("says so rather than returning nothing for a blank pattern", async () => {
     const workspace = await workspaceWithToolkits();
     const { tools } = toolsForAgent({ workspace });

--- a/src/file-ops.ts
+++ b/src/file-ops.ts
@@ -35,11 +35,11 @@ const MAX_BATCH_EDIT_LINES = 32;
 const MAX_BATCH_EDIT_CHARS = 2400;
 export const DEFAULT_READ_CONTEXT_LINES = 20;
 
-export type FindFilesResult = { output: string; totalMatches: number };
+export type FindFilesResult = { output: string; totalMatches: number; truncated: boolean };
 
 export async function findFiles(workspace: string, patterns: string[], maxResults = 40): Promise<FindFilesResult> {
   if (patterns.length === 0) throw new Error("At least one pattern is required");
-  const allFiles = await collectWorkspaceFiles(workspace);
+  const { files: allFiles, truncated: workspaceTruncated } = await collectWorkspaceFiles(workspace);
   const multi = patterns.length > 1;
   const sections: string[] = [];
   let totalMatches = 0;
@@ -62,16 +62,22 @@ export async function findFiles(workspace: string, patterns: string[], maxResult
     totalMatches += matched.length;
 
     if (multi) sections.push(`--- ${trimmed} ---`);
-    sections.push(ranked.length > 0 ? ranked.join("\n") : "No matches.");
-    if (matched.length > ranked.length) {
+    sections.push(
+      ranked.length > 0
+        ? ranked.join("\n")
+        : workspaceTruncated
+          ? "No matches in the scanned workspace files; the scan stopped at its limit."
+          : "No matches.",
+    );
+    if (workspaceTruncated || matched.length > ranked.length) {
       sections.push(
-        `(${matched.length} files matched, showing the first ${ranked.length}. Narrow the pattern to see the rest.)`,
+        `(${workspaceTruncated ? "At least " : ""}${matched.length} files matched, showing the first ${ranked.length}. Narrow the pattern to see the rest.)`,
       );
     }
   }
 
   if (sections.length === 0) sections.push("No matches."); // every pattern was blank
-  return { output: sections.join("\n"), totalMatches };
+  return { output: sections.join("\n"), totalMatches, truncated: workspaceTruncated };
 }
 
 /** Nothing is rejected here: the candidates are already confined to the workspace. */

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -34,7 +34,7 @@ function createFindFilesTool(input: ToolkitInput) {
     toolkit: "file",
     category: "search",
     description:
-      "Find files by name or path pattern. The pattern is a glob (`*`, `?`, `**`, `[abc]`, `{a,b}`) matched against workspace-relative paths, or a case-insensitive substring when it has no wildcard. A leading `/` anchors at the workspace root. Results are capped, and a cap notice reports the full match count. To search file contents use `file-search` instead.",
+      "Find files by name or path pattern. The pattern is a glob (`*`, `?`, `**`, `[abc]`, `{a,b}`) matched against workspace-relative paths, or a case-insensitive substring when it has no wildcard. A leading `/` anchors at the workspace root. Results are capped: the result cap reports the full match count, while a workspace scan cap reports a lower bound. To search file contents use `file-search` instead.",
     instruction: "Use `file-find` to locate files by name/path pattern.",
     inputSchema: z.object({
       pattern: z.string().min(1),
@@ -50,14 +50,14 @@ function createFindFilesTool(input: ToolkitInput) {
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "file-find", toolCallId, toolInput, async (callId) => {
         const patterns = [toolInput.pattern];
-        const { output, totalMatches } = await findFiles(input.workspace, patterns);
+        const { output, totalMatches, truncated } = await findFiles(input.workspace, patterns);
         const paths = findResultPaths(output);
         emitParts(findSummaryParts(paths, patterns, "tool.label.file_find"), "file-find", input.onOutput, callId);
         return {
           kind: "file-find" as const,
           pattern: toolInput.pattern,
           matches: totalMatches,
-          truncated: paths.length < totalMatches,
+          truncated: truncated || paths.length < totalMatches,
           paths,
           output,
         };

--- a/src/glob-match.test.ts
+++ b/src/glob-match.test.ts
@@ -43,6 +43,18 @@ describe("createPathMatcher", () => {
     expect(matched("src/**/*.tsx")).toEqual(["src/tui/tool-render.tsx", "src/tui/components.tsx"]);
   });
 
+  test("treats a trailing slash as a directory prefix", () => {
+    expect(matched("src/*/")).toEqual(["src/tui/tool-render.tsx", "src/tui/components.tsx"]);
+    expect(matched("src/**/")).toEqual([
+      "src/agent-toolkit.ts",
+      "src/file-toolkit.ts",
+      "src/file-ops.ts",
+      "src/cli-tool.ts",
+      "src/tui/tool-render.tsx",
+      "src/tui/components.tsx",
+    ]);
+  });
+
   test("an unanchored directory prefix matches nested directories", () => {
     expect(matched("tui/*.tsx")).toEqual(["src/tui/tool-render.tsx", "src/tui/components.tsx"]);
   });

--- a/src/glob-match.ts
+++ b/src/glob-match.ts
@@ -145,11 +145,12 @@ const MAX_BRACE_ALTERNATIVES = 64;
  */
 export function createPathMatcher(pattern: string): (path: string) => boolean {
   const normalized = pattern.replace(/^\.\/+/, "");
-  if (!normalized.startsWith("/") && !WILDCARD.test(normalized)) {
-    const needle = normalized.toLowerCase();
+  const directoryPattern = normalized.endsWith("/") ? `${normalized}**` : normalized;
+  if (!directoryPattern.startsWith("/") && !WILDCARD.test(directoryPattern)) {
+    const needle = directoryPattern.toLowerCase();
     return (path) => path.toLowerCase().includes(needle);
   }
-  const matchers = expandBraces(normalized).map(compileGlob);
+  const matchers = expandBraces(directoryPattern).map(compileGlob);
   return (path) => matchers.some((matches) => matches(path));
 }
 

--- a/src/tool-utils.int.test.ts
+++ b/src/tool-utils.int.test.ts
@@ -90,7 +90,7 @@ describe("collectWorkspaceFiles — gitignore integration", () => {
       "error.log": "",
     });
 
-    const files = await collectWorkspaceFiles(root);
+    const { files } = await collectWorkspaceFiles(root);
     expect(files).toContain("src/index.ts");
     expect(files).not.toContain("dist/bundle.js");
     expect(files).not.toContain("error.log");
@@ -105,7 +105,7 @@ describe("collectWorkspaceFiles — gitignore integration", () => {
       "lib/foo.generated.ts": "",
     });
 
-    const files = await collectWorkspaceFiles(root);
+    const { files } = await collectWorkspaceFiles(root);
     expect(files).toContain("src/foo.ts");
     expect(files).not.toContain("src/foo.generated.ts");
     expect(files).toContain("lib/foo.generated.ts");
@@ -117,7 +117,7 @@ describe("collectWorkspaceFiles — gitignore integration", () => {
       "src/index.ts": "",
     });
 
-    const files = await collectWorkspaceFiles(root);
+    const { files } = await collectWorkspaceFiles(root);
     expect(files).toContain(".github/workflows/ci.yml");
     expect(files).toContain("src/index.ts");
   });
@@ -129,7 +129,7 @@ describe("collectWorkspaceFiles — gitignore integration", () => {
       ".git/config": "",
     });
 
-    const files = await collectWorkspaceFiles(root);
+    const { files } = await collectWorkspaceFiles(root);
     expect(files).toContain("src/index.ts");
     expect(files.some((f) => f.startsWith("node_modules/"))).toBe(false);
     expect(files.some((f) => f.startsWith(".git/"))).toBe(false);

--- a/src/tool-utils.ts
+++ b/src/tool-utils.ts
@@ -110,7 +110,9 @@ export function isBinaryExtension(path: string): boolean {
   return BINARY_EXTENSIONS.has(path.slice(dot).toLowerCase());
 }
 
-export async function collectWorkspaceFiles(workspace: string, maxEntries = 5000): Promise<string[]> {
+export type WorkspaceFiles = { files: string[]; truncated: boolean };
+
+export async function collectWorkspaceFiles(workspace: string, maxEntries = 5000): Promise<WorkspaceFiles> {
   const out: string[] = [];
   const rootContext = await loadGitignoreContext(workspace);
   const rootContexts: GitignoreContext[] = rootContext ? [rootContext] : [];
@@ -118,7 +120,7 @@ export async function collectWorkspaceFiles(workspace: string, maxEntries = 5000
     { abs: workspace, rel: "", contexts: rootContexts },
   ];
 
-  while (stack.length > 0 && out.length < maxEntries) {
+  while (stack.length > 0) {
     const current = stack.pop();
     if (!current) break;
     let entries: Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean }>;
@@ -140,13 +142,13 @@ export async function collectWorkspaceFiles(workspace: string, maxEntries = 5000
         const childContexts = childContext ? [...current.contexts, childContext] : current.contexts;
         stack.push({ abs, rel, contexts: childContexts });
       } else if (entry.isFile()) {
+        if (out.length >= maxEntries) return { files: out, truncated: true };
         out.push(rel);
       }
-      if (out.length >= maxEntries) break;
     }
   }
 
-  return out;
+  return { files: out, truncated: false };
 }
 
 function normalizeRelPath(value: string): string {
@@ -157,7 +159,7 @@ function normalizeRelPath(value: string): string {
 }
 
 export async function resolveSearchScopeFiles(workspace: string, paths: string[] | undefined): Promise<string[]> {
-  const allFiles = await collectWorkspaceFiles(workspace);
+  const { files: allFiles } = await collectWorkspaceFiles(workspace);
   const sandboxRoot = resolveWorkspaceSandboxRoot(workspace);
   const normalizedPaths = (paths ?? []).map((path) => path.trim()).filter((path) => path.length > 0);
   if (normalizedPaths.length === 0) return allFiles;


### PR DESCRIPTION
## Summary

- disclose workspace discovery truncation as a lower-bound match count
- support trailing-slash file-find patterns as directory prefixes