### PR TITLE
fix(chat): keep console output off the frame

### DIFF
--- a/docs/tui.md
+++ b/docs/tui.md
@@ -73,6 +73,7 @@ Completion offers gitignored paths too, unlike the file tools, which are gitigno
 
 ## Design constraints
 
+- **The renderer owns the terminal alone** — a foreign write shifts the cursor its erase depends on, so the chat client sinks logs and `console.*` while mounted.
 - **Minimal primitive set** — every new prop becomes renderer debt. Add only what's needed.
 - **Layout rules are a product contract** — add tests before adding layout semantics.
 - **No "Ink, but homegrown."** If a feature doesn't materially help Acolyte's UX, don't add it.

--- a/src/chat-app.int.test.ts
+++ b/src/chat-app.int.test.ts
@@ -127,8 +127,13 @@ function withLogSinkEnv(
 describe("client log sink", () => {
   test("keeps logs off stdout when ACOLYTE_DEBUG is unset", () => {
     withLogSinkEnv(({ stdout }) => {
-      installClientLogSink();
-      log.debug("chat.submit", { value: "hello", resolved: "submit" });
+      let restoreConsole: (() => void) | null = null;
+      try {
+        restoreConsole = installClientLogSink();
+        log.debug("chat.submit", { value: "hello", resolved: "submit" });
+      } finally {
+        restoreConsole?.();
+      }
       expect(stdout.join("")).not.toMatch(/level=debug/);
     });
   });
@@ -136,8 +141,13 @@ describe("client log sink", () => {
   test("diverts logs to client.log under ACOLYTE_DEBUG, never stdout", () => {
     withLogSinkEnv(
       ({ stdout }) => {
-        installClientLogSink();
-        log.debug("chat.submit", { value: "hello", resolved: "submit" });
+        let restoreConsole: (() => void) | null = null;
+        try {
+          restoreConsole = installClientLogSink();
+          log.debug("chat.submit", { value: "hello", resolved: "submit" });
+        } finally {
+          restoreConsole?.();
+        }
         expect(stdout.join("")).not.toMatch(/level=debug/);
         const logged = readFileSync(join(stateDir(), "client.log"), "utf8");
         expect(logged).toMatch(/level=debug/);

--- a/src/chat-app.test.ts
+++ b/src/chat-app.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { installClientLogSink } from "./chat-app";
 import {
   applyAtSuggestion,
   extractAtReferencePaths,
@@ -7,7 +8,41 @@ import {
   shouldAutocompleteAtSubmit,
 } from "./chat-file-ref";
 import { toRows } from "./chat-session";
+import { setLogSink } from "./log";
 import { createSession } from "./test-utils";
+
+describe("client console capture", () => {
+  test("a dependency's console write is logged, not printed", () => {
+    const debug = process.env.ACOLYTE_DEBUG;
+    delete process.env.ACOLYTE_DEBUG;
+    const originalError = console.error;
+    const lines: string[] = [];
+    let restore: (() => void) | null = null;
+    try {
+      restore = installClientLogSink();
+      // Installed after the capture so the log lines are observable; the sink is the only
+      // path the wrapped methods take — `console.*` in Bun writes straight to the terminal.
+      setLogSink((line) => lines.push(line));
+      expect(console.error).not.toBe(originalError);
+      console.error("Maximum update depth exceeded.\n    at Component (file.tsx:1:1)");
+      console.warn("deprecation notice");
+      console.trace("stack probe");
+    } finally {
+      restore?.();
+      setLogSink(() => {});
+      if (debug === undefined) delete process.env.ACOLYTE_DEBUG;
+      else process.env.ACOLYTE_DEBUG = debug;
+    }
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toContain("source=console.error");
+    expect(lines[0]).toContain("level=error");
+    // A component stack stays one record, so client.log remains line-oriented.
+    expect(lines[0].trimEnd()).not.toContain("\n");
+    expect(lines[1]).toContain("level=warn");
+    expect(lines[2]).toContain("source=console.trace");
+    expect(console.error).toBe(originalError);
+  });
+});
 
 describe("chat-ui helpers", () => {
   test("extractAtReferenceQuery parses @prefix", () => {

--- a/src/chat-app.tsx
+++ b/src/chat-app.tsx
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { PromotedSliceView } from "./chat-promoted-slice";
 import { type ChatAppProps, useChatState } from "./chat-state";
 import { createChatViewportPresentation } from "./chat-viewport-presentation";
-import { setLogSink } from "./log";
+import { type LogLevel, log, setLogSink } from "./log";
 import { stateDir } from "./paths";
 import { PromptInputHandler } from "./prompt-input";
 import { layoutChatViewport, promptWrapWidth } from "./terminal-chat-layout";
@@ -66,21 +66,66 @@ function ChatApp(props: ChatAppProps) {
   );
 }
 
-export function installClientLogSink(): void {
+/** Every console method that writes output, mapped to the level it logs at. `console.*` in Bun
+ *  writes straight to the file descriptor, so a method left out here still reaches the frame. */
+const CONSOLE_LEVELS = {
+  debug: "debug",
+  dir: "debug",
+  dirxml: "debug",
+  error: "error",
+  group: "debug",
+  groupCollapsed: "debug",
+  info: "info",
+  log: "debug",
+  table: "debug",
+  timeEnd: "debug",
+  timeLog: "debug",
+  trace: "debug",
+  warn: "warn",
+} as const satisfies Record<string, LogLevel>;
+
+type CapturedConsoleMethod = keyof typeof CONSOLE_LEVELS;
+
+/** Route console output through the log sink for as long as the TUI owns the terminal. A
+ *  dependency that writes a diagnostic — React prints its nested-update warning this way —
+ *  otherwise lands mid-frame and shifts the cursor the renderer is tracking. Returns the
+ *  restore for the caller's teardown. */
+function captureConsole(): () => void {
+  // The per-method signatures (`dir`, `table`) differ, and every capture takes the same shape.
+  const target = console as unknown as Record<CapturedConsoleMethod, (...args: unknown[]) => void>;
+  const originals = new Map<CapturedConsoleMethod, (...args: unknown[]) => void>();
+  for (const method of Object.keys(CONSOLE_LEVELS) as CapturedConsoleMethod[]) {
+    originals.set(method, target[method]);
+    target[method] = (...args: unknown[]): void => {
+      // Newlines collapse so a component stack stays one logfmt record.
+      const message = args
+        .map(String)
+        .join(" ")
+        .replace(/\s*\n\s*/g, " ");
+      log[CONSOLE_LEVELS[method]](message, { source: `console.${method}` });
+    };
+  }
+  return () => {
+    for (const [method, original] of originals) target[method] = original;
+  };
+}
+
+export function installClientLogSink(): () => void {
   // The TUI owns stdout exclusively, so a sink is always installed to keep logs
   // off the frame; it writes to client.log under ACOLYTE_DEBUG, else swallows.
-  if (!process.env.ACOLYTE_DEBUG) {
-    setLogSink(() => {});
-    return;
-  }
-  const logPath = join(stateDir(), "client.log");
-  setLogSink((line) => {
-    try {
-      appendFileSync(logPath, line);
-    } catch {
-      // best-effort
-    }
-  });
+  const logPath = process.env.ACOLYTE_DEBUG ? join(stateDir(), "client.log") : null;
+  setLogSink(
+    logPath === null
+      ? () => {}
+      : (line) => {
+          try {
+            appendFileSync(logPath, line);
+          } catch {
+            // best-effort
+          }
+        },
+  );
+  return captureConsole();
 }
 
 export async function runChat(
@@ -88,7 +133,7 @@ export async function runChat(
   onMount?: (app: { flush: () => void; unmount: () => void }) => void,
   onFatalError?: (error: unknown) => void,
 ): Promise<void> {
-  installClientLogSink();
+  const restoreConsole = installClientLogSink();
   const app = render(<ChatApp {...props} />, { onFatalError });
   try {
     onMount?.(app);
@@ -103,6 +148,7 @@ export async function runChat(
   } finally {
     // Idempotent; repeated here so a throw above still releases the connection.
     props.client.close();
+    restoreConsole();
     setLogSink(null);
   }
 }

--- a/src/chat-effects.test.tsx
+++ b/src/chat-effects.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { useState } from "react";
 import { clampSuggestionIndex, useSuggestions } from "./chat-effects";
-import { renderHook, wait } from "./tui/test-utils";
+import { driveHookCommits, renderHook, wait } from "./tui/test-utils";
 
 function suggestionsHarness(initial: string) {
   return renderHook(() => {
@@ -15,6 +15,23 @@ describe("chat effects helpers", () => {
     expect(clampSuggestionIndex(3, 2)).toBe(1);
     expect(clampSuggestionIndex(-2, 2)).toBe(0);
     expect(clampSuggestionIndex(0, 0)).toBe(0);
+  });
+
+  test("suggestions never schedule an update from a commit", () => {
+    const original = console.error;
+    const messages: string[] = [];
+    console.error = (...args: unknown[]): void => {
+      messages.push(args.map(String).join(" "));
+    };
+    try {
+      // Well past React's 50-commit nested-update limit.
+      driveHookCommits(200, () => {
+        useSuggestions("");
+      });
+    } finally {
+      console.error = original;
+    }
+    expect(messages.filter((message) => message.includes("Maximum update depth exceeded"))).toEqual([]);
   });
 });
 

--- a/src/tui/effects.ts
+++ b/src/tui/effects.ts
@@ -28,9 +28,11 @@ export function useInterval(callback: () => void, delayMs: number | null): void 
 }
 
 /**
- * Run a synchronous side effect when dependencies change. Use for state-sync
- * cases where render-time setState would cause infinite loops (e.g. syncing
- * derived arrays that produce new references each render).
+ * Run a synchronous side effect when dependencies change. Every dependency must be
+ * value-stable across renders — a dependency whose identity changes every render runs
+ * the effect after every commit, and a `setState` there sustains an update chain that
+ * trips React's nested-update limit, whose warning prints onto the terminal the
+ * renderer owns.
  *
  * Unlike other wrappers in this file, this does NOT use ref indirection —
  * the effect closure must capture its own values so React can correctly

--- a/src/tui/test-utils.ts
+++ b/src/tui/test-utils.ts
@@ -257,12 +257,7 @@ export function assertCursorAccounting(frames: string[][], columns: number, rows
   });
 }
 
-export function renderHook<T>(hookFn: () => T): { result: { current: T }; unmount: () => void } {
-  const result = {} as { current: T };
-  function App() {
-    result.current = hookFn();
-    return h("tui-text", null, "");
-  }
+function createHookContainer(node: ReactNode): { unmount: () => void } {
   const root = createElement("tui-root", {});
   setOnCommit(() => {});
   const container = reconciler.createContainer(
@@ -279,15 +274,54 @@ export function renderHook<T>(hookFn: () => T): { result: { current: T }; unmoun
     () => {},
     () => {},
   );
-  reconciler.updateContainerSync(h(App), container, null, null);
+  reconciler.updateContainerSync(node, container, null, null);
   reconciler.flushSyncWork();
   reconciler.flushPassiveEffects();
   return {
-    result,
     unmount() {
       reconciler.updateContainerSync(null, container, null, null);
       reconciler.flushSyncWork();
       setOnCommit(null);
     },
   };
+}
+
+export function renderHook<T>(hookFn: () => T): { result: { current: T }; unmount: () => void } {
+  const result = {} as { current: T };
+  function App() {
+    result.current = hookFn();
+    return h("tui-text", null, "");
+  }
+  const { unmount } = createHookContainer(h(App));
+  return { result, unmount };
+}
+
+/**
+ * Drive `steps` commits of a hook, queueing the next update before each passive flush so
+ * React's eager same-state bailout cannot swallow a no-op set — the streaming condition, where
+ * a drip's transcript update is always already pending by the time effects flush.
+ */
+export function driveHookCommits(steps: number, hookFn: () => void): void {
+  let version = 0;
+  const listeners = new Set<() => void>();
+  const subscribe = (listener: () => void): (() => void) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  };
+  function App() {
+    useSyncExternalStore(subscribe, () => version);
+    hookFn();
+    return h("tui-text", null, "");
+  }
+  const { unmount } = createHookContainer(h(App));
+  try {
+    for (let step = 0; step < steps; step++) {
+      reconciler.flushSyncWork();
+      version += 1;
+      for (const listener of listeners) listener();
+      reconciler.flushPassiveEffects();
+    }
+  } finally {
+    unmount();
+  }
 }


### PR DESCRIPTION
## Motivation

A long streamed answer could duplicate a two-row block in the scrollback. React printed its nested-update warning into the live frame; at 120 columns it spans two rows, so the renderer's next erase fell two rows short, wiped the warning, and repainted below the rows it missed — corrupting the transcript and erasing the evidence of its own cause. #388 removed the warning's source; this closes the path that let any such write reach the frame.

## Summary

- route client `console.*` through the log sink while the TUI is mounted, so no dependency's diagnostic lands mid-frame
- tighten the `useSyncEffect` contract to value-stable dependencies
- cover the suggestion hook against scheduling an update from every commit, driving 200 commits past React's nested-update limit
