### PR TITLE
fix(chat): separate consecutive text blocks

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -165,6 +165,7 @@ A second premise is that completion belongs to the model, not the host. The runt
 - **TUI-12** — Exiting the chat client releases its connection immediately, so an in-flight task is cancelled rather than left running to completion after the user has quit.
 - **TUI-13** — A command, its subcommands, and its help text come from one descriptor, so the completion menu offers only what dispatch can run: it lists a command and its declared subcommands, while argument forms appear in the help pane.
 - **TUI-14** — A typed prompt wraps inside the input box: no row exceeds the box interior, wrapping preserves every character, and a run too long for one row breaks across rows. Vertical cursor motion steps between visual rows at the caret's display column.
+- **TUI-15** — Consecutive blocks of assistant prose render as one transcript row separated by a paragraph break, and that break is preserved in the answer text kept for model history; a row is sealed only by an interruption such as a tool call, and text resumed after a length cutoff continues the same block rather than opening a new one.
 
 ## 8. Observability requirements (OBS)
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -22,6 +22,7 @@ Events are append-only and ordered per request.
 - `tool-output` — incremental tool output for the call id
 - `tool-result` — tool completion (success/error, structured error detail)
 - `text-delta` — assistant text stream chunks
+- `text-end` — end of a block of assistant text; the next block opens a new paragraph
 - `usage` — token usage for the current generation step
 - `tasklist` — inline task list with group ID, title, and items
 - `error` — terminal stream error

