### PR TITLE
fix(tui): drop the $ skills shortcut

### DIFF
--- a/src/chat-keybindings.test.ts
+++ b/src/chat-keybindings.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
-  resolveBareCharShortcut,
   resolveEscapeAction,
   resolveHistoryDown,
   resolveHistoryUp,
   resolveTabAutocomplete,
   shouldCycleInputHistory,
+  shouldToggleHelp,
 } from "./chat-keybindings";
+import { resolvePromptEdit } from "./prompt-keymap";
 
 describe("chat keybindings helpers", () => {
   test("resolveHistoryUp starts browsing from latest entry and saves draft", () => {
@@ -83,20 +84,28 @@ describe("chat keybindings helpers", () => {
     expect(resolveTabAutocomplete({ ...shared, isTab: true })).toBe("/help");
   });
 
-  test("resolveBareCharShortcut ignores pasted ? and $ so they insert as text", () => {
+  test("shouldToggleHelp ignores a pasted ? so it inserts as text", () => {
     // Regression: pasting text ending in "?" popped the help panel.
-    expect(resolveBareCharShortcut({ keyInput: "?", paste: true, valueLength: 0, isPending: false })).toBeNull();
-    expect(resolveBareCharShortcut({ keyInput: "$", paste: true, valueLength: 0, isPending: false })).toBeNull();
+    expect(shouldToggleHelp({ keyInput: "?", paste: true, valueLength: 0 })).toBeFalse();
   });
 
-  test("resolveBareCharShortcut fires only on a genuine keystroke on an empty field", () => {
-    expect(resolveBareCharShortcut({ keyInput: "?", paste: false, valueLength: 0, isPending: false })).toBe("help");
-    expect(resolveBareCharShortcut({ keyInput: "$", paste: false, valueLength: 0, isPending: false })).toBe("skills");
+  test("shouldToggleHelp fires only on a genuine keystroke on an empty field", () => {
+    expect(shouldToggleHelp({ keyInput: "?", paste: false, valueLength: 0 })).toBeTrue();
     // non-empty field: a real char in the text, not a shortcut
-    expect(resolveBareCharShortcut({ keyInput: "?", paste: false, valueLength: 3, isPending: false })).toBeNull();
-    // help works while pending; skills does not
-    expect(resolveBareCharShortcut({ keyInput: "?", paste: false, valueLength: 0, isPending: true })).toBe("help");
-    expect(resolveBareCharShortcut({ keyInput: "$", paste: false, valueLength: 0, isPending: true })).toBeNull();
+    expect(shouldToggleHelp({ keyInput: "?", paste: false, valueLength: 3 })).toBeFalse();
+  });
+
+  test("a typed $ is not a shortcut", () => {
+    // Regression: "$" opened the skills picker and left a stray character behind.
+    expect(shouldToggleHelp({ keyInput: "$", paste: false, valueLength: 0 })).toBeFalse();
+  });
+
+  test("a bare character is claimed by the shortcut rule or the composer, never both", () => {
+    for (const keyInput of ["?", "$", "/", "@", "a"]) {
+      const shortcut = shouldToggleHelp({ keyInput, paste: false, valueLength: 0 });
+      const decision = resolvePromptEdit({ type: "insert", text: keyInput, paste: false }, { text: "", cursor: 0 });
+      expect(shortcut).toBe(decision.kind === "none");
+    }
   });
 
   test("resolveEscapeAction prefers interrupt while thinking", () => {

--- a/src/chat-keybindings.ts
+++ b/src/chat-keybindings.ts
@@ -25,21 +25,12 @@ type ResolveTabAutocompleteInput = {
   isGhostAccept?: boolean;
 };
 
-export type BareCharShortcut = "help" | "skills" | null;
-
-// `?`/`$` on an empty input are shortcuts only for a genuine keystroke — never
-// for a pasted character, which must insert literally (a paste with "?" would
-// otherwise pop the help panel).
-export function resolveBareCharShortcut(params: {
-  keyInput: string;
-  paste: boolean;
-  valueLength: number;
-  isPending: boolean;
-}): BareCharShortcut {
-  if (params.paste || params.valueLength !== 0) return null;
-  if (params.keyInput === "?") return "help";
-  if (params.keyInput === "$" && !params.isPending) return "skills";
-  return null;
+// `?` on an empty input is a shortcut only for a genuine keystroke — never for a
+// pasted character, which must insert literally (a paste with "?" would otherwise
+// pop the help panel).
+export function shouldToggleHelp(params: { keyInput: string; paste: boolean; valueLength: number }): boolean {
+  if (params.paste || params.valueLength !== 0) return false;
+  return params.keyInput === "?";
 }
 
 export function resolveHistoryUp(
@@ -132,7 +123,6 @@ type UseChatKeybindingsInput = {
   setSlashSuggestionIndex: (next: number | ((current: number) => number)) => void;
   setInputHistoryIndex: (next: number | ((current: number) => number)) => void;
   setInputHistoryDraft: (next: string) => void;
-  openSkillsPanel: () => Promise<void>;
   showHelp: boolean;
   setShowHelp: (next: boolean | ((current: boolean) => boolean)) => void;
   interruptCurrentTurn: () => void;
@@ -267,17 +257,7 @@ export function useChatKeybindings(input: UseChatKeybindingsInput): void {
           return;
         }
       }
-      const bareShortcut = resolveBareCharShortcut({
-        keyInput,
-        paste: key.paste,
-        valueLength: input.value.length,
-        isPending: input.isPending,
-      });
-      if (bareShortcut === "skills") {
-        void input.openSkillsPanel();
-        return;
-      }
-      if (bareShortcut === "help") {
+      if (shouldToggleHelp({ keyInput, paste: key.paste, valueLength: input.value.length })) {
         input.setShowHelp((current) => !current);
         return;
       }

--- a/src/chat-state.ts
+++ b/src/chat-state.ts
@@ -365,7 +365,6 @@ export function useChatState(props: ChatAppProps, exit: () => void): ChatStateRe
     setSlashSuggestionIndex,
     setInputHistoryIndex,
     setInputHistoryDraft,
-    openSkillsPanel,
     showHelp,
     setShowHelp,
     interruptCurrentTurn: () => {

--- a/src/prompt-keymap.test.ts
+++ b/src/prompt-keymap.test.ts
@@ -226,6 +226,13 @@ describe("resolvePromptEdit", () => {
         action: { kind: "insert", text: "?" },
       });
     });
+
+    test("a lone '$' on an empty buffer inserts", () => {
+      expect(resolvePromptEdit(insert("$"), { text: "", cursor: 0 })).toEqual({
+        kind: "edit",
+        action: { kind: "insert", text: "$" },
+      });
+    });
   });
 
   describe("movement", () => {


### PR DESCRIPTION
## Summary

- a typed `$` on an empty composer now inserts literally instead of opening the skills picker and leaving a stray character behind
- `/skills` and `/<skill-name>` stay the ways to reach skills
- `resolveBareCharShortcut` becomes `shouldToggleHelp`, `?` being the only bare-character shortcut left
- pins that a bare character is claimed by the shortcut rule or the composer, never both