### PR TITLE
fix(files): report overwritten only when replacing

### DIFF
--- a/src/file-ops.int.test.ts
+++ b/src/file-ops.int.test.ts
@@ -683,6 +683,32 @@ describe("createFile", () => {
     expect(result.result.output).toContain("bytes=5");
     expect(session.callLog[0]?.toolName).toBe("file-create");
   });
+
+  test("reports a new file as not overwritten", async () => {
+    const workspace = dirs.createDir("acolyte-create-new-ws-");
+    const filePath = join(workspace, `test-new-${testUuid()}.txt`);
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.createFile.execute({ path: filePath, content: "hello" }, "call_create_new");
+    expect(result.result.output).toContain("overwritten=false");
+  });
+
+  test("reports a replaced file as overwritten", async () => {
+    const workspace = dirs.createDir("acolyte-create-replace-ws-");
+    const filePath = join(workspace, `test-replace-${testUuid()}.txt`);
+    await writeFile(filePath, "before\n", "utf8");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.createFile.execute({ path: filePath, content: "after\n" }, "call_create_replace");
+    expect(result.result.output).toContain("overwritten=true");
+  });
+
+  test("reports an existing empty file as overwritten", async () => {
+    const workspace = dirs.createDir("acolyte-create-empty-ws-");
+    const filePath = join(workspace, `test-empty-${testUuid()}.txt`);
+    await writeFile(filePath, "", "utf8");
+    const { tools } = toolsForAgent({ workspace });
+    const result = await tools.createFile.execute({ path: filePath, content: "filled\n" }, "call_create_empty");
+    expect(result.result.output).toContain("overwritten=true");
+  });
 });
 
 describe("deleteFile", () => {

--- a/src/file-ops.ts
+++ b/src/file-ops.ts
@@ -377,7 +377,7 @@ export async function writeTextFile(input: {
   const parts = [
     `path=${absPath}`,
     `bytes=${Buffer.byteLength(input.content, "utf8")}`,
-    `overwritten=${overwrite ? "true" : "false"}`,
+    `overwritten=${previousContent !== null ? "true" : "false"}`,
     "",
     diff,
   ];

--- a/src/file-ops.ts
+++ b/src/file-ops.ts
@@ -353,19 +353,12 @@ export async function editFile(input: {
   ].join("\n");
 }
 
-export async function writeTextFile(input: {
-  workspace: string;
-  path: string;
-  content: string;
-  overwrite?: boolean;
-}): Promise<string> {
+export async function writeTextFile(input: { workspace: string; path: string; content: string }): Promise<string> {
   const absPath = ensurePathWithinSandbox(input.path, input.workspace);
-  const overwrite = input.overwrite ?? true;
   let previousContent: string | null = null;
 
   try {
     previousContent = await readFile(absPath, "utf8");
-    if (!overwrite) throw new Error("Target file already exists");
   } catch (error) {
     if (!(error instanceof Error) || !/ENOENT/.test(error.message)) throw error;
   }

--- a/src/file-toolkit.ts
+++ b/src/file-toolkit.ts
@@ -241,7 +241,6 @@ function createCreateFileTool(input: ToolkitInput) {
           workspace: input.workspace,
           path: toolInput.path,
           content: toolInput.content,
-          overwrite: true,
         });
         const summaryParts = diffSummaryParts(toolInput.path, rawResult, "tool.label.file_create");
         const diffParts = numberedUnifiedDiffLines(rawResult);


### PR DESCRIPTION
## Summary

- report `overwritten` from whether content existed, not from the caller's `overwrite` flag — every `file-create` said `overwritten=true`, including for brand-new files, in a string the model reads verbatim
- align the field with `createDiff`, which already used the same value to decide new-file versus modification, so the output no longer contradicts itself
- drop the `overwrite` parameter and its unreachable "Target file already exists" guard, which no caller ever triggered