### PR TITLE
fix(chat): gate workspace commands by flag

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -68,7 +68,7 @@ A second premise is that completion belongs to the model, not the host. The runt
 ### 2.5 Options / configuration
 
 - **FR-36** — Configuration merges a user-scoped source and a project-scoped source, with project overriding user; the resolved surface includes model, reasoning level, provider base URLs, locale, log format, embedding model and optional embedding base URL, distill model, reply timeout, daemon port, and feature flags. The full settable-key set is fixed by the configuration reference, and an unknown key is rejected.
-- **FR-37** — Feature flags are opt-in and default off: syncing AGENTS.md into project memory, undo checkpoints, parallel workspaces, cloud sync, and MCP. A disabled flag's surface (commands, tools, behavior) is absent, not merely inert.
+- **FR-37** — Feature flags are opt-in and default off: syncing AGENTS.md into project memory, undo checkpoints, workspaces, cloud sync, and MCP. A disabled flag's surface (commands, tools, behavior) is absent, not merely inert.
 - **FR-38** — Reasoning level (`low`/`medium`/`high`) is accepted and mapped to the selected provider's native reasoning control.
 - **FR-39** — Locale selects the UI language; an unset locale defaults to English, and an unavailable locale falls back rather than failing.
 - **FR-40** — Global update flags `--update` (force) and `--no-update` (skip) override the default startup update behavior; `--no-update` wins when both are present.
@@ -158,7 +158,7 @@ A second premise is that completion belongs to the model, not the host. The runt
 - **TUI-5** — TUI state reads that depend on current state use the functional-update form so concurrent updates from streaming events and input handlers do not race on a stale value.
 - **TUI-6** — Only active input handlers receive key events; terminal key parsing is centralized, with unambiguous modifier reporting on terminals that support the enhanced keyboard protocol.
 - **TUI-7** — A live status line shows location, model, token usage, active skill, and PR context, updating token totals during a turn.
-- **TUI-8** — Slash commands cover session control (new, clear, resume, sessions), model change, status, usage, memory management, skill run and skills picker, and exit; the parallel-workspaces commands appear only when that flag is enabled.
+- **TUI-8** — Slash commands cover session control (new, clear, resume, sessions), model change, status, usage, memory management, skill run and skills picker, and exit; the workspaces commands appear only when that flag is enabled.
 - **TUI-9** — Fuzzy autocomplete is offered for file paths, sessions, commands, and skills.
 - **TUI-10** — A queued message typed while a turn is running is handled cooperatively and processed in order rather than dropped or interleaved mid-step.
 - **TUI-11** — A user message preserves its whitespace in the transcript: leading indentation and internal whitespace runs are kept (tabs expanded to fixed-width stops), and a wrapped line repeats its indentation on each continuation row. Inline markup — backtick `code`, bold, and file paths — renders styled, with its delimiters interpreted. A fenced code block renders syntax-highlighted like assistant output, its fence interpreted; unfenced text stays verbatim.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,7 +169,7 @@ acolyte config set features.syncAgents true
 |------|-------------|
 | `syncAgents` | Sync `AGENTS.md` into a deterministic project memory record (`mem_agentsmd`). The model recalls it via `memory-search` instead of prompt injection. |
 | `undoCheckpoints` | Write tools create undo checkpoints under `.acolyte/undo/<sessionId>/`. The model can list and restore via `undo-list` and `undo-restore`. |
-| `parallelWorkspaces` | Enable `/workspaces` chat commands for managing git worktrees and workspace-scoped sessions. |
+| `workspaces` | Enable `/workspaces` chat commands for managing git worktrees and workspace-scoped sessions. |
 | `cloudSync` | Use the cloud API for memory and session storage. Requires `acolyte login`. |
 | `mcp` | Opt-in: load MCP servers from `.mcp.json` and expose their tools to the agent. |
 
@@ -192,6 +192,6 @@ acolyte config set features.syncAgents true
 | `replyTimeoutMs` | max reply wait time in ms (min 1000, default 180000) |
 | `features.syncAgents` | opt-in: sync `AGENTS.md` to project memory and omit it from prompt |
 | `features.undoCheckpoints` | opt-in: capture write-tool undo checkpoints |
