### PR TITLE
refactor(chat): dispatch commands from a registry

### DIFF
--- a/src/chat-command-registry.test.ts
+++ b/src/chat-command-registry.test.ts
@@ -57,6 +57,27 @@ describe("runCommandEntry", () => {
   });
 });
 
+describe("runCommandEntry argument arity", () => {
+  const createBareEntry = (usage?: string): CommandEntry => ({
+    spec: { name: "bare", source: "builtin", helpKey: "chat.slash.help.new", usage, subcommands: [] },
+    run: async () => ({ stop: true, userText: "ran" }),
+  });
+
+  test("refuses extra tokens for a root that declares no arguments", () => {
+    expect(runCommandEntry(createBareEntry(), ctx, parseSlashCommand("/bare some idea"))).toBeNull();
+  });
+
+  test("accepts arguments for a root that declares a usage form", async () => {
+    const result = runCommandEntry(createBareEntry("/bare <id>"), ctx, parseSlashCommand("/bare abc"));
+    expect(await result).toEqual({ stop: true, userText: "ran" });
+  });
+
+  test("still runs a bare root that declares no arguments", async () => {
+    const result = runCommandEntry(createBareEntry(), ctx, parseSlashCommand("/bare"));
+    expect(await result).toEqual({ stop: true, userText: "ran" });
+  });
+});
+
 describe("resolveCommandRegistry", () => {
   test("holds exactly one entry per name", () => {
     const names = resolveCommandRegistry().map((entry) => entry.spec.name);

--- a/src/chat-command-registry.test.ts
+++ b/src/chat-command-registry.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { appConfig } from "./app-config";
+import { findCommandEntry, resolveCommandRegistry, runCommandEntry } from "./chat-command-registry";
+import type { CommandContext, CommandEntry, ParsedCommand } from "./chat-commands-contract";
+import { parseSlashCommand } from "./chat-commands-contract";
+import { chatSlashCommands } from "./chat-slash";
+
+function setWorkspacesEnabled(enabled: boolean): () => void {
+  const cfg = appConfig as unknown as { features: { workspaces: boolean } };
+  const prev = cfg.features.workspaces;
+  cfg.features.workspaces = enabled;
+  return () => {
+    cfg.features.workspaces = prev;
+  };
+}
+
+function createProbeEntry(seen: { parsed: ParsedCommand | null; handler: string }): CommandEntry {
+  const record = (handler: string) => async (_ctx: CommandContext, parsed: ParsedCommand) => {
+    seen.parsed = parsed;
+    seen.handler = handler;
+    return { stop: true, userText: handler };
+  };
+  return {
+    spec: {
+      name: "probe",
+      source: "builtin",
+      helpKey: "chat.slash.help.memory",
+      subcommands: [{ name: "rm", usage: "/probe rm <id>", helpKey: "chat.slash.help.memory.rm" }],
+    },
+    run: record("root"),
+    runSub: { rm: record("rm") },
+  };
+}
+
+const ctx = {} as CommandContext;
+
+describe("runCommandEntry", () => {
+  test("routes a declared subcommand to its handler with the remaining args", async () => {
+    const seen = { parsed: null as ParsedCommand | null, handler: "" };
+    await runCommandEntry(createProbeEntry(seen), ctx, parseSlashCommand("/probe rm mem_abc"));
+    expect(seen.handler).toBe("rm");
+    expect(seen.parsed?.args).toEqual(["mem_abc"]);
+  });
+
+  test("routes a bare root to the root handler with no args", async () => {
+    const seen = { parsed: null as ParsedCommand | null, handler: "" };
+    await runCommandEntry(createProbeEntry(seen), ctx, parseSlashCommand("/probe"));
+    expect(seen.handler).toBe("root");
+    expect(seen.parsed?.args).toEqual([]);
+  });
+
+  test("folds an undeclared token into the root handler's args", async () => {
+    const seen = { parsed: null as ParsedCommand | null, handler: "" };
+    await runCommandEntry(createProbeEntry(seen), ctx, parseSlashCommand("/probe unknown extra"));
+    expect(seen.handler).toBe("root");
+    expect(seen.parsed?.args).toEqual(["unknown", "extra"]);
+  });
+});
+
+describe("resolveCommandRegistry", () => {
+  test("holds exactly one entry per name", () => {
+    const names = resolveCommandRegistry().map((entry) => entry.spec.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("declares a handler for every declared subcommand", () => {
+    for (const entry of resolveCommandRegistry()) {
+      for (const sub of entry.spec.subcommands) {
+        expect(entry.runSub?.[sub.name]).toBeFunction();
+      }
+    }
+  });
+
+  test("holds an entry for every enumerated slash command", () => {
+    const restore = setWorkspacesEnabled(true);
+    try {
+      for (const command of chatSlashCommands()) {
+        expect(findCommandEntry(command.slice(1))?.spec.name).toBe(command.slice(1));
+      }
+    } finally {
+      restore();
+    }
+  });
+
+  test("omits a flagged command while its flag is off", () => {
+    const restore = setWorkspacesEnabled(false);
+    try {
+      expect(findCommandEntry("workspaces")).toBeNull();
+    } finally {
+      restore();
+    }
+  });
+
+  test("includes a flagged command while its flag is on", () => {
+    const restore = setWorkspacesEnabled(true);
+    try {
+      expect(findCommandEntry("workspaces")?.spec.name).toBe("workspaces");
+    } finally {
+      restore();
+    }
+  });
+});

--- a/src/chat-command-registry.ts
+++ b/src/chat-command-registry.ts
@@ -20,7 +20,7 @@ const BUILTIN_COMMANDS: CommandEntry[] = [
     run: runClear,
   },
   {
-    spec: { name: "model", source: "builtin", helpKey: "chat.slash.help.model", subcommands: [] },
+    spec: { name: "model", source: "builtin", helpKey: "chat.slash.help.model", usage: "/model <id>", subcommands: [] },
     run: runModel,
   },
   {
@@ -51,7 +51,13 @@ const BUILTIN_COMMANDS: CommandEntry[] = [
     run: runSkillsPanel,
   },
   {
-    spec: { name: "resume", source: "builtin", helpKey: "chat.slash.help.resume", subcommands: [] },
+    spec: {
+      name: "resume",
+      source: "builtin",
+      helpKey: "chat.slash.help.resume",
+      usage: "/resume <session-id-prefix>",
+      subcommands: [],
+    },
     run: runResume,
   },
   {
@@ -87,14 +93,17 @@ export function findCommandEntry(name: string): CommandEntry | null {
   return resolveCommandRegistry().find((entry) => entry.spec.name === name) ?? null;
 }
 
+/** Null when the entry does not accept this input, so the caller reports an unknown command. */
 export function runCommandEntry(
   entry: CommandEntry,
   ctx: CommandContext,
   parsed: ParsedCommand,
-): Promise<CommandResult> {
+): Promise<CommandResult> | null {
   const declared = entry.spec.subcommands.some((sub) => sub.name === parsed.sub);
   const handler = declared ? entry.runSub?.[parsed.sub] : undefined;
   if (handler) return handler(ctx, parsed);
   const args = parsed.sub === "" ? parsed.args : [parsed.sub, ...parsed.args];
+  const takesArgs = entry.spec.usage !== undefined || entry.spec.subcommands.length > 0;
+  if (args.length > 0 && !takesArgs) return null;
   return entry.run(ctx, { ...parsed, sub: "", args });
 }

--- a/src/chat-command-registry.ts
+++ b/src/chat-command-registry.ts
@@ -1,0 +1,100 @@
+import { appConfig } from "./app-config";
+import type { CommandContext, CommandEntry, CommandResult, ParsedCommand } from "./chat-commands-contract";
+import { runMemoryAdd, runMemoryList, runMemoryRemove } from "./chat-commands-memory";
+import { runModel } from "./chat-commands-model";
+import { runResume } from "./chat-commands-resume";
+import { runClear, runExit, runNew } from "./chat-commands-session";
+import { runSessions } from "./chat-commands-sessions";
+import { runSkillsPanel } from "./chat-commands-skill";
+import { runStatus } from "./chat-commands-status";
+import { runUsage } from "./chat-commands-usage";
+import { runWorkspacesList, runWorkspacesNew, runWorkspacesSwitch } from "./chat-commands-workspaces";
+
+const BUILTIN_COMMANDS: CommandEntry[] = [
+  {
+    spec: { name: "new", source: "builtin", helpKey: "chat.slash.help.new", subcommands: [] },
+    run: runNew,
+  },
+  {
+    spec: { name: "clear", source: "builtin", helpKey: "chat.slash.help.clear", subcommands: [] },
+    run: runClear,
+  },
+  {
+    spec: { name: "model", source: "builtin", helpKey: "chat.slash.help.model", subcommands: [] },
+    run: runModel,
+  },
+  {
+    spec: { name: "status", source: "builtin", helpKey: "chat.slash.help.status", subcommands: [] },
+    run: runStatus,
+  },
+  {
+    spec: { name: "sessions", source: "builtin", helpKey: "chat.slash.help.sessions", subcommands: [] },
+    run: runSessions,
+  },
+  {
+    spec: {
+      name: "workspaces",
+      source: "builtin",
+      helpKey: "chat.slash.help.workspaces",
+      flag: "workspaces",
+      subcommands: [
+        { name: "list", usage: "/workspaces list", helpKey: "chat.slash.help.workspaces.list" },
+        { name: "new", usage: "/workspaces new <name> [-- <prompt>]", helpKey: "chat.slash.help.workspaces.new" },
+        { name: "switch", usage: "/workspaces switch <name>", helpKey: "chat.slash.help.workspaces.switch" },
+      ],
+    },
+    run: runWorkspacesList,
+    runSub: { list: runWorkspacesList, new: runWorkspacesNew, switch: runWorkspacesSwitch },
+  },
+  {
+    spec: { name: "skills", source: "builtin", helpKey: "chat.slash.help.skills", subcommands: [] },
+    run: runSkillsPanel,
+  },
+  {
+    spec: { name: "resume", source: "builtin", helpKey: "chat.slash.help.resume", subcommands: [] },
+    run: runResume,
+  },
+  {
+    spec: {
+      name: "memory",
+      source: "builtin",
+      helpKey: "chat.slash.help.memory",
+      subcommands: [
+        { name: "add", usage: "/memory add [--user|--project] <memory text>", helpKey: "chat.slash.help.memory.add" },
+        { name: "rm", usage: "/memory rm <id-prefix>", helpKey: "chat.slash.help.memory.rm" },
+        { name: "list", usage: "/memory list [all|user|project] [--archived]", helpKey: "chat.slash.help.memory.list" },
+      ],
+    },
+    run: runMemoryList,
+    runSub: { add: runMemoryAdd, rm: runMemoryRemove, list: runMemoryList },
+  },
+  {
+    spec: { name: "usage", source: "builtin", helpKey: "chat.slash.help.usage", subcommands: [] },
+    run: runUsage,
+  },
+  {
+    spec: { name: "exit", source: "builtin", helpKey: "chat.slash.help.exit", subcommands: [] },
+    run: runExit,
+  },
+];
+
+/** Commands available right now: a flagged command is absent while its flag is off, never inert. */
+export function resolveCommandRegistry(): CommandEntry[] {
+  return BUILTIN_COMMANDS.filter((entry) => entry.spec.flag === undefined || appConfig.features[entry.spec.flag]);
+}
+
+export function findCommandEntry(name: string): CommandEntry | null {
+  return resolveCommandRegistry().find((entry) => entry.spec.name === name) ?? null;
+}
+
+export function runCommandEntry(
+  entry: CommandEntry,
+  ctx: CommandContext,
+  parsed: ParsedCommand,
+): Promise<CommandResult> {
+  const declared = entry.spec.subcommands.some((sub) => sub.name === parsed.sub);
+  const handler = declared ? entry.runSub?.[parsed.sub] : undefined;
+  if (handler) return handler(ctx, parsed);
+  const args = parsed.sub === "" ? parsed.args : [parsed.sub, ...parsed.args];
+  return entry.run(ctx, { ...parsed, sub: "", args });
+}

--- a/src/chat-commands-contract.test.ts
+++ b/src/chat-commands-contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { dispatchSubcommandGroup, parseSlashCommand, type SubcommandGroup } from "./chat-commands-contract";
+import { parseSlashCommand } from "./chat-commands-contract";
 
 describe("parseSlashCommand", () => {
   test("parses root only", () => {
@@ -45,86 +45,5 @@ describe("parseSlashCommand", () => {
       args: ["fix-auth", "--", "do", "stuff"],
       raw: "/workspaces new fix-auth -- do stuff",
     });
-  });
-});
-
-describe("dispatchSubcommandGroup", () => {
-  test("dispatches to matching subcommand", async () => {
-    const group: SubcommandGroup = {
-      root: "test",
-      subcommands: [
-        {
-          name: "rm",
-          match: (sub) => sub === "rm",
-          run: async (parsed) => ({ stop: true, userText: `removed:${parsed.args[0]}` }),
-        },
-      ],
-      fallback: async () => ({ stop: true, userText: "fallback" }),
-    };
-    const result = await dispatchSubcommandGroup(group, "/test rm item");
-    expect(result).toEqual({ stop: true, userText: "removed:item" });
-  });
-
-  test("uses first matching subcommand", async () => {
-    const group: SubcommandGroup = {
-      root: "test",
-      subcommands: [
-        { name: "first", match: () => true, run: async () => ({ stop: true, userText: "first" }) },
-        { name: "second", match: () => true, run: async () => ({ stop: true, userText: "second" }) },
-      ],
-      fallback: async () => ({ stop: true, userText: "fallback" }),
-    };
-    const result = await dispatchSubcommandGroup(group, "/test anything");
-    expect(result.userText).toBe("first");
-  });
-
-  test("falls back when no subcommand matches", async () => {
-    const group: SubcommandGroup = {
-      root: "test",
-      subcommands: [{ name: "rm", match: (sub) => sub === "rm", run: async () => ({ stop: true, userText: "rm" }) }],
-      fallback: async () => ({ stop: true, userText: "fallback" }),
-    };
-    const result = await dispatchSubcommandGroup(group, "/test unknown");
-    expect(result.userText).toBe("fallback");
-  });
-
-  test("falls back for bare root command", async () => {
-    const group: SubcommandGroup = {
-      root: "test",
-      subcommands: [{ name: "rm", match: (sub) => sub === "rm", run: async () => ({ stop: true, userText: "rm" }) }],
-      fallback: async () => ({ stop: true, userText: "fallback" }),
-    };
-    const result = await dispatchSubcommandGroup(group, "/test");
-    expect(result.userText).toBe("fallback");
-  });
-
-  test("passes args to subcommand match", async () => {
-    let receivedArgs: string[] = [];
-    const group: SubcommandGroup = {
-      root: "test",
-      subcommands: [
-        {
-          name: "check",
-          match: (_sub, args) => {
-            receivedArgs = args;
-            return true;
-          },
-          run: async () => ({ stop: true, userText: "ok" }),
-        },
-      ],
-      fallback: async () => ({ stop: true, userText: "fallback" }),
-    };
-    await dispatchSubcommandGroup(group, "/test check a b c");
-    expect(receivedArgs).toEqual(["a", "b", "c"]);
-  });
-
-  test("falls back when subcommands array is empty", async () => {
-    const group: SubcommandGroup = {
-      root: "test",
-      subcommands: [],
-      fallback: async () => ({ stop: true, userText: "fallback" }),
-    };
-    const result = await dispatchSubcommandGroup(group, "/test anything");
-    expect(result.userText).toBe("fallback");
   });
 });

--- a/src/chat-commands-contract.ts
+++ b/src/chat-commands-contract.ts
@@ -1,6 +1,8 @@
+import { z } from "zod";
 import type { ChatRow } from "./chat-contract";
 import type { Client } from "./client-contract";
 import type { ConfigScope } from "./config-contract";
+import { featureFlagNameSchema } from "./feature-flags-contract";
 import type { addMemory, listArchivedMemories, listMemories, removeMemory } from "./memory-ops";
 import type { Session, SessionState, SessionTokenUsageEntry } from "./session-contract";
 
@@ -39,29 +41,11 @@ export type CommandContext = {
   }>;
 };
 
-export type SlashCommand = {
-  name: string;
-  match: (value: string) => boolean;
-  run: () => Promise<CommandResult>;
-};
-
 export type ParsedCommand = {
   root: string;
   sub: string;
   args: string[];
   raw: string;
-};
-
-export type Subcommand = {
-  name: string;
-  match: (sub: string, args: string[]) => boolean;
-  run: (parsed: ParsedCommand) => Promise<CommandResult>;
-};
-
-export type SubcommandGroup = {
-  root: string;
-  subcommands: Subcommand[];
-  fallback: (parsed: ParsedCommand) => Promise<CommandResult>;
 };
 
 export function parseSlashCommand(text: string): ParsedCommand {
@@ -72,10 +56,36 @@ export function parseSlashCommand(text: string): ParsedCommand {
   return { root, sub, args, raw: text };
 }
 
-export function dispatchSubcommandGroup(group: SubcommandGroup, text: string): Promise<CommandResult> {
-  const parsed = parseSlashCommand(text);
-  for (const sub of group.subcommands) {
-    if (sub.match(parsed.sub, parsed.args)) return sub.run(parsed);
-  }
-  return group.fallback(parsed);
-}
+export const commandSourceSchema = z.enum(["builtin", "project", "user", "bundled"]);
+export type CommandSource = z.infer<typeof commandSourceSchema>;
+
+export const commandRefSchema = z.object({
+  name: z.string(),
+  source: commandSourceSchema,
+});
+export type CommandRef = z.infer<typeof commandRefSchema>;
+
+export const subcommandSpecSchema = z.object({
+  name: z.string(),
+  usage: z.string(),
+  helpKey: z.string(),
+});
+export type SubcommandSpec = z.infer<typeof subcommandSpecSchema>;
+
+export const commandSpecSchema = z.object({
+  name: z.string(),
+  source: commandSourceSchema,
+  helpKey: z.string(),
+  flag: featureFlagNameSchema.optional(),
+  subcommands: z.array(subcommandSpecSchema),
+});
+export type CommandSpec = z.infer<typeof commandSpecSchema>;
+
+export type CommandHandler = (ctx: CommandContext, parsed: ParsedCommand) => Promise<CommandResult>;
+
+export type CommandEntry = {
+  spec: CommandSpec;
+  /** Runs a bare root and any undeclared token, which arrives as the handler's first argument. */
+  run: CommandHandler;
+  runSub?: Record<string, CommandHandler>;
+};

--- a/src/chat-commands-contract.ts
+++ b/src/chat-commands-contract.ts
@@ -57,26 +57,20 @@ export function parseSlashCommand(text: string): ParsedCommand {
 }
 
 export const commandSourceSchema = z.enum(["builtin", "project", "user", "bundled"]);
-export type CommandSource = z.infer<typeof commandSourceSchema>;
-
-export const commandRefSchema = z.object({
-  name: z.string(),
-  source: commandSourceSchema,
-});
-export type CommandRef = z.infer<typeof commandRefSchema>;
 
 export const subcommandSpecSchema = z.object({
   name: z.string(),
   usage: z.string(),
   helpKey: z.string(),
 });
-export type SubcommandSpec = z.infer<typeof subcommandSpecSchema>;
 
 export const commandSpecSchema = z.object({
   name: z.string(),
   source: commandSourceSchema,
   helpKey: z.string(),
   flag: featureFlagNameSchema.optional(),
+  /** Argument form of the bare root. Absent means the root takes none, and extra tokens are not this command. */
+  usage: z.string().optional(),
   subcommands: z.array(subcommandSpecSchema),
 });
 export type CommandSpec = z.infer<typeof commandSpecSchema>;

--- a/src/chat-commands-memory.ts
+++ b/src/chat-commands-memory.ts
@@ -1,11 +1,4 @@
-import type {
-  CommandContext,
-  CommandResult,
-  ParsedCommand,
-  SlashCommand,
-  SubcommandGroup,
-} from "./chat-commands-contract";
-import { dispatchSubcommandGroup } from "./chat-commands-contract";
+import type { CommandContext, CommandHandler, CommandResult, ParsedCommand } from "./chat-commands-contract";
 import { createRow } from "./chat-contract";
 import { formatUsage } from "./cli-help";
 import { t } from "./i18n";
@@ -77,13 +70,18 @@ async function handleMemoryList(
   parsed: ParsedCommand,
 ): Promise<CommandResult> {
   const { text } = ctx;
-  const scopeToken = parsed.sub === ARCHIVED_FLAG ? "" : parsed.sub;
-  const scope: MemoryContextScope = scopeToken === "" ? "all" : (scopeToken as MemoryContextScope);
-  const archived = parsed.sub === ARCHIVED_FLAG || parsed.args.includes(ARCHIVED_FLAG);
-  if (parsed.args.some((arg) => arg !== ARCHIVED_FLAG)) {
+  const archived = parsed.args.includes(ARCHIVED_FLAG);
+  const scopeTokens = parsed.args.filter((arg) => arg !== ARCHIVED_FLAG);
+  const scopeToken = scopeTokens[0] ?? "";
+  if (scopeToken !== "" && !isMemoryContextScope(scopeToken)) {
+    ctx.setRows((current) => [...current, createRow("system", formatUsage("/memory [add|rm|all|user|project]"))]);
+    return { stop: true, userText: text };
+  }
+  if (scopeTokens.length > 1) {
     ctx.setRows((current) => [...current, createRow("system", formatUsage("/memory [all|user|project] [--archived]"))]);
     return { stop: true, userText: text };
   }
+  const scope: MemoryContextScope = scopeToken === "" ? "all" : scopeToken;
   const resolvedScope = scope === "all" ? undefined : scope;
   try {
     if (archived) return await renderArchivedList(ctx, memoryApi, scope, resolvedScope);
@@ -186,43 +184,8 @@ async function handleMemoryAdd(
   return { stop: true, userText: text };
 }
 
-function createMemoryGroup(ctx: CommandContext, memoryApi: ReturnType<typeof resolveMemoryApi>): SubcommandGroup {
-  return {
-    root: "memory",
-    subcommands: [
-      {
-        name: "rm",
-        match: (sub) => sub === "rm",
-        run: (parsed) => handleMemoryRemove(ctx, memoryApi, parsed),
-      },
-      {
-        name: "add",
-        match: (sub) => sub === "add",
-        run: (parsed) => handleMemoryAdd(ctx, memoryApi, parsed),
-      },
-      {
-        name: "list",
-        match: (sub) => sub === "" || sub === ARCHIVED_FLAG || isMemoryContextScope(sub),
-        run: (parsed) => handleMemoryList(ctx, memoryApi, parsed),
-      },
-    ],
-    fallback: async () => {
-      ctx.setRows((current) => [...current, createRow("system", formatUsage("/memory [add|rm|all|user|project]"))]);
-      return { stop: true, userText: ctx.text };
-    },
-  };
-}
+export const runMemoryList: CommandHandler = (ctx, parsed) => handleMemoryList(ctx, resolveMemoryApi(ctx), parsed);
 
-export function createMemoryCommands(
-  ctx: CommandContext,
-  memoryApi: ReturnType<typeof resolveMemoryApi>,
-): SlashCommand[] {
-  const group = createMemoryGroup(ctx, memoryApi);
-  return [
-    {
-      name: "memory",
-      match: (value) => value === "/memory" || value.startsWith("/memory "),
-      run: () => dispatchSubcommandGroup(group, ctx.resolvedText),
-    },
-  ];
-}
+export const runMemoryAdd: CommandHandler = (ctx, parsed) => handleMemoryAdd(ctx, resolveMemoryApi(ctx), parsed);
+
+export const runMemoryRemove: CommandHandler = (ctx, parsed) => handleMemoryRemove(ctx, resolveMemoryApi(ctx), parsed);

--- a/src/chat-commands-model.ts
+++ b/src/chat-commands-model.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { setModel } from "./app-config";
-import type { CommandContext, CommandResult, SlashCommand } from "./chat-commands-contract";
+import type { CommandContext, CommandHandler, CommandResult } from "./chat-commands-contract";
 import { createRow } from "./chat-contract";
 import { formatUsage } from "./cli-help";
 import { setConfigValue } from "./config";
@@ -54,9 +54,5 @@ async function handleModelSet(ctx: CommandContext): Promise<CommandResult> {
   return { stop: true, userText: text };
 }
 
-export function createModelCommands(ctx: CommandContext): SlashCommand[] {
-  return [
-    { name: "model.panel", match: (value) => value === "/model", run: () => handleModelPanel(ctx) },
-    { name: "model.set", match: (value) => value.startsWith("/model "), run: () => handleModelSet(ctx) },
-  ];
-}
+export const runModel: CommandHandler = (ctx, parsed) =>
+  parsed.args.length === 0 ? handleModelPanel(ctx) : handleModelSet(ctx);

--- a/src/chat-commands-resume.ts
+++ b/src/chat-commands-resume.ts
@@ -1,4 +1,4 @@
-import type { CommandContext, CommandResult, SlashCommand } from "./chat-commands-contract";
+import type { CommandContext, CommandHandler, CommandResult } from "./chat-commands-contract";
 import { formatSessionList } from "./chat-commands-sessions";
 import { type ChatRow, createRow } from "./chat-contract";
 import { formatUsage } from "./cli-help";
@@ -67,9 +67,5 @@ async function handleResume(ctx: CommandContext): Promise<CommandResult> {
   return { stop: true, userText: text };
 }
 
-export function createResumeCommands(ctx: CommandContext): SlashCommand[] {
-  return [
-    { name: "resume.panel", match: (value) => value === "/resume", run: () => handleResumePanel(ctx) },
-    { name: "resume", match: (value) => value.startsWith("/resume"), run: () => handleResume(ctx) },
-  ];
-}
+export const runResume: CommandHandler = (ctx, parsed) =>
+  parsed.args.length === 0 ? handleResumePanel(ctx) : handleResume(ctx);

--- a/src/chat-commands-session.ts
+++ b/src/chat-commands-session.ts
@@ -1,0 +1,27 @@
+import { appConfig } from "./app-config";
+import type { CommandHandler } from "./chat-commands-contract";
+import { createSession } from "./session-store";
+
+export const runNew: CommandHandler = async (ctx) => {
+  const next = createSession(appConfig.model);
+  ctx.sessionState.sessions.unshift(next);
+  ctx.sessionState.activeSessionId = next.id;
+  ctx.setCurrentSession(next);
+  ctx.setTokenUsage?.(() => []);
+  ctx.clearTranscript(next.id);
+  ctx.setValue("");
+  ctx.setShowHelp(() => false);
+  await ctx.persist();
+  return { stop: true, userText: ctx.text };
+};
+
+export const runClear: CommandHandler = async (ctx) => {
+  ctx.clearTranscript();
+  return { stop: true, userText: ctx.text };
+};
+
+export const runExit: CommandHandler = async (ctx) => {
+  await ctx.persist();
+  ctx.exit();
+  return { stop: true, userText: ctx.text };
+};

--- a/src/chat-commands-sessions.ts
+++ b/src/chat-commands-sessions.ts
@@ -1,3 +1,4 @@
+import type { CommandHandler } from "./chat-commands-contract";
 import { type ChatRow, createRow } from "./chat-contract";
 import { alignCols } from "./chat-format";
 import { GLYPH_FILLED } from "./chat-glyphs";
@@ -24,3 +25,8 @@ export function sessionsRows(sessionState: SessionState, limit = 10): ChatRow[] 
     }),
   ];
 }
+
+export const runSessions: CommandHandler = async (ctx) => {
+  ctx.setRows((current) => [...current, ...sessionsRows(ctx.sessionState, 10)]);
+  return { stop: true, userText: ctx.text };
+};

--- a/src/chat-commands-skill.ts
+++ b/src/chat-commands-skill.ts
@@ -1,7 +1,12 @@
-import type { CommandContext, CommandResult } from "./chat-commands-contract";
+import type { CommandContext, CommandHandler, CommandResult } from "./chat-commands-contract";
 import { createRow } from "./chat-contract";
 import { t } from "./i18n";
 import { findSkillByName } from "./skill-ops";
+
+export const runSkillsPanel: CommandHandler = async (ctx) => {
+  await ctx.openSkillsPanel();
+  return { stop: true, userText: ctx.text };
+};
 
 export async function handleSkillActivation(ctx: CommandContext): Promise<CommandResult | null> {
   if (!ctx.activateSkill) return null;

--- a/src/chat-commands-status.ts
+++ b/src/chat-commands-status.ts
@@ -1,4 +1,6 @@
+import type { CommandHandler } from "./chat-commands-contract";
 import { type ChatRow, createRow } from "./chat-contract";
+import { t } from "./i18n";
 import type { StatusFields } from "./status-contract";
 import { createStatusOutput } from "./status-format";
 
@@ -7,3 +9,16 @@ export function statusRows(status: StatusFields): ChatRow[] {
   if (!output) return [];
   return [createRow("system", output)];
 }
+
+export const runStatus: CommandHandler = async (ctx) => {
+  try {
+    const status = await ctx.client.status();
+    ctx.setRows((current) => [...current, ...statusRows(status)]);
+  } catch (error) {
+    ctx.setRows((current) => [
+      ...current,
+      createRow("system", error instanceof Error ? error.message : t("chat.status.check_failed")),
+    ]);
+  }
+  return { stop: true, userText: ctx.text };
+};

--- a/src/chat-commands-usage.ts
+++ b/src/chat-commands-usage.ts
@@ -1,3 +1,4 @@
+import type { CommandHandler } from "./chat-commands-contract";
 import { type ChatRow, createRow } from "./chat-contract";
 import { alignCols, formatCompactNumber } from "./chat-format";
 import { t } from "./i18n";
@@ -63,3 +64,9 @@ export function usageRows(last: SessionTokenUsageEntry | null, all: SessionToken
   if (breakdown.length > 0) sections.push(breakdown);
   return [createRow("system", { header: t("chat.usage.header"), sections })];
 }
+
+export const runUsage: CommandHandler = async (ctx) => {
+  const last = ctx.tokenUsage.length > 0 ? ctx.tokenUsage[ctx.tokenUsage.length - 1] : null;
+  ctx.setRows((current) => [...current, ...usageRows(last, ctx.tokenUsage)]);
+  return { stop: true, userText: ctx.text };
+};

--- a/src/chat-commands-workspaces.ts
+++ b/src/chat-commands-workspaces.ts
@@ -1,13 +1,6 @@
 import type { z } from "zod";
 import { appConfig } from "./app-config";
-import type {
-  CommandContext,
-  CommandResult,
-  ParsedCommand,
-  SlashCommand,
-  SubcommandGroup,
-} from "./chat-commands-contract";
-import { dispatchSubcommandGroup } from "./chat-commands-contract";
+import type { CommandContext, CommandResult, ParsedCommand } from "./chat-commands-contract";
 import { createRow } from "./chat-contract";
 import { alignCols } from "./chat-format";
 import { GLYPH_FILLED } from "./chat-glyphs";
@@ -16,7 +9,7 @@ import { t } from "./i18n";
 import { createSession } from "./session-store";
 import { createGitWorktree, resolveGitRepoRoot, suggestWorkspaceName, workspaceNameSchema } from "./workspaces-ops";
 
-async function handleList(ctx: CommandContext, parsed: ParsedCommand): Promise<CommandResult> {
+export async function runWorkspacesList(ctx: CommandContext, parsed: ParsedCommand): Promise<CommandResult> {
   const { text } = ctx;
   if (parsed.args.length > 0) {
     ctx.setRows((current) => [...current, createRow("system", formatUsage("/workspaces [list|new|switch] ..."))]);
@@ -48,7 +41,7 @@ async function handleList(ctx: CommandContext, parsed: ParsedCommand): Promise<C
   return { stop: true, userText: text };
 }
 
-async function handleNew(ctx: CommandContext, parsed: ParsedCommand): Promise<CommandResult> {
+export async function runWorkspacesNew(ctx: CommandContext, parsed: ParsedCommand): Promise<CommandResult> {
   const { text } = ctx;
   const args = parsed.args;
   const showUsage = (): CommandResult => {
@@ -148,7 +141,7 @@ async function handleNew(ctx: CommandContext, parsed: ParsedCommand): Promise<Co
   return { stop: true, userText: text };
 }
 
-async function handleSwitch(ctx: CommandContext, parsed: ParsedCommand): Promise<CommandResult> {
+export async function runWorkspacesSwitch(ctx: CommandContext, parsed: ParsedCommand): Promise<CommandResult> {
   const { text } = ctx;
   const nameArg = parsed.args[0];
   const name = workspaceNameSchema.safeParse(nameArg);
@@ -169,35 +162,4 @@ async function handleSwitch(ctx: CommandContext, parsed: ParsedCommand): Promise
   await ctx.persist();
   ctx.setRows((current) => [...current, createRow("system", t("chat.workspaces.switched", { name: name.data }))]);
   return { stop: true, userText: text };
-}
-
-function createWorkspacesGroup(ctx: CommandContext): SubcommandGroup {
-  return {
-    root: "workspaces",
-    subcommands: [
-      {
-        name: "list",
-        match: (sub) => sub === "list" || sub === "",
-        run: (parsed) => handleList(ctx, parsed),
-      },
-      { name: "new", match: (sub) => sub === "new", run: (parsed) => handleNew(ctx, parsed) },
-      { name: "switch", match: (sub) => sub === "switch", run: (parsed) => handleSwitch(ctx, parsed) },
-    ],
-    fallback: async () => {
-      ctx.setRows((current) => [...current, createRow("system", formatUsage("/workspaces [list|new|switch] ..."))]);
-      return { stop: true, userText: ctx.text };
-    },
-  };
-}
-
-export function createWorkspacesCommands(ctx: CommandContext): SlashCommand[] {
-  if (!appConfig.features.workspaces) return [];
-  const group = createWorkspacesGroup(ctx);
-  return [
-    {
-      name: "workspaces",
-      match: (value) => value === "/workspaces" || value.startsWith("/workspaces "),
-      run: () => dispatchSubcommandGroup(group, ctx.resolvedText),
-    },
-  ];
 }

--- a/src/chat-commands.test.ts
+++ b/src/chat-commands.test.ts
@@ -123,6 +123,26 @@ describe("chat-commands", () => {
     expect(rows.some((row) => row.kind === "system" && row.content === "No memory saved yet.")).toBe(true);
   });
 
+  test("dispatchSlashCommand handles /memory list", async () => {
+    const memoryApi = createMemoryApi();
+    const { rows, stop } = await runCommand("/memory list", { memoryApi });
+    expect(stop).toBe(true);
+    expect(rows.some((row) => row.kind === "system" && row.content === "No memory saved yet.")).toBe(true);
+  });
+
+  test("dispatchSlashCommand scopes /memory list", async () => {
+    let receivedScope = "";
+    const memoryApi = createMemoryApi({
+      listMemories: async (options) => {
+        receivedScope = options?.scope ?? "";
+        return [];
+      },
+    });
+    const { stop } = await runCommand("/memory list project", { memoryApi });
+    expect(stop).toBe(true);
+    expect(receivedScope).toBe("project");
+  });
+
   test("dispatchSlashCommand handles scoped /memory with empty store", async () => {
     let receivedScope = "";
     const memoryApi = createMemoryApi({

--- a/src/chat-commands.ts
+++ b/src/chat-commands.ts
@@ -10,7 +10,8 @@ export async function dispatchSlashCommand(ctx: CommandContext): Promise<Command
   if (!resolvedText.startsWith("/")) return { stop: false, userText: text };
   const parsed = parseSlashCommand(resolvedText);
   const entry = findCommandEntry(parsed.root);
-  if (entry) return runCommandEntry(entry, ctx, parsed);
+  const running = entry ? runCommandEntry(entry, ctx, parsed) : null;
+  if (running) return running;
   const skillResult = await handleSkillActivation(ctx);
   if (skillResult) return skillResult;
   ctx.setRows((current) => [...current, createRow("system", t("chat.command.unknown", { command: text }))]);

--- a/src/chat-commands.ts
+++ b/src/chat-commands.ts
@@ -1,141 +1,18 @@
-import { appConfig } from "./app-config";
-import type { CommandContext, CommandResult, SlashCommand } from "./chat-commands-contract";
-import { createMemoryCommands, resolveMemoryApi } from "./chat-commands-memory";
-import { createModelCommands } from "./chat-commands-model";
-import { createResumeCommands } from "./chat-commands-resume";
-import { sessionsRows } from "./chat-commands-sessions";
+import { findCommandEntry, runCommandEntry } from "./chat-command-registry";
+import type { CommandContext, CommandResult } from "./chat-commands-contract";
+import { parseSlashCommand } from "./chat-commands-contract";
 import { handleSkillActivation } from "./chat-commands-skill";
-import { statusRows } from "./chat-commands-status";
-import { usageRows } from "./chat-commands-usage";
-import { createWorkspacesCommands } from "./chat-commands-workspaces";
 import { createRow } from "./chat-contract";
 import { t } from "./i18n";
-import { createSession } from "./session-store";
-
-function createSessionsCommand(ctx: CommandContext): SlashCommand {
-  return {
-    name: "sessions",
-    match: (value) => value === "/sessions",
-    run: async () => {
-      ctx.setRows((current) => [...current, ...sessionsRows(ctx.sessionState, 10)]);
-      return { stop: true, userText: ctx.text };
-    },
-  };
-}
-
-function createStatusCommand(ctx: CommandContext): SlashCommand {
-  return {
-    name: "status",
-    match: (value) => value === "/status",
-    run: async () => {
-      try {
-        const status = await ctx.client.status();
-        ctx.setRows((current) => [...current, ...statusRows(status)]);
-      } catch (error) {
-        ctx.setRows((current) => [
-          ...current,
-          createRow("system", error instanceof Error ? error.message : t("chat.status.check_failed")),
-        ]);
-      }
-      return { stop: true, userText: ctx.text };
-    },
-  };
-}
-
-function createUsageCommand(ctx: CommandContext): SlashCommand {
-  return {
-    name: "usage",
-    match: (value) => value === "/usage",
-    run: async () => {
-      const last = ctx.tokenUsage.length > 0 ? ctx.tokenUsage[ctx.tokenUsage.length - 1] : null;
-      ctx.setRows((current) => [...current, ...usageRows(last, ctx.tokenUsage)]);
-      return { stop: true, userText: ctx.text };
-    },
-  };
-}
-
-function createSkillsCommand(ctx: CommandContext): SlashCommand {
-  return {
-    name: "skills.panel",
-    match: (value) => value === "/skills",
-    run: async () => {
-      await ctx.openSkillsPanel();
-      return { stop: true, userText: ctx.text };
-    },
-  };
-}
-
-function createNewCommand(ctx: CommandContext): SlashCommand {
-  return {
-    name: "new",
-    match: (value) => value === "/new",
-    run: async () => {
-      const next = createSession(appConfig.model);
-      ctx.sessionState.sessions.unshift(next);
-      ctx.sessionState.activeSessionId = next.id;
-      ctx.setCurrentSession(next);
-      ctx.setTokenUsage?.(() => []);
-      ctx.clearTranscript(next.id);
-      ctx.setValue("");
-      ctx.setShowHelp(() => false);
-      await ctx.persist();
-      return { stop: true, userText: ctx.text };
-    },
-  };
-}
-
-function createExitCommand(ctx: CommandContext): SlashCommand {
-  return {
-    name: "exit",
-    match: (value) => value === "/exit",
-    run: async () => {
-      await ctx.persist();
-      ctx.exit();
-      return { stop: true, userText: ctx.text };
-    },
-  };
-}
-
-function createClearCommand(ctx: CommandContext): SlashCommand {
-  return {
-    name: "clear",
-    match: (value) => value === "/clear",
-    run: async () => {
-      ctx.clearTranscript();
-      return { stop: true, userText: ctx.text };
-    },
-  };
-}
-
-function resolveSlashCommands(ctx: CommandContext): SlashCommand[] {
-  const memoryApi = resolveMemoryApi(ctx);
-  return [
-    ...createResumeCommands(ctx),
-    createSessionsCommand(ctx),
-    ...createWorkspacesCommands(ctx),
-    createStatusCommand(ctx),
-    ...createModelCommands(ctx),
-    ...createMemoryCommands(ctx, memoryApi),
-    createUsageCommand(ctx),
-    createSkillsCommand(ctx),
-    createNewCommand(ctx),
-    createExitCommand(ctx),
-    createClearCommand(ctx),
-  ];
-}
 
 export async function dispatchSlashCommand(ctx: CommandContext): Promise<CommandResult> {
   const { text, resolvedText } = ctx;
-  const commands = resolveSlashCommands(ctx);
-  for (const command of commands) {
-    if (!command.match(resolvedText)) continue;
-    return command.run();
-  }
-  if (resolvedText.startsWith("/")) {
-    const skillResult = await handleSkillActivation(ctx);
-    if (skillResult) return skillResult;
-    ctx.setRows((current) => [...current, createRow("system", t("chat.command.unknown", { command: text }))]);
-    return { stop: true, userText: text };
-  }
-  return { stop: false, userText: text };
+  if (!resolvedText.startsWith("/")) return { stop: false, userText: text };
+  const parsed = parseSlashCommand(resolvedText);
+  const entry = findCommandEntry(parsed.root);
+  if (entry) return runCommandEntry(entry, ctx, parsed);
+  const skillResult = await handleSkillActivation(ctx);
+  if (skillResult) return skillResult;
+  ctx.setRows((current) => [...current, createRow("system", t("chat.command.unknown", { command: text }))]);
+  return { stop: true, userText: text };
 }

--- a/src/feature-flags-contract.ts
+++ b/src/feature-flags-contract.ts
@@ -23,6 +23,12 @@ export const featureFlagsSchema = z.object({
 
 export type FeatureFlags = z.infer<typeof featureFlagsSchema>;
 
+export const featureFlagNameSchema = z.enum(
+  Object.keys(featureFlagsSchema.shape) as [keyof FeatureFlags, ...(keyof FeatureFlags)[]],
+);
+
+export type FeatureFlagName = z.infer<typeof featureFlagNameSchema>;
+
 export const resolvedFeatureFlagsSchema = z.object({
   syncAgents: parseBoolSchema.optional().default(false),
   undoCheckpoints: parseBoolSchema.optional().default(false),


### PR DESCRIPTION
## Motivation

Command metadata was entangled with its handlers: `resolveSlashCommands` built closures over a full `CommandContext`, so nothing could enumerate commands without being able to run them.

## Summary

- commands are ctx-free `{ spec, run, runSub }` entries in a new `chat-command-registry.ts`; `dispatchSlashCommand` resolves by name through it
- `/memory list` reaches the list handler instead of printing a usage line that advertised a different set
- a command that declares no argument form now rejects trailing tokens rather than silently ignoring them
- drops `SlashCommand`, `Subcommand`, `SubcommandGroup`, and `dispatchSubcommandGroup`
- enumeration still reads its own literals; deriving it from the registry is the next step