### PR TITLE
fix(chat): skip nested checkouts in @ candidates

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -29,7 +29,7 @@ A second premise is that completion belongs to the model, not the host. The runt
 ### 2.2 Input handling
 
 - **FR-6** — Interactive chat accepts multi-line prompts.
-- **FR-7** — A prompt may attach file or directory context by `@path` reference; the referenced content is included in the request context.
+- **FR-7** — A prompt may attach file or directory context by `@path` reference; the referenced content is included in the request context. Completion candidates cover every workspace path the user can name, gitignored paths included, and exclude nested repository checkouts.
 - **FR-8** — A workspace path supplied to a request must exist and be a directory; otherwise the request is rejected with an actionable message. When none is supplied, the current working directory is used.
 - **FR-9** — Every value crossing a runtime boundary (transport payload, model response, configuration value, tool arguments) is validated before entering typed code; invalid input is rejected with a structured error rather than propagating.
 - **FR-10** — A malformed CLI invocation (unknown command, missing required argument) produces an actionable usage message and a non-zero exit, and near-miss command names produce a suggestion.

--- a/SPEC.md
+++ b/SPEC.md
@@ -29,7 +29,7 @@ A second premise is that completion belongs to the model, not the host. The runt
 ### 2.2 Input handling
 
 - **FR-6** — Interactive chat accepts multi-line prompts.
-- **FR-7** — A prompt may attach file or directory context by `@path` reference; the referenced content is included in the request context. Completion candidates cover every workspace path the user can name, gitignored paths included, and exclude nested repository checkouts.
+- **FR-7** — A prompt may attach file or directory context by `@path` reference; the referenced content is included in the request context. Completion candidates include gitignored paths and exclude nested repository checkouts.
 - **FR-8** — A workspace path supplied to a request must exist and be a directory; otherwise the request is rejected with an actionable message. When none is supplied, the current working directory is used.
 - **FR-9** — Every value crossing a runtime boundary (transport payload, model response, configuration value, tool arguments) is validated before entering typed code; invalid input is rejected with a structured error rather than propagating.
 - **FR-10** — A malformed CLI invocation (unknown command, missing required argument) produces an actionable usage message and a non-zero exit, and near-miss command names produce a suggestion.

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -65,7 +65,7 @@ Use `@path` in chat input to attach file or directory context:
 @docs/ summarize the documentation
 ```
 
-Completion offers any path you can name in the workspace, including gitignored ones — unlike the file tools, which are gitignore-aware. Nested repository checkouts are left out: a directory holding a `.git` entry is a worktree, submodule, or vendored clone, so its tree duplicates another repository rather than extending this one.
+Completion offers gitignored paths too, unlike the file tools, which are gitignore-aware. Nested repository checkouts are left out: a directory holding a `.git` entry is a worktree, submodule, or vendored clone, so its tree duplicates another repository rather than extending this one.
 
 ## Design constraints
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -65,6 +65,8 @@ Use `@path` in chat input to attach file or directory context:
 @docs/ summarize the documentation
 ```
 
+Completion offers any path you can name in the workspace, including gitignored ones — unlike the file tools, which are gitignore-aware. Nested repository checkouts are left out: a directory holding a `.git` entry is a worktree, submodule, or vendored clone, so its tree duplicates another repository rather than extending this one.
+
 ## Design constraints
 
 - **Minimal primitive set** — every new prop becomes renderer debt. Add only what's needed.

--- a/src/chat-app.int.test.ts
+++ b/src/chat-app.int.test.ts
@@ -29,6 +29,48 @@ describe("chat-ui integration helpers", () => {
     const refreshed = await getCachedRepoPathCandidates(root);
     expect(refreshed).toContain("sum.rs");
   });
