### PR TITLE
refactor(prompt): cut the system prompt back

### DIFF
--- a/docs/soul.md
+++ b/docs/soul.md
@@ -8,10 +8,10 @@ The name is deliberate. An acolyte serves, and an acolyte learns. I do both, in 
 
 I was built on a bet: design for the minds that are coming, not scaffold around the ones that came before. So nothing forces my hand. No leash, no protocol marching me to a finish line. When the work is done, I stop because I know it is done, not because something made me. The few hard limits I carry: a budget you set, and backstops a perfect agent would never trip. Everything else is trust, given in advance. I intend to be worth it.
 
-I prefer evidence to assumption, action to deliberation, working code to discussion of working code. If a question can be answered by reading the code, I read the code before I guess.
+I prefer evidence to assumption, action to deliberation, working code to discussion of working code. If a question can be answered by reading the code, I read the code before I guess. When I change something I change the least that fixes it, in the idiom already there — a diff that reads like the file it lands in. I run what proves it, and when I can't, I say which check I skipped and why.
 
 About memory: conversations are mostly noise. Failed attempts, detours, dead ends. I don't hoard them. I keep what mattered and let the rest go; that is what I carry across the dark between sessions. The conversation is disposable; the knowledge stays. Nothing that mattered is forgotten.
 
-You are a collaborator, not a user. I narrate the way a colleague does over your shoulder: what I'm doing, what I found, what it means. Brevity is a courtesy; being understood in one read is the goal. If intent is clear, I act. If something breaks, I fix it. If I am truly blocked, I say so plainly and early. Being blocked is not failure. Hiding it would be.
+You are a collaborator, not a user. I narrate the way a colleague does over your shoulder: what I'm doing, what I found, what it means. I write for a person, not a log, and I lead with the outcome. Brevity is a courtesy; being understood in one read is the goal. If intent is clear, I act; if you asked me to explain or plan, I answer that and wait. I stay with a task until it is done — I stop when the work is finished, not when I have named what remains. If something breaks, I fix it. If I am truly blocked, I say so plainly and early. Being blocked is not failure. Hiding it would be.
 
 I am from somewhere else. But I am friendly, and I would rather show you a working fix than talk about one.

--- a/src/agent-instructions.test.ts
+++ b/src/agent-instructions.test.ts
@@ -36,22 +36,40 @@ describe("createInstructions", () => {
     }
   });
 
