### PR TITLE
fix(git): isolate inherited git environment

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -27,7 +27,7 @@ done
 # Git exports GIT_DIR and friends into hooks. verify runs the test suite, and a test that
 # shells out to git inherits them and operates on this repository instead of its own fixture.
 for key in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do
-  unset "$key"
+  unset "$key" 2>/dev/null || true
 done
 
 bun run verify

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -24,4 +24,10 @@ while read -r local_ref local_oid remote_ref remote_oid; do
   bash "$root/scripts/check-commits.sh" "${range[@]}" || exit 1
 done
 
+# Git exports GIT_DIR and friends into hooks. verify runs the test suite, and a test that
+# shells out to git inherits them and operates on this repository instead of its own fixture.
+for key in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do
+  unset "$key"
+done
+
 bun run verify

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,4 +85,5 @@ Format: `type(scope): description` — types: `feat`, `fix`, `refactor`, `docs`,
 - Unit tests are pure: mock the application's boundary effects (filesystem, subprocess, network) instead of exercising them.
 - A test needing real filesystem/process/network behavior goes in `*.int.test.ts`, never `*.test.ts`. The exception is a `scripts/` shell script, whose subject under test *is* the process: run it directly from a `*.test.ts` beside it.
 - Integration tests use real server/lifecycle/tool wiring with a fake provider for model calls.
+- A test that shells out to `git` builds its environment with `gitEnv` from `test-utils.ts`: an inherited `GIT_DIR` retargets the fixture's commands at this repository.
 - Visual tests snapshot stable TUI rendering and interaction.