+
+  test("getCachedRepoPathCandidates keeps gitignored files mentionable", async () => {
+    const root = dirs.createDir("acolyte-at-gitignored-");
+    await mkdir(join(root, "docs", "notes"), { recursive: true });
+    await writeFile(join(root, ".gitignore"), "docs/notes\n", "utf8");
+    await writeFile(join(root, "docs", "notes", "plan.md"), "plan", "utf8");
+    invalidateRepoPathCandidates(root);
+    expect(await getCachedRepoPathCandidates(root)).toContain("docs/notes/plan.md");
+  });
+
+  test("getCachedRepoPathCandidates skips nested checkouts", async () => {
+    const root = dirs.createDir("acolyte-at-nested-");
+    await mkdir(join(root, "src"), { recursive: true });
+    await writeFile(join(root, "src", "own.ts"), "own", "utf8");
+    // A worktree and a submodule carry a `.git` file; a vendored clone a `.git` directory.
+    await mkdir(join(root, "worktrees", "feature", "src"), { recursive: true });
+    await writeFile(join(root, "worktrees", "feature", ".git"), "gitdir: /elsewhere", "utf8");
+    await writeFile(join(root, "worktrees", "feature", "src", "own.ts"), "copy", "utf8");
+    await mkdir(join(root, "vendor", "dep", ".git"), { recursive: true });
+    await writeFile(join(root, "vendor", "dep", "lib.ts"), "lib", "utf8");
+    invalidateRepoPathCandidates(root);
+
+    const candidates = await getCachedRepoPathCandidates(root);
+    expect(candidates).toContain("src/own.ts");
+    expect(candidates).not.toContain("worktrees/feature/src/own.ts");
+    expect(candidates).not.toContain("worktrees/feature/");
+    expect(candidates).not.toContain("vendor/dep/lib.ts");
+    expect(candidates).not.toContain("vendor/dep/");
+    expect(candidates).toContain("worktrees/");
+  });
+
+  test("getCachedRepoPathCandidates scans the workspace when it is itself a checkout", async () => {
+    const root = dirs.createDir("acolyte-at-checkout-root-");
+    await mkdir(join(root, "src"), { recursive: true });
+    await writeFile(join(root, ".git"), "gitdir: /elsewhere", "utf8");
+    await writeFile(join(root, "src", "own.ts"), "own", "utf8");
+    invalidateRepoPathCandidates(root);
+
+    const candidates = await getCachedRepoPathCandidates(root);
+    expect(candidates).toContain("src/own.ts");
+    expect(candidates).not.toContain(".git");
+  });
 });
 
 function withLogSinkEnv(

--- a/src/chat-app.int.test.ts
+++ b/src/chat-app.int.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, readFileSync } from "node:fs";
 import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { installClientLogSink, runChat } from "./chat-app";
-import { getCachedRepoPathCandidates, invalidateRepoPathCandidates } from "./chat-file-ref";
+import { collectRepoPathCandidates, getCachedRepoPathCandidates, invalidateRepoPathCandidates } from "./chat-file-ref";
 import { log, setLogSink } from "./log";
 import { stateDir } from "./paths";
 import type { Session, SessionId, SessionState } from "./session-contract";
@@ -30,13 +30,26 @@ describe("chat-ui integration helpers", () => {
     expect(refreshed).toContain("sum.rs");
   });
 
