### PR TITLE
feat(skills): user scope

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -44,8 +44,7 @@ A second premise is that completion belongs to the model, not the host. The runt
 - **FR-16** — Shell command execution and workspace test execution through the detected test command.
 - **FR-17** — Web search and web fetch for external information.
 - **FR-18** — Session search over the current conversation's history, available to the model on demand.
-- **FR-19** — Skill activation/deactivation: a roster of skills is always advertised, and the model activates or deactivates them at runtime rather than all being injected upfront.
-- **FR-19a** — Skills are discovered from `<cwd>/.agents/skills` and `~/.agents/skills`. A name claimed in both resolves to the project copy; a project or user skill replaces a bundled skill of the same name, and a bundled skill never replaces a built-in command.
+- **FR-19** — Skill activation/deactivation: a roster of skills is always advertised, and the model activates or deactivates them at runtime rather than all being injected upfront. Skills are discovered from `.agents/skills` in the workspace and in the home directory; a name claimed in both resolves to the workspace copy, a project or user skill replaces a bundled skill of the same name, and a bundled skill never replaces a built-in command.
 - **FR-20** — Inline multi-step task checklist the model maintains and the client renders.
 - **FR-21** — MCP client: when enabled, external MCP servers (stdio or HTTP transport) are connected and their tools appear alongside native tools.
 
@@ -160,12 +159,12 @@ A second premise is that completion belongs to the model, not the host. The runt
 - **TUI-6** — Only active input handlers receive key events; terminal key parsing is centralized, with unambiguous modifier reporting on terminals that support the enhanced keyboard protocol.
 - **TUI-7** — A live status line shows location, model, token usage, active skill, and PR context, updating token totals during a turn.
 - **TUI-8** — Slash commands cover session control (new, clear, resume, sessions), model change, status, usage, memory management, skill run and skills picker, and exit; the workspaces commands appear only when that flag is enabled. A skill runs as `/<skill-name>`, and a project or user skill of the same name replaces the built-in command.
-- **TUI-8a** — A command, its subcommands, and its help text come from one descriptor, so the completion menu offers only what dispatch can run. The menu lists a command and its declared subcommands; argument forms appear in the help pane.
 - **TUI-9** — Fuzzy autocomplete is offered for file paths, sessions, commands, and skills.
 - **TUI-10** — A queued message typed while a turn is running is handled cooperatively and processed in order rather than dropped or interleaved mid-step.
 - **TUI-11** — A user message preserves its whitespace in the transcript: leading indentation and internal whitespace runs are kept (tabs expanded to fixed-width stops), and a wrapped line repeats its indentation on each continuation row. Inline markup — backtick `code`, bold, and file paths — renders styled, with its delimiters interpreted. A fenced code block renders syntax-highlighted like assistant output, its fence interpreted; unfenced text stays verbatim.
 - **TUI-12** — Exiting the chat client releases its connection immediately, so an in-flight task is cancelled rather than left running to completion after the user has quit.
-- **TUI-13** — A typed prompt wraps inside the input box: no row exceeds the box interior, wrapping preserves every character, and a run too long for one row breaks across rows. Vertical cursor motion steps between visual rows at the caret's display column.
+- **TUI-13** — A command, its subcommands, and its help text come from one descriptor, so the completion menu offers only what dispatch can run: it lists a command and its declared subcommands, while argument forms appear in the help pane.
+- **TUI-14** — A typed prompt wraps inside the input box: no row exceeds the box interior, wrapping preserves every character, and a run too long for one row breaks across rows. Vertical cursor motion steps between visual rows at the caret's display column.
 
 ## 8. Observability requirements (OBS)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -45,6 +45,7 @@ A second premise is that completion belongs to the model, not the host. The runt
 - **FR-17** — Web search and web fetch for external information.
 - **FR-18** — Session search over the current conversation's history, available to the model on demand.
 - **FR-19** — Skill activation/deactivation: a roster of skills is always advertised, and the model activates or deactivates them at runtime rather than all being injected upfront.
+- **FR-19a** — Skills are discovered from `<cwd>/.agents/skills` and `~/.agents/skills`. A name claimed in both resolves to the project copy; a project or user skill replaces a bundled skill of the same name, and a bundled skill never replaces a built-in command.
 - **FR-20** — Inline multi-step task checklist the model maintains and the client renders.
 - **FR-21** — MCP client: when enabled, external MCP servers (stdio or HTTP transport) are connected and their tools appear alongside native tools.
 
@@ -158,7 +159,8 @@ A second premise is that completion belongs to the model, not the host. The runt
 - **TUI-5** — TUI state reads that depend on current state use the functional-update form so concurrent updates from streaming events and input handlers do not race on a stale value.
 - **TUI-6** — Only active input handlers receive key events; terminal key parsing is centralized, with unambiguous modifier reporting on terminals that support the enhanced keyboard protocol.
 - **TUI-7** — A live status line shows location, model, token usage, active skill, and PR context, updating token totals during a turn.