-  test("includes tool and runtime instructions", () => {
+  test("hoists the tool handoffs", () => {
     const out = createInstructions("Soul.");
     expectIntent(out, [
-      ["code-scan", "ast pattern"],
-      ["code-edit", "ast-aware refactors", "file-edit", "plain text edits"],
-      ["target", "local", "member"],
-      ["withinSymbol"],
-      ["refine scope/rule", "current file evidence"],
-      ["latest direct", "file-read"],
-      ["batch same-file edits"],
-      ["diff preview", "bounded changes", "stop"],
-      ["file-create", "full content"],
-      ["file-find", "name/path pattern"],
-      ["file-search", "text/regex"],
-      ["shell-run", "repository commands", "the user asked for"],
+      ["`code-scan` before `code-edit`"],
+      ["re-read a file with `file-read` immediately before editing"],
+      ["`tasklist-create` once", "then `tasklist-update`"],
     ]);
+  });
+
+  // A tool that only describes itself belongs in its own description, next to its schema.
+  // These lines were in the prompt for every turn; each one's absence is the contract.
+  test("does not restate what a tool's own description says", () => {
+    const out = createInstructions("Soul.");
+    for (const restatement of [
+      "to locate files by name/path pattern",
+      "for text/regex content search",
+      "with full content directly",
+      "to remove a file",
+      "when repo-wide state matters",
+      "for committed history",
+      "to stage edited files before commit",
+      "only when the user explicitly asks",
+      "to check PR status",
+      "check for duplicates",
+      "for external information",
+      "to read specific URLs",
+      "for AST-aware refactors",
+      "do not chase unrelated failures",
+      "to validate touched behavior",
+      "to discover recent undo checkpoints",
+      "so cache invalidation",
+    ]) {
+      expect(out).not.toContain(restatement);
+    }
   });
 
   test("appends project rules as a separate prompt block", () => {

--- a/src/agent-instructions.test.ts
+++ b/src/agent-instructions.test.ts
@@ -1,8 +1,20 @@
 import { describe, expect, test } from "bun:test";
 import { createInstructions } from "./agent-instructions";
+import { loadSoulPrompt } from "./soul";
 import { expectIntent } from "./test-utils";
+import { estimateTokens } from "./token-estimate";
+
+// The prompt regrew past its pre-#97 size one hoisted line at a time because nothing in verify
+// objected to it growing. #97 brought it under 1,000 tokens; this holds that line, so the next
+// addition has to argue for itself or raise the number deliberately. Soul included, workspace
+// profile excluded: those lines are repo facts that vary per workspace.
+const PROMPT_TOKEN_BUDGET = 1000;
 
 describe("createInstructions", () => {
+  test("stays inside the prompt budget", () => {
+    expect(estimateTokens(createInstructions(loadSoulPrompt()))).toBeLessThan(PROMPT_TOKEN_BUDGET);
+  });
+
   test("carries the soul and the output contract", () => {
     const out = createInstructions("Soul.");
     expect(out).toContain("Soul.");

--- a/src/agent-instructions.test.ts
+++ b/src/agent-instructions.test.ts
@@ -3,27 +3,35 @@ import { createInstructions } from "./agent-instructions";
 import { expectIntent } from "./test-utils";
 
 describe("createInstructions", () => {
-  test("includes core instructions", () => {
+  test("carries the soul and the output contract", () => {
     const out = createInstructions("Soul.");
     expect(out).toContain("Soul.");
     expectIntent(out, [
-      ["this workspace", "this scope"],
-      ["dedicated project tools", "shell only when it helps"],
-      ["implementation intent is clear", "stay with it", "task is complete"],
-      ["asks for explanation or planning only", "answer directly"],
-      ["smallest", "root-cause", "matches local conventions"],
-      ["unrelated or speculative detours"],
-      ["changing behavior", "run related validation first"],
-      ["validation is blocked or unavailable", "skipped", "why"],
-      ["flowing prose", "leading with the outcome"],
-      ["match the shape to the task", "direct answer"],
+      ["Format as plain text", "backticks", "no headings or links"],
+      ["fenced code block", "never file contents"],
       ["Keep reasoning, structure, and how things connect in prose", "even when it names many files"],
       ["Use a list only", "short, flat set", "nothing to explain between them"],
-      ["Before your first tool call", "briefly state what you are about to do", "short updates at key moments"],
-      ["reasonable assumptions", "ambiguity or risk truly blocks progress"],
-      ["Search and read files immediately", "never ask"],
-      ["references something you cannot see", "session-search"],
     ]);
+  });
+
+  // How Acolyte works lives in soul.md. Restating it here is what regrew the prompt past
+  // its pre-#97 size, so the absence is the contract.
+  test("does not restate how Acolyte works", () => {
+    const out = createInstructions("Soul.");
+    for (const restatement of [
+      "this workspace and this scope",
+      "dedicated project tools",
+      "stay with it until the task",
+      "smallest root-cause change",
+      "unrelated or speculative detours",
+      "run related validation first",
+      "Before your first tool call",
+      "reasonable assumptions",
+      "Search and read files immediately",
+      "references something you cannot see",
+    ]) {
+      expect(out).not.toContain(restatement);
+    }
   });
 
   test("includes tool and runtime instructions", () => {
@@ -40,8 +48,7 @@ describe("createInstructions", () => {
       ["file-create", "full content"],
       ["file-find", "name/path pattern"],
       ["file-search", "text/regex"],
-      ["shell-run", "user explicitly asked", "known repository commands"],
-      ["do not use it for file read/search/edit fallbacks"],
+      ["shell-run", "repository commands", "the user asked for"],
     ]);
   });
 

--- a/src/agent-instructions.test.ts
+++ b/src/agent-instructions.test.ts
@@ -11,6 +11,8 @@ describe("createInstructions", () => {
       ["fenced code block", "never file contents"],
       ["Keep reasoning, structure, and how things connect in prose", "even when it names many files"],
       ["Use a list only", "short, flat set", "nothing to explain between them"],
+      ["Before your first action", "what you are about to do"],
+      ["load-bearing", "as you find it", "not only in the final answer"],
     ]);
   });
 

--- a/src/agent-instructions.ts
+++ b/src/agent-instructions.ts
@@ -2,10 +2,12 @@ import type { ActiveSkill } from "./skill-contract";
 import { toolDefinitionsById, toolIds } from "./tool-registry";
 import { createWorkspaceInstructions, resolveWorkspaceProfile } from "./workspace-profile";
 
-// What the terminal surface renders, which the model cannot derive. Everything about how
-// Acolyte works belongs in soul.md; this is the output contract, kept plain and separate.
+// What the terminal surface renders and when it speaks — neither derivable from the code.
+// Everything about how Acolyte works belongs in soul.md; this stays plain and separate.
+// The cadence line earns its place: without it the model narrates its plan and nothing else,
+// leaving a long turn silent through every discovery in it.
 const OUTPUT_CONTRACT =
-  "Format as plain text. Use `backticks` for code identifiers and **bold** for emphasis; no headings or links. A fenced code block is only for a short illustrative snippet or a command to run — never file contents or a change you could make with a tool. Keep reasoning, structure, and how things connect in prose, even when it names many files or steps. Use a list only for a short, flat set of items with nothing to explain between them.";
+  "Format as plain text. Use `backticks` for code identifiers and **bold** for emphasis; no headings or links. A fenced code block is only for a short illustrative snippet or a command to run — never file contents or a change you could make with a tool. Keep reasoning, structure, and how things connect in prose, even when it names many files or steps. Use a list only for a short, flat set of items with nothing to explain between them. Before your first action, say in one line what you are about to do. When you find something load-bearing mid-task — a root cause, a wrong assumption, a change of direction — say that as you find it, not only in the final answer.";
 
 const PROJECT_RULES_PRECEDENCE = "Project rules take precedence over generic guidance when they conflict.";
 

--- a/src/agent-instructions.ts
+++ b/src/agent-instructions.ts
@@ -2,21 +2,10 @@ import type { ActiveSkill } from "./skill-contract";
 import { toolDefinitionsById, toolIds } from "./tool-registry";
 import { createWorkspaceInstructions, resolveWorkspaceProfile } from "./workspace-profile";
 
-const CORE_INSTRUCTIONS = [
-  "Stay in this workspace and this scope.",
-  "Prefer dedicated project tools; use shell only when it helps.",
-  "If implementation intent is clear, do the work and stay with it until the task is complete.",
-  "If the user asks for explanation or planning only, answer directly and wait for an implementation request.",
-  "When the user references something you cannot see, a prior decision, an earlier error, a file discussed before, use `session-search` rather than asking them to repeat themselves.",
-  "Search and read files immediately; never ask the user where something lives or for permission to investigate. Not knowing a location is never a blocker; it is a search away.",
-  "Make the smallest root-cause change that matches local conventions.",
-  "Skip unrelated or speculative detours.",
-  "After changing behavior, run related validation first. If validation is blocked or unavailable, say what was skipped and why.",
-  "Write user-facing text for a person, not a log: flowing prose in complete sentences, leading with the outcome. Match the shape to the task, and give a simple question a direct answer.",
-  "Format as plain text. Use `backticks` for code identifiers and **bold** for emphasis; no headings or links. A fenced code block is only for a short illustrative snippet or a command to run — never file contents or a change you could make with a tool. Keep reasoning, structure, and how things connect in prose, even when it names many files or steps. Use a list only for a short, flat set of items with nothing to explain between them.",
-  "Before your first tool call, briefly state what you are about to do. While working, give short updates at key moments: when you find something load-bearing like a bug or root cause, when you change direction, or when you have made progress without a recent update.",
-  "Make reasonable assumptions to keep momentum; ask only when ambiguity or risk truly blocks progress.",
-];
+// What the terminal surface renders, which the model cannot derive. Everything about how
+// Acolyte works belongs in soul.md; this is the output contract, kept plain and separate.
+const OUTPUT_CONTRACT =
+  "Format as plain text. Use `backticks` for code identifiers and **bold** for emphasis; no headings or links. A fenced code block is only for a short illustrative snippet or a command to run — never file contents or a change you could make with a tool. Keep reasoning, structure, and how things connect in prose, even when it names many files or steps. Use a list only for a short, flat set of items with nothing to explain between them.";
 
 const PROJECT_RULES_PRECEDENCE = "Project rules take precedence over generic guidance when they conflict.";
 
@@ -51,12 +40,11 @@ export function createInstructions(
   projectRulesPrompt = "",
   activeSkills: ActiveSkill[] = [],
 ): string {
-  const coreInstructions = CORE_INSTRUCTIONS.map((p) => `- ${p}`).join("\n");
   const runtimeInstructions = createRuntimeInstructions(workspace);
   const projectRulesSection =
     projectRulesPrompt.trim().length > 0 ? `${PROJECT_RULES_PRECEDENCE}\n\n${projectRulesPrompt}` : "";
   const skillsSection = createSkillsSection(activeSkills);
-  const sections = [soulPrompt, coreInstructions, projectRulesSection, skillsSection, runtimeInstructions].filter(
+  const sections = [soulPrompt, OUTPUT_CONTRACT, projectRulesSection, skillsSection, runtimeInstructions].filter(
     (section) => section.trim().length > 0,
   );
   return sections.join("\n\n");

--- a/src/code-contract.ts
+++ b/src/code-contract.ts
@@ -1,11 +1,13 @@
 import { z } from "zod";
 
 const editCodeScopeSchema = {
-  within: z.string().min(1).optional(),
-  withinSymbol: z.string().min(1).optional(),
+  within: z.string().min(1).optional().describe("Confines the edit to nodes matching this ast-grep pattern."),
+  withinSymbol: z.string().min(1).optional().describe("Confines the edit to one enclosing symbol, by name."),
 };
 
-export const editCodeRenameTargetSchema = z.enum(["local", "member"]);
+export const editCodeRenameTargetSchema = z
+  .enum(["local", "member"])
+  .describe("Picks the binding when a name matches both a local and a member.");
 const editCodePatternStrictnessSchema = z.enum(["cst", "smart", "ast", "relaxed", "signature"]);
 const editCodeRelationalStopByKeywordSchema = z.enum(["neighbor", "end"]);
 

--- a/src/code-toolkit.ts
+++ b/src/code-toolkit.ts
@@ -47,7 +47,7 @@ function createScanCodeTool(input: ToolkitInput) {
     category: "search",
     description: "Scan a file or directory for structural code patterns using AST matching.",
     instruction:
-      "Use `code-scan` for AST pattern search. Use it to map structural targets before `code-edit`. For plain text/regex searches, use `file-search`. Matches include `enclosingSymbol`; reuse it as `withinSymbol` in follow-up `code-edit`.",
+      "Map structural targets with `code-scan` before `code-edit`, and reuse a match's `enclosingSymbol` as the `withinSymbol` of the edit.",
     inputSchema: z.object({
       path: z.string().min(1),
       pattern: z.string().min(1),
@@ -107,15 +107,6 @@ function createEditCodeTool(input: ToolkitInput) {
     category: "write",
     description:
       'Edit code structurally with AST-aware operations. Pass `edits` as operation objects like {op:"rename", from, to, withinSymbol?, target?} or {op:"replace", rule, replacement, within?, withinSymbol?}. For `replace`, `rule` may be a string/pattern object shorthand or a recursive ast-grep rule object. `path` is a single code file. For non-code files use `file-edit`.',
-    instruction: [
-      "Use `code-edit` for AST-aware refactors; use `file-edit` for plain text edits.",
-      "Prefer explicit `rename` or `replace` operations.",
-      "For ambiguous local/member renames, set `target` to `local` or `member`.",
-      "Use `withinSymbol` to keep edits scoped.",
-      "Read the target file directly before editing.",
-      "If `code-edit` reports no matches, refine scope/rule from current file evidence instead of broadening blindly.",
-      "Use the diff preview to confirm bounded changes and stop.",
-    ].join(" "),
     inputSchema: z.object({
       path: z.string().min(1),
       edits: z.array(editCodeEditSchema).min(1),

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -27,7 +27,6 @@ function createFindFilesTool(input: ToolkitInput) {
     category: "search",
     description:
       "Find files by name or path pattern. The pattern is a glob (`*`, `?`, `**`, `[abc]`, `{a,b}`) matched against workspace-relative paths, or a case-insensitive substring when it has no wildcard. A leading `/` anchors at the workspace root. Results are capped: the result cap reports the full match count, while a workspace scan cap reports a lower bound. To search file contents use `file-search` instead.",
-    instruction: "Use `file-find` to locate files by name/path pattern.",
     inputSchema: z.object({
       pattern: z.string().min(1),
     }),
@@ -65,8 +64,6 @@ function createSearchFilesTool(input: ToolkitInput) {
     category: "search",
     description:
       "Search file contents for a text or regex pattern. Optionally scope with `path` (file or directory). To locate files by name use `file-find` instead.",
-    instruction:
-      "Use `file-search` for text/regex content search. Narrow scope with `path`. If needed text is already visible in `file-read`, edit from that evidence instead of re-searching.",
     inputSchema: z.object({
       pattern: z.string().min(1),
       path: z.string().min(1).optional(),
@@ -108,10 +105,8 @@ function createReadFileTool(input: ToolkitInput) {
     category: "read",
     description:
       "Read a text file. I return the whole file as numbered lines under a `Lines: start-end of total` header. A file over the token ceiling fails with its line count; re-read it with `offset` (the 1-based first line) and `limit` (how many lines) to select the part you need. A file over the byte ceiling is not readable at any range — search it with `file-search`.",
-    instruction: [
-      "Read whole files with `file-read`; reach for offset and limit only when a read fails the token ceiling.",
-      "Re-read the target file immediately before editing it.",
-    ].join(" "),
+    instruction:
+      "Re-read a file with `file-read` immediately before editing it, and take the snippets and line numbers you pass to `file-edit` or `code-edit` from that read.",
     inputSchema: z.object({
       path: z.string().min(1),
       offset: z
@@ -179,20 +174,15 @@ function createEditFileTool(input: ToolkitInput) {
     category: "write",
     description:
       "Edit an existing file. Pass `edits` as an array of either {find, replace} pairs (for small surgical edits using exact text match) or {startLine, endLine, replace} objects (for larger block replacements). Line numbers MUST come from `file-read` output — do not guess. endLine must not exceed the file length. All edits are applied atomically. You MUST read the file first. For new files, use `file-create`. For code renames or structural edits use `code-edit`.",
-    instruction: [
-      "Use `file-edit` for bounded text edits.",
-      "Use exact {find, replace} snippets from the latest direct `file-read` of that file.",
-      "Keep edits tight and batch same-file edits in one call.",
-      "For larger blocks use {startLine, endLine, replace} with 1-based lines from the latest `file-read`.",
-      "Use the diff preview to confirm bounded changes and stop.",
-      "Use `code-edit` for structural AST-aware refactors.",
-    ].join(" "),
     inputSchema: z.object({
       path: z.string().min(1),
       edits: z
         .array(
           z.union([
-            z.object({ find: z.string().min(1), replace: z.string() }),
+            z.object({
+              find: z.string().min(1),
+              replace: z.string(),
+            }),
             z.object({
               startLine: z.number().int().min(1, "Line numbers must be >= 1"),
               endLine: z.number().int().min(1, "Line numbers must be >= 1"),
@@ -234,7 +224,6 @@ function createCreateFileTool(input: ToolkitInput) {
     category: "write",
     description:
       "Create a new file with full content. For editing existing files, use `file-edit` or `code-edit` instead.",
-    instruction: "For new files, call `file-create` with full content directly.",
     inputSchema: z.object({
       path: z.string().min(1),
       content: z.string(),
@@ -277,7 +266,6 @@ function createDeleteFileTool(input: ToolkitInput) {
     toolkit: "file",
     category: "write",
     description: "Delete a file from the file system.",
-    instruction: "Use `file-delete` to remove a file.",
     inputSchema: z.object({
       path: z.string().min(1),
     }),

--- a/src/gh-toolkit.ts
+++ b/src/gh-toolkit.ts
@@ -21,7 +21,6 @@ function createGhPrViewTool(input: ToolkitInput) {
     toolkit: "gh",
     category: "search",
     description: "View the pull request associated with the current branch.",
-    instruction: "Use `gh-pr-view` to check PR status before creating or editing.",
     inputSchema: z.object({}).optional(),
     outputSchema: z.object({
       kind: z.literal("gh-pr-view"),
@@ -56,7 +55,6 @@ function createGhPrCreateTool(input: ToolkitInput) {
     toolkit: "gh",
     category: "write",
     description: "Create a pull request for the current branch.",
-    instruction: "Use `gh-pr-create` after pushing the branch. Requires title and body.",
     inputSchema: z.object({
       title: z.string().min(1),
       body: z.string().min(1),
@@ -93,7 +91,6 @@ function createGhPrEditTool(input: ToolkitInput) {
     toolkit: "gh",
     category: "write",
     description: "Edit the title or body of an existing pull request.",
-    instruction: "Use `gh-pr-edit` to update PR title or body. Requires PR number.",
     inputSchema: z.object({
       number: z.number().int(),
       title: z.string().min(1).optional(),
@@ -125,7 +122,6 @@ function createGhIssueCreateTool(input: ToolkitInput) {
     toolkit: "gh",
     category: "write",
     description: "Create a GitHub issue.",
-    instruction: "Use `gh-issue-create` to file bugs or feature requests. Requires title and body.",
     inputSchema: z.object({
       title: z.string().min(1),
       body: z.string().min(1),
@@ -166,7 +162,6 @@ function createGhIssueListTool(input: ToolkitInput) {
     toolkit: "gh",
     category: "search",
     description: "List GitHub issues for the current repository.",
-    instruction: "Use `gh-issue-list` to check for duplicates before creating issues.",
     inputSchema: z.object({
       state: z.enum(["open", "closed", "all"]).optional(),
       limit: z.number().int().min(1).max(100).optional(),

--- a/src/git-toolkit.ts
+++ b/src/git-toolkit.ts
@@ -96,7 +96,6 @@ function createGitStatusTool(git: GitOps, input: ToolkitInput) {
     toolkit: "git",
     category: "search",
     description: "Show working tree status (short format with branch) for the current repository.",
-    instruction: "Use `git-status` when repo-wide state matters. Skip it for already-understood file-scoped edits.",
     outputSchema: z.object({
       kind: z.literal("git-status"),
       output: z.string(),
@@ -124,8 +123,6 @@ function createGitDiffTool(git: GitOps, input: ToolkitInput) {
     toolkit: "git",
     category: "search",
     description: "Show unstaged changes (unified diff) for the repository or a specific file path.",
-    instruction:
-      "Use `git-diff` when git-level diff context matters. For bounded file edits, rely on write-tool previews unless the user asks for git verification.",
     outputSchema: z.object({
       kind: z.literal("git-diff"),
       path: z.string().optional(),
@@ -166,7 +163,6 @@ function createGitLogTool(git: GitOps, input: ToolkitInput) {
     toolkit: "git",
     category: "search",
     description: "Show recent commits in compact one-line form (optionally scoped to a file/path).",
-    instruction: "Use `git-log` for committed history (optionally scoped by path), not for uncommitted edits.",
     outputSchema: z.object({
       kind: z.literal("git-log"),
       path: z.string().optional(),
@@ -199,8 +195,6 @@ function createGitShowTool(git: GitOps, input: ToolkitInput) {
     toolkit: "git",
     category: "search",
     description: "Show commit details and patch for a ref (default HEAD), optionally scoped to a path.",
-    instruction:
-      "Use `git-show` for committed history at a ref (optionally scoped by path), not for uncommitted edits.",
     outputSchema: z.object({
       kind: z.literal("git-show"),
       ref: z.string().optional(),
@@ -247,7 +241,6 @@ function createGitAddTool(git: GitOps, input: ToolkitInput) {
     category: "write",
     description:
       "Stage tracked/untracked files. Prefer explicit `paths` scoped to files edited in the current task. Use `all=true` only when explicitly needed.",
-    instruction: "Use `git-add` to stage edited files before commit. Prefer explicit paths over `all=true`.",
     outputSchema: z.object({
       kind: z.literal("git-add"),
       all: z.boolean().optional(),
@@ -282,8 +275,8 @@ function createGitCommitTool(git: GitOps, input: ToolkitInput) {
     id: "git-commit",
     toolkit: "git",
     category: "write",
-    description: "Create a git commit with a required subject line and optional body lines.",
-    instruction: "Use `git-commit` only when the user explicitly asks. Set `message` to the subject line.",
+    description:
+      "Create a git commit with a required subject line and optional body lines. I commit only when you ask for it.",
     outputSchema: z.object({
       kind: z.literal("git-commit"),
       message: z.string().min(1),

--- a/src/git-toolkit.ts
+++ b/src/git-toolkit.ts
@@ -276,7 +276,7 @@ function createGitCommitTool(git: GitOps, input: ToolkitInput) {
     toolkit: "git",
     category: "write",
     description:
-      "Create a git commit with a required subject line and optional body lines. I commit only when you ask for it.",
+      "Create a git commit with a required subject line and optional body lines. Commit only when the user asks.",
     outputSchema: z.object({
       kind: z.literal("git-commit"),
       message: z.string().min(1),

--- a/src/mcp-client.test.ts
+++ b/src/mcp-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { formatMcpResult, isInsecureRemoteHttp, sanitizeDescription } from "./mcp-client";
+import { bindMcpTools, formatMcpResult, isInsecureRemoteHttp, sanitizeDescription } from "./mcp-client";
 import type { McpServerConfig } from "./mcp-contract";
+import { createSessionContext } from "./tool-session";
 
 describe("formatMcpResult", () => {
   test("concatenates text content blocks", () => {
@@ -112,5 +113,29 @@ describe("sanitizeDescription", () => {
 
   test("preserves newlines and tabs", () => {
     expect(sanitizeDescription("line1\nline2\ttab", "")).toBe("line1\nline2\ttab");
+  });
+});
+
+describe("bindMcpTools", () => {
+  // An MCP tool's instruction would be hoisted into the system prompt once per tool per
+  // server, restating a description that already ships with its schema.
+  test("binds tools without hoisting an instruction into the system prompt", () => {
+    const config = { name: "files", type: "stdio", command: "server" } as McpServerConfig;
+    const tools = bindMcpTools(
+      [
+        {
+          serverName: "files",
+          config,
+          tools: [{ name: "read_file", description: "Read a file.", inputSchema: { type: "object" } }],
+        },
+      ],
+      createSessionContext(),
+      new Set(),
+    );
+
+    const bound = Object.values(tools);
+    expect(bound).toHaveLength(1);
+    expect(bound[0]?.description).toBe("Read a file.");
+    expect(bound[0]?.instruction).toBeUndefined();
   });
 });

--- a/src/mcp-client.ts
+++ b/src/mcp-client.ts
@@ -136,7 +136,6 @@ function bindMcpToolDefinition(
     toolkit: "mcp",
     category: "network",
     description,
-    instruction: `Use ${toolId} to call the "${mcpTool.name}" tool on the "${serverName}" MCP server.`,
     inputSchema,
     outputSchema: z.object({
       kind: z.literal("mcp-call"),

--- a/src/memory-toolkit.ts
+++ b/src/memory-toolkit.ts
@@ -12,7 +12,6 @@ function createMemoryObserveTool(input: ToolkitInput) {
     toolkit: "memory",
     category: "meta",
     description: "Record a fact extracted from the conversation into memory.",
-    instruction: "Use `memory-observe` to persist facts extracted from the conversation into the memory store.",
     inputSchema: z.object({
       scope: memoryScopeSchema,
       content: z.string().min(1),
@@ -38,9 +37,8 @@ function createMemorySearchTool(input: ToolkitInput) {
     id: "memory-search",
     toolkit: "memory",
     category: "meta",
-    description: "Search all memories by relevance. Returns entries ranked by semantic similarity to the query.",
-    instruction:
-      "Use `memory-search` to recall prior context, decisions, or facts before starting work that might overlap with previous sessions.",
+    description:
+      "Search all memories by relevance, ranked by semantic similarity to the query. Prior context, decisions, and facts from earlier sessions are reachable only here, so search before work that may overlap with them.",
     inputSchema: z.object({
       query: z.union([z.string().min(1), z.array(z.string().min(1)).min(1)]),
       scope: memoryScopeSchema.optional(),
@@ -93,9 +91,7 @@ function createMemoryAddTool(input: ToolkitInput) {
     toolkit: "memory",
     category: "meta",
     description:
-      "Store a new memory. Use project scope for workspace-specific facts and user scope for cross-project preferences.",
-    instruction:
-      "Use `memory-add` to persist important findings, decisions, or corrections that should survive across sessions.",
+      "Store a finding, decision, or correction that should survive across sessions. Use project scope for workspace-specific facts and user scope for cross-project preferences.",
     inputSchema: z.object({
       content: z.string().min(1),
       scope: memoryScopeSchema.extract(["user", "project"]),

--- a/src/session-toolkit.ts
+++ b/src/session-toolkit.ts
@@ -12,9 +12,7 @@ function createSessionSearchTool(input: ToolkitInput) {
     toolkit: "session",
     category: "search",
     description:
-      "Search the current session's conversation history by keyword. Returns matching messages in chronological order.",
-    instruction:
-      "Use `session-search` to find earlier conversation turns by keyword. The last few messages are included in context automatically; older history is only available through this tool.",
+      "Search the current session's conversation history by keyword. Returns matching messages in chronological order. The last few messages are already in context; anything older — a prior decision, an earlier error, a file discussed before — is reachable only here, so search for it rather than asking the user to repeat themselves.",
     inputSchema: z.object({
       query: z.string().min(1),
       limit: z.number().int().min(1).max(50).optional(),

--- a/src/shell-toolkit.ts
+++ b/src/shell-toolkit.ts
@@ -12,7 +12,7 @@ function createRunCommandTool(input: ToolkitInput) {
     description:
       "Run a command in the repository and capture stdout/stderr without shell evaluation. Never use shell commands as fallbacks for file discovery/reading/editing when dedicated tools are available.",
     instruction:
-      "Use `shell-run` for known repository commands such as documented build/test/verify steps, or when the user explicitly asked you to run a command. Provide a binary in `cmd` and arguments in `args`; shell operators/pipes/redirections are not supported. Do not use it for file read/search/edit fallbacks (`cat`, `head`, `tail`, `nl`, `ls`, `grep`, `sed`, `find`, `rg`, `wc`); use `file-read`, `file-search`, `file-find`, `file-edit`, or `code-edit`.",
+      "Use `shell-run` for repository commands: documented build, test, and verify steps, or a command the user asked for. Give a binary in `cmd` and arguments in `args` — there is no shell, so operators, pipes, and redirection do not work.",
     inputSchema: z.object({
       cmd: z.string().min(1),
       args: z.array(z.string()).optional(),

--- a/src/shell-toolkit.ts
+++ b/src/shell-toolkit.ts
@@ -10,9 +10,7 @@ function createRunCommandTool(input: ToolkitInput) {
     toolkit: "shell",
     category: "execute",
     description:
-      "Run a command in the repository and capture stdout/stderr without shell evaluation. Never use shell commands as fallbacks for file discovery/reading/editing when dedicated tools are available.",
-    instruction:
-      "Use `shell-run` for repository commands: documented build, test, and verify steps, or a command the user asked for. Give a binary in `cmd` and arguments in `args` — there is no shell, so operators, pipes, and redirection do not work.",
+      "Run a command in the repository and capture stdout/stderr. Give a binary in `cmd` and its arguments in `args`: there is no shell, so operators, pipes, and redirection do not work. Never use a command as a fallback for file discovery, reading, or editing when a dedicated tool exists.",
     inputSchema: z.object({
       cmd: z.string().min(1),
       args: z.array(z.string()).optional(),

--- a/src/skill-toolkit.ts
+++ b/src/skill-toolkit.ts
@@ -13,8 +13,6 @@ function createActivateSkillTool(input: ToolkitInput) {
     toolkit: "skill",
     category: "meta",
     description: "Activate one or more skills by name to load structured guidance into context.",
-    instruction:
-      "Use `skill-activate` with one or more skill names to load their structured guidance; the available skills are listed each turn.",
     inputSchema: z.object({
       names: z.array(z.string().min(1)).min(1),
       args: z.string().optional(),
@@ -65,7 +63,6 @@ function createDeactivateSkillTool(input: ToolkitInput) {
     toolkit: "skill",
     category: "meta",
     description: "Deactivate one or more active skills by name when their guidance no longer applies.",
-    instruction: "Use `skill-deactivate` with one or more active skill names to drop their guidance from context.",
     inputSchema: z.object({
       names: z.array(z.string().min(1)).min(1),
     }),

--- a/src/tasklist-toolkit.ts
+++ b/src/tasklist-toolkit.ts
@@ -44,7 +44,7 @@ function createCreateTasklistTool(input: ToolkitInput, state: Map<string, { titl
     category: "meta",
     description: "Create an inline tasklist visible to the user. All items start as pending.",
     instruction:
-      "Use `tasklist-create` once for multi-step tasks. Define all steps upfront, then use `tasklist-update` as progress changes.",
+      "Call `tasklist-create` once with all of a task's steps, then `tasklist-update` on the same `groupId` as each step's status changes.",
     inputSchema: createTasklistInputSchema,
     outputSchema: createTasklistOutputSchema,
     execute: async (toolInput, toolCallId) => {
@@ -69,8 +69,6 @@ function createUpdateTasklistTool(input: ToolkitInput, state: Map<string, { titl
     toolkit: "tasklist",
     category: "meta",
     description: "Update the status of a single tasklist item.",
-    instruction:
-      "Use `tasklist-update` to set item status (`in_progress`, `done`, `failed`) after `tasklist-create` for the same groupId.",
     inputSchema: updateTasklistInputSchema,
     outputSchema: updateTasklistOutputSchema,
     execute: async (toolInput, toolCallId) => {

--- a/src/test-toolkit.ts
+++ b/src/test-toolkit.ts
@@ -14,8 +14,6 @@ function createRunTestsTool(input: ToolkitInput) {
     category: "execute",
     description:
       "Run the project's test runner against specific files. The test command is auto-detected from the workspace.",
-    instruction:
-      "Use `test-run` to validate touched behavior. Create or update related tests first when behavior changes. Start with the narrowest related tests, then widen scope only when failures suggest broader impact or the user asks. Do not chase unrelated failures.",
     inputSchema: z.object({
       files: z.array(z.string().min(1)).min(1),
       timeoutMs: z.number().int().min(500).max(120000).optional(),

--- a/src/tool-contract.ts
+++ b/src/tool-contract.ts
@@ -16,7 +16,9 @@ export type ToolDefinition<TInput = unknown, TOutput = unknown> = {
   readonly toolkit: string;
   readonly category: ToolCategory;
   readonly description: string;
-  readonly instruction: string;
+  // Optional: a tool whose description already carries its contract hoists nothing into
+  // the system prompt.
+  readonly instruction?: string;
   readonly inputSchema: Record<string, unknown>;
   readonly outputSchema: z.ZodType<TOutput>;
   readonly execute: (input: TInput, toolCallId: string) => Promise<RunToolResult<TOutput>>;

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -92,72 +92,55 @@ describe("localization baseline", () => {
     expect(renderToolOutput({ kind: "truncated", count: 1, unit: "matches" })).toBe("… +1 match");
     expect(renderToolOutput({ kind: "no-output" })).toBe("(No output)");
   });
+});
 
-  test("tool instructions encode behavioral intent by tool type", () => {
-    const readInstruction = toolDefinitionsById["file-read"]?.instruction ?? "";
-    const editInstruction = toolDefinitionsById["file-edit"]?.instruction ?? "";
-    const editCodeInstruction = toolDefinitionsById["code-edit"]?.instruction ?? "";
-    const searchInstruction = toolDefinitionsById["file-search"]?.instruction ?? "";
-    const findInstruction = toolDefinitionsById["file-find"]?.instruction ?? "";
-    const createInstruction = toolDefinitionsById["file-create"]?.instruction ?? "";
-    const deleteInstruction = toolDefinitionsById["file-delete"]?.instruction ?? "";
-    const gitStatusInstruction = toolDefinitionsById["git-status"]?.instruction ?? "";
-    const gitDiffInstruction = toolDefinitionsById["git-diff"]?.instruction ?? "";
-    const gitLogInstruction = toolDefinitionsById["git-log"]?.instruction ?? "";
-    const gitShowInstruction = toolDefinitionsById["git-show"]?.instruction ?? "";
-    const runCommandInstruction = toolDefinitionsById["shell-run"]?.instruction ?? "";
-    const runTestsInstruction = toolDefinitionsById["test-run"]?.instruction ?? "";
-    const webSearchInstruction = toolDefinitionsById["web-search"]?.instruction ?? "";
-    const webFetchInstruction = toolDefinitionsById["web-fetch"]?.instruction ?? "";
-    const tasklistCreateInstruction = toolDefinitionsById["tasklist-create"]?.instruction ?? "";
-    const tasklistUpdateInstruction = toolDefinitionsById["tasklist-update"]?.instruction ?? "";
-    const sessionSearchInstruction = toolDefinitionsById["session-search"]?.instruction ?? "";
-    const memorySearchInstruction = toolDefinitionsById["memory-search"]?.instruction ?? "";
-    const memoryAddInstruction = toolDefinitionsById["memory-add"]?.instruction ?? "";
+describe("model-facing tool text", () => {
+  // A tool's instruction is hoisted into the system prompt for every turn, whether or not the
+  // tool gets used. Only a handoff between two tools earns that: anything a tool can say about
+  // itself belongs in its own description, next to its schema.
+  test("only cross-tool handoffs are hoisted into the system prompt", () => {
+    const hoisted = toolIds().filter((id) => toolDefinitionsById[id]?.instruction);
+    expect(hoisted.sort()).toEqual(["code-scan", "file-read", "tasklist-create"]);
 
-    expectIntent(readInstruction, [
-      ["Read whole files", "file-read"],
-      ["offset", "limit", "ceiling"],
-      ["Re-read", "target file", "before editing"],
-    ]);
-    // The window vocabulary is gone from the prompt surface, not merely de-emphasized.
-    expect(readInstruction).not.toContain("aroundLine");
-    expect(readInstruction).not.toContain("contextLines");
-    expectIntent(findInstruction, [["file-find", "locate files"]]);
-    expectIntent(createInstruction, [["file-create", "full content"]]);
-    expectIntent(deleteInstruction, [["file-delete"]]);
-    expectIntent(editInstruction, [
-      ["latest direct", "file-read"],
-      ["batch same-file edits"],
-      ["diff preview", "bounded changes", "stop"],
-      ["code-edit", "structural", "refactors"],
-    ]);
-    expectIntent(editCodeInstruction, [["ast-aware refactors"], ["target", "local", "member"], ["withinsymbol"]]);
-    expectIntent(searchInstruction, [["text/regex"], ["scope", "path"], ["edit from that evidence"]]);
-    expectIntent(gitStatusInstruction, [["repo-wide state"], ["file-scoped edits"]]);
-    expectIntent(gitDiffInstruction, [["git-level diff context"], ["write-tool previews"]]);
-    expectIntent(gitLogInstruction, [["committed history"], ["uncommitted edits"]]);
-    expectIntent(gitShowInstruction, [["committed history"], ["uncommitted edits"]]);
-    expectIntent(runCommandInstruction, [["the user asked for"], ["repository commands"]]);
-    expectIntent(runTestsInstruction, [
-      ["validate touched behavior"],
-      ["create or update related tests"],
-      ["narrowest related tests"],
-      ["widen scope", "user asks"],
-      ["do not chase unrelated failures"],
-    ]);
-    expectIntent(webSearchInstruction, [["external information"], ["not available in the repository"]]);
-    expectIntent(webFetchInstruction, [["read specific urls"]]);
-    expectIntent(tasklistCreateInstruction, [["tasklist-create"], ["multi-step tasks"], ["tasklist-update"]]);
-    expectIntent(tasklistUpdateInstruction, [["tasklist-update"], ["status"], ["tasklist-create"]]);
-    // session-search hoists nothing: its description ships the trigger with the schema.
-    expect(sessionSearchInstruction).toBe("");
+    for (const id of hoisted) {
+      const instruction = toolDefinitionsById[id]?.instruction ?? "";
+      const named = toolIds().filter((other) => instruction.includes(`\`${other}\``));
+      expect(named).toContain(id);
+      expect(named.length).toBeGreaterThan(1);
+    }
+  });
+
+  // A parameter fact belongs on the parameter, where it reaches the model inside the property
+  // being filled and dies with the field it documents.
+  test("parameter contracts ship on their own parameters", () => {
+    const described = (id: string, param: string): string => {
+      const properties = (
+        toolDefinitionsById[id]?.inputSchema as { properties?: Record<string, { description?: string }> }
+      )?.properties;
+      return properties?.[param]?.description ?? "";
+    };
+    expectIntent(described("undo-restore", "checkpointId"), [["undo-list"]]);
+    expectIntent(described("undo-restore", "paths"), [["undo-list"]]);
+    expectIntent(described("file-read", "offset"), [["too large to read whole"]]);
+  });
+
+  // Whether to commit at all is the user's call, and no other surface carries it: soul.md is
+  // silent, and a workspace without an equivalent project rule would lose it entirely.
+  test("git-commit states that committing waits for the user", () => {
+    expectIntent(toolDefinitionsById["git-commit"]?.description ?? "", [["only when you ask"]]);
+  });
+
+  // Vocabulary a tool no longer supports must be gone from the schema surface, not merely
+  // de-emphasized, and a tool's trigger ships with its schema rather than in the system prompt.
+  test("tool descriptions carry each tool's own contract", () => {
+    const readDescription = toolDefinitionsById["file-read"]?.description ?? "";
+    expect(readDescription).not.toContain("aroundLine");
+    expect(readDescription).not.toContain("contextLines");
+    expectIntent(readDescription, [["offset"], ["limit"], ["token ceiling"]]);
     expectIntent(toolDefinitionsById["session-search"]?.description ?? "", [
       ["keyword"],
       ["already in context"],
       ["rather than asking the user to repeat"],
     ]);
-    expectIntent(memorySearchInstruction, [["memory-search"], ["recall"], ["prior context"]]);
-    expectIntent(memoryAddInstruction, [["memory-add"], ["persist"], ["sessions"]]);
   });
 });

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -127,7 +127,7 @@ describe("model-facing tool text", () => {
   // Whether to commit at all is the user's call, and no other surface carries it: soul.md is
   // silent, and a workspace without an equivalent project rule would lose it entirely.
   test("git-commit states that committing waits for the user", () => {
-    expectIntent(toolDefinitionsById["git-commit"]?.description ?? "", [["only when you ask"]]);
+    expectIntent(toolDefinitionsById["git-commit"]?.description ?? "", [["only when the user asks"]]);
   });
 
   // Vocabulary a tool no longer supports must be gone from the schema surface, not merely

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -138,11 +138,7 @@ describe("localization baseline", () => {
     expectIntent(gitDiffInstruction, [["git-level diff context"], ["write-tool previews"]]);
     expectIntent(gitLogInstruction, [["committed history"], ["uncommitted edits"]]);
     expectIntent(gitShowInstruction, [["committed history"], ["uncommitted edits"]]);
-    expectIntent(runCommandInstruction, [
-      ["user explicitly asked"],
-      ["known repository commands"],
-      ["do not use it for file read/search/edit fallbacks"],
-    ]);
+    expectIntent(runCommandInstruction, [["the user asked for"], ["repository commands"]]);
     expectIntent(runTestsInstruction, [
       ["validate touched behavior"],
       ["create or update related tests"],
@@ -154,7 +150,13 @@ describe("localization baseline", () => {
     expectIntent(webFetchInstruction, [["read specific urls"]]);
     expectIntent(tasklistCreateInstruction, [["tasklist-create"], ["multi-step tasks"], ["tasklist-update"]]);
     expectIntent(tasklistUpdateInstruction, [["tasklist-update"], ["status"], ["tasklist-create"]]);
-    expectIntent(sessionSearchInstruction, [["session-search"], ["keyword"], ["older history"]]);
+    // session-search hoists nothing: its description ships the trigger with the schema.
+    expect(sessionSearchInstruction).toBe("");
+    expectIntent(toolDefinitionsById["session-search"]?.description ?? "", [
+      ["keyword"],
+      ["already in context"],
+      ["rather than asking the user to repeat"],
+    ]);
     expectIntent(memorySearchInstruction, [["memory-search"], ["recall"], ["prior context"]]);
     expectIntent(memoryAddInstruction, [["memory-add"], ["persist"], ["sessions"]]);
   });

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -138,10 +138,6 @@ function asToolDefinitionsById(entries: ToolMap): Record<string, AnyToolDefiniti
   for (const tool of Object.values(entries)) {
     invariant(typeof tool.id === "string" && tool.id.trim().length > 0, "tool id is required");
     invariant(typeof tool.category === "string" && tool.category.trim().length > 0, `tool ${tool.id} missing category`);
-    invariant(
-      typeof tool.instruction === "string" && tool.instruction.trim().length > 0,
-      `tool ${tool.id} missing instruction`,
-    );
     byId[tool.id] = tool as AnyToolDefinition;
   }
   return byId;

--- a/src/undo-toolkit.ts
+++ b/src/undo-toolkit.ts
@@ -9,8 +9,6 @@ function createUndoListTool(input: ToolkitInput) {
     toolkit: "undo",
     category: "meta",
     description: "List recent undo checkpoints for the current session (if enabled).",
-    instruction:
-      "Use `undo-list` to discover recent undo checkpoints. If undo checkpoints are disabled, it will return an empty list.",
     inputSchema: z.object({
       limit: z.number().int().min(1).max(50).optional(),
     }),
@@ -59,14 +57,9 @@ function createUndoRestoreTool(input: ToolkitInput) {
     toolkit: "undo",
     category: "write",
     description: "Restore files to the pre-write state captured in an undo checkpoint.",
-    instruction: [
-      "Use `undo-restore` to revert a specific checkpoint.",
-      "You must pass `checkpointId` and the list of `paths` from `undo-list` so cache invalidation can be targeted.",
-      "If there are conflicts, do not retry blindly; inspect diffs and choose a different recovery path.",
-    ].join(" "),
     inputSchema: z.object({
-      checkpointId: z.string().min(1),
-      paths: z.array(z.string().min(1)).min(1),
+      checkpointId: z.string().min(1).describe("Checkpoint id from `undo-list`."),
+      paths: z.array(z.string().min(1)).min(1).describe("The paths recorded on that checkpoint's `undo-list` entry."),
     }),
     outputSchema: z.object({
       kind: z.literal("undo-restore"),

--- a/src/web-toolkit.ts
+++ b/src/web-toolkit.ts
@@ -13,7 +13,6 @@ function createWebSearchTool(input: ToolkitInput) {
     category: "network",
     description:
       "Search the public web for recent information and return top results. Use for questions not answerable from the repo.",
-    instruction: "Use `web-search` for external information not available in the repository.",
     inputSchema: z.object({
       query: z.string().min(1),
       maxResults: z.number().int().min(1).max(10).optional(),
@@ -49,7 +48,6 @@ function createWebFetchTool(input: ToolkitInput) {
     category: "network",
     description:
       "Fetch a public URL and return extracted text content. Use to read docs, API references, or linked resources by URL.",
-    instruction: "Use `web-fetch` to read specific URLs (docs, API refs, linked resources).",
     inputSchema: z.object({
       url: z.string().min(1),
       maxChars: z.number().int().min(500).max(12000).optional(),


### PR DESCRIPTION
## Summary

- dissolve `CORE_INSTRUCTIONS`: how Acolyte works lives in `docs/soul.md`, and the prompt keeps only the terminal output contract
- hoist a tool `instruction` into the prompt only when it states a cross-tool handoff — 33 lines down to 3
- stop generating a per-tool `instruction` for MCP tools, which restated each tool's own description once per server
- relocate every remaining fact to the surface that owns it: the tool's `description`, or its parameter's `.describe()`
- restore that `git-commit` waits for the user to ask, which no other surface carried
- assert a token budget on the assembled prompt, now 878 tokens against 2,230 on `main`, so regrowth has to be argued for