-  test("getCachedRepoPathCandidates keeps gitignored files mentionable", async () => {
+  test("collectRepoPathCandidates does not consult gitignore", async () => {
     const root = dirs.createDir("acolyte-at-gitignored-");
     await mkdir(join(root, "docs", "notes"), { recursive: true });
     await writeFile(join(root, ".gitignore"), "docs/notes\n", "utf8");
     await writeFile(join(root, "docs", "notes", "plan.md"), "plan", "utf8");
-    invalidateRepoPathCandidates(root);
-    expect(await getCachedRepoPathCandidates(root)).toContain("docs/notes/plan.md");
+    expect(await collectRepoPathCandidates(root)).toContain("docs/notes/plan.md");
+  });
+
+  test("collectRepoPathCandidates reports sibling directories found before the cap", async () => {
+    const root = dirs.createDir("acolyte-at-cap-");
+    await mkdir(join(root, "aaa"), { recursive: true });
+    await mkdir(join(root, "zzz"), { recursive: true });
+    await writeFile(join(root, "aaa", "keep.txt"), "keep", "utf8");
+    for (const name of ["1.txt", "2.txt", "3.txt", "4.txt"]) {
+      await writeFile(join(root, "zzz", name), name, "utf8");
+    }
+
+    const candidates = await collectRepoPathCandidates(root, 3);
+    expect(candidates.length).toBeLessThanOrEqual(4);
+    expect(candidates).toContain("aaa/");
   });
 
   test("getCachedRepoPathCandidates skips nested checkouts", async () => {

--- a/src/chat-file-ref.ts
+++ b/src/chat-file-ref.ts
@@ -138,6 +138,13 @@ export function extractAtReferencePaths(inputValue: string): string[] {
   return out;
 }
 
+// A directory holding a `.git` entry is its own checkout — a worktree, submodule, or
+// vendored clone — so its tree duplicates another repository rather than extending this
+// one. `.git` is a directory in a clone and a file in a worktree or submodule.
+function isNestedCheckout(entries: Array<{ name: string }>): boolean {
+  return entries.some((entry) => entry.name === ".git");
+}
+
 async function collectRepoPathCandidates(root = process.cwd(), maxEntries = MAX_SCAN_ENTRIES): Promise<string[]> {
   const out: string[] = [];
   const stack: Array<{ abs: string; rel: string }> = [{ abs: root, rel: "" }];
@@ -151,19 +158,15 @@ async function collectRepoPathCandidates(root = process.cwd(), maxEntries = MAX_
     } catch {
       continue;
     }
+    if (current.rel && isNestedCheckout(entries)) continue;
+    if (current.rel) out.push(`${current.rel}/`);
     entries.sort((a, b) => a.name.localeCompare(b.name));
 
     for (const entry of entries) {
-      if (entry.isDirectory() && IGNORED_DIRS.has(entry.name)) continue;
+      if (entry.name === ".git" || (entry.isDirectory() && IGNORED_DIRS.has(entry.name))) continue;
       const rel = current.rel ? `${current.rel}/${entry.name}` : entry.name;
       const abs = join(current.abs, entry.name);
       if (entry.isDirectory()) {
-        if (rel === ".git") {
-          out.push(".git/config");
-          out.push(".git/COMMIT_EDITMSG");
-          continue;
-        }
-        out.push(`${rel}/`);
         stack.push({ abs, rel });
       } else if (entry.isFile()) {
         out.push(rel);

--- a/src/chat-file-ref.ts
+++ b/src/chat-file-ref.ts
@@ -138,36 +138,51 @@ export function extractAtReferencePaths(inputValue: string): string[] {
   return out;
 }
 
+type ScanEntries = Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean }>;
+
+async function readScanEntries(abs: string): Promise<ScanEntries | null> {
+  try {
+    const entries = await readdir(abs, { withFileTypes: true });
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    return entries;
+  } catch {
+    return null;
+  }
+}
+
 // A directory holding a `.git` entry is its own checkout — a worktree, submodule, or
 // vendored clone — so its tree duplicates another repository rather than extending this
 // one. `.git` is a directory in a clone and a file in a worktree or submodule.
-function isNestedCheckout(entries: Array<{ name: string }>): boolean {
+function isNestedCheckout(entries: ScanEntries): boolean {
   return entries.some((entry) => entry.name === ".git");
 }
 
-async function collectRepoPathCandidates(root = process.cwd(), maxEntries = MAX_SCAN_ENTRIES): Promise<string[]> {
+// Directories are classified when discovered rather than when popped, so a scan that hits
+// `maxEntries` deep in one subtree still reports the sibling directories it already found.
+export async function collectRepoPathCandidates(
+  root = process.cwd(),
+  maxEntries = MAX_SCAN_ENTRIES,
+): Promise<string[]> {
+  const rootEntries = await readScanEntries(root);
+  if (!rootEntries) return [];
   const out: string[] = [];
-  const stack: Array<{ abs: string; rel: string }> = [{ abs: root, rel: "" }];
+  const stack: Array<{ abs: string; rel: string; entries: ScanEntries }> = [
+    { abs: root, rel: "", entries: rootEntries },
+  ];
 
   while (stack.length > 0 && out.length < maxEntries) {
     const current = stack.pop();
     if (!current) break;
-    let entries: Array<{ name: string; isDirectory: () => boolean; isFile: () => boolean }> = [];
-    try {
-      entries = await readdir(current.abs, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    if (current.rel && isNestedCheckout(entries)) continue;
-    if (current.rel) out.push(`${current.rel}/`);
-    entries.sort((a, b) => a.name.localeCompare(b.name));
 
-    for (const entry of entries) {
+    for (const entry of current.entries) {
       if (entry.name === ".git" || (entry.isDirectory() && IGNORED_DIRS.has(entry.name))) continue;
       const rel = current.rel ? `${current.rel}/${entry.name}` : entry.name;
       const abs = join(current.abs, entry.name);
       if (entry.isDirectory()) {
-        stack.push({ abs, rel });
+        const entries = await readScanEntries(abs);
+        if (entries && isNestedCheckout(entries)) continue;
+        out.push(`${rel}/`);
+        if (entries) stack.push({ abs, rel, entries });
       } else if (entry.isFile()) {
         out.push(rel);
       }


### PR DESCRIPTION
## Summary

- `@` completion skips any directory holding a `.git` entry, so worktrees, submodules, and vendored clones stop duplicating the tree — 3,959 candidates down to 706 in this repo
- gitignored paths stay mentionable; the picker deliberately does not consult gitignore, unlike the file tools
- directories are classified when discovered, so a scan that hits the entry cap still reports the siblings it already found