-- **TUI-8** — Slash commands cover session control (new, clear, resume, sessions), model change, status, usage, memory management, skill run and skills picker, and exit; the workspaces commands appear only when that flag is enabled.
+- **TUI-8** — Slash commands cover session control (new, clear, resume, sessions), model change, status, usage, memory management, skill run and skills picker, and exit; the workspaces commands appear only when that flag is enabled. A skill runs as `/<skill-name>`, and a project or user skill of the same name replaces the built-in command.
+- **TUI-8a** — A command, its subcommands, and its help text come from one descriptor, so the completion menu offers only what dispatch can run. The menu lists a command and its declared subcommands; argument forms appear in the help pane.
 - **TUI-9** — Fuzzy autocomplete is offered for file paths, sessions, commands, and skills.
 - **TUI-10** — A queued message typed while a turn is running is handled cooperatively and processed in order rather than dropped or interleaved mid-step.
 - **TUI-11** — A user message preserves its whitespace in the transcript: leading indentation and internal whitespace runs are kept (tabs expanded to fixed-width stops), and a wrapped line repeats its indentation on each continuation row. Inline markup — backtick `code`, bold, and file paths — renders styled, with its delimiters interpreted. A fenced code block renders syntax-highlighted like assistant output, its fence interpreted; unfenced text stays verbatim.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -91,7 +91,7 @@ timestamp=... task_id=task_abc123 event=lifecycle.summary model_calls=1 read=3 s
 
 ## Skills and extensibility
 