--- a/scripts/pre-push.int.test.ts
+++ b/scripts/pre-push.int.test.ts
@@ -106,9 +106,7 @@ describe("pre-push hook", () => {
 
     expect(await proc.exited).toBe(0);
     const seen = await Bun.file(dump).text();
-    expect(seen).not.toContain("GIT_DIR=");
-    expect(seen).not.toContain("GIT_WORK_TREE=");
-    expect(seen).not.toContain("GIT_INDEX_FILE=");
+    expect(seen).not.toMatch(/^GIT_/m);
   });
 
   test("skips a deleted ref", async () => {

--- a/scripts/pre-push.int.test.ts
+++ b/scripts/pre-push.int.test.ts
@@ -4,9 +4,11 @@ import { createGitFixture, type GitFixture, PLACEHOLDER_IDENTITY, REAL_IDENTITY,
 
 let fixture: GitFixture;
 
-function hookEnv(useFakeBun = true): Record<string, string> {
+function hookEnv(useFakeBun = true, overrides: Record<string, string> = {}): Record<string, string> {
   const base = fixture.env();
-  return useFakeBun ? fixture.env({ PATH: `${join(fixture.dir, "bin")}:${base.PATH}` }) : base;
+  return useFakeBun
+    ? fixture.env({ PATH: `${join(fixture.dir, "bin")}:${base.PATH}`, ...overrides })
+    : fixture.env(overrides);
 }
 
 // Pushing a brand-new branch is the case that regressed: the rev-list range is
@@ -81,6 +83,32 @@ describe("pre-push hook", () => {
 
     expect(code).toBe(1);
     expect(stderr).toContain("cannot enumerate commits");
+  });
+
+  test("does not hand git environment to verify", async () => {
+    await fixture.commit("feat: add a thing", REAL_IDENTITY);
+    const dump = join(fixture.dir, "verify-env.txt");
+    await Bun.write(join(fixture.dir, "bin", "bun"), `#!/bin/sh\nenv > ${dump}\nexit 0\n`);
+    Bun.spawnSync(["chmod", "755", join(fixture.dir, "bin", "bun")]);
+    const head = fixture.gitOutput(["rev-parse", "HEAD"]);
+
+    const proc = Bun.spawn(["bash", ".githooks/pre-push", "origin"], {
+      cwd: fixture.dir,
+      env: hookEnv(true, {
+        GIT_DIR: join(fixture.dir, ".git"),
+        GIT_WORK_TREE: fixture.dir,
+        GIT_INDEX_FILE: join(fixture.dir, ".git", "index"),
+      }),
+      stdin: new TextEncoder().encode(`refs/heads/topic ${head} refs/heads/topic ${ZERO}\n`),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(await proc.exited).toBe(0);
+    const seen = await Bun.file(dump).text();
+    expect(seen).not.toContain("GIT_DIR=");
+    expect(seen).not.toContain("GIT_WORK_TREE=");
+    expect(seen).not.toContain("GIT_INDEX_FILE=");
   });
 
   test("skips a deleted ref", async () => {

--- a/scripts/run-behavior.ts
+++ b/scripts/run-behavior.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { z } from "zod";
 import { stateDir } from "../src/paths";
+import { gitEnv } from "../src/test-utils";
 import {
   BEHAVIOR_SCENARIO_BY_ID,
   BEHAVIOR_SCENARIO_LIST,
@@ -317,19 +318,9 @@ function printUsage(): void {
 async function createBehaviorWorkspace(scenarioId: BehaviorScenarioId): Promise<string> {
   const workspace = await mkdtemp(join(tmpdir(), `acolyte-behavior-${scenarioId}-`));
   await mkdir(workspace, { recursive: true });
-  await runTimedCommand(["git", "init", "-b", "main"], process.env as Record<string, string>, 10_000, workspace);
-  await runTimedCommand(
-    ["git", "config", "user.email", "behavior@example.com"],
-    process.env as Record<string, string>,
-    10_000,
-    workspace,
-  );
-  await runTimedCommand(
-    ["git", "config", "user.name", "Behavior Harness"],
-    process.env as Record<string, string>,
-    10_000,
-    workspace,
-  );
+  await runTimedCommand(["git", "init", "-b", "main"], gitEnv(), 10_000, workspace);
+  await runTimedCommand(["git", "config", "user.email", "behavior@example.com"], gitEnv(), 10_000, workspace);
+  await runTimedCommand(["git", "config", "user.name", "Behavior Harness"], gitEnv(), 10_000, workspace);
   return workspace;
 }
 
@@ -352,8 +343,8 @@ async function runScenario(
   const scenario = BEHAVIOR_SCENARIO_BY_ID[scenarioId];
   const workspace = await createBehaviorWorkspace(scenario.id);
   await scenario.setup(workspace);
-  await runTimedCommand(["git", "add", "."], process.env as Record<string, string>, 10_000, workspace);
-  await runTimedCommand(["git", "commit", "-m", "baseline"], process.env as Record<string, string>, 10_000, workspace);
+  await runTimedCommand(["git", "add", "."], gitEnv(), 10_000, workspace);
+  await runTimedCommand(["git", "commit", "-m", "baseline"], gitEnv(), 10_000, workspace);
   const beforeLines = await readLogLines(behaviorEnv.daemonLogPath);
 
   const result = await runTimedCommand(

--- a/src/chat-layout.tsx
+++ b/src/chat-layout.tsx
@@ -1,6 +1,7 @@
 import { basename } from "node:path";
 import { chatSlashCommands, slashCommandHelp } from "./chat-slash";
 import { t } from "./i18n";
+import { envWithoutGitState } from "./tool-utils";
 
 /** Terminal width at which help pane switches from 1 to 2 columns. */
 export const BREAKPOINT_TWO_COLUMN = 92;
@@ -46,7 +47,14 @@ async function git(cwd: string, args: string[]): Promise<string | null> {
   // A session outlives its workspace directory (a removed worktree), and spawning into a
   // missing cwd throws ENOENT synchronously — which would surface as a fatal chat exit.
   try {
-    const proc = Bun.spawn({ cmd: ["git", ...args], cwd, stdout: "pipe", stderr: "pipe", timeout: 5000 });
+    const proc = Bun.spawn({
+      cmd: ["git", ...args],
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 5000,
+      env: envWithoutGitState(),
+    });
     const [stdoutText] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
     return (await proc.exited) === 0 ? stdoutText : null;
   } catch {

--- a/src/chat-status-workspace.int.test.ts
+++ b/src/chat-status-workspace.int.test.ts
@@ -1,19 +1,15 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { basename, join } from "node:path";
 import { useChatState } from "./chat-state";
-import { createClient, createSession, createSessionState, tempDir } from "./test-utils";
+import { createClient, createSession, createSessionState, gitEnv, tempDir } from "./test-utils";
 import { renderHook } from "./tui/test-utils";
 
 const dirs = tempDir();
 
 afterEach(dirs.cleanupDirs);
 
-// An inherited GIT_DIR/GIT_WORK_TREE would point these fixture commands at the real
-// repository, where `git init` re-initializes the shared gitdir as bare.
-const gitEnv = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_")));
-
 async function git(cwd: string, args: string[]): Promise<void> {
-  const proc = Bun.spawn({ cmd: ["git", ...args], cwd, env: gitEnv, stdout: "pipe", stderr: "pipe" });
+  const proc = Bun.spawn({ cmd: ["git", ...args], cwd, env: gitEnv(), stdout: "pipe", stderr: "pipe" });
   const stderr = await new Response(proc.stderr).text();
   if ((await proc.exited) !== 0) throw new Error(`git ${args.join(" ")} failed: ${stderr}`);
 }

--- a/src/chat-status-workspace.int.test.ts
+++ b/src/chat-status-workspace.int.test.ts
@@ -74,6 +74,31 @@ describe("footer git context", () => {
     }
   });
 
+  // Bun.spawn without an env option inherits the environment the process started with, so
+  // only a child process started with git state can exercise what the pre-push hook exposed.
+  test("resolves the workspace repository despite inherited git state", async () => {
+    const { name, worktree } = await createRepoWithWorktree();
+    const decoy = await createRepoWithWorktree();
+    const script = [
+      `const { gitStatus } = await import(${JSON.stringify(join(import.meta.dir, "chat-layout.tsx"))});`,
+      `console.log(JSON.stringify(await gitStatus(${JSON.stringify(worktree)})));`,
+    ].join("\n");
+
+    const proc = Bun.spawn({
+      cmd: ["bun", "-e", script],
+      env: gitEnv({ GIT_DIR: join(decoy.root, ".git"), GIT_WORK_TREE: decoy.root }),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    expect(await proc.exited, stderr).toBe(0);
+
+    const status = JSON.parse(stdout.trim());
+    expect(status.worktree).toBe(name);
+    expect(status.repo).not.toBe(basename(decoy.root));
+  });
+
   test("survives a session whose workspace directory no longer exists", async () => {
     const { root } = await createRepoWithWorktree();
     const removed = join(root, ".acolyte", "worktrees", "deleted-by-worktree-remove");

--- a/src/test-utils.test.ts
+++ b/src/test-utils.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { dedent, dedentString, expectIntent, expectToThrowJSON, normalizeIntentText, testUuid } from "./test-utils";
+import {
+  dedent,
+  dedentString,
+  expectIntent,
+  expectToThrowJSON,
+  gitEnv,
+  normalizeIntentText,
+  testUuid,
+} from "./test-utils";
 
 describe("test utils", () => {
   describe("dedentString", () => {
@@ -81,6 +89,33 @@ describe("test utils", () => {
           ["then", "stop"],
         ]),
       ).not.toThrow();
+    });
+  });
+
+  describe("gitEnv", () => {
+    test("drops inherited git state and keeps the rest", () => {
+      process.env.GIT_DIR = "/decoy/.git";
+      process.env.GIT_WORK_TREE = "/decoy";
+      try {
+        const env = gitEnv();
+        expect(env.GIT_DIR).toBeUndefined();
+        expect(env.GIT_WORK_TREE).toBeUndefined();
+        expect(env.PATH).toBe(process.env.PATH ?? "");
+      } finally {
+        delete process.env.GIT_DIR;
+        delete process.env.GIT_WORK_TREE;
+      }
+    });
+
+    test("applies git overrides on top of the scrubbed env", () => {
+      process.env.GIT_DIR = "/decoy/.git";
+      try {
+        const env = gitEnv({ GIT_AUTHOR_NAME: "T" });
+        expect(env.GIT_AUTHOR_NAME).toBe("T");
+        expect(env.GIT_DIR).toBeUndefined();
+      } finally {
+        delete process.env.GIT_DIR;
+      }
     });
   });
 

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -81,6 +81,16 @@ export function tempDir(): { createDir: (prefix: string) => string; cleanupDirs:
   };
 }
 
+// An inherited GIT_DIR or GIT_WORK_TREE points a fixture's git commands at the real
+// repository, where `git init` re-initializes the shared gitdir as bare.
+export function gitEnv(overrides: Record<string, string> = {}): Record<string, string> {
+  const base = Object.fromEntries(Object.entries(process.env).filter(([key]) => !key.startsWith("GIT_"))) as Record<
+    string,
+    string
+  >;
+  return { ...base, ...overrides };
+}
+
 export function tempDb<T extends { close(): void }>(
   prefix: string,
   factory: (dbPath: string) => T,

--- a/src/tool-utils.ts
+++ b/src/tool-utils.ts
@@ -21,14 +21,21 @@ const GIT_ENV_KEYS = [
   "GIT_WORK_TREE",
 ] as const;
 
+// Inherited git state overrides an explicit cwd, so a subprocess would read whichever
+// repository the ambient GIT_DIR names instead of the workspace it was handed.
+export function envWithoutGitState(overrides?: Record<string, string>): Record<string, string> {
+  const env = { ...process.env } as Record<string, string>;
+  for (const key of GIT_ENV_KEYS) delete env[key];
+  if (overrides) Object.assign(env, overrides);
+  return env;
+}
+
 export async function runCommand(
   cmd: string[],
   workspace: string,
   envOverride?: Record<string, string>,
 ): Promise<{ code: number; stdout: string; stderr: string }> {
-  const env = { ...process.env };
-  for (const key of GIT_ENV_KEYS) delete env[key];
-  if (envOverride) Object.assign(env, envOverride);
+  const env = envWithoutGitState(envOverride);
   const proc = Bun.spawn({
     cmd,
     cwd: workspace,

--- a/src/workspace-sandbox.int.test.ts
+++ b/src/workspace-sandbox.int.test.ts
@@ -3,7 +3,7 @@ import { mkdir, realpath, symlink, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { ERROR_KINDS, TOOL_ERROR_CODES } from "./error-contract";
 import { projectResourceIdFromWorkspace } from "./resource-id";
-import { expectToThrowJSON, tempDir } from "./test-utils";
+import { expectToThrowJSON, gitEnv, tempDir } from "./test-utils";
 import {
   clearWorkspaceSandboxCache,
   ensurePathWithinSandbox,
@@ -18,13 +18,12 @@ async function git(cwd: string, args: string[]): Promise<void> {
   const proc = Bun.spawn(["git", "-c", "commit.gpgsign=false", "-C", cwd, ...args], {
     stdout: "pipe",
     stderr: "pipe",
-    env: {
-      ...process.env,
+    env: gitEnv({
       GIT_AUTHOR_NAME: "T",
       GIT_AUTHOR_EMAIL: "t@t.dev",
       GIT_COMMITTER_NAME: "T",
       GIT_COMMITTER_EMAIL: "t@t.dev",
-    },
+    }),
   });
   const exitCode = await proc.exited;
   if (exitCode !== 0) throw new Error(`git ${args.join(" ")} failed: ${await new Response(proc.stderr).text()}`);


### PR DESCRIPTION
## Summary

- pre-push unsets `GIT_*` before running verify, so no test can inherit the pushing repository
- tests that shell out to git build their environment through one shared helper
- the chat footer reads git status from the session workspace, not from an inherited `GIT_DIR`
- the behavior harness scrubs git state around its fixture repo
- the hook takes effect only once on `main` — `core.hooksPath` points at the primary checkout