--- a/src/agent-contract.ts
+++ b/src/agent-contract.ts
@@ -50,6 +50,7 @@ export type ModelUsagePayload = {
 export type StreamChunk =
   | { type: "step-start" }
   | { type: "text-delta"; payload: TextDeltaPayload }
+  | { type: "text-end" }
   | { type: "reasoning-delta"; payload: TextDeltaPayload }
   | { type: "tool-call"; payload: ToolCallPayload }
   | { type: "tool-result"; payload: ToolResultPayload }

--- a/src/agent-stream.test.ts
+++ b/src/agent-stream.test.ts
@@ -659,6 +659,24 @@ describe("consecutive text blocks", () => {
     expect(chunks.filter((chunk) => chunk.type === "text-end")).toHaveLength(2);
   });
 
+  test("an empty trailing block adds no separator", async () => {
+    const turns: LanguageModelV4StreamPart[][] = [
+      [
+        { type: "text-start", id: "t_1" },
+        { type: "text-delta", id: "t_1", delta: "Testing received." },
+        { type: "text-end", id: "t_1" },
+        { type: "text-start", id: "t_2" },
+        { type: "text-end", id: "t_2" },
+        finishPart("stop"),
+      ],
+    ];
+    const model = scriptedModel(turns, []);
+    const stream = createAgentStream(model, "sys", {}, noopRateLimiter);
+    const { getFullOutput } = await stream("hi", {});
+
+    expect((await getFullOutput()).text).toBe("Testing received.");
+  });
+
   test("a single block carries no trailing separator", async () => {
     const turns: LanguageModelV4StreamPart[][] = [
       [

--- a/src/agent-stream.test.ts
+++ b/src/agent-stream.test.ts
@@ -625,3 +625,53 @@ describe("cancellation", () => {
     expect(calls[0]?.abortSignal).toBe(controller.signal);
   });
 });
+
+describe("consecutive text blocks", () => {
+  test("two blocks in one step stay separated in the answer", async () => {
+    const turns: LanguageModelV4StreamPart[][] = [
+      [
+        { type: "text-start", id: "t_1" },
+        { type: "text-delta", id: "t_1", delta: "I'll answer the latest turn directly." },
+        { type: "text-end", id: "t_1" },
+        { type: "text-start", id: "t_2" },
+        { type: "text-delta", id: "t_2", delta: "Testing received." },
+        { type: "text-end", id: "t_2" },
+        finishPart("stop"),
+      ],
+    ];
+    const model = scriptedModel(turns, []);
+    const stream = createAgentStream(model, "sys", {}, noopRateLimiter);
+    const { fullStream, getFullOutput } = await stream("hi", {});
+
+    const chunks: StreamChunk[] = [];
+    const reader = fullStream.getReader();
+    const drain = (async () => {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+      }
+    })();
+    const output = await getFullOutput();
+    await drain;
+
+    expect(output.text).toBe("I'll answer the latest turn directly.\n\nTesting received.");
+    expect(chunks.filter((chunk) => chunk.type === "text-end")).toHaveLength(2);
+  });
+
+  test("a single block carries no trailing separator", async () => {
+    const turns: LanguageModelV4StreamPart[][] = [
+      [
+        { type: "text-start", id: "t_1" },
+        { type: "text-delta", id: "t_1", delta: "Testing received." },
+        { type: "text-end", id: "t_1" },
+        finishPart("stop"),
+      ],
+    ];
+    const model = scriptedModel(turns, []);
+    const stream = createAgentStream(model, "sys", {}, noopRateLimiter);
+    const { getFullOutput } = await stream("hi", {});
+
+    expect((await getFullOutput()).text).toBe("Testing received.");
+  });
+});

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -126,13 +126,14 @@ export function createAgentStream(
           }> = [];
           finishReason = undefined;
           const stepTextParts: string[] = [];
+          const textBlocks = { paragraphPending: false };
           const reasoningBlocks = new Map<string, ReasoningBlock>();
 
           const reader = streamResult.stream.getReader();
           while (true) {
             const { done, value: part } = await reader.read();
             if (done) break;
-            emitStreamPart(part, streamController, stepTextParts, pendingToolCalls, reasoningBlocks);
+            emitStreamPart(part, streamController, stepTextParts, pendingToolCalls, reasoningBlocks, textBlocks);
             if (part.type === "finish") {
               finishReason = part.finishReason;
               streamController.enqueue({
@@ -327,10 +328,15 @@ function emitStreamPart(
   textParts: string[],
   pendingToolCalls: Array<{ toolCallId: string; toolName: string; input: string }>,
   reasoningBlocks: Map<string, ReasoningBlock>,
+  textBlocks: { paragraphPending: boolean },
 ): void {
   switch (part.type) {
     case "text-delta": {
       if (part.delta.length > 0) {
+        if (textBlocks.paragraphPending) {
+          textBlocks.paragraphPending = false;
+          if (textParts.length > 0) textParts.push("\n\n");
+        }
         textParts.push(part.delta);
         controller.enqueue({ type: "text-delta", payload: { text: part.delta } });
       }
@@ -338,14 +344,12 @@ function emitStreamPart(
     }
     // A block boundary is the only marker that one piece of prose ended and another began.
     // Dropping it concatenates a preamble onto the answer that follows with no separator —
-    // on screen and in the history the model reads back. The separator belongs to the block
-    // that starts, not the one that ends: a `length` cutoff also ends a block, and its
-    // continuation resumes the same sentence rather than opening a new paragraph.
-    case "text-start": {
-      if (textParts.length > 0) textParts.push("\n\n");
-      break;
-    }
+    // on screen and in the history the model reads back. The break is owed to the next block
+    // and paid when its first text arrives, so an empty or absent following block leaves no
+    // trailing separator, and a `length` cutoff — which also ends a block — stitches its
+    // continuation onto the same sentence instead of opening a paragraph.
     case "text-end": {
+      textBlocks.paragraphPending = true;
       controller.enqueue({ type: "text-end" });
       break;
     }

--- a/src/agent-stream.ts
+++ b/src/agent-stream.ts
@@ -336,6 +336,19 @@ function emitStreamPart(
       }
       break;
     }
+    // A block boundary is the only marker that one piece of prose ended and another began.
+    // Dropping it concatenates a preamble onto the answer that follows with no separator —
+    // on screen and in the history the model reads back. The separator belongs to the block
+    // that starts, not the one that ends: a `length` cutoff also ends a block, and its
+    // continuation resumes the same sentence rather than opening a new paragraph.
+    case "text-start": {
+      if (textParts.length > 0) textParts.push("\n\n");
+      break;
+    }
+    case "text-end": {
+      controller.enqueue({ type: "text-end" });
+      break;
+    }
     case "reasoning-start": {
       const block = reasoningBlocks.get(part.id) ?? { text: "" };
       if (part.providerMetadata) block.providerOptions = { ...block.providerOptions, ...part.providerMetadata };

--- a/src/chat-message-handler-stream.test.ts
+++ b/src/chat-message-handler-stream.test.ts
@@ -208,6 +208,23 @@ describe("chat-message-handler-stream", () => {
     state.dispose();
   });
 
+  test("a tool call between blocks drops the owed paragraph break", () => {
+    const { rows, setRows } = createRowsHarness();
+    const state = createMessageStreamState({ setRows });
+
+    state.onEvent({ type: "text-delta", text: "Let me read that." });
+    state.onEvent({ type: "text-end" });
+    state.onToolCall();
+    state.onEvent({ type: "text-delta", text: "It returns a scene." });
+    state.finalize();
+
+    expect(rows.filter((row) => row.kind === "assistant").map((row) => row.content)).toEqual([
+      "Let me read that.",
+      "It returns a scene.",
+    ]);
+    state.dispose();
+  });
+
   test("a text-end before any prose opens no blank paragraph", () => {
     const { rows, setRows } = createRowsHarness();
     const state = createMessageStreamState({ setRows });

--- a/src/chat-message-handler-stream.test.ts
+++ b/src/chat-message-handler-stream.test.ts
@@ -192,6 +192,34 @@ describe("chat-message-handler-stream", () => {
     state.dispose();
   });
 
+  test("a text-block boundary is a paragraph break within one row", () => {
+    const { rows, setRows } = createRowsHarness();
+    const state = createMessageStreamState({ setRows });
+
+    state.onEvent({ type: "text-delta", text: "I'll answer the latest turn directly." });
+    state.onEvent({ type: "text-end" });
+    state.onEvent({ type: "text-delta", text: "Testing received." });
+    state.onEvent({ type: "text-end" });
+    state.finalize();
+
+    expect(rows.filter((row) => row.kind === "assistant").map((row) => row.content)).toEqual([
+      "I'll answer the latest turn directly.\n\nTesting received.",
+    ]);
+    state.dispose();
+  });
+
+  test("a text-end before any prose opens no blank paragraph", () => {
+    const { rows, setRows } = createRowsHarness();
+    const state = createMessageStreamState({ setRows });
+
+    state.onEvent({ type: "text-end" });
+    state.onEvent({ type: "text-delta", text: "Testing received." });
+    state.finalize();
+
+    expect(rows.filter((row) => row.kind === "assistant").map((row) => row.content)).toEqual(["Testing received."]);
+    state.dispose();
+  });
+
   test("leading newlines are stripped when creating new assistant row", () => {
     jest.useFakeTimers();
     const { rows, setRows } = createRowsHarness();

--- a/src/chat-message-handler-stream.ts
+++ b/src/chat-message-handler-stream.ts
@@ -12,6 +12,7 @@ export type MessageStreamState = {
    *  events (status/usage/reasoning) are ignored — the caller owns those. */
   onEvent: (event: StreamEvent) => void;
   onDelta: (delta: string) => void;
+  onTextEnd: () => void;
   onToolCall: () => void;
   onOutput: (entry: { toolCallId: string; toolName: string; content: ToolOutputPart }) => void;
   onToolResult: (entry: {
@@ -51,6 +52,9 @@ export function createMessageStreamState(input: {
   // Text received but not yet revealed. The tick drips it into `agentContent`; every path
   // that reads `agentContent` as the authoritative prose must drain this first.
   let pendingText = "";
+  // A closed text block owes the next one a paragraph break. Held until that block actually
+  // starts, so the last block of a turn leaves no trailing blank line.
+  let paragraphPending = false;
   let tickTimer: ReturnType<typeof setTimeout> | null = null;
   /** Every agent row ID we've created, so dispose() can remove them on the error path. */
   const agentRowIds: string[] = [];
@@ -149,6 +153,7 @@ export function createMessageStreamState(input: {
       );
     activeRowId = null;
     agentContent = "";
+    paragraphPending = false;
   }
 
   const state: MessageStreamState = {
@@ -156,6 +161,9 @@ export function createMessageStreamState(input: {
       switch (event.type) {
         case "text-delta":
           state.onDelta(event.text);
+          break;
+        case "text-end":
+          state.onTextEnd();
           break;
         case "tool-call":
           state.onToolCall();
@@ -180,8 +188,19 @@ export function createMessageStreamState(input: {
 
     onDelta: (delta) => {
       if (delta.length === 0) return;
+      if (paragraphPending) {
+        paragraphPending = false;
+        if (agentContent.length > 0 || pendingText.length > 0) pendingText += "\n\n";
+      }
       pendingText += delta;
       scheduleTick();
+    },
+
+    // A block boundary is a paragraph break, not an interruption: nothing happened between
+    // the two blocks, so they stay one row. Sealing is reserved for a tool call, where the
+    // assistant genuinely stopped to do work.
+    onTextEnd: () => {
+      paragraphPending = true;
     },
 
     onToolCall: () => {

--- a/src/client-contract.test.ts
+++ b/src/client-contract.test.ts
@@ -10,4 +10,11 @@ describe("parseStreamEvent", () => {
   test("rejects a skill-activated event with a malformed skill", () => {
     expect(parseStreamEvent({ type: "skill-activated", skill: { name: "build" } })).toBeNull();
   });
+
+  // An unparsed event is dropped silently, so the block boundary would vanish over the wire
+  // while every same-process test still passed.
+  test("accepts a text-end event", () => {
+    const event: StreamEvent = { type: "text-end" };
+    expect(parseStreamEvent(event)).toEqual(event);
+  });
 });

--- a/src/client-contract.ts
+++ b/src/client-contract.ts
@@ -27,6 +27,7 @@ export interface ClientOptions {
 }
 
 const textDeltaEventSchema = z.object({ type: z.literal("text-delta"), text: z.string() });
+const textEndEventSchema = z.object({ type: z.literal("text-end") });
 const reasoningEventSchema = z.object({ type: z.literal("reasoning"), text: z.string() });
 const toolCallEventSchema = z.object({
   type: z.literal("tool-call"),
@@ -85,6 +86,7 @@ const noticeEventSchema = z.object({
 
 export const streamEventSchema = z.discriminatedUnion("type", [
   textDeltaEventSchema,
+  textEndEventSchema,
   reasoningEventSchema,
   toolCallEventSchema,
   toolOutputEventSchema,

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -364,6 +364,10 @@ const CHUNK_HANDLERS: Record<StreamChunk["type"], ChunkHandler> = {
     }
   },
 
+  "text-end"(ctx) {
+    ctx.emit({ type: "text-end" });
+  },
+
   "reasoning-delta"(ctx, chunk) {
     if (chunk.type !== "reasoning-delta") return;
     const text = chunk.payload?.text;


### PR DESCRIPTION
## Summary

- carry the text-block boundary through the stream as a `text-end` event; dropping it glued a preamble onto the answer that followed, on screen and in the history the model reads back
- render a boundary as a paragraph break within the same row; sealing stays reserved for a tool call
- preserve the break in the answer text kept for model history
- owe the break to the next block and pay it when its first text arrives, so an empty trailing block leaves no separator and a `length` cutoff still stitches mid-sentence