-| `features.parallelWorkspaces` | opt-in: enable `/workspaces` chat commands |
+| `features.workspaces` | opt-in: enable `/workspaces` chat commands |
 | `features.cloudSync` | opt-in: use cloud API for memory and session storage |
 | `features.mcp` | opt-in: enable MCP servers from `.mcp.json` |

--- a/docs/features.md
+++ b/docs/features.md
@@ -83,6 +83,6 @@ Implemented but gated behind feature flags. See [Configuration](configuration.md
 
 - `syncAgents` — sync `AGENTS.md` into project memory for on-demand recall
 - `undoCheckpoints` — session-level undo via write-tool checkpoints
-- `parallelWorkspaces` — manage git worktrees and workspace-scoped sessions via `/workspaces`
+- `workspaces` — manage git worktrees and workspace-scoped sessions via `/workspaces`
 - `cloudSync` — portable memory and sessions across machines via `acolyte login` and `acolyte logout`
 - Postgres session storage backend and Postgres + pgvector memory backend (used by cloud tier)

--- a/src/chat-commands-workspaces.ts
+++ b/src/chat-commands-workspaces.ts
@@ -191,18 +191,13 @@ function createWorkspacesGroup(ctx: CommandContext): SubcommandGroup {
 }
 
 export function createWorkspacesCommands(ctx: CommandContext): SlashCommand[] {
+  if (!appConfig.features.workspaces) return [];
   const group = createWorkspacesGroup(ctx);
   return [
     {
       name: "workspaces",
       match: (value) => value === "/workspaces" || value.startsWith("/workspaces "),
-      run: () => {
-        if (!appConfig.features.parallelWorkspaces) {
-          ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.disabled"))]);
-          return Promise.resolve({ stop: true, userText: ctx.text });
-        }
-        return dispatchSubcommandGroup(group, ctx.resolvedText);
-      },
+      run: () => dispatchSubcommandGroup(group, ctx.resolvedText),
     },
   ];
 }

--- a/src/chat-commands.int.test.ts
+++ b/src/chat-commands.int.test.ts
@@ -10,19 +10,19 @@ async function runCommand(text: string, overrides: Parameters<typeof createComma
   return { ...spies, stop: result.stop, userText: result.userText };
 }
 
-function setParallelWorkspacesEnabled(enabled: boolean): () => void {
-  const cfg = appConfig as unknown as { features: { parallelWorkspaces: boolean } };
-  const prev = cfg.features.parallelWorkspaces;
-  cfg.features.parallelWorkspaces = enabled;
+function setWorkspacesEnabled(enabled: boolean): () => void {
+  const cfg = appConfig as unknown as { features: { workspaces: boolean } };
+  const prev = cfg.features.workspaces;
+  cfg.features.workspaces = enabled;
   return () => {
-    cfg.features.parallelWorkspaces = prev;
+    cfg.features.workspaces = prev;
   };
 }
 
 describe("chat-commands", () => {
   describe("/workspaces", () => {
     test("new reports errors from worktree creation instead of throwing", async () => {
-      const restore = setParallelWorkspacesEnabled(true);
+      const restore = setWorkspacesEnabled(true);
       try {
         const sessionState = createSessionState({ sessions: [], activeSessionId: undefined });
         const { createDir, cleanupDirs } = tempDir();

--- a/src/chat-commands.test.ts
+++ b/src/chat-commands.test.ts
@@ -539,34 +539,40 @@ describe("chat-commands", () => {
   });
 
   describe("/workspaces", () => {
-    function setParallelWorkspacesEnabled(enabled: boolean): () => void {
-      const cfg = appConfig as unknown as { features: { parallelWorkspaces: boolean } };
-      const prev = cfg.features.parallelWorkspaces;
-      cfg.features.parallelWorkspaces = enabled;
+    function setWorkspacesEnabled(enabled: boolean): () => void {
+      const cfg = appConfig as unknown as { features: { workspaces: boolean } };
+      const prev = cfg.features.workspaces;
+      cfg.features.workspaces = enabled;
       return () => {
-        cfg.features.parallelWorkspaces = prev;
+        cfg.features.workspaces = prev;
       };
     }
 
-    test("is gated by features.parallelWorkspaces", async () => {
-      const restore = setParallelWorkspacesEnabled(false);
+    test("is unknown while features.workspaces is off", async () => {
+      const restore = setWorkspacesEnabled(false);
       try {
         const { rows, stop } = await runCommand("/workspaces");
         expect(stop).toBe(true);
-        expect(
-          rows.some(
-            (row) =>
-              row.content ===
-              "Workspaces are disabled. Enable with: acolyte config set --project features.parallelWorkspaces true",
-          ),
-        ).toBe(true);
+        expect(rows.some((row) => row.content === "Unknown command: /workspaces")).toBe(true);
+        expect(rows.some((row) => typeof row.content === "string" && row.content.includes("config set"))).toBe(false);
+      } finally {
+        restore();
+      }
+    });
+
+    test("subcommands are unknown while features.workspaces is off", async () => {
+      const restore = setWorkspacesEnabled(false);
+      try {
+        const { rows, stop } = await runCommand("/workspaces list");
+        expect(stop).toBe(true);
+        expect(rows.some((row) => row.content === "Unknown command: /workspaces list")).toBe(true);
       } finally {
         restore();
       }
     });
 
     test("list renders existing workspace sessions", async () => {
-      const restore = setParallelWorkspacesEnabled(true);
+      const restore = setWorkspacesEnabled(true);
       try {
         const ws = createSession({
           id: "sess_ws1",

--- a/src/chat-layout.tsx
+++ b/src/chat-layout.tsx
@@ -1,25 +1,35 @@
 import { basename } from "node:path";
-import { slashCommandHelp } from "./chat-slash";
+import { chatSlashCommands, slashCommandHelp } from "./chat-slash";
 import { t } from "./i18n";
 
 /** Terminal width at which help pane switches from 1 to 2 columns. */
 export const BREAKPOINT_TWO_COLUMN = 92;
 
-export const SHORTCUT_ITEMS = [
-  { key: "@path", description: t("chat.at_ref.mention_path") },
-  { key: "/new", description: slashCommandHelp("/new") },
-  { key: "/clear", description: slashCommandHelp("/clear") },
-  { key: "/resume <id>", description: slashCommandHelp("/resume") },
-  { key: "/sessions", description: slashCommandHelp("/sessions") },
-  { key: "/workspaces", description: slashCommandHelp("/workspaces") },
-  { key: "/model", description: slashCommandHelp("/model") },
-  { key: "/status", description: slashCommandHelp("/status") },
-  { key: "/memory [scope]", description: slashCommandHelp("/memory") },
-  { key: "/memory add <text>", description: slashCommandHelp("/memory add") },
-  { key: "/usage", description: slashCommandHelp("/usage") },
-  { key: "/skills", description: slashCommandHelp("/skills") },
-  { key: "/exit", description: slashCommandHelp("/exit") },
-] as const;
+export type ShortcutItem = { key: string; description: string };
+
+/** Help entries, resolved per call so flag-gated commands stay absent while their flag is off. */
+export function shortcutItems(): ShortcutItem[] {
+  const enabled = new Set(chatSlashCommands());
+  const items: ShortcutItem[] = [
+    { key: "@path", description: t("chat.at_ref.mention_path") },
+    { key: "/new", description: slashCommandHelp("/new") },
+    { key: "/clear", description: slashCommandHelp("/clear") },
+    { key: "/resume <id>", description: slashCommandHelp("/resume") },
+    { key: "/sessions", description: slashCommandHelp("/sessions") },
+    { key: "/workspaces", description: slashCommandHelp("/workspaces") },
+    { key: "/model", description: slashCommandHelp("/model") },
+    { key: "/status", description: slashCommandHelp("/status") },
+    { key: "/memory [scope]", description: slashCommandHelp("/memory") },
+    { key: "/memory add <text>", description: slashCommandHelp("/memory add") },
+    { key: "/usage", description: slashCommandHelp("/usage") },
+    { key: "/skills", description: slashCommandHelp("/skills") },
+    { key: "/exit", description: slashCommandHelp("/exit") },
+  ];
+  return items.filter((item) => {
+    const command = item.key.split(" ")[0];
+    return !command.startsWith("/") || enabled.has(command);
+  });
+}
 
 export type GitStatus = {
   /** Repo name (main working-tree root basename); null outside a git repo. */

--- a/src/chat-layout.tsx
+++ b/src/chat-layout.tsx
@@ -43,9 +43,15 @@ export type GitStatus = {
 };
 
 async function git(cwd: string, args: string[]): Promise<string | null> {
-  const proc = Bun.spawn({ cmd: ["git", ...args], cwd, stdout: "pipe", stderr: "pipe", timeout: 5000 });
-  const [stdoutText] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
-  return (await proc.exited) === 0 ? stdoutText : null;
+  // A session outlives its workspace directory (a removed worktree), and spawning into a
+  // missing cwd throws ENOENT synchronously — which would surface as a fatal chat exit.
+  try {
+    const proc = Bun.spawn({ cmd: ["git", ...args], cwd, stdout: "pipe", stderr: "pipe", timeout: 5000 });
+    const [stdoutText] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+    return (await proc.exited) === 0 ? stdoutText : null;
+  } catch {
+    return null;
+  }
 }
 
 export async function gitStatus(cwd = process.cwd()): Promise<GitStatus | null> {

--- a/src/chat-slash.test.ts
+++ b/src/chat-slash.test.ts
@@ -1,6 +1,22 @@
 import { beforeEach, describe, expect, test } from "bun:test";
-import { isKnownSlashToken, shouldAutocompleteSlashSubmit, slashCommandHelp, suggestSlashCommands } from "./chat-slash";
+import { appConfig } from "./app-config";
+import {
+  chatSlashCommands,
+  isKnownSlashToken,
+  shouldAutocompleteSlashSubmit,
+  slashCommandHelp,
+  suggestSlashCommands,
+} from "./chat-slash";
 import { resetSkillCache } from "./skill-ops";
+
+function setWorkspacesEnabled(enabled: boolean): () => void {
+  const cfg = appConfig as unknown as { features: { workspaces: boolean } };
+  const prev = cfg.features.workspaces;
+  cfg.features.workspaces = enabled;
+  return () => {
+    cfg.features.workspaces = prev;
+  };
+}
 
 beforeEach(() => resetSkillCache());
 
@@ -39,13 +55,18 @@ describe("chat-slash helpers", () => {
   });
 
   test("suggestSlashCommands fuzzy-matches root and expands subcommands", () => {
-    expect(suggestSlashCommands("/mov")).toEqual([
-      "/model",
-      "/workspaces",
-      "/workspaces list",
-      "/workspaces new",
-      "/workspaces switch",
-    ]);
+    const restore = setWorkspacesEnabled(true);
+    try {
+      expect(suggestSlashCommands("/mov")).toEqual([
+        "/model",
+        "/workspaces",
+        "/workspaces list",
+        "/workspaces new",
+        "/workspaces switch",
+      ]);
+    } finally {
+      restore();
+    }
     expect(suggestSlashCommands("/modle")).toEqual(["/model"]);
     expect(suggestSlashCommands("/memry")).toEqual([
       "/memory",
@@ -54,6 +75,37 @@ describe("chat-slash helpers", () => {
       "/memory list",
       "/memory all",
     ]);
+  });
+
+  test("workspaces commands are absent while the flag is off", () => {
+    const restore = setWorkspacesEnabled(false);
+    try {
+      expect(chatSlashCommands()).not.toContain("/workspaces");
+      expect(suggestSlashCommands("/w")).toEqual([]);
+      expect(suggestSlashCommands("/workspaces")).toEqual([]);
+      expect(suggestSlashCommands("/mov")).not.toContain("/workspaces");
+      expect(isKnownSlashToken("/workspaces")).toBe(false);
+      expect(isKnownSlashToken("/workspaces list")).toBe(false);
+    } finally {
+      restore();
+    }
+  });
+
+  test("workspaces commands are present while the flag is on", () => {
+    const restore = setWorkspacesEnabled(true);
+    try {
+      expect(chatSlashCommands()).toContain("/workspaces");
+      expect(suggestSlashCommands("/w")).toEqual([
+        "/workspaces",
+        "/workspaces list",
+        "/workspaces new",
+        "/workspaces switch",
+      ]);
+      expect(isKnownSlashToken("/workspaces")).toBe(true);
+      expect(isKnownSlashToken("/workspaces list")).toBe(true);
+    } finally {
+      restore();
+    }
   });
 
   test("suggestSlashCommands fuzzy-matches multi-token input", () => {

--- a/src/chat-slash.ts
+++ b/src/chat-slash.ts
@@ -1,3 +1,4 @@
+import { appConfig } from "./app-config";
 import { t } from "./i18n";
 import { getLoadedSkills } from "./skill-ops";
 
@@ -15,10 +16,28 @@ const CHAT_SLASH_COMMANDS = [
   "/exit",
 ] as const;
 
-const SUB_COMMANDS: Record<string, string[]> = {
+/** Slash commands whose surface is absent unless their feature flag is on. */
+const FLAGGED_COMMANDS: Record<string, keyof typeof appConfig.features> = {
+  "/workspaces": "workspaces",
+};
+
+function isEnabled(command: string): boolean {
+  const flag = FLAGGED_COMMANDS[command.split(" ")[0]];
+  return flag === undefined || appConfig.features[flag] === true;
+}
+
+const ALL_SUB_COMMANDS: Record<string, string[]> = {
   "/memory": ["/memory add", "/memory rm", "/memory list", "/memory all", "/memory user", "/memory project"],
   "/workspaces": ["/workspaces list", "/workspaces new", "/workspaces switch"],
 };
+
+function subCommands(): Record<string, string[]> {
+  return Object.fromEntries(Object.entries(ALL_SUB_COMMANDS).filter(([root]) => isEnabled(root)));
+}
+
+export function chatSlashCommands(): string[] {
+  return CHAT_SLASH_COMMANDS.filter(isEnabled);
+}
 
 const SLASH_HELP: Record<string, string> = {
   "/new": t("chat.slash.help.new"),
@@ -47,8 +66,8 @@ const SUGGEST_MAX_DISTANCE = 3;
 
 function allSlashCommands(): string[] {
   const skillCommands = getLoadedSkills().map((s) => `/${s.name}`);
-  const subs = Object.values(SUB_COMMANDS).flat();
-  return [...CHAT_SLASH_COMMANDS, ...subs, ...skillCommands];
+  const subs = Object.values(subCommands()).flat();
+  return [...chatSlashCommands(), ...subs, ...skillCommands];
 }
 
 function editDistance(a: string, b: string): number {
@@ -69,8 +88,8 @@ function editDistance(a: string, b: string): number {
 }
 
 export function isKnownSlashToken(token: string): boolean {
-  if (CHAT_SLASH_COMMANDS.includes(token as (typeof CHAT_SLASH_COMMANDS)[number])) return true;
-  for (const subs of Object.values(SUB_COMMANDS)) {
+  if (chatSlashCommands().includes(token)) return true;
+  for (const subs of Object.values(subCommands())) {
     if (subs.includes(token)) return true;
   }
   if (token.startsWith("/")) {
@@ -88,11 +107,11 @@ function truncatedEditDistance(a: string, b: string): number {
 
 function rootCommands(): string[] {
   const skillCommands = getLoadedSkills().map((s) => `/${s.name}`);
-  return [...CHAT_SLASH_COMMANDS, ...skillCommands];
+  return [...chatSlashCommands(), ...skillCommands];
 }
 
 function commandWithSubs(root: string): string[] {
-  const subs = SUB_COMMANDS[root];
+  const subs = subCommands()[root];
   return subs ? [root, ...subs] : [root];
 }
 

--- a/src/chat-state.ts
+++ b/src/chat-state.ts
@@ -232,7 +232,7 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
         slashSuggestions,
         slashSuggestionIndex,
       }),
-      help: { visible: showHelp, entries: shortcutItems() },
+      help: { visible: showHelp, entries: showHelp ? shortcutItems() : [] },
       ctrlCPending,
       footer: statusLine,
     },

--- a/src/chat-state.ts
+++ b/src/chat-state.ts
@@ -6,7 +6,7 @@ import { useSuggestions } from "./chat-effects";
 import { processInputSubmit } from "./chat-input-handlers";
 import { useInputState } from "./chat-input-state";
 import { useChatKeybindings } from "./chat-keybindings";
-import { type GitStatus, gitStatus, SHORTCUT_ITEMS } from "./chat-layout";
+import { type GitStatus, gitStatus, shortcutItems } from "./chat-layout";
 import { createMessageHandler } from "./chat-message-handler";
 import { usePendingState } from "./chat-pending";
 import { type PickerState, pickerItemCount, reduceModelPickerAction } from "./chat-picker";
@@ -232,7 +232,7 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
         slashSuggestions,
         slashSuggestionIndex,
       }),
-      help: { visible: showHelp, entries: SHORTCUT_ITEMS },
+      help: { visible: showHelp, entries: shortcutItems() },
       ctrlCPending,
       footer: statusLine,
     },

--- a/src/chat-state.ts
+++ b/src/chat-state.ts
@@ -197,7 +197,7 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
 
   const tokenTotals = statusTokenTotals(tokenUsage, runningUsage);
   const statusLine: FooterStatus = {
-    repo: git?.repo ?? basename(process.cwd()),
+    repo: git?.repo ?? basename(currentSession.workspace ?? process.cwd()),
     worktree: git?.worktree ?? null,
     branch: git?.branch ?? null,
     dirty: git?.dirty ?? false,
@@ -268,10 +268,10 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
     async (cancelled) => {
       await Bun.sleep(GIT_REFRESH_DEBOUNCE_MS);
       if (cancelled()) return;
-      const result = await gitStatus();
+      const result = await gitStatus(currentSession.workspace);
       if (!cancelled()) setGit((previous) => result ?? previous);
     },
-    [pendingState],
+    [pendingState, currentSession.workspace],
   );
 
   const activateSkill = createSkillActivator({

--- a/src/chat-status-workspace.int.test.ts
+++ b/src/chat-status-workspace.int.test.ts
@@ -8,8 +8,12 @@ const dirs = tempDir();
 
 afterEach(dirs.cleanupDirs);
 
+// An inherited GIT_DIR/GIT_WORK_TREE would point these fixture commands at the real
+// repository, where `git init` re-initializes the shared gitdir as bare.
+const gitEnv = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")));
+
 async function git(cwd: string, args: string[]): Promise<void> {
-  const proc = Bun.spawn({ cmd: ["git", ...args], cwd, stdout: "pipe", stderr: "pipe" });
+  const proc = Bun.spawn({ cmd: ["git", ...args], cwd, env: gitEnv, stdout: "pipe", stderr: "pipe" });
   const stderr = await new Response(proc.stderr).text();
   if ((await proc.exited) !== 0) throw new Error(`git ${args.join(" ")} failed: ${stderr}`);
 }

--- a/src/chat-status-workspace.int.test.ts
+++ b/src/chat-status-workspace.int.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { useChatState } from "./chat-state";
+import { createClient, createSession, createSessionState, tempDir } from "./test-utils";
+import { renderHook } from "./tui/test-utils";
+
+const dirs = tempDir();
+
+afterEach(dirs.cleanupDirs);
+
+async function git(cwd: string, args: string[]): Promise<void> {
+  const proc = Bun.spawn({ cmd: ["git", ...args], cwd, stdout: "pipe", stderr: "pipe" });
+  const stderr = await new Response(proc.stderr).text();
+  if ((await proc.exited) !== 0) throw new Error(`git ${args.join(" ")} failed: ${stderr}`);
+}
+
+/** A repository with one linked worktree; returns the worktree path and its name. */
+async function createRepoWithWorktree(): Promise<{ root: string; worktree: string; name: string }> {
+  const root = dirs.createDir("acolyte-status-repo-");
+  await git(root, ["init", "--initial-branch=main"]);
+  await git(root, ["config", "user.email", "test@acolyte.test"]);
+  await git(root, ["config", "user.name", "Test"]);
+  await git(root, ["config", "commit.gpgsign", "false"]);
+  await Bun.write(join(root, "README.md"), "seed\n");
+  await git(root, ["add", "."]);
+  await git(root, ["commit", "-m", "seed"]);
+
+  const name = "side-quest";
+  const worktree = join(root, ".acolyte", "worktrees", name);
+  await git(root, ["worktree", "add", "-b", name, worktree]);
+  return { root, worktree, name };
+}
+
+function statusFor(workspace: string | undefined) {
+  const session = createSession({ id: "sess_status01", workspace });
+  const sessionState = createSessionState({ sessions: [session], activeSessionId: session.id });
+  return renderHook(() =>
+    useChatState(
+      {
+        client: createClient({ status: async () => ({}) }),
+        session,
+        sessionState,
+        persist: async () => {},
+        version: "0.0.0-test",
+      },
+      () => {},
+    ),
+  );
+}
+
+describe("footer git context", () => {
+  test("names the session's worktree rather than the process working directory", async () => {
+    const { name, worktree } = await createRepoWithWorktree();
+    const { result, unmount } = statusFor(worktree);
+    try {
+      await Bun.sleep(600);
+      expect(result.current.statusLine.worktree).toBe(name);
+      expect(result.current.statusLine.branch).toBe(name);
+    } finally {
+      unmount();
+    }
+  });
+
+  test("reports the session's repository, not the one the client was launched from", async () => {
+    const { root } = await createRepoWithWorktree();
+    const { result, unmount } = statusFor(root);
+    try {
+      await Bun.sleep(600);
+      expect(result.current.statusLine.worktree).toBeNull();
+      expect(result.current.statusLine.repo).not.toBe("acolyte");
+    } finally {
+      unmount();
+    }
+  });
+});

--- a/src/chat-status-workspace.int.test.ts
+++ b/src/chat-status-workspace.int.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { useChatState } from "./chat-state";
 import { createClient, createSession, createSessionState, tempDir } from "./test-utils";
 import { renderHook } from "./tui/test-utils";
@@ -71,7 +71,21 @@ describe("footer git context", () => {
     try {
       await Bun.sleep(600);
       expect(result.current.statusLine.worktree).toBeNull();
-      expect(result.current.statusLine.repo).not.toBe("acolyte");
+      expect(result.current.statusLine.repo).toBe(basename(root));
+      expect(result.current.statusLine.repo).not.toBe(basename(process.cwd()));
+    } finally {
+      unmount();
+    }
+  });
+
+  test("survives a session whose workspace directory no longer exists", async () => {
+    const { root } = await createRepoWithWorktree();
+    const removed = join(root, ".acolyte", "worktrees", "deleted-by-worktree-remove");
+    const { result, unmount } = statusFor(removed);
+    try {
+      await Bun.sleep(600);
+      expect(result.current.statusLine.worktree).toBeNull();
+      expect(result.current.statusLine.repo).toBe("deleted-by-worktree-remove");
     } finally {
       unmount();
     }

--- a/src/chat.tui.test.tsx
+++ b/src/chat.tui.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { SHORTCUT_ITEMS } from "./chat-layout";
+import { shortcutItems } from "./chat-layout";
 import type { ViewportPickerInput, ViewportSuggestionsInput } from "./chat-viewport-contract";
 import { createChatViewportPresentation } from "./chat-viewport-presentation";
 import { layoutChatViewport, layoutFooterStatus, layoutHeader } from "./terminal-chat-layout";
@@ -91,7 +91,7 @@ function composerScene(overrides: InputPanelOverrides, columns: number) {
       input: { text: value, cursor: value.length },
       picker,
       suggestions,
-      help: overrides.showHelp ? { visible: true, entries: SHORTCUT_ITEMS } : { visible: false, entries: [] },
+      help: overrides.showHelp ? { visible: true, entries: shortcutItems() } : { visible: false, entries: [] },
       ctrlCPending: overrides.ctrlCPending ?? false,
       footer: overrides.statusLine ?? DEFAULT_STATUS_LINE,
     },
@@ -140,7 +140,6 @@ describe("chat tui visual regression: status line and help", () => {
     "     /clear              clear transcript",
     "     /resume <id>        resume session",
     "     /sessions           show sessions",
-    "     /workspaces         manage workspaces",
     "     /model              change model",
     "     /status             show server status",
     "     /memory [scope]     show memory notes",

--- a/src/config.ts
+++ b/src/config.ts
@@ -145,8 +145,7 @@ function serializeToml(config: Config): string {
     if (typeof config.features.syncAgents === "boolean") lines.push(`syncAgents = ${config.features.syncAgents}`);
     if (typeof config.features.undoCheckpoints === "boolean")
       lines.push(`undoCheckpoints = ${config.features.undoCheckpoints}`);
-    if (typeof config.features.parallelWorkspaces === "boolean")
-      lines.push(`parallelWorkspaces = ${config.features.parallelWorkspaces}`);
+    if (typeof config.features.workspaces === "boolean") lines.push(`workspaces = ${config.features.workspaces}`);
     if (typeof config.features.cloudSync === "boolean") lines.push(`cloudSync = ${config.features.cloudSync}`);
   }
   return `${lines.join("\n")}${lines.length > 0 ? "\n" : ""}`;
@@ -228,7 +227,7 @@ export async function writeConfig(config: Config, options?: ConfigOptions): Prom
 }
 
 const RECORD_VALID_KEYS: Partial<Record<keyof Config, Set<string>>> = {
-  features: new Set(["syncAgents", "undoCheckpoints", "parallelWorkspaces", "cloudSync"]),
+  features: new Set(["syncAgents", "undoCheckpoints", "workspaces", "cloudSync"]),
 };
 
 function parseDottedKey(key: string): { section: keyof Config; subKey: string } | null {

--- a/src/feature-flags-contract.ts
+++ b/src/feature-flags-contract.ts
@@ -13,8 +13,8 @@ export const featureFlagsSchema = z.object({
   syncAgents: parseBoolSchema.optional(),
   // When enabled, capture write-tool checkpoints under .acolyte/undo/<sessionId> and allow undo tools.
   undoCheckpoints: parseBoolSchema.optional(),
-  // When enabled, allow managing parallel workspaces (git worktrees) from chat commands.
-  parallelWorkspaces: parseBoolSchema.optional(),
+  // When enabled, allow managing workspaces (git worktrees) from chat commands.
+  workspaces: parseBoolSchema.optional(),
   // When enabled, use the cloud API for memory and session storage.
   cloudSync: parseBoolSchema.optional(),
   // When enabled, connect to MCP servers configured in .mcp.json.
@@ -26,7 +26,7 @@ export type FeatureFlags = z.infer<typeof featureFlagsSchema>;
 export const resolvedFeatureFlagsSchema = z.object({
   syncAgents: parseBoolSchema.optional().default(false),
   undoCheckpoints: parseBoolSchema.optional().default(false),
-  parallelWorkspaces: parseBoolSchema.optional().default(false),
+  workspaces: parseBoolSchema.optional().default(false),
   cloudSync: parseBoolSchema.optional().default(false),
   mcp: parseBoolSchema.optional().default(false),
 });

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -121,8 +121,6 @@ export const EN_MESSAGES = {
   "cli.help.desc.start": "start server",
   "cli.help.desc.status": "show server status",
   "cli.help.desc.stop": "stop all servers",
-  "chat.workspaces.disabled":
-    "Workspaces are disabled. Enable with: acolyte config set --project features.parallelWorkspaces true",
   "chat.workspaces.created": "Created workspace {name}.",
   "chat.workspaces.create_failed": "Failed to create workspace: {reason}",
   "chat.workspaces.switched": "Switched to workspace {name}.",

--- a/src/lifecycle.int.test.ts
+++ b/src/lifecycle.int.test.ts
@@ -280,7 +280,7 @@ printf '%s\n' "$@" > "${formatLog}"
         request: { model: "gpt-5-mini", message: "test", history: [], sessionId: "sess_undo" },
         soulPrompt: "SOUL",
         workspace: undoWorkspace,
-        features: { syncAgents: false, undoCheckpoints: true, parallelWorkspaces: false, cloudSync: false, mcp: false },
+        features: { syncAgents: false, undoCheckpoints: true, workspaces: false, cloudSync: false, mcp: false },
       }),
       deps,
     );


### PR DESCRIPTION
## Summary

- return no workspace commands while the flag is off, so they fall through to the unknown-command path
- filter the slash listing, subcommands, suggestions, and help pane through one flagged-command map
- resolve help entries per call instead of at module load, and build them only when help is shown
- rename the feature flag from `parallelWorkspaces` to `workspaces`
- name the session's worktree in the footer instead of the client's launch directory
- keep the footer working when a session's workspace directory no longer exists
- isolate the new git fixtures from an ambient `GIT_DIR`