### PR TITLE
refactor(prompt): consolidate the prompt input

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,7 +17,7 @@ Acolyte separates pure unit tests, wired integration tests, stable TUI snapshots
 
 ## TUI unit testing
 
-- Headless input logic (keystroke → edit action → callbacks) is unit-tested at its seam: render the handler under a fake `InputContext` that captures the registered handler, then drive it with synthetic `KeyEvent`s. Byte-level key parsing stays in `prompt-keymap`'s own tests, so a handler test asserts behavior, not escape sequences.
+- Headless input logic (keystroke → edit action → callbacks) is unit-tested in two layers. Keyboard policy is pure and tested directly in `prompt-keymap`'s own tests: which chord a key means, and which edit that chord implies for a given buffer, including the guards that decide an edit is a no-op. The handler test covers only what the stateful shim owns — meta-prefix timing, state that outlives a render, and a suppressed edit emitting nothing — by rendering it under a fake `InputContext` that captures the registered handler and driving it with synthetic `KeyEvent`s. Byte-level key parsing stays in `tui/input`'s tests, so neither layer asserts escape sequences.
 - Layout parity between two render paths (the live tail vs. scrollback, or chat vs. CLI) is pinned by rendering both from one scene and asserting byte-equality, so a forked renderer cannot pass silently.
 
 ## Integration test boundary

--- a/src/prompt-input.test.tsx
+++ b/src/prompt-input.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import { createElement as h } from "react";
 import {
   createInputController,
@@ -17,6 +17,8 @@ type PressKey = Partial<KeyEvent>;
 
 type Harness = {
   press: (input: string, key?: PressKey) => void;
+  pressWithoutRender: (input: string, key?: PressKey) => void;
+  render: () => void;
   state: () => InputControllerState;
   actions: InputEditAction[];
   pastes: boolean[];
@@ -90,6 +92,10 @@ function mountControlled(initial = "", options: { wrapWidth?: number } = {}): Ha
       handler?.(input, { ...emptyKey(), ...key });
       flush();
     },
+    pressWithoutRender(input, key) {
+      handler?.(input, { ...emptyKey(), ...key });
+    },
+    render: flush,
     state: () => current,
     actions,
     pastes,
@@ -148,27 +154,6 @@ describe("PromptInputHandler: text entry", () => {
   });
 });
 
