### PR TITLE
refactor(tools): drop tool input type parameter

### DIFF
--- a/src/cli-tool.ts
+++ b/src/cli-tool.ts
@@ -1,6 +1,7 @@
 import { resolve } from "node:path";
 import { printToolResult } from "./cli-format";
 import { t } from "./i18n";
+import type { ToolDefinition } from "./tool-contract";
 import { toolsForAgent } from "./tool-registry";
 import { resolveWorkspaceProfile } from "./workspace-profile";
 
@@ -56,14 +57,7 @@ export async function toolMode(args: string[], deps: ToolModeDeps): Promise<void
   const { tools, session } = toolsForAgent({ workspace });
   session.workspaceProfile = resolveWorkspaceProfile(workspace);
 
-  const toolMap = tools as Record<
-    string,
-    {
-      id: string;
-      execute: (input: unknown, callId: string) => Promise<unknown>;
-    }
-  >;
-  const tool = Object.values(toolMap).find((entry) => entry.id === toolId);
+  const tool = Object.values<ToolDefinition>(tools).find((entry) => entry.id === toolId);
   if (!tool) {
     printError(t("cli.tool.usage"));
     process.exitCode = 1;

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -34,7 +34,6 @@ import { providerFromModel } from "./provider-config";
 import type { ActiveSkill } from "./skill-contract";
 import type { StreamError } from "./stream-error";
 import { estimateTokens } from "./token-estimate";
-import type { ToolDefinition } from "./tool-contract";
 import { extractToolErrorCode } from "./tool-error";
 import { renderToolOutput } from "./tool-output-render";
 import type { Toolset } from "./tool-registry";
@@ -121,7 +120,7 @@ export function createRunAgent(input: {
   return createAgent({
     model: input.model,
     instructions: createInstructions(input.soulPrompt, input.workspace, input.projectRulesPrompt, input.activeSkills),
-    tools: input.tools as Record<string, ToolDefinition>,
+    tools: input.tools,
   });
 }
 

--- a/src/mcp-client.ts
+++ b/src/mcp-client.ts
@@ -23,9 +23,6 @@ import type { SessionContext } from "./tool-contract";
 import { createTool, type ToolDefinition } from "./tool-contract";
 import { runTool } from "./tool-execution";
 
-// biome-ignore lint/suspicious/noExplicitAny: MCP tools have open-world schemas
-type AnyToolDefinition = ToolDefinition<any, any>;
-
 const MCP_DESCRIPTION_MAX_CHARS = 512;
 
 export type McpToolListing = {
@@ -126,7 +123,7 @@ function bindMcpToolDefinition(
   config: McpServerConfig,
   session: SessionContext,
   sessionId?: string,
-): AnyToolDefinition {
+): ToolDefinition {
   const toolId = buildToolId(serverName, mcpTool.name);
   const inputSchema = (mcpTool.inputSchema ?? { type: "object", properties: {} }) as Record<string, unknown>;
   const description = sanitizeDescription(mcpTool.description, `Call ${mcpTool.name} on MCP server "${serverName}"`);
@@ -144,9 +141,8 @@ function bindMcpToolDefinition(
       output: z.string(),
     }),
     execute: async (toolInput, toolCallId) => {
-      return runTool(session, toolId, toolCallId, toolInput as Record<string, unknown>, async () => {
-        const args = toolInput as Record<string, unknown>;
-
+      const args = toolInput as Record<string, unknown>;
+      return runTool(session, toolId, toolCallId, args, async () => {
         if (sessionId) {
           // Reuse the persistent session connection (self-healing via onclose).
           const { client } = await getOrConnectClient(sessionId, serverName, config);
@@ -219,8 +215,8 @@ export function bindMcpTools(
   session: SessionContext,
   nativeToolIds: Set<string>,
   sessionId?: string,
-): Record<string, AnyToolDefinition> {
-  const toolMap: Record<string, AnyToolDefinition> = {};
+): Record<string, ToolDefinition> {
+  const toolMap: Record<string, ToolDefinition> = {};
 
   for (const { serverName, config, tools } of listings) {
     for (const mcpTool of tools) {

--- a/src/tool-contract.test.ts
+++ b/src/tool-contract.test.ts
@@ -19,7 +19,7 @@ describe("createTool", () => {
       },
     });
 
-    await tool.execute({ path: "src/index.ts", extra: 1 } as unknown as { path: string }, "call_1");
+    await tool.execute({ path: "src/index.ts", extra: 1 }, "call_1");
     expect(seen).toEqual({ path: "src/index.ts" });
   });
 
@@ -35,7 +35,7 @@ describe("createTool", () => {
       execute: async () => ({ result: { ok: true as const } }),
     });
 
-    await expect(tool.execute({ path: "" } as unknown as { path: string }, "call_2")).rejects.toThrow();
+    await expect(tool.execute({ path: "" }, "call_2")).rejects.toThrow();
   });
 
   test("passes through input for raw json schema tools", async () => {
@@ -58,7 +58,7 @@ describe("createTool", () => {
       },
     });
 
-    await tool.execute({ q: "hello", extra: true } as unknown as { q: string }, "call_3");
+    await tool.execute({ q: "hello", extra: true }, "call_3");
     expect(seen).toEqual({ q: "hello", extra: true });
   });
 
@@ -75,7 +75,7 @@ describe("createTool", () => {
     });
 
     const { result } = await tool.execute({}, "call_cap");
-    expect((result as { output: string }).output.length).toBe(500_000);
+    expect(result.output.length).toBe(500_000);
   });
 
   test("preserves output under safety cap", async () => {
@@ -92,7 +92,7 @@ describe("createTool", () => {
     });
 
     const { result } = await tool.execute({}, "call_no_cap");
-    expect((result as { output: string }).output).toBe(content);
+    expect(result.output).toBe(content);
   });
 
   test("stores json-schema form on tool definition", () => {

--- a/src/tool-contract.ts
+++ b/src/tool-contract.ts
@@ -11,7 +11,7 @@ export type ToolCategory = "read" | "search" | "write" | "execute" | "network" |
 
 const OUTPUT_SAFETY_CAP = 500_000;
 
-export type ToolDefinition<TInput = unknown, TOutput = unknown> = {
+export type ToolDefinition<TOutput = unknown> = {
   readonly id: string;
   readonly toolkit: string;
   readonly category: ToolCategory;
@@ -21,7 +21,7 @@ export type ToolDefinition<TInput = unknown, TOutput = unknown> = {
   readonly instruction?: string;
   readonly inputSchema: Record<string, unknown>;
   readonly outputSchema: z.ZodType<TOutput>;
-  readonly execute: (input: TInput, toolCallId: string) => Promise<RunToolResult<TOutput>>;
+  readonly execute: (input: unknown, toolCallId: string) => Promise<RunToolResult<TOutput>>;
 };
 
 export type TasklistListener = (event: { groupId: string; groupTitle: string; items: TasklistItem[] }) => void;
@@ -91,8 +91,16 @@ export type SessionContext = {
   activeSkills?: ActiveSkill[];
 };
 
-type CreateToolConfig<TInput, TOutput> = Omit<ToolDefinition<TInput, TOutput>, "inputSchema"> & {
-  inputSchema: z.ZodType<TInput> | Record<string, unknown>;
+type ToolConfigBase<TOutput> = Omit<ToolDefinition<TOutput>, "inputSchema" | "execute">;
+
+type ZodInputToolConfig<TInput, TOutput> = ToolConfigBase<TOutput> & {
+  inputSchema: z.ZodType<TInput>;
+  execute: (input: TInput, toolCallId: string) => Promise<RunToolResult<TOutput>>;
+};
+
+type RawInputToolConfig<TOutput> = ToolConfigBase<TOutput> & {
+  inputSchema: Record<string, unknown>;
+  execute: (input: unknown, toolCallId: string) => Promise<RunToolResult<TOutput>>;
 };
 
 function isZodSchema(s: unknown): s is z.ZodType {
@@ -105,9 +113,9 @@ function toJsonSchema(schema: z.ZodType | Record<string, unknown>): Record<strin
   return rest;
 }
 
-type AnyToolDefinition = Pick<ToolDefinition, "id" | "description" | "inputSchema">;
+type FunctionToolSource = Pick<ToolDefinition, "id" | "description" | "inputSchema">;
 
-export function toFunctionTool(tool: AnyToolDefinition): LanguageModelV4FunctionTool {
+export function toFunctionTool(tool: FunctionToolSource): LanguageModelV4FunctionTool {
   return {
     type: "function",
     name: tool.id,
@@ -116,20 +124,24 @@ export function toFunctionTool(tool: AnyToolDefinition): LanguageModelV4Function
   };
 }
 
-export function toFunctionTools(tools: Record<string, AnyToolDefinition>): LanguageModelV4FunctionTool[] {
+export function toFunctionTools(tools: Record<string, FunctionToolSource>): LanguageModelV4FunctionTool[] {
   return Object.values(tools).map(toFunctionTool);
 }
 
+export function createTool<TInput, TOutput>(config: ZodInputToolConfig<TInput, TOutput>): ToolDefinition<TOutput>;
+export function createTool<TOutput>(config: RawInputToolConfig<TOutput>): ToolDefinition<TOutput>;
 export function createTool<TInput, TOutput>(
-  config: CreateToolConfig<TInput, TOutput>,
-): ToolDefinition<TInput, TOutput> {
+  config: ZodInputToolConfig<TInput, TOutput> | RawInputToolConfig<TOutput>,
+): ToolDefinition<TOutput> {
   const inputParser = isZodSchema(config.inputSchema) ? config.inputSchema : undefined;
+  // Sound at exactly this seam: the Zod arm receives only parser output, the raw arm declares `unknown`.
+  const configExecute = config.execute as (input: unknown, toolCallId: string) => Promise<RunToolResult<TOutput>>;
   return {
     ...config,
     inputSchema: toJsonSchema(config.inputSchema),
     execute: async (input, toolCallId) => {
-      const parsedInput = inputParser ? (inputParser.parse(input) as TInput) : input;
-      const runResult = await config.execute(parsedInput, toolCallId);
+      const validatedInput = inputParser ? inputParser.parse(input) : input;
+      const runResult = await configExecute(validatedInput, toolCallId);
       let parsed = config.outputSchema.parse(runResult.result);
       if (parsed && typeof parsed === "object" && "output" in parsed) {
         const output = (parsed as Record<string, unknown>).output;

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -25,8 +25,7 @@ import { createSessionContext } from "./tool-session";
 import { createUndoToolkit } from "./undo-toolkit";
 import { createWebToolkit } from "./web-toolkit";
 
-// biome-ignore lint/suspicious/noExplicitAny: ToolDefinition variance requires any here
-type ToolMap = Record<string, ToolDefinition<any>>;
+type ToolMap = Record<string, ToolDefinition>;
 
 type RegisteredToolkit = ReturnType<typeof createFileToolkit> &
   ReturnType<typeof createCodeToolkit> &
@@ -44,8 +43,6 @@ type RegisteredToolkit = ReturnType<typeof createFileToolkit> &
 export type Toolset = {
   [Key in keyof RegisteredToolkit]: RegisteredToolkit[Key];
 };
-
-type AnyToolDefinition = ToolDefinition<unknown>;
 
 export const TOOLKIT_REGISTRY: {
   id: string;
@@ -133,12 +130,12 @@ function collectTools(
   return combined;
 }
 
-function asToolDefinitionsById(entries: ToolMap): Record<string, AnyToolDefinition> {
-  const byId: Record<string, AnyToolDefinition> = {};
+function asToolDefinitionsById(entries: ToolMap): Record<string, ToolDefinition> {
+  const byId: Record<string, ToolDefinition> = {};
   for (const tool of Object.values(entries)) {
     invariant(typeof tool.id === "string" && tool.id.trim().length > 0, "tool id is required");
     invariant(typeof tool.category === "string" && tool.category.trim().length > 0, `tool ${tool.id} missing category`);
-    byId[tool.id] = tool as AnyToolDefinition;
+    byId[tool.id] = tool;
   }
   return byId;
 }


### PR DESCRIPTION
## Summary

- drop `TInput` from `ToolDefinition`; `execute` takes `unknown`, which is what the wrapper already passes it after parsing
- move the input type onto two `createTool` config arms: a Zod-schema arm with a typed `execute`, and a raw-JSON-schema arm that accepts `unknown`
- close a validation hole on the raw-schema path (MCP tools), where input reached `config.execute` unparsed behind an `as TInput`
- delete three divergent `AnyToolDefinition` aliases and both `noExplicitAny` suppressions; one audited cast remains, at the parse seam