### PR TITLE
fix(prompt): correct the composer wrap model

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -163,6 +163,7 @@ A second premise is that completion belongs to the model, not the host. The runt
 - **TUI-10** — A queued message typed while a turn is running is handled cooperatively and processed in order rather than dropped or interleaved mid-step.
 - **TUI-11** — A user message preserves its whitespace in the transcript: leading indentation and internal whitespace runs are kept (tabs expanded to fixed-width stops), and a wrapped line repeats its indentation on each continuation row. Inline markup — backtick `code`, bold, and file paths — renders styled, with its delimiters interpreted. A fenced code block renders syntax-highlighted like assistant output, its fence interpreted; unfenced text stays verbatim.
 - **TUI-12** — Exiting the chat client releases its connection immediately, so an in-flight task is cancelled rather than left running to completion after the user has quit.
+- **TUI-13** — A typed prompt wraps inside the input box: no row exceeds the box interior, wrapping preserves every character, and a run too long for one row breaks across rows. Vertical cursor motion steps between visual rows at the caret's display column.
 
 ## 8. Observability requirements (OBS)
 

--- a/docs/chat-presentation.md
+++ b/docs/chat-presentation.md
@@ -39,7 +39,7 @@ The scene is the physical output of *lay out*. It contains no React nodes.
 | `sections` | `header`, one section per transcript row, optional `pending`, `composer`, and `footer`. |
 | `fill` | Optional line-level background role. |
 
-The scene is the only home for display-cell measurement, grapheme-safe wrapping, gutters, borders, background fill, and cursor geometry. A line fill paints from the first non-blank span to the row end, leaving leading indentation unpainted; diff bands can therefore span gutter, text, and trailing pad while span foregrounds remain independent.
+The scene is the only home for display-cell measurement, grapheme-safe wrapping, gutters, borders, background fill, and cursor geometry, apart from the composer's own row model below. A line fill paints from the first non-blank span to the row end, leaving leading indentation unpainted; diff bands can therefore span gutter, text, and trailing pad while span foregrounds remain independent.
 
 A section is **finalized** only when its bytes can never change. Streaming prose, active tools, pending rows, and mutable geometry are never finalized.
 
@@ -56,7 +56,8 @@ finalized section → immutable slice → terminal scrollback → removed from a
 
 ## Layout ownership
 
-- **One owner** — layout owns display-cell measurement, grapheme-safe wrapping, gutters, markers, borders, fills, ellipsis, diff line numbers, composer geometry, and cursor coordinates.
+- **One owner** — layout owns display-cell measurement, grapheme-safe wrapping, gutters, markers, borders, fills, ellipsis, diff line numbers, and cursor coordinates.
+- **Composer rows** — `prompt-display` wraps the typed prompt into rows that tile the text and fit the box interior in display cells, and maps a cursor offset to a row and column. Layout renders those rows and the input handler moves through them; neither re-derives the wrapping.
 - **Local coordinates** — sub-layouts receive only a width budget and lay out from column zero. Composition alone applies physical insets and frames.
 - **Shared tool layout** — CLI output and interactive chat consume the same tool layout, preserving ordering, headers, diff gutters, fitting, and truncation.
 - **One truncation rule** — content exceeding any width budget, terminal-wide or nested, receives a trailing ellipsis through the grapheme-aware layout helper.