-Acolyte supports the [SKILL.md standard](https://agentskills.io) for declarative prompt extensions. Skills live in `.agents/skills/`; users can activate them with slash commands or the picker, and the model activates and deactivates them as work changes. Active skills persist across turns, and multiple skills can remain active in one session.
+Acolyte supports the [SKILL.md standard](https://agentskills.io) for declarative prompt extensions. Skills live in `<cwd>/.agents/skills/` for a project and `~/.agents/skills/` globally; users can activate them with slash commands or the picker, and the model activates and deactivates them as work changes. Active skills persist across turns, and multiple skills can remain active in one session.
 
 The other compared projects also document skills or equivalent skill and plugin extensions. The extension models differ: some treat skills as prompt resources, while others also expose executable plugins or MCP servers.
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -91,7 +91,7 @@ timestamp=... task_id=task_abc123 event=lifecycle.summary model_calls=1 read=3 s
 
 ## Skills and extensibility
 
-Acolyte supports the [SKILL.md standard](https://agentskills.io) for declarative prompt extensions. Skills live in `<cwd>/.agents/skills/` for a project and `~/.agents/skills/` globally; users can activate them with slash commands or the picker, and the model activates and deactivates them as work changes. Active skills persist across turns, and multiple skills can remain active in one session.
+Acolyte supports the [SKILL.md standard](https://agentskills.io) for declarative prompt extensions. Skills live in `.agents/skills/`, in the workspace for a project and in the home directory globally; users can activate them with slash commands or the picker, and the model activates and deactivates them as work changes. Active skills persist across turns, and multiple skills can remain active in one session.
 
 The other compared projects also document skills or equivalent skill and plugin extensions. The extension models differ: some treat skills as prompt resources, while others also expose executable plugins or MCP servers.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -13,6 +13,7 @@ Acolyte combines a terminal-first client, headless daemon, lifecycle effects, pe
 - slash commands and skill invocation
 - engineering skills for structured workflows (plan, build, review)
 - an always-available skill roster the agent activates and deactivates on demand
+- project and user skills, discovered from `.agents/skills` in the workspace and the home directory
 - configurable locale
 - multi-line input
 - custom terminal renderer with React reconciler and structured output

--- a/docs/features.md
+++ b/docs/features.md
@@ -13,7 +13,7 @@ Acolyte combines a terminal-first client, headless daemon, lifecycle effects, pe
 - slash commands and skill invocation
 - engineering skills for structured workflows (plan, build, review)
 - an always-available skill roster the agent activates and deactivates on demand
-- project and user skills, discovered from `.agents/skills` in the workspace and the home directory
+- project and user skills from `.agents/skills`
 - configurable locale
 - multi-line input
 - custom terminal renderer with React reconciler and structured output

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -21,7 +21,7 @@ Project-scoped config is always at `<cwd>/.acolyte/config.toml`, regardless of p
 
 ## Skills
 
-Skills load from `<cwd>/.agents/skills` and `~/.agents/skills`, outside the XDG layout: `.agents/` is the cross-tool SKILL.md convention.
+Skills load from `<cwd>/.agents/skills` and `~/.agents/skills`, outside the XDG layout: `.agents/` is the cross-tool SKILL.md convention. Each skill is a directory holding a `SKILL.md`, and a symlink to one loads the same as a real directory.
 
 ## Key files
 

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -19,6 +19,10 @@ Acolyte uses one XDG-style global layout on macOS and Linux. Environment variabl
 
 Project-scoped config is always at `<cwd>/.acolyte/config.toml`, regardless of platform. Project `.acolyte/` is workspace metadata, not global state.
 
+## Skills
+
+Skills load from `<cwd>/.agents/skills` and `~/.agents/skills`. Both sit outside the XDG layout because `.agents/` is the cross-tool SKILL.md convention, so global skills are shared with every agent that reads it.
+
 ## Key files
 
 - `src/paths.ts` — path resolution logic

--- a/docs/paths.md
+++ b/docs/paths.md
@@ -21,7 +21,7 @@ Project-scoped config is always at `<cwd>/.acolyte/config.toml`, regardless of p
 
 ## Skills
 
-Skills load from `<cwd>/.agents/skills` and `~/.agents/skills`. Both sit outside the XDG layout because `.agents/` is the cross-tool SKILL.md convention, so global skills are shared with every agent that reads it.
+Skills load from `<cwd>/.agents/skills` and `~/.agents/skills`, outside the XDG layout: `.agents/` is the cross-tool SKILL.md convention.
 
 ## Key files
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -52,11 +52,13 @@ Components register handlers through `useInput`. Only handlers with `isActive: t
 - `/memory list [all|user|project] [--archived]` — show memory notes
 - `/memory add [--user|--project] <text>` — save memory note
 - `/memory rm <id-prefix>` — remove memory note
-- `/skill <name>` — run a skill command
+- `/<skill-name> [prompt]` — run a skill
 - `/skills` — show skills picker
 - `/exit` — exit chat
 
 Every command, its subcommands, and its help text come from one descriptor per command (`chat-command-specs.ts`), so the completion menu, the `?` pane, and dispatch cannot disagree. The menu offers a command and its declared subcommands; argument forms like `--archived` appear in the `?` pane rather than as completions.
+
+Skills load from `<cwd>/.agents/skills` and `~/.agents/skills` and are invoked by name. A project or user skill replaces a built-in command of the same name, and the `/skills` picker names the scope each one resolved from.
 
 ## File attachments
 

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -58,7 +58,7 @@ Components register handlers through `useInput`. Only handlers with `isActive: t
 
 Every command, its subcommands, and its help text come from one descriptor per command (`chat-command-specs.ts`), so the completion menu, the `?` pane, and dispatch cannot disagree. The menu offers a command and its declared subcommands; argument forms like `--archived` appear in the `?` pane rather than as completions.
 
-Skills load from `<cwd>/.agents/skills` and `~/.agents/skills` and are invoked by name. A project or user skill replaces a built-in command of the same name, and the `/skills` picker names the scope each one resolved from.
+Skills load from `.agents/skills` in the workspace and in the home directory, and are invoked by name. A project or user skill replaces a built-in command of the same name, and the `/skills` picker names the scope each one resolved from.
 
 ## File attachments
 

--- a/src/chat-command-registry.int.test.ts
+++ b/src/chat-command-registry.int.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { BUNDLED_SKILLS } from "./bundled-skills";
+import { findCommandEntry, resolveCommandRegistry } from "./chat-command-registry";
+import { getSkillLoadDiagnostics, loadSkills, resetSkillCache } from "./skill-ops";
+import { tempDir, writeSkill } from "./test-utils";
+
+const { createDir, cleanupDirs } = tempDir();
+const originalHome = process.env.HOME;
+
+beforeEach(() => {
+  process.env.HOME = createDir("acolyte-registry-home-");
+});
+
+afterEach(() => {
+  process.env.HOME = originalHome;
+  resetSkillCache();
+  cleanupDirs();
+});
+
+describe("registry with loaded skills", () => {
+  test("a project skill takes a builtin name", async () => {
+    const cwd = createDir("acolyte-registry-shadow-");
+    writeSkill(cwd, "new", "---\nname: new\ndescription: Mine\n---", "# Mine");
+    await loadSkills(cwd);
+
+    const entry = findCommandEntry("new");
+    expect(entry?.spec.source).toBe("project");
+    expect(resolveCommandRegistry().filter((item) => item.spec.name === "new")).toHaveLength(1);
+  });
+
+  test("a user skill is reachable as a command", async () => {
+    const home = createDir("acolyte-registry-user-");
+    process.env.HOME = home;
+    writeSkill(home, "globaldemo", "---\nname: globaldemo\ndescription: User scope\n---", "# User");
+    await loadSkills(createDir("acolyte-registry-cwd-"));
+
+    expect(findCommandEntry("globaldemo")?.spec.source).toBe("user");
+  });
+
+  test("a bundled skill never takes a builtin name", async () => {
+    await loadSkills(createDir("acolyte-registry-bundled-"));
+
+    for (const bundled of BUNDLED_SKILLS) {
+      const entry = findCommandEntry(bundled.name);
+      if (entry) expect(entry.spec.source).toBe("bundled");
+    }
+    expect(findCommandEntry("new")?.spec.source).toBe("builtin");
+    expect(getSkillLoadDiagnostics().builtinCollisions).toBe(0);
+  });
+
+  test("every registry name resolves to exactly one entry", async () => {
+    const cwd = createDir("acolyte-registry-unique-");
+    writeSkill(cwd, "review", "---\nname: review\ndescription: Mine\n---", "# Mine");
+    await loadSkills(cwd);
+
+    const names = resolveCommandRegistry().map((entry) => entry.spec.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});

--- a/src/chat-command-registry.ts
+++ b/src/chat-command-registry.ts
@@ -18,10 +18,12 @@ import { runModel } from "./chat-commands-model";
 import { runResume } from "./chat-commands-resume";
 import { runClear, runExit, runNew } from "./chat-commands-session";
 import { runSessions } from "./chat-commands-sessions";
-import { runSkillsPanel } from "./chat-commands-skill";
+import { createSkillHandler, runSkillsPanel } from "./chat-commands-skill";
 import { runStatus } from "./chat-commands-status";
 import { runUsage } from "./chat-commands-usage";
 import { runWorkspacesList, runWorkspacesNew, runWorkspacesSwitch } from "./chat-commands-workspaces";
+import type { SkillMeta } from "./skill-contract";
+import { getLoadedSkills } from "./skill-ops";
 
 const BUILTIN_COMMANDS: CommandEntry[] = [
   { spec: NEW_SPEC, run: runNew },
@@ -45,9 +47,28 @@ const BUILTIN_COMMANDS: CommandEntry[] = [
   { spec: EXIT_SPEC, run: runExit },
 ];
 
-/** Commands available right now: a flagged command is absent while its flag is off, never inert. */
+function skillEntry(skill: SkillMeta): CommandEntry {
+  return {
+    spec: {
+      name: skill.name,
+      source: skill.source,
+      helpKey: "chat.slash.help.skill",
+      usage: `/${skill.name} [prompt]`,
+      subcommands: [],
+    },
+    run: createSkillHandler(skill),
+  };
+}
+
+/** A project or user skill takes a builtin's name: the user wrote it deliberately, so their authority wins. */
 export function resolveCommandRegistry(): CommandEntry[] {
-  return BUILTIN_COMMANDS.filter((entry) => entry.spec.flag === undefined || appConfig.features[entry.spec.flag]);
+  const skills = getLoadedSkills().map(skillEntry);
+  const shadowing = new Set(skills.filter((entry) => entry.spec.source !== "bundled").map((entry) => entry.spec.name));
+  const builtins = BUILTIN_COMMANDS.filter(
+    (entry) =>
+      (entry.spec.flag === undefined || appConfig.features[entry.spec.flag]) && !shadowing.has(entry.spec.name),
+  );
+  return [...builtins, ...skills];
 }
 
 export function findCommandEntry(name: string): CommandEntry | null {

--- a/src/chat-command-specs.ts
+++ b/src/chat-command-specs.ts
@@ -100,3 +100,24 @@ export function subcommandUsage(spec: CommandSpec, name: string): string {
   if (!sub) throw new Error(`${spec.name} declares no subcommand ${name}`);
   return sub.usage;
 }
+
+const BUILTIN_COMMAND_NAMES = new Set(
+  [
+    NEW_SPEC,
+    CLEAR_SPEC,
+    MODEL_SPEC,
+    STATUS_SPEC,
+    SESSIONS_SPEC,
+    WORKSPACES_SPEC,
+    SKILLS_SPEC,
+    RESUME_SPEC,
+    MEMORY_SPEC,
+    USAGE_SPEC,
+    EXIT_SPEC,
+  ].map((spec) => spec.name),
+);
+
+/** Flag-independent: a flagged command still owns its name while the flag is off. */
+export function isBuiltinCommandName(name: string): boolean {
+  return BUILTIN_COMMAND_NAMES.has(name);
+}

--- a/src/chat-commands-skill.ts
+++ b/src/chat-commands-skill.ts
@@ -1,20 +1,22 @@
 import type { CommandContext, CommandHandler, CommandResult } from "./chat-commands-contract";
 import { createRow } from "./chat-contract";
 import { t } from "./i18n";
-import { findSkillByName } from "./skill-ops";
+import type { SkillMeta } from "./skill-contract";
 
 export const runSkillsPanel: CommandHandler = async (ctx) => {
   await ctx.openSkillsPanel();
   return { stop: true, userText: ctx.text };
 };
 
-export async function handleSkillActivation(ctx: CommandContext): Promise<CommandResult | null> {
-  if (!ctx.activateSkill) return null;
-  const [head, ...rest] = ctx.resolvedText.split(/\s+/);
-  const skillName = (head ?? "").slice(1);
-  const skill = findSkillByName(skillName);
-  if (!skill) return null;
-  const args = rest.join(" ").trim();
+export function createSkillHandler(skill: SkillMeta): CommandHandler {
+  return async (ctx, parsed) => activateSkill(ctx, skill, parsed.args.join(" ").trim());
+}
+
+async function activateSkill(ctx: CommandContext, skill: SkillMeta, args: string): Promise<CommandResult> {
+  if (!ctx.activateSkill) {
+    ctx.setRows((current) => [...current, createRow("system", t("chat.skill.failed", { skill: skill.name }))]);
+    return { stop: true, userText: ctx.text };
+  }
   const ok = await ctx.activateSkill(skill.name, args);
   if (!ok) {
     ctx.setRows((current) => [...current, createRow("system", t("chat.skill.failed", { skill: skill.name }))]);

--- a/src/chat-commands.ts
+++ b/src/chat-commands.ts
@@ -1,7 +1,6 @@
 import { findCommandEntry, runCommandEntry } from "./chat-command-registry";
 import type { CommandContext, CommandResult } from "./chat-commands-contract";
 import { parseSlashCommand } from "./chat-commands-contract";
-import { handleSkillActivation } from "./chat-commands-skill";
 import { createRow } from "./chat-contract";
 import { t } from "./i18n";
 
@@ -12,8 +11,6 @@ export async function dispatchSlashCommand(ctx: CommandContext): Promise<Command
   const entry = findCommandEntry(parsed.root);
   const running = entry ? runCommandEntry(entry, ctx, parsed) : null;
   if (running) return running;
-  const skillResult = await handleSkillActivation(ctx);
-  if (skillResult) return skillResult;
   ctx.setRows((current) => [...current, createRow("system", t("chat.command.unknown", { command: text }))]);
   return { stop: true, userText: text };
 }

--- a/src/chat-slash.int.test.ts
+++ b/src/chat-slash.int.test.ts
@@ -31,6 +31,14 @@ describe("chat-slash with loaded skills", () => {
     expect(shortcutItems().some((item) => item.key === "/dogfood")).toBe(false);
   });
 
+  test("a skill is offered once", async () => {
+    const tmpDir = createDir("acolyte-slash-once-");
+    writeSkill(tmpDir, "dogfood", "---\nname: dogfood\ndescription: Test\n---", "# Test");
+    await loadSkills(tmpDir);
+
+    expect(suggestSlashCommands("/dogfood", 20)).toEqual(["/dogfood"]);
+  });
+
   test("isKnownSlashToken recognizes skill names", async () => {
     const tmpDir = createDir("acolyte-slash-known-");
     writeSkill(tmpDir, "dogfood", "---\nname: dogfood\ndescription: Test\n---", "# Test");

--- a/src/chat-slash.ts
+++ b/src/chat-slash.ts
@@ -1,7 +1,6 @@
 import { resolveCommandRegistry } from "./chat-command-registry";
 import type { CommandSource } from "./chat-commands-contract";
-import { t, tDynamic } from "./i18n";
-import { getLoadedSkills } from "./skill-ops";
+import { tDynamic } from "./i18n";
 
 export type SlashCommandRow = {
   /** What the user types to reach it, and what the completion menu offers. */
@@ -22,14 +21,6 @@ export function slashCommandRows(): SlashCommandRow[] {
     for (const sub of entry.spec.subcommands) {
       rows.push({ command: `${command} ${sub.name}`, usage: sub.usage, help: tDynamic(sub.helpKey), source });
     }
-  }
-  for (const skill of getLoadedSkills()) {
-    rows.push({
-      command: `/${skill.name}`,
-      usage: `/${skill.name}`,
-      help: t("chat.slash.help.skill"),
-      source: skill.source,
-    });
   }
   return rows;
 }

--- a/src/chat-viewport-contract.ts
+++ b/src/chat-viewport-contract.ts
@@ -3,7 +3,7 @@ import { transcriptRowSchema } from "./chat-transcript-contract";
 import { pendingStateSchema } from "./client-contract";
 import { footerStatusSchema } from "./footer-status-contract";
 import { inputControllerStateSchema } from "./input-controller";
-import { skillMetaSchema } from "./skill-contract";
+import { skillMetaSchema, skillSourceSchema } from "./skill-contract";
 
 export const headerPresentationSchema = z.object({
   title: z.string(),
@@ -28,7 +28,7 @@ export const composerPickerItemSchema = z.object({
   value: z.string(),
   detail: z.string().optional(),
   active: z.boolean().optional(),
-  source: z.enum(["bundled", "project"]).optional(),
+  source: skillSourceSchema.optional(),
 });
 export const composerPickerSchema = z.discriminatedUnion("kind", [
   z.object({

--- a/src/skill-contract.ts
+++ b/src/skill-contract.ts
@@ -13,7 +13,7 @@ export function isActiveSkillsPayload(value: unknown): value is ActiveSkill[] {
   return activeSkillsSchema.safeParse(value).success;
 }
 
-export const skillSourceSchema = z.enum(["bundled", "project"]);
+export const skillSourceSchema = z.enum(["bundled", "user", "project"]);
 export type SkillSource = z.infer<typeof skillSourceSchema>;
 
 export const skillMetaSchema = z.object({
@@ -29,6 +29,8 @@ export const skillLoadDiagnosticsSchema = z.object({
   loaded: z.number().int().nonnegative(),
   invalid: z.number().int().nonnegative(),
   duplicates: z.number().int().nonnegative(),
+  overrides: z.number().int().nonnegative(),
+  builtinCollisions: z.number().int().nonnegative(),
   readErrors: z.number().int().nonnegative(),
   missingSkillFiles: z.number().int().nonnegative(),
   scannedAt: z.string().nullable(),
@@ -43,6 +45,8 @@ export function createEmptySkillLoadDiagnostics(): SkillLoadDiagnostics {
     loaded: 0,
     invalid: 0,
     duplicates: 0,
+    overrides: 0,
+    builtinCollisions: 0,
     readErrors: 0,
     missingSkillFiles: 0,
     scannedAt: null,

--- a/src/skill-ops.int.test.ts
+++ b/src/skill-ops.int.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { BUNDLED_SKILLS } from "./bundled-skills";
 import {
@@ -167,6 +167,33 @@ describe("skill scopes", () => {
     expect(shared[0].source).toBe("project");
     expect(shared[0].description).toBe("Project copy");
     expect(getSkillLoadDiagnostics().duplicates).toBe(1);
+  });
+
+  test("discovers a user skill whose directory is a symlink", async () => {
+    const home = createDir("acolyte-skills-symlink-home-");
+    process.env.HOME = home;
+    const source = createDir("acolyte-skills-symlink-source-");
+    writeSkill(source, "linked", "---\nname: linked\ndescription: Linked scope\n---", "# Linked");
+    const userRoot = join(home, ".agents", "skills");
+    mkdirSync(userRoot, { recursive: true });
+    symlinkSync(join(source, ".agents", "skills", "linked"), join(userRoot, "linked"), "dir");
+
+    const skills = await loadSkills(createDir("acolyte-skills-symlink-cwd-"));
+    const found = skills.find((s) => s.name === "linked");
+    expect(found?.source).toBe("user");
+    expect(found?.description).toBe("Linked scope");
+  });
+
+  test("a broken symlink is skipped without counting as a missing skill file", async () => {
+    const home = createDir("acolyte-skills-broken-home-");
+    process.env.HOME = home;
+    const userRoot = join(home, ".agents", "skills");
+    mkdirSync(userRoot, { recursive: true });
+    symlinkSync(join(home, "nowhere"), join(userRoot, "dangling"), "dir");
+
+    const skills = await loadSkills(createDir("acolyte-skills-broken-cwd-"));
+    expect(skills).toHaveLength(BUNDLED_COUNT);
+    expect(getSkillLoadDiagnostics().missingSkillFiles).toBe(0);
   });
 
   test("a scanned skill replacing a bundled one is counted", async () => {

--- a/src/skill-ops.int.test.ts
+++ b/src/skill-ops.int.test.ts
@@ -1,12 +1,26 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { BUNDLED_SKILLS } from "./bundled-skills";
-import { findSkillByName, loadSkills, readSkillInstructions, resetSkillCache } from "./skill-ops";
+import {
+  findSkillByName,
+  getSkillLoadDiagnostics,
+  loadSkills,
+  readSkillInstructions,
+  resetSkillCache,
+} from "./skill-ops";
 import { tempDir, writeSkill } from "./test-utils";
 
 const { createDir, cleanupDirs } = tempDir();
+const originalHome = process.env.HOME;
+
+// The loader reads ~/.agents/skills, so every case owns its home directory rather than the developer's.
+beforeEach(() => {
+  process.env.HOME = createDir("acolyte-skills-home-");
+});
+
 afterEach(() => {
+  process.env.HOME = originalHome;
   resetSkillCache();
   cleanupDirs();
 });
@@ -125,5 +139,45 @@ describe("readSkillInstructions", () => {
     writeFileSync(file, "---\nname: demo\ndescription: Demo\n---\n\nDo: $ARGUMENTS", "utf8");
     const body = await readSkillInstructions(file, "");
     expect(body).toBe("Do: ");
+  });
+});
+
+describe("skill scopes", () => {
+  test("discovers a user skill from the home directory", async () => {
+    const home = createDir("acolyte-skills-user-");
+    process.env.HOME = home;
+    writeSkill(home, "globaldemo", "---\nname: globaldemo\ndescription: User scope\n---", "# User");
+
+    const skills = await loadSkills(createDir("acolyte-skills-cwd-"));
+    const found = skills.find((s) => s.name === "globaldemo");
+    expect(found?.source).toBe("user");
+    expect(found?.description).toBe("User scope");
+  });
+
+  test("a project skill wins the name and the user copy counts as a duplicate", async () => {
+    const home = createDir("acolyte-skills-user-dup-");
+    process.env.HOME = home;
+    writeSkill(home, "shared", "---\nname: shared\ndescription: User copy\n---", "# User");
+    const cwd = createDir("acolyte-skills-project-dup-");
+    writeSkill(cwd, "shared", "---\nname: shared\ndescription: Project copy\n---", "# Project");
+
+    const skills = await loadSkills(cwd);
+    const shared = skills.filter((s) => s.name === "shared");
+    expect(shared).toHaveLength(1);
+    expect(shared[0].source).toBe("project");
+    expect(shared[0].description).toBe("Project copy");
+    expect(getSkillLoadDiagnostics().duplicates).toBe(1);
+  });
+
+  test("a scanned skill replacing a bundled one is counted", async () => {
+    const cwd = createDir("acolyte-skills-override-");
+    const bundledName = BUNDLED_SKILLS[0].name;
+    writeSkill(cwd, bundledName, `---\nname: ${bundledName}\ndescription: Mine\n---`, "# Mine");
+
+    const skills = await loadSkills(cwd);
+    const replaced = skills.filter((s) => s.name === bundledName);
+    expect(replaced).toHaveLength(1);
+    expect(replaced[0].source).toBe("project");
+    expect(getSkillLoadDiagnostics().overrides).toBe(1);
   });
 });

--- a/src/skill-ops.ts
+++ b/src/skill-ops.ts
@@ -2,10 +2,13 @@ import { type Dirent, existsSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { BUNDLED_SKILLS } from "./bundled-skills";
+import { isBuiltinCommandName } from "./chat-command-specs";
+import { resolveHomeDir } from "./paths";
 import {
   createEmptySkillLoadDiagnostics,
   type SkillLoadDiagnostics,
   type SkillMeta,
+  type SkillSource,
   validateSkillName,
 } from "./skill-contract";
 
@@ -62,21 +65,36 @@ function stripFrontmatter(input: string): string {
 
 const SKILL_DIR = ".agents/skills";
 
+/** `~/.agents/skills` stays outside the XDG layout so global skills are shared with every agent reading that convention. */
 async function scanSkills(cwd = process.cwd()): Promise<{ skills: SkillMeta[]; diagnostics: SkillLoadDiagnostics }> {
   const diagnostics = createEmptySkillLoadDiagnostics();
   const seen = new Set<string>();
   const found: SkillMeta[] = [];
-
-  const root = join(cwd, SKILL_DIR);
   diagnostics.scannedAt = new Date().toISOString();
-  if (!existsSync(root)) return { skills: [], diagnostics };
+
+  await scanSkillRoot(join(cwd, SKILL_DIR), "project", found, seen, diagnostics);
+  await scanSkillRoot(join(resolveHomeDir(), SKILL_DIR), "user", found, seen, diagnostics);
+
+  found.sort((a, b) => a.name.localeCompare(b.name));
+  diagnostics.loaded = found.length;
+  return { skills: found, diagnostics };
+}
+
+async function scanSkillRoot(
+  root: string,
+  source: Extract<SkillSource, "project" | "user">,
+  found: SkillMeta[],
+  seen: Set<string>,
+  diagnostics: SkillLoadDiagnostics,
+): Promise<void> {
+  if (!existsSync(root)) return;
 
   let dirs: Dirent[];
   try {
     dirs = await readdir(root, { withFileTypes: true });
   } catch {
     diagnostics.readErrors += 1;
-    return { skills: [], diagnostics };
+    return;
   }
 
   for (const entry of dirs) {
@@ -117,17 +135,13 @@ async function scanSkills(cwd = process.cwd()): Promise<{ skills: SkillMeta[]; d
         name,
         description,
         path: skillPath,
-        source: "project",
+        source,
       });
     } catch {
       diagnostics.readErrors += 1;
       // Skip unreadable skills.
     }
   }
-
-  found.sort((a, b) => a.name.localeCompare(b.name));
-  diagnostics.loaded = found.length;
-  return { skills: found, diagnostics };
 }
 
 let bundledSkillCache: { skills: SkillMeta[]; contentByName: Map<string, string> } | null = null;
@@ -152,9 +166,14 @@ function loadBundledSkills(): { skills: SkillMeta[]; contentByName: Map<string, 
   return bundledSkillCache;
 }
 
-function mergeSkills(bundled: SkillMeta[], project: SkillMeta[]): SkillMeta[] {
-  const projectNames = new Set(project.map((s) => s.name));
-  const merged = [...project, ...bundled.filter((s) => !projectNames.has(s.name))];
+function mergeSkills(bundled: SkillMeta[], scanned: SkillMeta[], diagnostics: SkillLoadDiagnostics): SkillMeta[] {
+  const scannedNames = new Set(scanned.map((s) => s.name));
+  const unshadowed = bundled.filter((s) => !scannedNames.has(s.name));
+  diagnostics.overrides = bundled.length - unshadowed.length;
+  // A bundled name colliding with a builtin is a packaging mistake, not user authority.
+  const kept = unshadowed.filter((s) => !isBuiltinCommandName(s.name));
+  diagnostics.builtinCollisions = unshadowed.length - kept.length;
+  const merged = [...scanned, ...kept];
   merged.sort((a, b) => a.name.localeCompare(b.name));
   return merged;
 }
@@ -164,7 +183,7 @@ let cachedSkillDiagnostics: SkillLoadDiagnostics = createEmptySkillLoadDiagnosti
 
 export async function loadSkills(cwd?: string): Promise<SkillMeta[]> {
   const result = await scanSkills(cwd);
-  cachedSkills = mergeSkills(loadBundledSkills().skills, result.skills);
+  cachedSkills = mergeSkills(loadBundledSkills().skills, result.skills, result.diagnostics);
   cachedSkillDiagnostics = result.diagnostics;
   return cachedSkills;
 }

--- a/src/skill-ops.ts
+++ b/src/skill-ops.ts
@@ -1,4 +1,4 @@
-import { type Dirent, existsSync } from "node:fs";
+import { type Dirent, existsSync, statSync } from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { BUNDLED_SKILLS } from "./bundled-skills";
@@ -80,6 +80,17 @@ async function scanSkills(cwd = process.cwd()): Promise<{ skills: SkillMeta[]; d
   return { skills: found, diagnostics };
 }
 
+/** `readdir` reports a symlinked directory as a link, and populating a skill root by symlink is a supported layout. */
+function isSkillDir(root: string, entry: Dirent): boolean {
+  if (entry.isDirectory()) return true;
+  if (!entry.isSymbolicLink()) return false;
+  try {
+    return statSync(join(root, entry.name)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
 async function scanSkillRoot(
   root: string,
   source: Extract<SkillSource, "project" | "user">,
@@ -98,9 +109,9 @@ async function scanSkillRoot(
   }
 
   for (const entry of dirs) {
-    if (!entry.isDirectory()) continue;
+    if (!isSkillDir(root, entry)) continue;
     diagnostics.scannedDirs += 1;
-    const dirName = entry.name as string;
+    const dirName = entry.name;
     const skillPath = join(root, dirName, "SKILL.md");
     if (!existsSync(skillPath)) {
       diagnostics.missingSkillFiles += 1;

--- a/src/terminal-chat-layout.ts
+++ b/src/terminal-chat-layout.ts
@@ -487,7 +487,9 @@ export function layoutComposerStatus(input: {
       // Skills are not windowed (no scrollOffset); render the full list, as legacy did.
       pickerItems = picker.items.map((item, index) => {
         const label = truncateToWidth(item.label, PICKER_LABEL_WIDTH).padEnd(PICKER_LABEL_WIDTH);
-        const detail = item.detail ?? "";
+        // Only an authored skill names its scope: a bundled one is what remains when nothing took the name.
+        const scope = item.source && item.source !== "bundled" ? `${item.source} · ` : "";
+        const detail = `${scope}${item.detail ?? ""}`;
         if (index === selectedRel) return row(index, `${label} ${detail}`);
         return {
           spans: [


### PR DESCRIPTION
## Summary

- skills load from `.agents/skills` in the home directory as well as the workspace, with a `user` source
- a name claimed in both scopes resolves to the workspace copy and counts the other as a duplicate
- skills are registry entries, so `/<skill-name>` dispatches like any command and a project or user skill takes a built-in's name
- a bundled skill never takes a built-in's name; the collision is dropped and counted in skill diagnostics
- the `/skills` picker names the scope each skill resolved from