-describe("PromptInputHandler: help swallow", () => {
-  test("a lone '?' on an empty prompt is swallowed", () => {
-    const h = mount();
-    h.press("?");
-    expect(h.actions).toEqual([]);
-    expect(h.state()).toEqual({ text: "", cursor: 0 });
-  });
-
-  test("'?' inserts once the prompt is non-empty", () => {
-    const h = mount("a");
-    h.press("?");
-    expect(h.state()).toEqual({ text: "a?", cursor: 2 });
-  });
-
-  test("a pasted '?' on an empty prompt is not swallowed", () => {
-    const h = mount();
-    h.press("?", { paste: true });
-    expect(h.state()).toEqual({ text: "?", cursor: 1 });
-  });
-});
-
 describe("PromptInputHandler: deletion", () => {
   test("backspace deletes the char before the cursor", () => {
     const h = mount("ab");
@@ -177,13 +162,17 @@ describe("PromptInputHandler: deletion", () => {
     expect(h.actions).toEqual([{ kind: "delete-backward" }]);
   });
 
-  test("backspace at the start of the prompt is a no-op", () => {
+  /** The guard matrix lives with resolvePromptEdit; this pins that a suppressed
+   *  decision reaches neither onAction nor onCursorLine, which chat-state reads
+   *  as "the text did not change". */
+  test("a suppressed edit emits nothing at all", () => {
     const h = mount("ab");
-    h.press("", { leftArrow: true });
-    h.press("", { leftArrow: true });
-    h.actions.length = 0;
+    h.press("", { home: true });
+    h.cursorLines.length = 0;
     h.press("", { backspace: true });
-    expect(h.actions).toEqual([]);
+    expect(h.actions).toEqual([{ kind: "move", direction: "home" }]);
+    expect(h.cursorLines).toEqual([]);
+    expect(h.state()).toEqual({ text: "ab", cursor: 0 });
   });
 
   test("forward-delete removes the char after the cursor", () => {
@@ -191,13 +180,6 @@ describe("PromptInputHandler: deletion", () => {
     h.press("", { home: true });
     h.press("", { delete: true });
     expect(h.state()).toEqual({ text: "b", cursor: 0 });
-  });
-
-  test("forward-delete at the end is a no-op", () => {
-    const h = mount("ab");
-    h.actions.length = 0;
-    h.press("", { delete: true });
-    expect(h.actions).toEqual([]);
   });
 
   test("ctrl+w deletes the previous word", () => {
@@ -212,12 +194,6 @@ describe("PromptInputHandler: deletion", () => {
     h.press("u", { ctrl: true });
     expect(h.state()).toEqual({ text: "", cursor: 0 });
     expect(h.actions).toEqual([{ kind: "clear" }]);
-  });
-
-  test("ctrl+u on an empty line is a no-op", () => {
-    const h = mount("");
-    h.press("u", { ctrl: true });
-    expect(h.actions).toEqual([]);
   });
 });
 
@@ -296,5 +272,122 @@ describe("PromptInputHandler: meta prefix", () => {
     const h = mount("foo bar");
     h.press("", { backspace: true });
     expect(h.actions).toEqual([{ kind: "delete-backward" }]);
+  });
+});
+
+/** The armed prefix is observable only through backspace, which resolves to
+ *  delete_word_back while it is live and delete_back once it is cleared. */
+describe("PromptInputHandler: meta prefix lifetime", () => {
+  test("an inert key clears the prefix", () => {
+    const h = mount("foo bar");
+    h.press("", { escape: true });
+    h.press("", { tab: true });
+    h.press("", { backspace: true });
+    expect(h.actions).toEqual([{ kind: "delete-backward" }]);
+  });
+
+  test("a word deletion clears the prefix", () => {
+    const h = mount("foo bar");
+    h.press("", { escape: true });
+    h.press("w", { ctrl: true });
+    h.press("", { backspace: true });
+    expect(h.actions).toEqual([{ kind: "delete-word-backward" }, { kind: "delete-backward" }]);
+    expect(h.state()).toEqual({ text: "foo", cursor: 3 });
+  });
+
+  test("a forward delete clears the prefix even when suppressed as a no-op", () => {
+    const h = mount("foo bar");
+    h.press("", { escape: true });
+    h.press("", { delete: true });
+    h.press("", { backspace: true });
+    expect(h.actions).toEqual([{ kind: "delete-backward" }]);
+  });
+
+  test("an insert clears the prefix", () => {
+    const h = mount("foo bar");
+    h.press("", { escape: true });
+    h.press("x");
+    h.press("", { backspace: true });
+    expect(h.actions).toEqual([{ kind: "insert", text: "x" }, { kind: "delete-backward" }]);
+  });
+
+  test("a horizontal move leaves the prefix armed", () => {
+    const h = mount("foo bar");
+    h.press("", { escape: true });
+    h.press("", { leftArrow: true });
+    h.press("", { backspace: true });
+    expect(h.actions.at(-1)).toEqual({ kind: "delete-word-backward" });
+  });
+
+  test("an end jump leaves the prefix armed", () => {
+    const h = mount("foo bar");
+    h.press("", { home: true });
+    h.press("", { escape: true });
+    h.press("", { end: true });
+    h.press("", { backspace: true });
+    expect(h.actions.at(-1)).toEqual({ kind: "delete-word-backward" });
+    expect(h.state()).toEqual({ text: "foo ", cursor: 4 });
+  });
+
+  test("a vertical move leaves the prefix armed", () => {
+    const h = mount("foo\nbar baz");
+    h.press("", { escape: true });
+    h.press("", { upArrow: true });
+    h.press("", { backspace: true });
+    expect(h.actions.at(-1)).toEqual({ kind: "delete-word-backward" });
+  });
+
+  test("the prefix expires once its window has passed", () => {
+    const clock = spyOn(Date, "now");
+    try {
+      clock.mockReturnValue(1_000);
+      const armed = mount("foo bar");
+      armed.press("", { escape: true });
+      clock.mockReturnValue(1_150);
+      armed.press("", { backspace: true });
+      expect(armed.actions).toEqual([{ kind: "delete-word-backward" }]);
+      armed.unmount();
+
+      clock.mockReturnValue(1_000);
+      const expired = mount("foo bar");
+      expired.press("", { escape: true });
+      clock.mockReturnValue(1_151);
+      expired.press("", { backspace: true });
+      expect(expired.actions).toEqual([{ kind: "delete-backward" }]);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  test("submit leaves the prefix armed", () => {
+    const h = mount("foo bar");
+    h.press("", { escape: true });
+    h.press("", { return: true });
+    h.press("", { backspace: true });
+    expect(h.submits).toEqual(["foo bar"]);
+    expect(h.actions).toEqual([{ kind: "delete-word-backward" }]);
+  });
+});
+
+describe("PromptInputHandler: keystrokes between renders", () => {
+  test("a second keystroke resolves against the first, not against stale props", () => {
+    const h = mount();
+    h.pressWithoutRender("a");
+    h.pressWithoutRender("?");
+    h.render();
+    expect(h.actions).toEqual([
+      { kind: "insert", text: "a" },
+      { kind: "insert", text: "?" },
+    ]);
+    expect(h.state()).toEqual({ text: "a?", cursor: 2 });
+  });
+
+  test("a no-op guard sees an edit that has not rendered yet", () => {
+    const h = mount("a");
+    h.pressWithoutRender("", { backspace: true });
+    h.pressWithoutRender("", { backspace: true });
+    h.render();
+    expect(h.actions).toEqual([{ kind: "delete-backward" }]);
+    expect(h.state()).toEqual({ text: "", cursor: 0 });
   });
 });

--- a/src/prompt-input.test.tsx
+++ b/src/prompt-input.test.tsx
@@ -160,6 +160,14 @@ describe("PromptInputHandler: deletion", () => {
     h.press("", { backspace: true });
     expect(h.state()).toEqual({ text: "a", cursor: 1 });
     expect(h.actions).toEqual([{ kind: "delete-backward" }]);
+    expect(h.pastes).toEqual([false]);
+  });
+
+  test("only an insert can report a paste, whatever the key carries", () => {
+    const h = mount("ab");
+    h.press("", { backspace: true, paste: true });
+    expect(h.actions).toEqual([{ kind: "delete-backward" }]);
+    expect(h.pastes).toEqual([false]);
   });
 
   /** The guard matrix lives with resolvePromptEdit; this pins that a suppressed

--- a/src/prompt-input.tsx
+++ b/src/prompt-input.tsx
@@ -1,162 +1,44 @@
-import { useCallback, useRef, useState } from "react";
-import { unreachable } from "./assert";
-import {
-  type InputControllerState,
-  type InputEditAction,
-  reduceInput,
-  wordBoundaryLeft,
-  wordBoundaryRight,
-} from "./input-controller";
-import { cursorLineIndex, moveLineDown, moveLineUp } from "./prompt-display";
-import type { PromptAction } from "./prompt-keymap";
-import { resolvePromptAction } from "./prompt-keymap";
+import { useCallback, useRef } from "react";
+import { type InputControllerState, type InputEditAction, reduceInput } from "./input-controller";
+import { cursorLineIndex } from "./prompt-display";
+import { consumesMetaPrefix, resolvePromptAction, resolvePromptEdit } from "./prompt-keymap";
 import { useInput } from "./tui";
 
 const META_PREFIX_WINDOW_MS = 150;
 
 interface PromptInputProps {
   value: string;
-  cursor?: number;
-  placeholder?: string;
-  focus?: boolean;
-  caretVisible?: boolean;
-  linePrefixFirst?: string;
-  linePrefixRest?: string;
-  onChange?: (next: string, fromPaste?: boolean) => void;
-  onAction?: (action: InputEditAction, fromPaste: boolean) => void;
+  cursor: number;
+  onAction: (action: InputEditAction, fromPaste: boolean) => void;
   onSubmit: (value: string) => void;
   onCursorLine: (line: number) => void;
   wrapWidth?: number;
 }
 
-export function usePromptInput({
+export function PromptInputHandler({
   value,
   cursor,
-  focus = true,
-  onChange,
   onAction,
   onSubmit,
   onCursorLine,
   wrapWidth,
-}: PromptInputProps): { effectiveCursor: number } {
-  const controlled = onAction !== undefined && cursor !== undefined;
-  const [cursorOffset, setCursorOffset] = useState(value.length);
+}: PromptInputProps): null {
   const metaPrefixAt = useRef<number | null>(null);
-  const valueRef = useRef(value);
-  // cursorRef is the source of truth for keystroke handling — only updated
-  // by moveCursor (synchronous) during input, never from React state which
-  // can lag behind between re-renders. For external value changes (e.g.
-  // history navigation), we clamp synchronously during render.
-  const cursorRef = useRef(cursorOffset);
-  const onChangeRef = useRef(onChange);
   const onSubmitRef = useRef(onSubmit);
   const onCursorLineRef = useRef(onCursorLine);
   const onActionRef = useRef(onAction);
-  const controlledStateRef = useRef<InputControllerState>({ text: value, cursor: value.length });
+  const wrapWidthRef = useRef(wrapWidth);
+  // stateRef is the source of truth for keystroke handling: props can lag a
+  // render behind, so each render overwrites it and keystrokes between renders
+  // reduce against it in turn.
+  const stateRef = useRef<InputControllerState>({ text: value, cursor });
+  onSubmitRef.current = onSubmit;
   onCursorLineRef.current = onCursorLine;
   onActionRef.current = onAction;
-  const wrapWidthRef = useRef(wrapWidth);
   wrapWidthRef.current = wrapWidth;
-  if (controlled) {
-    controlledStateRef.current = { text: value, cursor: Math.max(0, Math.min(cursor ?? value.length, value.length)) };
-  } else if (valueRef.current !== value) {
-    const clamped = Math.max(0, Math.min(cursorRef.current, value.length));
-    cursorRef.current = clamped;
-    if (cursorOffset !== clamped) setCursorOffset(clamped);
-  }
-  valueRef.current = value;
-  onChangeRef.current = onChange;
-  onSubmitRef.current = onSubmit;
-
-  const handleControlledInput = useCallback((input: string, key: Parameters<Parameters<typeof useInput>[0]>[1]) => {
-    const dispatchAction = (action: InputEditAction, fromPaste = false) => {
-      const next = reduceInput(controlledStateRef.current, action);
-      controlledStateRef.current = next;
-      onActionRef.current?.(action, fromPaste);
-      onCursorLineRef.current(cursorLineIndex(next.text, next.cursor, wrapWidthRef.current));
-    };
-    const { text: v, cursor: c } = controlledStateRef.current;
-    const now = Date.now();
-    const hasMetaPrefix = metaPrefixAt.current !== null && now - metaPrefixAt.current <= META_PREFIX_WINDOW_MS;
-    if (key.escape && !input) {
-      metaPrefixAt.current = now;
-      return;
-    }
-    const action: PromptAction = resolvePromptAction(input, key, { hasMetaPrefix });
-    switch (action.type) {
-      case "noop":
-        metaPrefixAt.current = null;
-        return;
-      case "submit":
-        onSubmitRef.current(v);
-        return;
-      case "move_home":
-        dispatchAction({ kind: "move", direction: "home" });
-        return;
-      case "move_end":
-        dispatchAction({ kind: "move", direction: "end" });
-        return;
-      case "move_word_left":
-        dispatchAction({ kind: "move-word", direction: "left" });
-        return;
-      case "move_word_right":
-        dispatchAction({ kind: "move-word", direction: "right" });
-        return;
-      case "delete_word_back":
-        metaPrefixAt.current = null;
-        if (c === 0) return;
-        dispatchAction({ kind: "delete-word-backward" });
-        return;
-      case "clear_line":
-        metaPrefixAt.current = null;
-        if (v.length === 0) return;
-        dispatchAction({ kind: "clear" });
-        return;
-      case "move_left":
-        dispatchAction({ kind: "move", direction: "left" });
-        return;
-      case "move_right":
-        dispatchAction({ kind: "move", direction: "right" });
-        return;
-      case "move_up":
-        dispatchAction({ kind: "set-cursor", cursor: moveLineUp(v, c, wrapWidthRef.current) });
-        return;
-      case "move_down":
-        dispatchAction({ kind: "set-cursor", cursor: moveLineDown(v, c, wrapWidthRef.current) });
-        return;
-      case "delete_back":
-        metaPrefixAt.current = null;
-        if (c === 0) return;
-        dispatchAction({ kind: "delete-backward" });
-        return;
-      case "delete_forward":
-        metaPrefixAt.current = null;
-        if (c >= v.length) return;
-        dispatchAction({ kind: "delete-forward" });
-        return;
-      case "insert":
-        metaPrefixAt.current = null;
-        if (v.length === 0 && action.text === "?" && !key.paste) return;
-        dispatchAction({ kind: "insert", text: action.text }, key.paste);
-        return;
-      default:
-        unreachable(action);
-    }
-  }, []);
+  stateRef.current = { text: value, cursor: Math.max(0, Math.min(cursor, value.length)) };
 
   const handleInput = useCallback((input: string, key: Parameters<Parameters<typeof useInput>[0]>[1]) => {
-    const emitChange = (next: string, fromPaste = false) => {
-      valueRef.current = next;
-      onChangeRef.current?.(next, fromPaste);
-    };
-    const moveCursor = (next: number) => {
-      cursorRef.current = next;
-      setCursorOffset(next);
-      onCursorLineRef.current(cursorLineIndex(valueRef.current, next, wrapWidthRef.current));
-    };
-
-    const v = valueRef.current;
-    const c = cursorRef.current;
     const now = Date.now();
     const hasMetaPrefix = metaPrefixAt.current !== null && now - metaPrefixAt.current <= META_PREFIX_WINDOW_MS;
     if (key.escape && !input) {
@@ -164,80 +46,22 @@ export function usePromptInput({
       return;
     }
 
-    const action: PromptAction = resolvePromptAction(input, key, { hasMetaPrefix });
-    switch (action.type) {
-      case "noop":
-        metaPrefixAt.current = null;
-        return;
-      case "submit":
-        onSubmitRef.current(v);
-        return;
-      case "move_home":
-        moveCursor(0);
-        return;
-      case "move_end":
-        moveCursor(v.length);
-        return;
-      case "move_word_left":
-        moveCursor(wordBoundaryLeft(v, c));
-        return;
-      case "move_word_right":
-        moveCursor(wordBoundaryRight(v, c));
-        return;
-      case "delete_word_back": {
-        metaPrefixAt.current = null;
-        if (c === 0) return;
-        const next = wordBoundaryLeft(v, c);
-        emitChange(`${v.slice(0, next)}${v.slice(c)}`);
-        moveCursor(next);
-        return;
-      }
-      case "clear_line":
-        metaPrefixAt.current = null;
-        if (v.length === 0) return;
-        emitChange("");
-        moveCursor(0);
-        return;
-      case "move_left":
-        moveCursor(Math.max(0, c - 1));
-        return;
-      case "move_right":
-        moveCursor(Math.min(v.length, c + 1));
-        return;
-      case "move_up":
-        moveCursor(moveLineUp(v, c, wrapWidthRef.current));
-        return;
-      case "move_down":
-        moveCursor(moveLineDown(v, c, wrapWidthRef.current));
-        return;
-      case "delete_back":
-        metaPrefixAt.current = null;
-        if (c === 0) return;
-        emitChange(`${v.slice(0, c - 1)}${v.slice(c)}`);
-        moveCursor(c - 1);
-        return;
-      case "delete_forward":
-        metaPrefixAt.current = null;
-        if (c >= v.length) return;
-        emitChange(`${v.slice(0, c)}${v.slice(c + 1)}`);
-        return;
-      case "insert":
-        metaPrefixAt.current = null;
-        emitChange(`${v.slice(0, c)}${action.text}${v.slice(c)}`, key.paste);
-        moveCursor(c + action.text.length);
-        return;
-      default:
-        unreachable(action);
+    const action = resolvePromptAction(input, key, { hasMetaPrefix });
+    const decision = resolvePromptEdit(action, stateRef.current, wrapWidthRef.current);
+    if (consumesMetaPrefix(action)) metaPrefixAt.current = null;
+    if (decision.kind === "submit") {
+      onSubmitRef.current(stateRef.current.text);
+      return;
     }
+    if (decision.kind === "none") return;
+
+    const next = reduceInput(stateRef.current, decision.action);
+    stateRef.current = next;
+    onActionRef.current(decision.action, action.type === "insert" && action.paste);
+    onCursorLineRef.current(cursorLineIndex(next.text, next.cursor, wrapWidthRef.current));
   }, []);
 
-  useInput(controlled ? handleControlledInput : handleInput, { isActive: focus });
+  useInput(handleInput);
 
-  const effectiveCursor = controlled ? controlledStateRef.current.cursor : cursorOffset;
-  return { effectiveCursor };
-}
-
-export function PromptInputHandler(props: PromptInputProps): null {
-  usePromptInput(props);
   return null;
 }

--- a/src/prompt-input.tsx
+++ b/src/prompt-input.tsx
@@ -31,12 +31,13 @@ export function PromptInputHandler({
   // stateRef is the source of truth for keystroke handling: props can lag a
   // render behind, so each render overwrites it and keystrokes between renders
   // reduce against it in turn.
-  const stateRef = useRef<InputControllerState>({ text: value, cursor });
+  const fromProps: InputControllerState = { text: value, cursor: Math.max(0, Math.min(cursor, value.length)) };
+  const stateRef = useRef(fromProps);
   onSubmitRef.current = onSubmit;
   onCursorLineRef.current = onCursorLine;
   onActionRef.current = onAction;
   wrapWidthRef.current = wrapWidth;
-  stateRef.current = { text: value, cursor: Math.max(0, Math.min(cursor, value.length)) };
+  stateRef.current = fromProps;
 
   const handleInput = useCallback((input: string, key: Parameters<Parameters<typeof useInput>[0]>[1]) => {
     const now = Date.now();

--- a/src/prompt-keymap.test.ts
+++ b/src/prompt-keymap.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { resolvePromptAction } from "./prompt-keymap";
+import { consumesMetaPrefix, type PromptAction, resolvePromptAction, resolvePromptEdit } from "./prompt-keymap";
 import type { KeyEvent } from "./tui/context";
 import { emptyKey } from "./tui/input";
 
@@ -15,13 +15,22 @@ describe("prompt keymap", () => {
   });
 
   test("insert plain text", () => {
-    expect(resolvePromptAction("x", emptyKey(), noMeta)).toEqual({ type: "insert", text: "x" });
+    expect(resolvePromptAction("x", emptyKey(), noMeta)).toEqual({ type: "insert", text: "x", paste: false });
+  });
+
+  test("insert carries the paste bit", () => {
+    expect(resolvePromptAction("x", key({ paste: true }), noMeta)).toEqual({
+      type: "insert",
+      text: "x",
+      paste: true,
+    });
   });
 
   test("shift+enter inserts newline", () => {
     expect(resolvePromptAction("", key({ return: true, shift: true }), noMeta)).toEqual({
       type: "insert",
       text: "\n",
+      paste: false,
     });
   });
 
@@ -141,5 +150,158 @@ describe("prompt keymap", () => {
     test("right arrow", () => {
       expect(resolvePromptAction("", key({ rightArrow: true }), noMeta)).toEqual({ type: "move_right" });
     });
+  });
+});
+
+const insert = (text: string, paste = false): PromptAction => ({ type: "insert", text, paste });
+
+describe("resolvePromptEdit", () => {
+  describe("suppressed edits", () => {
+    test("backspace at the start of the buffer", () => {
+      expect(resolvePromptEdit({ type: "delete_back" }, { text: "ab", cursor: 0 })).toEqual({ kind: "none" });
+    });
+
+    test("forward delete at the end of the buffer", () => {
+      expect(resolvePromptEdit({ type: "delete_forward" }, { text: "ab", cursor: 2 })).toEqual({ kind: "none" });
+    });
+
+    test("word deletion at the start of the buffer", () => {
+      expect(resolvePromptEdit({ type: "delete_word_back" }, { text: "foo bar", cursor: 0 })).toEqual({ kind: "none" });
+    });
+
+    test("clear on an empty buffer", () => {
+      expect(resolvePromptEdit({ type: "clear_line" }, { text: "", cursor: 0 })).toEqual({ kind: "none" });
+    });
+
+    test("an inert chord", () => {
+      expect(resolvePromptEdit({ type: "noop" }, { text: "ab", cursor: 1 })).toEqual({ kind: "none" });
+    });
+  });
+
+  describe("deletions past their guard", () => {
+    test("backspace", () => {
+      expect(resolvePromptEdit({ type: "delete_back" }, { text: "ab", cursor: 1 })).toEqual({
+        kind: "edit",
+        action: { kind: "delete-backward" },
+      });
+    });
+
+    test("forward delete", () => {
+      expect(resolvePromptEdit({ type: "delete_forward" }, { text: "ab", cursor: 1 })).toEqual({
+        kind: "edit",
+        action: { kind: "delete-forward" },
+      });
+    });
+
+    test("word deletion", () => {
+      expect(resolvePromptEdit({ type: "delete_word_back" }, { text: "foo bar", cursor: 7 })).toEqual({
+        kind: "edit",
+        action: { kind: "delete-word-backward" },
+      });
+    });
+
+    test("clear", () => {
+      expect(resolvePromptEdit({ type: "clear_line" }, { text: "ab", cursor: 2 })).toEqual({
+        kind: "edit",
+        action: { kind: "clear" },
+      });
+    });
+  });
+
+  describe("help swallow", () => {
+    test("a lone '?' on an empty buffer decides nothing", () => {
+      expect(resolvePromptEdit(insert("?"), { text: "", cursor: 0 })).toEqual({ kind: "none" });
+    });
+
+    test("'?' inserts once the buffer is non-empty", () => {
+      expect(resolvePromptEdit(insert("?"), { text: "a", cursor: 1 })).toEqual({
+        kind: "edit",
+        action: { kind: "insert", text: "?" },
+      });
+    });
+
+    test("a pasted '?' on an empty buffer inserts", () => {
+      expect(resolvePromptEdit(insert("?", true), { text: "", cursor: 0 })).toEqual({
+        kind: "edit",
+        action: { kind: "insert", text: "?" },
+      });
+    });
+  });
+
+  describe("movement", () => {
+    test("horizontal and bound moves map onto move actions", () => {
+      const state = { text: "foo bar", cursor: 3 };
+      expect(resolvePromptEdit({ type: "move_left" }, state)).toEqual({
+        kind: "edit",
+        action: { kind: "move", direction: "left" },
+      });
+      expect(resolvePromptEdit({ type: "move_right" }, state)).toEqual({
+        kind: "edit",
+        action: { kind: "move", direction: "right" },
+      });
+      expect(resolvePromptEdit({ type: "move_home" }, state)).toEqual({
+        kind: "edit",
+        action: { kind: "move", direction: "home" },
+      });
+      expect(resolvePromptEdit({ type: "move_end" }, state)).toEqual({
+        kind: "edit",
+        action: { kind: "move", direction: "end" },
+      });
+    });
+
+    test("word moves map onto move-word actions", () => {
+      const state = { text: "foo bar", cursor: 3 };
+      expect(resolvePromptEdit({ type: "move_word_left" }, state)).toEqual({
+        kind: "edit",
+        action: { kind: "move-word", direction: "left" },
+      });
+      expect(resolvePromptEdit({ type: "move_word_right" }, state)).toEqual({
+        kind: "edit",
+        action: { kind: "move-word", direction: "right" },
+      });
+    });
+
+    test("vertical moves resolve to an absolute cursor through the wrapped layout", () => {
+      // "aaa bbb ccc" at width 5 soft-wraps to rows ["aaa ", "bbb ", "ccc"].
+      const up = resolvePromptEdit({ type: "move_up" }, { text: "aaa bbb ccc", cursor: 11 }, 5);
+      expect(up.kind).toBe("edit");
+      expect(up).toEqual({ kind: "edit", action: { kind: "set-cursor", cursor: 7 } });
+      const down = resolvePromptEdit({ type: "move_down" }, { text: "hello\nworld", cursor: 0 });
+      expect(down).toEqual({ kind: "edit", action: { kind: "set-cursor", cursor: 6 } });
+    });
+
+    test("an unwrapped vertical move ignores the wrapped geometry", () => {
+      expect(resolvePromptEdit({ type: "move_up" }, { text: "aaa bbb ccc", cursor: 11 })).toEqual({
+        kind: "edit",
+        action: { kind: "set-cursor", cursor: 11 },
+      });
+    });
+  });
+
+  test("submit carries no edit", () => {
+    expect(resolvePromptEdit({ type: "submit" }, { text: "ship it", cursor: 7 })).toEqual({ kind: "submit" });
+  });
+});
+
+describe("consumesMetaPrefix", () => {
+  test("edits and inert chords consume the prefix", () => {
+    expect(consumesMetaPrefix({ type: "noop" })).toBe(true);
+    expect(consumesMetaPrefix(insert("x"))).toBe(true);
+    expect(consumesMetaPrefix({ type: "delete_back" })).toBe(true);
+    expect(consumesMetaPrefix({ type: "delete_forward" })).toBe(true);
+    expect(consumesMetaPrefix({ type: "delete_word_back" })).toBe(true);
+    expect(consumesMetaPrefix({ type: "clear_line" })).toBe(true);
+  });
+
+  test("moves and submit leave the prefix armed", () => {
+    expect(consumesMetaPrefix({ type: "submit" })).toBe(false);
+    expect(consumesMetaPrefix({ type: "move_left" })).toBe(false);
+    expect(consumesMetaPrefix({ type: "move_right" })).toBe(false);
+    expect(consumesMetaPrefix({ type: "move_home" })).toBe(false);
+    expect(consumesMetaPrefix({ type: "move_end" })).toBe(false);
+    expect(consumesMetaPrefix({ type: "move_word_left" })).toBe(false);
+    expect(consumesMetaPrefix({ type: "move_word_right" })).toBe(false);
+    expect(consumesMetaPrefix({ type: "move_up" })).toBe(false);
+    expect(consumesMetaPrefix({ type: "move_down" })).toBe(false);
   });
 });

--- a/src/prompt-keymap.ts
+++ b/src/prompt-keymap.ts
@@ -88,7 +88,7 @@ export function consumesMetaPrefix(action: PromptAction): boolean {
 }
 
 const NONE: PromptEditDecision = { kind: "none" };
-const edit = (action: InputEditAction): PromptEditDecision => ({ kind: "edit", action });
+const asEdit = (action: InputEditAction): PromptEditDecision => ({ kind: "edit", action });
 
 export function resolvePromptEdit(
   action: PromptAction,
@@ -102,34 +102,34 @@ export function resolvePromptEdit(
     case "submit":
       return { kind: "submit" };
     case "move_home":
-      return edit({ kind: "move", direction: "home" });
+      return asEdit({ kind: "move", direction: "home" });
     case "move_end":
-      return edit({ kind: "move", direction: "end" });
+      return asEdit({ kind: "move", direction: "end" });
     case "move_left":
-      return edit({ kind: "move", direction: "left" });
+      return asEdit({ kind: "move", direction: "left" });
     case "move_right":
-      return edit({ kind: "move", direction: "right" });
+      return asEdit({ kind: "move", direction: "right" });
     case "move_word_left":
-      return edit({ kind: "move-word", direction: "left" });
+      return asEdit({ kind: "move-word", direction: "left" });
     case "move_word_right":
-      return edit({ kind: "move-word", direction: "right" });
+      return asEdit({ kind: "move-word", direction: "right" });
     case "move_up":
-      return edit({ kind: "set-cursor", cursor: moveLineUp(text, cursor, wrapWidth) });
+      return asEdit({ kind: "set-cursor", cursor: moveLineUp(text, cursor, wrapWidth) });
     case "move_down":
-      return edit({ kind: "set-cursor", cursor: moveLineDown(text, cursor, wrapWidth) });
+      return asEdit({ kind: "set-cursor", cursor: moveLineDown(text, cursor, wrapWidth) });
     case "delete_word_back":
-      return cursor === 0 ? NONE : edit({ kind: "delete-word-backward" });
+      return cursor === 0 ? NONE : asEdit({ kind: "delete-word-backward" });
     case "clear_line":
-      return text.length === 0 ? NONE : edit({ kind: "clear" });
+      return text.length === 0 ? NONE : asEdit({ kind: "clear" });
     case "delete_back":
-      return cursor === 0 ? NONE : edit({ kind: "delete-backward" });
+      return cursor === 0 ? NONE : asEdit({ kind: "delete-backward" });
     case "delete_forward":
-      return cursor >= text.length ? NONE : edit({ kind: "delete-forward" });
+      return cursor >= text.length ? NONE : asEdit({ kind: "delete-forward" });
     // A lone "?" opens help instead of typing, so it reaches the buffer only as paste.
     case "insert":
       return text.length === 0 && action.text === "?" && !action.paste
         ? NONE
-        : edit({ kind: "insert", text: action.text });
+        : asEdit({ kind: "insert", text: action.text });
     default:
       return unreachable(action);
   }

--- a/src/prompt-keymap.ts
+++ b/src/prompt-keymap.ts
@@ -1,3 +1,6 @@
+import { unreachable } from "./assert";
+import type { InputControllerState, InputEditAction } from "./input-controller";
+import { moveLineDown, moveLineUp } from "./prompt-display";
 import type { KeyEvent } from "./tui/context";
 
 export type PromptAction =
@@ -15,7 +18,19 @@ export type PromptAction =
   | { type: "clear_line" }
   | { type: "move_up" }
   | { type: "move_down" }
-  | { type: "insert"; text: string };
+  | { type: "insert"; text: string; paste: boolean };
+
+export type PromptEditDecision = { kind: "submit" } | { kind: "edit"; action: InputEditAction } | { kind: "none" };
+
+// Chords that consume the armed meta prefix; a move or a submit leaves it armed.
+const META_PREFIX_CONSUMERS = new Set<PromptAction["type"]>([
+  "noop",
+  "insert",
+  "delete_back",
+  "delete_forward",
+  "delete_word_back",
+  "clear_line",
+]);
 
 export function resolvePromptAction(input: string, key: KeyEvent, options: { hasMetaPrefix: boolean }): PromptAction {
   // Noop: tab, ctrl+c
@@ -26,8 +41,8 @@ export function resolvePromptAction(input: string, key: KeyEvent, options: { has
   if (key.downArrow) return { type: "move_down" };
 
   // Submit / newline
-  if (key.return && key.shift) return { type: "insert", text: "\n" };
-  if (key.return && key.meta) return { type: "insert", text: "\n" };
+  if (key.return && key.shift) return { type: "insert", text: "\n", paste: key.paste };
+  if (key.return && key.meta) return { type: "insert", text: "\n", paste: key.paste };
   if (key.return) return { type: "submit" };
 
   // Home: Home key, Cmd+Left, Ctrl+A
@@ -65,5 +80,57 @@ export function resolvePromptAction(input: string, key: KeyEvent, options: { has
   // No printable input or modifier held — noop
   if (!input || key.ctrl || key.meta) return { type: "noop" };
 
-  return { type: "insert", text: input };
+  return { type: "insert", text: input, paste: key.paste };
+}
+
+export function consumesMetaPrefix(action: PromptAction): boolean {
+  return META_PREFIX_CONSUMERS.has(action.type);
+}
+
+const NONE: PromptEditDecision = { kind: "none" };
+const edit = (action: InputEditAction): PromptEditDecision => ({ kind: "edit", action });
+
+export function resolvePromptEdit(
+  action: PromptAction,
+  state: InputControllerState,
+  wrapWidth?: number,
+): PromptEditDecision {
+  const { text, cursor } = state;
+  switch (action.type) {
+    case "noop":
+      return NONE;
+    case "submit":
+      return { kind: "submit" };
+    case "move_home":
+      return edit({ kind: "move", direction: "home" });
+    case "move_end":
+      return edit({ kind: "move", direction: "end" });
+    case "move_left":
+      return edit({ kind: "move", direction: "left" });
+    case "move_right":
+      return edit({ kind: "move", direction: "right" });
+    case "move_word_left":
+      return edit({ kind: "move-word", direction: "left" });
+    case "move_word_right":
+      return edit({ kind: "move-word", direction: "right" });
+    case "move_up":
+      return edit({ kind: "set-cursor", cursor: moveLineUp(text, cursor, wrapWidth) });
+    case "move_down":
+      return edit({ kind: "set-cursor", cursor: moveLineDown(text, cursor, wrapWidth) });
+    case "delete_word_back":
+      return cursor === 0 ? NONE : edit({ kind: "delete-word-backward" });
+    case "clear_line":
+      return text.length === 0 ? NONE : edit({ kind: "clear" });
+    case "delete_back":
+      return cursor === 0 ? NONE : edit({ kind: "delete-backward" });
+    case "delete_forward":
+      return cursor >= text.length ? NONE : edit({ kind: "delete-forward" });
+    // A lone "?" opens help instead of typing, so it reaches the buffer only as paste.
+    case "insert":
+      return text.length === 0 && action.text === "?" && !action.paste
+        ? NONE
+        : edit({ kind: "insert", text: action.text });
+    default:
+      return unreachable(action);
+  }
 }


### PR DESCRIPTION
## Summary

- delete the unreachable uncontrolled keystroke path and the `controlled` flag that selected it
- drop the dead props; `cursor` and `onAction` are now required
- add `resolvePromptEdit` and `consumesMetaPrefix` to `prompt-keymap.ts`, giving the guards, the help swallow, and meta-prefix clearing one owner each
- carry the paste bit on the `insert` action so the help swallow needs no key event
- fold `usePromptInput` into `PromptInputHandler`, leaving prefix timing, the state ref, and dispatch
- move the guard tests down to the pure layer; pin meta-prefix lifetime, keystrokes between renders, and `fromPaste`