--- a/src/prompt-display.test.ts
+++ b/src/prompt-display.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { buildPromptDisplayLines, cursorLineIndex, moveLineDown, moveLineUp } from "./prompt-display";
+import {
+  buildPromptDisplayLines,
+  cursorLineIndex,
+  moveLineDown,
+  moveLineUp,
+  promptDisplayRows,
+  softWrapLine,
+} from "./prompt-display";
 
 describe("prompt input word navigation", () => {
   test("buildPromptDisplayLines resolves cursor on multiline input", () => {
@@ -90,5 +97,96 @@ describe("moveLineUp/Down with wrapWidth", () => {
   test("moves down across wrapped segments", () => {
     const result = moveLineDown("aaa bbb ccc ddd", 2, 8);
     expect(result).toBe(10);
+  });
+});
+
+describe("softWrapLine", () => {
+  const cases: Array<[string, string, number]> = [
+    ["a run no row can hold", "a".repeat(120), 112],
+    ["an over-long run mid-line", `see https://example.com/${"x".repeat(100)} end`, 112],
+    ["a wrap that falls on a space run", "word ".repeat(30).trim(), 112],
+    ["runs of spaces only", " ".repeat(30), 8],
+    ["a line ending in spaces", `${"word ".repeat(4)}     `, 12],
+  ];
+
+  for (const [label, line, width] of cases) {
+    test(`tiles the line and holds the width: ${label}`, () => {
+      const rows = softWrapLine(line, width);
+      expect(rows.join("")).toBe(line);
+      for (const row of rows) expect(row.length).toBeLessThanOrEqual(width);
+    });
+  }
+
+  test("breaks a run that exceeds the width instead of overflowing the row", () => {
+    expect(softWrapLine("a".repeat(20), 8)).toEqual(["aaaaaaaa", "aaaaaaaa", "aaaa"]);
+  });
+
+  test("keeps a word whole when it fits on the next row", () => {
+    expect(softWrapLine("aaa bbbbbb", 8)).toEqual(["aaa ", "bbbbbb"]);
+  });
+});
+
+describe("promptDisplayRows", () => {
+  test("every row's text is the value's own slice at its offset", () => {
+    const value = `${"word ".repeat(30).trim()}\n${"b".repeat(200)}\n`;
+    for (const row of promptDisplayRows(value, 112)) {
+      expect(value.slice(row.startOffset, row.startOffset + row.text.length)).toBe(row.text);
+    }
+  });
+});
+
+describe("wrapped rows the composer cannot scroll sideways", () => {
+  const long = "a".repeat(120);
+
+  test("a run wider than the row reports the row the cursor is really on", () => {
+    expect(cursorLineIndex(long, 120, 112)).toBe(1);
+    expect(cursorLineIndex(long, 0, 112)).toBe(0);
+  });
+
+  test("vertical motion crosses a hard-broken run", () => {
+    expect(moveLineDown(long, 0, 112)).toBe(112);
+    expect(moveLineUp(long, 115, 112)).toBe(3);
+  });
+});
+
+describe("cursor on a wrap boundary", () => {
+  const value = "word ".repeat(30).trim();
+  const boundary = promptDisplayRows(value, 112)[0]?.text.length ?? 0;
+
+  test("moving up from the first column of a wrapped row lands on the row above", () => {
+    expect(moveLineUp(value, boundary, 112)).toBe(0);
+  });
+
+  test("moving down and back up returns to where it started", () => {
+    const down = moveLineDown(value, 0, 112);
+    expect(down).toBe(boundary);
+    expect(moveLineUp(value, down, 112)).toBe(0);
+  });
+});
+
+describe("wide characters and grapheme clusters", () => {
+  test("a run of double-width characters wraps on cells, not code units", () => {
+    const line = "漢字".repeat(40);
+    const rows = softWrapLine(line, 20);
+    expect(rows.join("")).toBe(line);
+    for (const row of rows) expect(Bun.stringWidth(row)).toBeLessThanOrEqual(20);
+    expect(rows.length).toBeGreaterThan(1);
+  });
+
+  test("a multi-codepoint emoji is never split across rows", () => {
+    const family = "👨‍👩‍👧‍👦";
+    const line = family.repeat(10);
+    const rows = softWrapLine(line, 8);
+    expect(rows.join("")).toBe(line);
+    for (const row of rows) {
+      expect(Bun.stringWidth(row)).toBeLessThanOrEqual(8);
+      expect(row.length % family.length).toBe(0);
+    }
+  });
+
+  test("vertical motion holds the visual column across a double-width row", () => {
+    // "漢字" is 4 cells wide but 2 code units, so column 4 lands on the fifth character below.
+    expect(moveLineDown("漢字漢字\nabcdefgh", 2)).toBe(9);
+    expect(moveLineUp("漢字漢字\nabcdefgh", 9)).toBe(2);
   });
 });

--- a/src/prompt-display.ts
+++ b/src/prompt-display.ts
@@ -1,105 +1,103 @@
-export function cursorLineIndex(value: string, cursorOffset: number, wrapWidth?: number): number {
-  const clamped = Math.max(0, Math.min(cursorOffset, value.length));
-  if (!wrapWidth) return value.slice(0, clamped).split("\n").length - 1;
-  const lines = buildPromptDisplayLines(value, clamped, wrapWidth);
-  for (let i = lines.length - 1; i >= 0; i--) {
-    if (lines[i]?.cursor !== null) return i;
+const graphemes = new Intl.Segmenter();
+
+// Rows are measured in display cells, the unit the composer box is sized in, while offsets stay
+// string indices, the unit the cursor moves in.
+function cells(text: string): number {
+  return Bun.stringWidth(text);
+}
+
+export type PromptDisplayRow = { text: string; startOffset: number };
+
+// Rows tile the value exactly: every character sits in one row, so an offset maps to a row and
+// column by summing row lengths. The composer renders these same rows, so its geometry and the
+// input handler's line math cannot disagree.
+export function promptDisplayRows(value: string, wrapWidth?: number): PromptDisplayRow[] {
+  const rows: PromptDisplayRow[] = [];
+  let offset = 0;
+  for (const line of value.split("\n")) {
+    let lineOffset = offset;
+    for (const segment of wrapWidth ? softWrapLine(line, wrapWidth) : [line]) {
+      rows.push({ text: segment, startOffset: lineOffset });
+      lineOffset += segment.length;
+    }
+    offset += line.length + 1;
+  }
+  return rows;
+}
+
+function rowIndexAt(rows: PromptDisplayRow[], offset: number): number {
+  for (let i = rows.length - 1; i >= 0; i--) {
+    if (offset >= (rows[i]?.startOffset ?? 0)) return i;
   }
   return 0;
 }
 
+function clampOffset(value: string, cursor: number): number {
+  return Math.max(0, Math.min(cursor, value.length));
+}
+
+export function cursorLineIndex(value: string, cursorOffset: number, wrapWidth?: number): number {
+  return rowIndexAt(promptDisplayRows(value, wrapWidth), clampOffset(value, cursorOffset));
+}
+
 export function moveLineUp(value: string, cursor: number, wrapWidth?: number): number {
-  if (wrapWidth) return moveVisualLine(value, cursor, wrapWidth, -1);
-  const clamped = Math.max(0, Math.min(cursor, value.length));
-  const before = value.slice(0, clamped);
-  const currentLineStart = before.lastIndexOf("\n") + 1;
-  if (currentLineStart === 0) return cursor;
-  const column = clamped - currentLineStart;
-  const prevLineEnd = currentLineStart - 1;
-  const prevLineStart = before.lastIndexOf("\n", prevLineEnd - 1) + 1;
-  const prevLineLength = prevLineEnd - prevLineStart;
-  return prevLineStart + Math.min(column, prevLineLength);
+  return moveRow(value, cursor, wrapWidth, -1);
 }
 
 export function moveLineDown(value: string, cursor: number, wrapWidth?: number): number {
-  if (wrapWidth) return moveVisualLine(value, cursor, wrapWidth, 1);
-  const clamped = Math.max(0, Math.min(cursor, value.length));
-  const before = value.slice(0, clamped);
-  const currentLineStart = before.lastIndexOf("\n") + 1;
-  const column = clamped - currentLineStart;
-  const nextNewline = value.indexOf("\n", clamped);
-  if (nextNewline === -1) return cursor;
-  const nextLineStart = nextNewline + 1;
-  const nextNextNewline = value.indexOf("\n", nextLineStart);
-  const nextLineLength = (nextNextNewline === -1 ? value.length : nextNextNewline) - nextLineStart;
-  return nextLineStart + Math.min(column, nextLineLength);
+  return moveRow(value, cursor, wrapWidth, 1);
 }
 
-function moveVisualLine(value: string, cursor: number, wrapWidth: number, direction: -1 | 1): number {
-  const clamped = Math.max(0, Math.min(cursor, value.length));
-  const displayLines = buildPromptDisplayLines(value, clamped, wrapWidth);
-  let currentIdx = 0;
-  for (let i = displayLines.length - 1; i >= 0; i--) {
-    if (displayLines[i]?.cursor !== null) {
-      currentIdx = i;
-      break;
-    }
+function moveRow(value: string, cursor: number, wrapWidth: number | undefined, direction: -1 | 1): number {
+  const clamped = clampOffset(value, cursor);
+  const rows = promptDisplayRows(value, wrapWidth);
+  const index = rowIndexAt(rows, clamped);
+  const current = rows[index];
+  const target = rows[index + direction];
+  if (!current || !target) return cursor;
+  const column = cells(current.text.slice(0, clamped - current.startOffset));
+  let used = 0;
+  let offset = target.startOffset;
+  for (const { segment } of graphemes.segment(target.text)) {
+    const segmentCells = cells(segment);
+    if (used + segmentCells > column) break;
+    used += segmentCells;
+    offset += segment.length;
   }
-  const targetIdx = currentIdx + direction;
-  if (targetIdx < 0 || targetIdx >= displayLines.length) return cursor;
-  let currentStartOffset = 0;
-  const logicalLines = value.split("\n");
-  let offset = 0;
-  outer: for (const line of logicalLines) {
-    const wrapped = softWrapLine(line, wrapWidth);
-    let lineOffset = offset;
-    for (const segment of wrapped) {
-      if (lineOffset <= clamped && clamped <= lineOffset + segment.length) {
-        currentStartOffset = lineOffset;
-        break outer;
-      }
-      lineOffset += segment.length;
-    }
-    offset += line.length + 1;
-  }
-  const column = clamped - currentStartOffset;
-
-  // Find target display line's start offset
-  let targetStartOffset = 0;
-  let displayIdx = 0;
-  offset = 0;
-  for (const line of logicalLines) {
-    const wrapped = softWrapLine(line, wrapWidth);
-    let lineOffset = offset;
-    for (const segment of wrapped) {
-      if (displayIdx === targetIdx) {
-        targetStartOffset = lineOffset;
-        const targetLength = segment.length;
-        return targetStartOffset + Math.min(column, targetLength);
-      }
-      lineOffset += segment.length;
-      displayIdx++;
-    }
-    offset += line.length + 1;
-  }
-  return cursor;
+  return offset;
 }
 
+// Greedy word wrap that never drops a character and never returns a row wider than `width` cells:
+// a run too long for any row is broken across rows, because the composer box cannot scroll
+// sideways. Only a single grapheme too wide for an empty row can exceed the width.
 export function softWrapLine(line: string, width: number): string[] {
-  if (width <= 0 || line.length <= width) return [line];
-  const words = line.split(/( +)/);
-  const result: string[] = [];
+  if (width <= 0 || cells(line) <= width) return [line];
+  const rows: string[] = [];
   let current = "";
-  for (const word of words) {
-    if (current.length + word.length <= width || current.length === 0) {
-      current += word;
-    } else {
-      result.push(current);
-      current = word.trimStart();
+  let used = 0;
+  const flush = () => {
+    rows.push(current);
+    current = "";
+    used = 0;
+  };
+  for (const token of line.split(/( +)/)) {
+    if (!token) continue;
+    const tokenCells = cells(token);
+    if (used > 0 && used + tokenCells > width && tokenCells <= width) flush();
+    if (used + tokenCells <= width) {
+      current += token;
+      used += tokenCells;
+      continue;
+    }
+    for (const { segment } of graphemes.segment(token)) {
+      const segmentCells = cells(segment);
+      if (used > 0 && used + segmentCells > width) flush();
+      current += segment;
+      used += segmentCells;
     }
   }
-  if (current.length > 0) result.push(current);
-  return result.length > 0 ? result : [""];
+  if (current.length > 0) rows.push(current);
+  return rows.length > 0 ? rows : [""];
 }
 
 export type PromptDisplayLine = {
@@ -109,38 +107,19 @@ export type PromptDisplayLine = {
 };
 
 export function buildPromptDisplayLines(value: string, cursorOffset: number, wrapWidth?: number): PromptDisplayLine[] {
-  const clamped = Math.max(0, Math.min(cursorOffset, value.length));
-  const logicalLines = value.split("\n");
-  const displayLines: { text: string; startOffset: number }[] = [];
-  let offset = 0;
-  for (let i = 0; i < logicalLines.length; i++) {
-    const line = logicalLines[i] ?? "";
-    const wrapped = wrapWidth ? softWrapLine(line, wrapWidth) : [line];
-    let lineOffset = offset;
-    for (const segment of wrapped) {
-      displayLines.push({ text: segment, startOffset: lineOffset });
-      lineOffset += segment.length;
-    }
-    offset += line.length + 1; // +1 for \n
-  }
-  let cursorDisplayLine = 0;
-  for (let i = displayLines.length - 1; i >= 0; i--) {
-    const dl = displayLines[i];
-    if (dl && clamped >= dl.startOffset) {
-      cursorDisplayLine = i;
-      break;
-    }
-  }
-  return displayLines.map((dl, index) => {
-    if (index !== cursorDisplayLine) return { before: dl.text, cursor: null, after: "" };
-    const col = clamped - dl.startOffset;
-    if (col < dl.text.length) {
+  const clamped = clampOffset(value, cursorOffset);
+  const rows = promptDisplayRows(value, wrapWidth);
+  const cursorRow = rowIndexAt(rows, clamped);
+  return rows.map((row, index) => {
+    if (index !== cursorRow) return { before: row.text, cursor: null, after: "" };
+    const column = clamped - row.startOffset;
+    if (column < row.text.length) {
       return {
-        before: dl.text.slice(0, col),
-        cursor: dl.text[col] ?? " ",
-        after: dl.text.slice(col + 1),
+        before: row.text.slice(0, column),
+        cursor: row.text[column] ?? " ",
+        after: row.text.slice(column + 1),
       };
     }
-    return { before: dl.text, cursor: " ", after: "" };
+    return { before: row.text, cursor: " ", after: "" };
   });
 }


### PR DESCRIPTION
## Motivation

The composer's rows could exceed the box interior and could drop characters, so the row table disagreed with what the terminal drew: the box border broke, vertical motion dropped keystrokes, and the first-row check that gates input-history recall misfired and overwrote a live draft.

## Summary

- wrap composer rows on display cells over graphemes, so a row never exceeds the box interior
- keep every character when wrapping, so a cursor offset maps to the row and column actually drawn
- break a run too long for any row instead of letting it overflow
- give the row table and its boundary rule one owner, replacing three walks that resolved boundaries differently
- state the contract as TUI-13 and name the row-model owner in the presentation doc
