### PR TITLE
fix(chat): preserve user message indentation

### DIFF
--- a/src/chat-message-handler.int.test.ts
+++ b/src/chat-message-handler.int.test.ts
@@ -87,15 +87,28 @@ describe("chat message handler", () => {
     expect(calls.setShowHelp).toEqual([]);
   });
 
+  test("preserves leading indentation in the committed user row", async () => {
+    const { handleMessage, rows } = createMessageHandlerHarness({
+      client: createClient({
+        status: async () => ({}),
+        replyStream: async () => ({ model: "gpt-5-mini", outputStreamed: false, output: "indented" }),
+      }),
+    });
+
+    await handleMessage("    Reply with exactly: indented");
+
+    expect(rows.find((row) => row.kind === "user")?.content).toBe("    Reply with exactly: indented");
+  });
+
   test("requeues input it cannot run instead of dropping it", async () => {
     const { handleMessage, startAssistantTurn, interrupt, calls } = createMessageHandlerHarness({
       client: abortableClient(),
     });
     const turn = startAssistantTurn("long running turn");
 
-    await handleMessage("hello");
+    await handleMessage("    hello");
 
-    expect(calls.requeued).toEqual(["hello"]);
+    expect(calls.requeued).toEqual(["    hello"]);
     expect(calls.setInputHistory).toBe(0);
     expect(calls.setValue).toEqual([]);
     await interruptTurn(interrupt, turn);

--- a/src/chat-message-handler.ts
+++ b/src/chat-message-handler.ts
@@ -264,12 +264,13 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
   };
 
   const handler = async (raw: string): Promise<void> => {
+    const displayText = raw;
     const text = raw.trim();
     const busy = turnState === "running" || input.isPending();
     log.debug("chat.handler", { text, turnState, busy });
     if (!text) return;
     if (busy && !text.startsWith("/")) {
-      input.requeueMessage(text);
+      input.requeueMessage(raw);
       return;
     }
     if (text.startsWith("/") && !text.includes(" ") && !isKnownSlashToken(text)) {
@@ -294,7 +295,7 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
       input.currentSession.updatedAt = input.nowIso();
       const { row: userRow } = applyUserTurn({
         session: input.currentSession,
-        displayText: text,
+        displayText,
       });
       input.setRows((current) => [...current, userRow]);
       startPending();
@@ -361,7 +362,7 @@ export function createMessageHandler(input: CreateMessageHandlerInput): {
     userText = commandResult.userText;
     const { row: userRow } = applyUserTurn({
       session: input.currentSession,
-      displayText: text,
+      displayText,
     });
     input.setRows((current) => [...current, userRow]);
     await startAssistantTurn(userText);

--- a/src/chat-submit.test.ts
+++ b/src/chat-submit.test.ts
@@ -53,6 +53,13 @@ describe("chat submit helpers", () => {
     });
   });
 
+  test("resolveQueueSubmit preserves indentation while thinking", () => {
+    expect(resolveQueueSubmit({ value: "    queued message", isPending: true })).toEqual({
+      kind: "submit",
+      value: "    queued message",
+    });
+  });
+
   test("resolveQueueSubmit submits slash commands while thinking", () => {
     expect(resolveQueueSubmit({ value: "/status", isPending: true })).toEqual({
       kind: "submit",

--- a/src/chat-submit.ts
+++ b/src/chat-submit.ts
@@ -50,7 +50,7 @@ export function resolveSubmitInput(input: ResolveSubmitInput): SubmitResolution 
 export function resolveQueueSubmit(input: { value: string; isPending: boolean }): QueueSubmitResolution {
   const trimmed = input.value.trim();
   if (!trimmed) return { kind: "ignore" };
-  if (input.isPending) return { kind: "submit", value: trimmed };
+  if (input.isPending) return { kind: "submit", value: input.value };
   return { kind: "submit", value: input.value };
 }
 

--- a/src/terminal-chat-layout.ts
+++ b/src/terminal-chat-layout.ts
@@ -407,7 +407,7 @@ export function layoutPending(input: {
     lines.push({ spans: [{ text: "", role: "plain" }] });
     lines.push({ spans: [{ text: "", role: "plain" }] });
     lines.push(
-      ...wrapTerminalProse(message, Math.max(24, input.columns - 2)).map((line, index) => ({
+      ...wrapUserText(message, Math.max(24, input.columns - 2)).map((line, index) => ({
         spans: [
           { text: index === 0 ? "❯ " : "  ", role: "muted" as const },
           { text: line, role: "muted" as const },

--- a/src/terminal-pending-layout.test.ts
+++ b/src/terminal-pending-layout.test.ts
@@ -36,6 +36,22 @@ test("each queued message is padded to a sent message's vertical rhythm", () => 
   expect(rows.slice(1)).toEqual(["", "", "❯ first", "", "", "", "❯ second", ""]);
 });
 
+test("queued messages preserve leading indentation", () => {
+  const rows = layoutPending({
+    presentation: {
+      state: { kind: "running", toolCalls: 0 },
+      frame: 0,
+      startedAt: 0,
+      queuedMessages: ["    next task"],
+      runningUsage: null,
+    },
+    now: 0,
+    columns: 80,
+  }).lines.map((line) => line.spans.map((span) => span.text).join(""));
+
+  expect(rows).toContain("❯     next task");
+});
+
 test("pending marker and text carry separate roles per kind", () => {
   const marker = (kind: "running" | "queued" | "accepted") =>
     layoutPending({


### PR DESCRIPTION
## Summary

- preserve leading whitespace in direct and queued user messages
- render queued messages with whitespace-faithful wrapping