### PR TITLE
feat(scripts): measure complexity erosion

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "behavior:run": "bun run scripts/run-behavior.ts",
     "perf:run": "bun run scripts/run-perf.ts",
     "memory-bench:run": "bun run scripts/run-memory-bench.ts",
+    "erosion:run": "bun run scripts/run-erosion.ts",
     "serve": "bun --env-file=.env run src/server.ts",
     "serve:watch": "bun --watch --env-file=.env run src/server.ts",
     "wait:server": "bun run scripts/wait-server.ts",

--- a/scripts/erosion-metrics.test.ts
+++ b/scripts/erosion-metrics.test.ts
@@ -86,6 +86,35 @@ describe("analyzeSource units", () => {
     expect(complexityOf(source, "inner")).toBe(2);
   });
 
+  test("a top-level callback with no enclosing unit is measured rather than dropped", () => {
+    const source = [
+      "const handlers = [",
+      "  (a: boolean) => (a ? 1 : 0),",
+      "  (b: boolean) => (b ? 2 : 0),",
+      "];",
+    ].join("\n");
+    const metrics = analyzeSource("sample.ts", source);
+    expect(metrics.length).toBe(2);
+    expect(metrics.map((metric) => metric.cyclomatic)).toEqual([2, 2]);
+  });
+
+  test("a module-scope IIFE is measured", () => {
+    const source = ["const value = (() => {", "  if (process.env.HOME) return 1;", "  return 0;", "})();"].join("\n");
+    const metrics = analyzeSource("sample.ts", source);
+    expect(metrics.length).toBe(1);
+    expect(metrics[0].cyclomatic).toBe(2);
+  });
+
+  test("a promoted callback is named after the call it is passed to", () => {
+    const source = ["register((a: boolean) => {", "  return a ? 1 : 0;", "});"].join("\n");
+    expect(analyzeSource("sample.ts", source).map((metric) => metric.name)).toEqual(["register() callback"]);
+  });
+
+  test("a method on a class expression is named after the binding", () => {
+    const source = ["const Store = class {", "  read(key: string) {", "    return key;", "  }", "};"].join("\n");
+    expect(analyzeSource("sample.ts", source).map((metric) => metric.name)).toEqual(["Store.read"]);
+  });
+
   test("methods and accessors are named after their class", () => {
     const source = [
       "class Store {",

--- a/scripts/erosion-metrics.test.ts
+++ b/scripts/erosion-metrics.test.ts
@@ -36,6 +36,14 @@ describe("analyzeSource complexity", () => {
     expect(complexityOf(source, "f")).toBe(4);
   });
 
+  test("optional chaining is not a decision", () => {
+    expect(complexityOf("function f(a?: { b?: number }) {\n  return a?.b;\n}\n", "f")).toBe(1);
+  });
+
+  test("logical assignment counts as a decision", () => {
+    expect(complexityOf("function f(a: number | null) {\n  let b = a;\n  b ??= 1;\n  return b;\n}\n", "f")).toBe(2);
+  });
+
   test("case clauses count but an empty fallthrough and default do not", () => {
     const source = [
       "function f(kind: string) {",
@@ -98,11 +106,17 @@ describe("analyzeSource units", () => {
     expect(metrics.map((metric) => metric.cyclomatic)).toEqual([2, 2]);
   });
 
-  test("a module-scope IIFE is measured", () => {
+  test("a module-scope IIFE is measured and named after its binding", () => {
     const source = ["const value = (() => {", "  if (process.env.HOME) return 1;", "  return 0;", "})();"].join("\n");
     const metrics = analyzeSource("sample.ts", source);
     expect(metrics.length).toBe(1);
     expect(metrics[0].cyclomatic).toBe(2);
+    expect(metrics[0].name).toBe("value");
+  });
+
+  test("a default-exported function is named as the default export", () => {
+    const source = ["export default (a: boolean) => {", "  return a ? 1 : 0;", "};"].join("\n");
+    expect(analyzeSource("sample.ts", source).map((metric) => metric.name)).toEqual(["default export"]);
   });
 
   test("a promoted callback is named after the call it is passed to", () => {
@@ -144,8 +158,19 @@ describe("analyzeSource sloc", () => {
       "  return inner();",
       "}",
     ].join("\n");
-    const outer = analyzeSource("sample.ts", source).find((metric) => metric.name === "outer");
-    expect(outer?.sloc).toBe(4);
+    const metrics = analyzeSource("sample.ts", source);
+    expect(metrics.find((metric) => metric.name === "outer")?.sloc).toBe(3);
+    expect(metrics.find((metric) => metric.name === "inner")?.sloc).toBe(3);
+    expect(metrics.reduce((sum, metric) => sum + metric.sloc, 0)).toBe(6);
+  });
+
+  test("a line holding a single-line nested unit is counted once, by the nested unit", () => {
+    const source = ["function outer() {", "  const inner = () => 1;", "  return inner();", "}"].join("\n");
+    const metrics = analyzeSource("sample.ts", source);
+    const total = metrics.reduce((sum, metric) => sum + metric.sloc, 0);
+    expect(total).toBe(4);
+    expect(metrics.find((metric) => metric.name === "inner")?.sloc).toBe(1);
+    expect(metrics.find((metric) => metric.name === "outer")?.sloc).toBe(3);
   });
 
   test("mass weights complexity by the square root of sloc", () => {

--- a/scripts/erosion-metrics.test.ts
+++ b/scripts/erosion-metrics.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import { analyzeSource, computeErosion, HIGH_COMPLEXITY_THRESHOLD } from "./erosion-metrics";
+
+function complexityOf(source: string, name: string): number {
+  const metric = analyzeSource("sample.ts", source).find((entry) => entry.name === name);
+  if (!metric) throw new Error(`no metric for ${name}`);
+  return metric.cyclomatic;
+}
+
+describe("analyzeSource complexity", () => {
+  test("a straight-line function scores 1", () => {
+    expect(complexityOf("function f() {\n  return 1;\n}\n", "f")).toBe(1);
+  });
+
+  test("branches, loops, and catch each add one", () => {
+    const source = [
+      "function f(items: number[]) {",
+      "  let total = 0;",
+      "  if (items.length === 0) return 0;",
+      "  for (const item of items) {",
+      "    while (total < item) total += 1;",
+      "  }",
+      "  try {",
+      "    total += 1;",
+      "  } catch {",
+      "    total = 0;",
+      "  }",
+      "  return total;",
+      "}",
+    ].join("\n");
+    expect(complexityOf(source, "f")).toBe(5);
+  });
+
+  test("logical operators and ternaries count as decisions", () => {
+    const source = "function f(a: boolean, b: boolean, c: number | null) {\n  return a && b ? (c ?? 0) : 1;\n}\n";
+    expect(complexityOf(source, "f")).toBe(4);
+  });
+
+  test("case clauses count but an empty fallthrough and default do not", () => {
+    const source = [
+      "function f(kind: string) {",
+      "  switch (kind) {",
+      "    case 'a':",
+      "    case 'b':",
+      "      return 1;",
+      "    default:",
+      "      return 0;",
+      "  }",
+      "}",
+    ].join("\n");
+    expect(complexityOf(source, "f")).toBe(2);
+  });
+});
+
+describe("analyzeSource units", () => {
+  test("an inline callback folds into its enclosing function", () => {
+    const source = [
+      "function f(items: number[]) {",
+      "  return items.filter((item) => item > 0 && item < 10);",
+      "}",
+    ].join("\n");
+    const metrics = analyzeSource("sample.ts", source);
+    expect(metrics.map((metric) => metric.name)).toEqual(["f"]);
+    expect(metrics[0].cyclomatic).toBe(2);
+  });
+
+  test("an arrow bound to a name is its own unit", () => {
+    const source = "const f = (a: boolean) => (a ? 1 : 0);\n";
+    const metrics = analyzeSource("sample.ts", source);
+    expect(metrics.map((metric) => metric.name)).toEqual(["f"]);
+    expect(metrics[0].cyclomatic).toBe(2);
+  });
+
+  test("a nested named function is measured separately from its parent", () => {
+    const source = [
+      "function outer(a: boolean) {",
+      "  function inner(b: boolean) {",
+      "    return b ? 1 : 0;",
+      "  }",
+      "  return a ? inner(a) : 0;",
+      "}",
+    ].join("\n");
+    const metrics = analyzeSource("sample.ts", source);
+    expect(metrics.map((metric) => metric.name).sort()).toEqual(["inner", "outer"]);
+    expect(complexityOf(source, "outer")).toBe(2);
+    expect(complexityOf(source, "inner")).toBe(2);
+  });
+
+  test("methods and accessors are named after their class", () => {
+    const source = [
+      "class Store {",
+      "  constructor() {}",
+      "  get size() {",
+      "    return 0;",
+      "  }",
+      "  read(key: string) {",
+      "    return key;",
+      "  }",
+      "}",
+    ].join("\n");
+    const names = analyzeSource("sample.ts", source).map((metric) => metric.name);
+    expect(names).toEqual(["Store.constructor", "Store.size", "Store.read"]);
+  });
+});
+
+describe("analyzeSource sloc", () => {
+  test("blank lines, comments, and nested unit bodies are excluded", () => {
+    const source = [
+      "function outer() {",
+      "  // a comment",
+      "",
+      "  const inner = () => {",
+      "    return 1;",
+      "  };",
+      "  return inner();",
+      "}",
+    ].join("\n");
+    const outer = analyzeSource("sample.ts", source).find((metric) => metric.name === "outer");
+    expect(outer?.sloc).toBe(4);
+  });
+
+  test("mass weights complexity by the square root of sloc", () => {
+    const metrics = analyzeSource("sample.ts", "function f() {\n  return 1;\n}\n");
+    expect(metrics[0].mass).toBeCloseTo(Math.sqrt(3), 10);
+  });
+});
+
+describe("computeErosion", () => {
+  test("erosion is the share of mass held by high-complexity functions", () => {
+    const metrics = [
+      { file: "a.ts", name: "light", line: 1, cyclomatic: 2, sloc: 4, mass: 4 },
+      { file: "a.ts", name: "heavy", line: 9, cyclomatic: HIGH_COMPLEXITY_THRESHOLD + 1, sloc: 36, mass: 12 },
+    ];
+    const report = computeErosion(metrics, 1);
+    expect(report.erosion).toBeCloseTo(0.75, 10);
+    expect(report.highFunctions).toBe(1);
+    expect(report.functions).toBe(2);
+    expect(report.sloc).toBe(40);
+  });
+
+  test("an empty codebase reports zero erosion rather than dividing by zero", () => {
+    expect(computeErosion([], 0).erosion).toBe(0);
+  });
+});

--- a/scripts/erosion-metrics.ts
+++ b/scripts/erosion-metrics.ts
@@ -80,8 +80,9 @@ function unitName(node: ts.Node): string {
     const owner = ownerName(node);
     return owner ? `${owner}.${name}` : name;
   }
-  const parent = node.parent;
+  const parent = bindingParent(node);
   if (parent && ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) return parent.name.text;
+  if (parent && ts.isExportAssignment(parent)) return "default export";
   if (parent && ts.isPropertyDeclaration(parent) && ts.isIdentifier(parent.name)) {
     const owner = ownerName(parent);
     return owner ? `${owner}.${parent.name.text}` : parent.name.text;
@@ -92,6 +93,16 @@ function unitName(node: ts.Node): string {
     if (label) return `${label}() callback`;
   }
   return "<anonymous>";
+}
+
+// An IIFE is bound above the call that invokes it, while a callback argument is bound by
+// the call itself — which is what distinguishes `const x = (() => {})()` from `run(() => {})`.
+function bindingParent(node: ts.Node): ts.Node | undefined {
+  let current: ts.Node = node;
+  while (current.parent && ts.isParenthesizedExpression(current.parent)) current = current.parent;
+  const parent = current.parent;
+  if (parent && ts.isCallExpression(parent) && parent.expression === current) return parent.parent;
+  return parent;
 }
 
 function calleeLabel(call: ts.CallExpression): string | null {
@@ -146,6 +157,8 @@ function nestedUnits(unit: ts.Node, units: Set<ts.Node>): ts.Node[] {
   return nested;
 }
 
+// Every physical line belongs to the innermost unit spanning it, so a line is never
+// counted twice across units and the reported SLOC matches the file.
 function ownLineNumbers(unit: ts.Node, units: Set<ts.Node>, source: ts.SourceFile): Set<number> {
   const start = source.getLineAndCharacterOfPosition(unit.getStart(source)).line;
   const end = source.getLineAndCharacterOfPosition(unit.end).line;
@@ -154,7 +167,7 @@ function ownLineNumbers(unit: ts.Node, units: Set<ts.Node>, source: ts.SourceFil
   for (const nested of nestedUnits(unit, units)) {
     const nestedStart = source.getLineAndCharacterOfPosition(nested.getStart(source)).line;
     const nestedEnd = source.getLineAndCharacterOfPosition(nested.end).line;
-    for (let line = nestedStart + 1; line <= nestedEnd; line++) lines.delete(line);
+    for (let line = nestedStart; line <= nestedEnd; line++) lines.delete(line);
   }
   return lines;
 }

--- a/scripts/erosion-metrics.ts
+++ b/scripts/erosion-metrics.ts
@@ -40,9 +40,15 @@ function isDecision(node: ts.Node): boolean {
   return false;
 }
 
+function isFunctionLike(node: ts.Node): boolean {
+  if (ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node) || ts.isConstructorDeclaration(node)) return true;
+  if (ts.isGetAccessorDeclaration(node) || ts.isSetAccessorDeclaration(node)) return true;
+  return ts.isFunctionExpression(node) || ts.isArrowFunction(node);
+}
+
 // A unit is what a reader calls "a function". Inline callbacks are folded into their
 // enclosing unit so that `.map(x => x + 1)` does not dilute the mass denominator.
-function isUnit(node: ts.Node): boolean {
+function isNamedUnit(node: ts.Node): boolean {
   if (ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node) || ts.isConstructorDeclaration(node)) return true;
   if (ts.isGetAccessorDeclaration(node) || ts.isSetAccessorDeclaration(node)) return true;
   if (ts.isFunctionExpression(node) || ts.isArrowFunction(node)) {
@@ -55,7 +61,11 @@ function isUnit(node: ts.Node): boolean {
 function ownerName(node: ts.Node): string | null {
   const parent = node.parent;
   if (parent && ts.isClassDeclaration(parent) && parent.name) return parent.name.text;
-  if (parent && ts.isClassExpression(parent) && parent.name) return parent.name.text;
+  if (parent && ts.isClassExpression(parent)) {
+    if (parent.name) return parent.name.text;
+    const holder = parent.parent;
+    if (holder && ts.isVariableDeclaration(holder) && ts.isIdentifier(holder.name)) return holder.name.text;
+  }
   return null;
 }
 
@@ -77,7 +87,18 @@ function unitName(node: ts.Node): string {
     return owner ? `${owner}.${parent.name.text}` : parent.name.text;
   }
   if (parent && ts.isPropertyAssignment(parent) && ts.isIdentifier(parent.name)) return parent.name.text;
+  if (parent && ts.isCallExpression(parent)) {
+    const label = calleeLabel(parent);
+    if (label) return `${label}() callback`;
+  }
   return "<anonymous>";
+}
+
+function calleeLabel(call: ts.CallExpression): string | null {
+  const callee = call.expression;
+  if (ts.isIdentifier(callee)) return callee.text;
+  if (ts.isPropertyAccessExpression(callee)) return callee.name.text;
+  return null;
 }
 
 function scriptKindFor(file: string): ts.ScriptKind {
@@ -90,29 +111,32 @@ function isCodeLine(line: string): boolean {
   return !(trimmed.startsWith("//") || trimmed.startsWith("/*") || trimmed.startsWith("*"));
 }
 
-function collectUnits(source: ts.SourceFile): ts.Node[] {
-  const units: ts.Node[] = [];
-  const visit = (node: ts.Node): void => {
-    if (isUnit(node)) units.push(node);
-    node.forEachChild(visit);
+// An inline callback with no enclosing unit has nowhere to fold into, so it becomes its
+// own unit — otherwise its complexity would leave both sides of the ratio.
+function collectUnits(source: ts.SourceFile): Set<ts.Node> {
+  const units = new Set<ts.Node>();
+  const visit = (node: ts.Node, insideUnit: boolean): void => {
+    const unit = isNamedUnit(node) || (isFunctionLike(node) && !insideUnit);
+    if (unit) units.add(node);
+    node.forEachChild((child) => visit(child, insideUnit || unit));
   };
-  source.forEachChild(visit);
+  source.forEachChild((node) => visit(node, false));
   return units;
 }
 
-function walkOwnNodes(unit: ts.Node, visit: (node: ts.Node) => void): void {
+function walkOwnNodes(unit: ts.Node, units: Set<ts.Node>, visit: (node: ts.Node) => void): void {
   const step = (node: ts.Node): void => {
-    if (node !== unit && isUnit(node)) return;
+    if (node !== unit && units.has(node)) return;
     visit(node);
     node.forEachChild(step);
   };
   step(unit);
 }
 
-function nestedUnits(unit: ts.Node): ts.Node[] {
+function nestedUnits(unit: ts.Node, units: Set<ts.Node>): ts.Node[] {
   const nested: ts.Node[] = [];
   const step = (node: ts.Node, depth: number): void => {
-    if (isUnit(node) && depth > 0) {
+    if (units.has(node) && depth > 0) {
       nested.push(node);
       return;
     }
@@ -122,12 +146,12 @@ function nestedUnits(unit: ts.Node): ts.Node[] {
   return nested;
 }
 
-function ownLineNumbers(unit: ts.Node, source: ts.SourceFile): Set<number> {
+function ownLineNumbers(unit: ts.Node, units: Set<ts.Node>, source: ts.SourceFile): Set<number> {
   const start = source.getLineAndCharacterOfPosition(unit.getStart(source)).line;
   const end = source.getLineAndCharacterOfPosition(unit.end).line;
   const lines = new Set<number>();
   for (let line = start; line <= end; line++) lines.add(line);
-  for (const nested of nestedUnits(unit)) {
+  for (const nested of nestedUnits(unit, units)) {
     const nestedStart = source.getLineAndCharacterOfPosition(nested.getStart(source)).line;
     const nestedEnd = source.getLineAndCharacterOfPosition(nested.end).line;
     for (let line = nestedStart + 1; line <= nestedEnd; line++) lines.delete(line);
@@ -138,13 +162,14 @@ function ownLineNumbers(unit: ts.Node, source: ts.SourceFile): Set<number> {
 export function analyzeSource(file: string, text: string): FunctionMetric[] {
   const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true, scriptKindFor(file));
   const lines = text.split("\n");
-  return collectUnits(source).map((unit) => {
+  const units = collectUnits(source);
+  return [...units].map((unit) => {
     let cyclomatic = 1;
-    walkOwnNodes(unit, (node) => {
+    walkOwnNodes(unit, units, (node) => {
       if (isDecision(node)) cyclomatic += 1;
     });
     let sloc = 0;
-    for (const line of ownLineNumbers(unit, source)) {
+    for (const line of ownLineNumbers(unit, units, source)) {
       if (isCodeLine(lines[line] ?? "")) sloc += 1;
     }
     return {

--- a/scripts/erosion-metrics.ts
+++ b/scripts/erosion-metrics.ts
@@ -1,0 +1,174 @@
+import ts from "typescript";
+
+export const HIGH_COMPLEXITY_THRESHOLD = 10;
+
+export type FunctionMetric = {
+  file: string;
+  name: string;
+  line: number;
+  cyclomatic: number;
+  sloc: number;
+  mass: number;
+};
+
+export type ErosionReport = {
+  erosion: number;
+  files: number;
+  functions: number;
+  highFunctions: number;
+  totalMass: number;
+  highMass: number;
+  sloc: number;
+};
+
+const DECISION_OPERATORS = new Set<ts.SyntaxKind>([
+  ts.SyntaxKind.AmpersandAmpersandToken,
+  ts.SyntaxKind.BarBarToken,
+  ts.SyntaxKind.QuestionQuestionToken,
+  ts.SyntaxKind.AmpersandAmpersandEqualsToken,
+  ts.SyntaxKind.BarBarEqualsToken,
+  ts.SyntaxKind.QuestionQuestionEqualsToken,
+]);
+
+function isDecision(node: ts.Node): boolean {
+  if (ts.isIfStatement(node) || ts.isConditionalExpression(node)) return true;
+  if (ts.isForStatement(node) || ts.isForInStatement(node) || ts.isForOfStatement(node)) return true;
+  if (ts.isWhileStatement(node) || ts.isDoStatement(node)) return true;
+  if (ts.isCatchClause(node)) return true;
+  if (ts.isCaseClause(node)) return node.statements.length > 0;
+  if (ts.isBinaryExpression(node)) return DECISION_OPERATORS.has(node.operatorToken.kind);
+  return false;
+}
+
+// A unit is what a reader calls "a function". Inline callbacks are folded into their
+// enclosing unit so that `.map(x => x + 1)` does not dilute the mass denominator.
+function isUnit(node: ts.Node): boolean {
+  if (ts.isFunctionDeclaration(node) || ts.isMethodDeclaration(node) || ts.isConstructorDeclaration(node)) return true;
+  if (ts.isGetAccessorDeclaration(node) || ts.isSetAccessorDeclaration(node)) return true;
+  if (ts.isFunctionExpression(node) || ts.isArrowFunction(node)) {
+    const parent = node.parent;
+    return ts.isVariableDeclaration(parent) || ts.isPropertyDeclaration(parent) || ts.isPropertyAssignment(parent);
+  }
+  return false;
+}
+
+function ownerName(node: ts.Node): string | null {
+  const parent = node.parent;
+  if (parent && ts.isClassDeclaration(parent) && parent.name) return parent.name.text;
+  if (parent && ts.isClassExpression(parent) && parent.name) return parent.name.text;
+  return null;
+}
+
+function unitName(node: ts.Node): string {
+  if (ts.isConstructorDeclaration(node)) {
+    const owner = ownerName(node);
+    return owner ? `${owner}.constructor` : "constructor";
+  }
+  if (ts.isFunctionDeclaration(node)) return node.name?.text ?? "<anonymous>";
+  if (ts.isMethodDeclaration(node) || ts.isGetAccessorDeclaration(node) || ts.isSetAccessorDeclaration(node)) {
+    const name = ts.isIdentifier(node.name) || ts.isStringLiteral(node.name) ? node.name.text : "<computed>";
+    const owner = ownerName(node);
+    return owner ? `${owner}.${name}` : name;
+  }
+  const parent = node.parent;
+  if (parent && ts.isVariableDeclaration(parent) && ts.isIdentifier(parent.name)) return parent.name.text;
+  if (parent && ts.isPropertyDeclaration(parent) && ts.isIdentifier(parent.name)) {
+    const owner = ownerName(parent);
+    return owner ? `${owner}.${parent.name.text}` : parent.name.text;
+  }
+  if (parent && ts.isPropertyAssignment(parent) && ts.isIdentifier(parent.name)) return parent.name.text;
+  return "<anonymous>";
+}
+
+function scriptKindFor(file: string): ts.ScriptKind {
+  return file.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+}
+
+function isCodeLine(line: string): boolean {
+  const trimmed = line.trim();
+  if (trimmed === "") return false;
+  return !(trimmed.startsWith("//") || trimmed.startsWith("/*") || trimmed.startsWith("*"));
+}
+
+function collectUnits(source: ts.SourceFile): ts.Node[] {
+  const units: ts.Node[] = [];
+  const visit = (node: ts.Node): void => {
+    if (isUnit(node)) units.push(node);
+    node.forEachChild(visit);
+  };
+  source.forEachChild(visit);
+  return units;
+}
+
+function walkOwnNodes(unit: ts.Node, visit: (node: ts.Node) => void): void {
+  const step = (node: ts.Node): void => {
+    if (node !== unit && isUnit(node)) return;
+    visit(node);
+    node.forEachChild(step);
+  };
+  step(unit);
+}
+
+function nestedUnits(unit: ts.Node): ts.Node[] {
+  const nested: ts.Node[] = [];
+  const step = (node: ts.Node, depth: number): void => {
+    if (isUnit(node) && depth > 0) {
+      nested.push(node);
+      return;
+    }
+    node.forEachChild((child) => step(child, depth + 1));
+  };
+  step(unit, 0);
+  return nested;
+}
+
+function ownLineNumbers(unit: ts.Node, source: ts.SourceFile): Set<number> {
+  const start = source.getLineAndCharacterOfPosition(unit.getStart(source)).line;
+  const end = source.getLineAndCharacterOfPosition(unit.end).line;
+  const lines = new Set<number>();
+  for (let line = start; line <= end; line++) lines.add(line);
+  for (const nested of nestedUnits(unit)) {
+    const nestedStart = source.getLineAndCharacterOfPosition(nested.getStart(source)).line;
+    const nestedEnd = source.getLineAndCharacterOfPosition(nested.end).line;
+    for (let line = nestedStart + 1; line <= nestedEnd; line++) lines.delete(line);
+  }
+  return lines;
+}
+
+export function analyzeSource(file: string, text: string): FunctionMetric[] {
+  const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true, scriptKindFor(file));
+  const lines = text.split("\n");
+  return collectUnits(source).map((unit) => {
+    let cyclomatic = 1;
+    walkOwnNodes(unit, (node) => {
+      if (isDecision(node)) cyclomatic += 1;
+    });
+    let sloc = 0;
+    for (const line of ownLineNumbers(unit, source)) {
+      if (isCodeLine(lines[line] ?? "")) sloc += 1;
+    }
+    return {
+      file,
+      name: unitName(unit),
+      line: source.getLineAndCharacterOfPosition(unit.getStart(source)).line + 1,
+      cyclomatic,
+      sloc,
+      mass: cyclomatic * Math.sqrt(sloc),
+    };
+  });
+}
+
+export function computeErosion(metrics: FunctionMetric[], files: number): ErosionReport {
+  const high = metrics.filter((metric) => metric.cyclomatic > HIGH_COMPLEXITY_THRESHOLD);
+  const totalMass = metrics.reduce((sum, metric) => sum + metric.mass, 0);
+  const highMass = high.reduce((sum, metric) => sum + metric.mass, 0);
+  return {
+    erosion: totalMass === 0 ? 0 : highMass / totalMass,
+    files,
+    functions: metrics.length,
+    highFunctions: high.length,
+    totalMass,
+    highMass,
+    sloc: metrics.reduce((sum, metric) => sum + metric.sloc, 0),
+  };
+}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -48,6 +48,11 @@ echo "$old → $new"
 # outer `bun run` exported before the bump — resolveCliVersion prefers it.
 env -u npm_package_version bun run verify
 
+# Where complexity sits in the release being cut. Reported, never a gate: the score is a
+# ratio, so removing simple code raises it, and a threshold would fail good releases.
+echo ""
+bun run erosion:run --top 5
+
 # Commit and tag
 git add -A
 git commit -m "chore: release v${new}"

--- a/scripts/run-erosion.test.ts
+++ b/scripts/run-erosion.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { isSourceFile, parseErosionArgs } from "./run-erosion";
+
+describe("parseErosionArgs", () => {
+  test("defaults to src with no flags", () => {
+    expect(parseErosionArgs([])).toEqual({
+      paths: ["src"],
+      includeTests: false,
+      json: false,
+      top: 10,
+      tags: false,
+      limit: null,
+    });
+  });
+
+  test("collects positional paths", () => {
+    expect(parseErosionArgs(["src/tui", "scripts"]).paths).toEqual(["src/tui", "scripts"]);
+  });
+
+  test("reads the flags it supports", () => {
+    const args = parseErosionArgs(["--tags", "--json", "--include-tests", "--top", "3", "--limit", "5"]);
+    expect(args).toEqual({ paths: ["src"], includeTests: true, json: true, top: 3, tags: true, limit: 5 });
+  });
+
+  test("accepts a top of zero to suppress the ranking", () => {
+    expect(parseErosionArgs(["--top", "0"]).top).toBe(0);
+  });
+
+  test("rejects an unknown flag", () => {
+    expect(() => parseErosionArgs(["--nope"])).toThrow("unknown flag: --nope");
+  });
+
+  test("rejects a non-numeric or missing top", () => {
+    expect(() => parseErosionArgs(["--top", "many"])).toThrow("--top requires a non-negative number");
+    expect(() => parseErosionArgs(["--top"])).toThrow("--top requires a non-negative number");
+  });
+
+  test("rejects a negative top", () => {
+    expect(() => parseErosionArgs(["--top", "-1"])).toThrow("--top requires a non-negative number");
+  });
+
+  test("rejects a limit below one", () => {
+    expect(() => parseErosionArgs(["--limit", "0"])).toThrow("--limit requires a positive number");
+    expect(() => parseErosionArgs(["--limit"])).toThrow("--limit requires a positive number");
+  });
+});
+
+describe("isSourceFile", () => {
+  test("accepts TypeScript sources", () => {
+    expect(isSourceFile("src/chat-state.ts", false)).toBe(true);
+    expect(isSourceFile("src/tui/render.tsx", false)).toBe(true);
+  });
+
+  test("rejects declarations and non-TypeScript files", () => {
+    expect(isSourceFile("src/globals.d.ts", false)).toBe(false);
+    expect(isSourceFile("src/notes.md", false)).toBe(false);
+    expect(isSourceFile("scripts/release.sh", false)).toBe(false);
+  });
+
+  test("excludes tests unless asked for them", () => {
+    for (const file of ["src/a.test.ts", "src/a.test.tsx", "src/a.int.test.ts"]) {
+      expect(isSourceFile(file, false)).toBe(false);
+      expect(isSourceFile(file, true)).toBe(true);
+    }
+  });
+});

--- a/scripts/run-erosion.ts
+++ b/scripts/run-erosion.ts
@@ -1,0 +1,183 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, relative, resolve } from "node:path";
+import {
+  analyzeSource,
+  computeErosion,
+  type ErosionReport,
+  type FunctionMetric,
+  HIGH_COMPLEXITY_THRESHOLD,
+} from "./erosion-metrics";
+
+type ErosionArgs = {
+  paths: string[];
+  includeTests: boolean;
+  json: boolean;
+  top: number;
+  tags: boolean;
+  limit: number | null;
+};
+
+type TagReport = { tag: string; report: ErosionReport };
+
+const REPO_DIR = join(import.meta.dir, "..");
+const DEFAULT_PATHS = ["src"];
+const DEFAULT_TOP = 10;
+const SKIPPED_DIRS = new Set(["node_modules", ".git", "dist", "build"]);
+
+export function parseErosionArgs(argv: string[]): ErosionArgs {
+  const paths: string[] = [];
+  let includeTests = false;
+  let json = false;
+  let top = DEFAULT_TOP;
+  let tags = false;
+  let limit: number | null = null;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--include-tests") includeTests = true;
+    else if (arg === "--json") json = true;
+    else if (arg === "--tags") tags = true;
+    else if (arg === "--top") top = Number(argv[++i]);
+    else if (arg === "--limit") limit = Number(argv[++i]);
+    else if (arg.startsWith("--")) throw new Error(`unknown flag: ${arg}`);
+    else paths.push(arg);
+  }
+
+  if (!Number.isFinite(top) || top < 0) throw new Error("--top requires a non-negative number");
+  if (limit !== null && (!Number.isFinite(limit) || limit < 1)) throw new Error("--limit requires a positive number");
+
+  return { paths: paths.length > 0 ? paths : DEFAULT_PATHS, includeTests, json, top, tags, limit };
+}
+
+export function isSourceFile(file: string, includeTests: boolean): boolean {
+  if (!(file.endsWith(".ts") || file.endsWith(".tsx"))) return false;
+  if (file.endsWith(".d.ts")) return false;
+  if (includeTests) return true;
+  return !(file.endsWith(".test.ts") || file.endsWith(".test.tsx") || file.endsWith(".int.test.ts"));
+}
+
+function collectFiles(root: string, includeTests: boolean): string[] {
+  const stats = statSync(root, { throwIfNoEntry: false });
+  if (!stats) return [];
+  if (stats.isFile()) return isSourceFile(root, includeTests) ? [root] : [];
+
+  const found: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (entry.isSymbolicLink()) continue;
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) {
+      if (!SKIPPED_DIRS.has(entry.name)) found.push(...collectFiles(path, includeTests));
+      continue;
+    }
+    if (isSourceFile(path, includeTests)) found.push(path);
+  }
+  return found;
+}
+
+function measure(
+  baseDir: string,
+  paths: string[],
+  includeTests: boolean,
+): { metrics: FunctionMetric[]; files: number } {
+  const metrics: FunctionMetric[] = [];
+  let files = 0;
+  for (const path of paths) {
+    const root = resolve(baseDir, path);
+    const displayBase = dirname(root);
+    for (const file of collectFiles(root, includeTests)) {
+      files += 1;
+      metrics.push(...analyzeSource(relative(displayBase, file), readFileSync(file, "utf8")));
+    }
+  }
+  return { metrics, files };
+}
+
+function git(args: string[]): string {
+  return execFileSync("git", args, { cwd: REPO_DIR, encoding: "utf8", maxBuffer: 256 * 1024 * 1024 });
+}
+
+function releaseTags(limit: number | null): string[] {
+  const tags = git(["tag", "--sort=v:refname"])
+    .split("\n")
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.startsWith("v"));
+  return limit === null ? tags : tags.slice(-limit);
+}
+
+function measureTag(tag: string, paths: string[], includeTests: boolean): ErosionReport {
+  const workDir = mkdtempSync(join(tmpdir(), "acolyte-erosion-"));
+  const archive = join(workDir, "tree.tar");
+  try {
+    writeFileSync(
+      archive,
+      execFileSync("git", ["archive", tag, "--", ...paths], { cwd: REPO_DIR, maxBuffer: 256 * 1024 * 1024 }),
+    );
+    execFileSync("tar", ["-x", "-f", archive, "-C", workDir]);
+    const { metrics, files } = measure(workDir, paths, includeTests);
+    return computeErosion(metrics, files);
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function printReport(report: ErosionReport, metrics: FunctionMetric[], top: number): void {
+  console.log(
+    `erosion   ${formatPercent(report.erosion)}  (CC > ${HIGH_COMPLEXITY_THRESHOLD} share of complexity mass)`,
+  );
+  console.log(`files     ${report.files}`);
+  console.log(`functions ${report.functions} (${report.highFunctions} high-complexity)`);
+  console.log(`sloc      ${report.sloc}`);
+  if (top === 0) return;
+
+  const heaviest = [...metrics].sort((a, b) => b.mass - a.mass).slice(0, top);
+  if (heaviest.length === 0) return;
+  console.log(`\ntop ${heaviest.length} by mass (cc x sqrt(sloc)):`);
+  const width = Math.max(...heaviest.map((metric) => metric.name.length));
+  for (const metric of heaviest) {
+    const location = `${metric.file}:${metric.line}`;
+    console.log(
+      `  ${metric.name.padEnd(width)}  cc ${String(metric.cyclomatic).padStart(3)}  sloc ${String(metric.sloc).padStart(4)}  mass ${metric.mass.toFixed(1).padStart(6)}  ${location}`,
+    );
+  }
+}
+
+function printCurve(reports: TagReport[]): void {
+  console.log("tag       erosion  functions  high  sloc");
+  for (const { tag, report } of reports) {
+    console.log(
+      `${tag.padEnd(9)} ${formatPercent(report.erosion).padStart(6)}  ${String(report.functions).padStart(9)}  ${String(report.highFunctions).padStart(4)}  ${String(report.sloc).padStart(5)}`,
+    );
+  }
+}
+
+export async function runErosion(argv: string[]): Promise<void> {
+  const args = parseErosionArgs(argv);
+
+  if (args.tags) {
+    const reports = releaseTags(args.limit).map((tag) => ({
+      tag,
+      report: measureTag(tag, args.paths, args.includeTests),
+    }));
+    if (args.json) console.log(JSON.stringify(reports, null, 2));
+    else printCurve(reports);
+    return;
+  }
+
+  const { metrics, files } = measure(REPO_DIR, args.paths, args.includeTests);
+  const report = computeErosion(metrics, files);
+  if (args.json) {
+    console.log(JSON.stringify({ report, functions: metrics }, null, 2));
+    return;
+  }
+  printReport(report, metrics, args.top);
+}
+
+if (import.meta.main) {
+  await runErosion(process.argv.slice(2));
+}

--- a/scripts/run-erosion.ts
+++ b/scripts/run-erosion.ts
@@ -60,7 +60,7 @@ export function isSourceFile(file: string, includeTests: boolean): boolean {
 
 function collectFiles(root: string, includeTests: boolean): string[] {
   const stats = statSync(root, { throwIfNoEntry: false });
-  if (!stats) return [];
+  if (!stats) throw new Error(`no such path: ${root}`);
   if (stats.isFile()) return isSourceFile(root, includeTests) ? [root] : [];
 
   const found: string[] = [];
@@ -85,7 +85,7 @@ function measure(
   let files = 0;
   for (const path of paths) {
     const root = resolve(baseDir, path);
-    const displayBase = dirname(root);
+    const displayBase = root === baseDir ? root : dirname(root);
     for (const file of collectFiles(root, includeTests)) {
       files += 1;
       metrics.push(...analyzeSource(relative(displayBase, file), readFileSync(file, "utf8")));
@@ -106,7 +106,9 @@ function releaseTags(limit: number | null): string[] {
   return limit === null ? tags : tags.slice(-limit);
 }
 
-function measureTag(tag: string, paths: string[], includeTests: boolean): ErosionReport {
+// A tag predating every measured path has nothing to archive, so it is reported as skipped
+// rather than aborting the curve for the tags that do have it.
+function measureTag(tag: string, paths: string[], includeTests: boolean): ErosionReport | null {
   const workDir = mkdtempSync(join(tmpdir(), "acolyte-erosion-"));
   const archive = join(workDir, "tree.tar");
   try {
@@ -117,6 +119,8 @@ function measureTag(tag: string, paths: string[], includeTests: boolean): Erosio
     execFileSync("tar", ["-x", "-f", archive, "-C", workDir]);
     const { metrics, files } = measure(workDir, paths, includeTests);
     return computeErosion(metrics, files);
+  } catch {
+    return null;
   } finally {
     rmSync(workDir, { recursive: true, force: true });
   }
@@ -160,12 +164,19 @@ export async function runErosion(argv: string[]): Promise<void> {
   const args = parseErosionArgs(argv);
 
   if (args.tags) {
-    const reports = releaseTags(args.limit).map((tag) => ({
+    const measured = releaseTags(args.limit).map((tag) => ({
       tag,
       report: measureTag(tag, args.paths, args.includeTests),
     }));
-    if (args.json) console.log(JSON.stringify(reports, null, 2));
+    const reports: TagReport[] = [];
+    const skipped: string[] = [];
+    for (const entry of measured) {
+      if (entry.report === null) skipped.push(entry.tag);
+      else reports.push({ tag: entry.tag, report: entry.report });
+    }
+    if (args.json) console.log(JSON.stringify({ reports, skipped }, null, 2));
     else printCurve(reports);
+    if (skipped.length > 0) console.log(`\nskipped (path absent at tag): ${skipped.join(", ")}`);
     return;
   }
 
@@ -179,5 +190,10 @@ export async function runErosion(argv: string[]): Promise<void> {
 }
 
 if (import.meta.main) {
-  await runErosion(process.argv.slice(2));
+  try {
+    await runErosion(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
 }


### PR DESCRIPTION
## Summary

- add `bun run erosion:run` — per-function cyclomatic complexity over `src`, reporting the share of complexity mass held by functions above cc 10 and the heaviest functions by mass
- `--tags` measures each release tag for a per-release curve; `--json`, `--top`, `--include-tests` for the rest
- inline callbacks fold into their enclosing function; one with no enclosing function becomes its own unit, so no complexity leaves the ratio
- report the numbers when cutting a release — informational, never a gate