### PR TITLE
fix(cli): one owner for run-mode line breaks

### DIFF
--- a/src/cli-format.ts
+++ b/src/cli-format.ts
@@ -7,7 +7,7 @@ import type { ToolOutputPart } from "./tool-output-contract";
 import { toolLabelKey } from "./tool-output-format";
 import { renderToolOutput } from "./tool-output-render";
 import { CLI_TOOL_OUTPUT_LIMITS } from "./tool-policy";
-import { printDim, printToolHeader } from "./ui";
+import { dimText, printDim, printOutput, printToolHeader } from "./ui";
 
 export function displayPath(pathInput: string): string {
   const rel = relative(process.cwd(), pathInput);
@@ -18,10 +18,15 @@ export function displayPath(pathInput: string): string {
 /** Columns every tool-output body line is indented under its header in run mode. */
 export const TOOL_BODY_INDENT = 2;
 
+export function formatIndentedDim(content: string): string {
+  return content
+    .split("\n")
+    .map((line) => (line.length > 0 ? dimText(`${" ".repeat(TOOL_BODY_INDENT)}${line}`) : ""))
+    .join("\n");
+}
+
 export function printIndentedDim(content: string): void {
-  for (const line of content.split("\n")) {
-    printDim(line.length > 0 ? `${" ".repeat(TOOL_BODY_INDENT)}${line}` : "");
-  }
+  printOutput(formatIndentedDim(content));
 }
 
 export function printToolResult(toolId: string, raw: string, detail?: string): void {

--- a/src/cli-prompt-golden.test.ts
+++ b/src/cli-prompt-golden.test.ts
@@ -80,7 +80,7 @@ describe("cli-prompt golden output (output-path fold safety net)", () => {
     // stream's tasklist event produces no rows. The final answer ("Updated the config.")
     // diverges from the streamed preview and appears in full.
     expect(out).toBe(
-      "❯ check config\n◆ Let me check the config.◆ tool.file_read.header src/config.ts\ntrace sink is dark\n\n\n\n◆ Updated the config.",
+      "❯ check config\n◆ Let me check the config.\n◆ tool.file_read.header src/config.ts\ntrace sink is dark\n\n\n◆ Updated the config.",
     );
   });
 
@@ -92,7 +92,7 @@ describe("cli-prompt golden output (output-path fold safety net)", () => {
         error: "Cannot finish yet: validation missing",
       }),
     );
-    expect(out).toBe("❯ fix\n◆ Trying the edit.Cannot finish yet: validation missing");
+    expect(out).toBe("❯ fix\n◆ Trying the edit.\nCannot finish yet: validation missing");
   });
 
   test("a lone detail-less tool header prints nothing until it has content", async () => {

--- a/src/cli-prompt.test.ts
+++ b/src/cli-prompt.test.ts
@@ -196,6 +196,53 @@ describe("cli-prompt", () => {
     expect(output).toBe("❯ hi\n◆ Hello there.");
   });
 
+  // Regression: prose leaves its line open, so a tool row used to print onto the end of
+  // the sentence and the resumed answer then lost its indent and printed at column 0.
+  test("a tool row starts its own line after mid-line prose, and the answer resumes indented", async () => {
+    const client: Client = {
+      replyStream: async (input) => {
+        input.onEvent({ type: "text-delta", text: "Reading the file." });
+        input.onEvent({
+          type: "tool-output",
+          toolCallId: "call_1",
+          toolName: "file-read",
+          content: { kind: "tool-header", labelKey: "tool.file_read.header", detail: "src/a.ts" },
+        });
+        return {
+          outputStreamed: true,
+          output: "Reading the file. It exports one function.",
+          model: "gpt-5-mini",
+          toolCalls: ["file-read"],
+        };
+      },
+      status: async () => ({}),
+      taskStatus: async () => null,
+      close: () => {},
+    };
+
+    const { output } = await runPromptAndCapture("read a.ts", createTestSession(), client);
+
+    expect(output).toBe(
+      "❯ read a.ts\n◆ Reading the file.\n◆ tool.file_read.header src/a.ts\n\n\n   It exports one function.",
+    );
+  });
+
+  // Regression: a blocking error printed onto the end of the open prose line.
+  test("a blocking error starts its own line after mid-line prose", async () => {
+    const client: Client = {
+      replyStream: async (input) => {
+        input.onEvent({ type: "text-delta", text: "Trying the edit." });
+        return { outputStreamed: true, output: "", model: "gpt-5-mini", error: "validation missing" };
+      },
+      status: async () => ({}),
+      taskStatus: async () => null,
+      close: () => {},
+    };
+
+    const { output } = await runPromptAndCapture("fix", createTestSession(), client);
+    expect(output).toBe("❯ fix\n◆ Trying the edit.\nvalidation missing");
+  });
+
   // Regression: a notice appended while agent prose is still buffered used to render
   // before the prose (the flush timer had not fired yet), inverting their order.
   test("buffered prose flushes before a notice", async () => {

--- a/src/cli-prompt.test.ts
+++ b/src/cli-prompt.test.ts
@@ -227,6 +227,36 @@ describe("cli-prompt", () => {
     );
   });
 
+  test("each assistant row after a tool row leads with its own marker", async () => {
+    const client: Client = {
+      replyStream: async (input) => {
+        input.onEvent({ type: "text-delta", text: "Opening the file." });
+        input.onEvent({
+          type: "tool-output",
+          toolCallId: "call_1",
+          toolName: "file-read",
+          content: { kind: "tool-header", labelKey: "tool.file_read.header", detail: "src/a.ts" },
+        });
+        input.onEvent({ type: "text-delta", text: "It exports one function." });
+        return {
+          outputStreamed: true,
+          output: "It exports one function.",
+          model: "gpt-5-mini",
+          toolCalls: ["file-read"],
+        };
+      },
+      status: async () => ({}),
+      taskStatus: async () => null,
+      close: () => {},
+    };
+
+    const { output } = await runPromptAndCapture("read a.ts", createTestSession(), client);
+
+    expect(output).toBe(
+      "❯ read a.ts\n◆ Opening the file.\n◆ tool.file_read.header src/a.ts\n◆ It exports one function.",
+    );
+  });
+
   // Regression: a blocking error printed onto the end of the open prose line.
   test("a blocking error starts its own line after mid-line prose", async () => {
     const client: Client = {
@@ -252,7 +282,7 @@ describe("cli-prompt", () => {
     ];
 
     const { output } = await runPromptAndCapture("hi", createTestSession(), createStreamingClient(events));
-    expect(output.indexOf("Alpha text.")).toBeLessThan(output.indexOf("trace sink is dark"));
+    expect(output).toBe("❯ hi\n◆ Alpha text.\ntrace sink is dark\n\n\n◆ done");
   });
 
   // Regression: a failed turn left the flush timer armed, so buffered text wrote to

--- a/src/cli-prompt.ts
+++ b/src/cli-prompt.ts
@@ -8,7 +8,7 @@ import { formatPromptError } from "./error-messages";
 import { t } from "./i18n";
 import type { ResourceId } from "./resource-id";
 import type { Session } from "./session-contract";
-import { printError, printOutput } from "./ui";
+import { printOutput } from "./ui";
 
 function setSessionTitle(session: Session, inputText: string): void {
   if (session.title !== t("chat.session.default_title")) return;
@@ -50,7 +50,7 @@ export async function handlePrompt(
     streamState.finalize();
 
     if (reply.error) {
-      printError(reply.error);
+      projector.renderError(reply.error);
       return false;
     }
     await projector.renderReply(reply.output);
@@ -67,8 +67,8 @@ export async function handlePrompt(
     // A failed turn may leave a flush timer armed; dispose it so buffered text can't
     // write to stdout after we've returned (mirrors the TUI's non-abort catch).
     streamState.dispose();
-    if (!(error instanceof Error)) printError(t("error.prompt.request_failed"));
-    else printError(formatPromptError(error.message));
+    if (!(error instanceof Error)) projector.renderError(t("error.prompt.request_failed"));
+    else projector.renderError(formatPromptError(error.message));
     session.updatedAt = nowIso();
     return false;
   }

--- a/src/cli-stdout-projector.ts
+++ b/src/cli-stdout-projector.ts
@@ -1,59 +1,76 @@
 import { stdout as output } from "node:process";
 import { type ChatRow, isToolOutput } from "./chat-contract";
 import { rowMarker } from "./chat-row-marker";
-import { formatAgentReplyOutput, printIndentedDim, TOOL_BODY_INDENT } from "./cli-format";
+import { formatAgentReplyOutput, formatIndentedDim, TOOL_BODY_INDENT } from "./cli-format";
 import { renderToolOutput } from "./tool-output-render";
-import { printError, printMarkerLine, printOutput, printWarning, streamText } from "./ui";
+import { errorText, formatMarkerLine, streamText, warningText, writeChunk } from "./ui";
 
 /**
  * Projects the row model (fed by MessageStreamState.onEvent) onto append-only stdout,
  * reproducing run mode's incremental rendering. Diffs each row against what it has
  * already emitted so growing tool output and streamed text print only their new tail —
  * the relocation of cli-prompt's hand-rolled `snapshotByCallId` logic.
+ *
+ * Every write goes through `writeLine`/`writeStream`, the sole owners of newline
+ * discipline: streamed prose is the one emitter that can leave a line open, and any
+ * whole-line emitter closes it first.
  */
 export function createStdoutRowProjector(): {
   setRows: (updater: (current: ChatRow[]) => ChatRow[]) => void;
+  renderError: (message: string) => void;
   renderReply: (replyOutput: string) => Promise<void>;
 } {
   let rows: ChatRow[] = [];
-  let atLineStart = true;
-  let agentStreamStarted = false;
+  let midLine = false;
+  let openStreamRowId: string | null = null;
   let agentStreamText = "";
   let assistantMarker = "";
+  let assistantRowId = "";
   let hasPrintedProgress = false;
 
   const emittedAssistant = new Map<string, string>();
   const emittedTool = new Map<string, string>();
   const emittedRowIds = new Set<string>();
 
-  function writeRaw(text: string): void {
-    if (text.length === 0) return;
+  function endLine(): void {
+    if (!midLine) return;
+    writeChunk("\n");
+    midLine = false;
+  }
+
+  function writeLine(text: string): void {
+    endLine();
+    writeChunk(`${text}\n`);
+  }
+
+  function writeStream(rowId: string, marker: string, text: string): void {
     let remaining = text;
     while (remaining.length > 0) {
-      if (atLineStart) {
-        output.write(agentStreamStarted ? "  " : `${assistantMarker} `);
-        agentStreamStarted = true;
+      if (!midLine) {
+        writeChunk(openStreamRowId === rowId ? "  " : `${marker} `);
+        openStreamRowId = rowId;
+        midLine = true;
       }
       const newlineIndex = remaining.indexOf("\n");
       if (newlineIndex === -1) {
-        output.write(remaining);
-        atLineStart = false;
-        break;
+        writeChunk(remaining);
+        return;
       }
-      output.write(`${remaining.slice(0, newlineIndex)}\n`);
+      writeChunk(`${remaining.slice(0, newlineIndex)}\n`);
+      midLine = false;
       remaining = remaining.slice(newlineIndex + 1);
-      atLineStart = true;
     }
   }
 
   function renderAssistant(row: ChatRow): void {
     assistantMarker = rowMarker(row).glyph;
+    assistantRowId = row.id;
     const full = typeof row.content === "string" ? row.content : "";
     const prev = emittedAssistant.get(row.id) ?? "";
     const delta = full.startsWith(prev) ? full.slice(prev.length) : full;
     emittedAssistant.set(row.id, full);
     agentStreamText = full;
-    writeRaw(delta);
+    writeStream(row.id, assistantMarker, delta);
   }
 
   function renderTool(row: ChatRow): void {
@@ -69,21 +86,21 @@ export function createStdoutRowProjector(): {
       const before = previous.trimEnd();
       if (current === before) return;
       if (current.startsWith(`${before}\n`)) {
-        printIndentedDim(current.slice(before.length + 1));
+        writeLine(formatIndentedDim(current.slice(before.length + 1)));
         hasPrintedProgress = true;
         return;
       }
       const currentLines = current.split("\n");
       const previousLines = before.split("\n");
       if (currentLines.length > previousLines.length) {
-        printIndentedDim(currentLines.slice(previousLines.length).join("\n"));
+        writeLine(formatIndentedDim(currentLines.slice(previousLines.length).join("\n")));
         hasPrintedProgress = true;
       }
       return;
     }
     const marker = rowMarker(row);
-    printMarkerLine(marker.glyph, marker.color, rendered.split("\n")[0] ?? "");
-    if (rendered.includes("\n")) printIndentedDim(rendered.slice(rendered.indexOf("\n") + 1));
+    writeLine(formatMarkerLine(marker.glyph, marker.color, rendered.split("\n")[0] ?? ""));
+    if (rendered.includes("\n")) writeLine(formatIndentedDim(rendered.slice(rendered.indexOf("\n") + 1)));
     hasPrintedProgress = true;
   }
 
@@ -102,8 +119,7 @@ export function createStdoutRowProjector(): {
             if (!emittedRowIds.has(row.id) && typeof row.content === "string") {
               // Color by the notice/error level carried on the row's semantic outcome:
               // error→red, everything else (warning)→yellow.
-              if (row.style?.outcome === "error") printError(row.content);
-              else printWarning(row.content);
+              writeLine(row.style?.outcome === "error" ? errorText(row.content) : warningText(row.content));
               hasPrintedProgress = true;
             }
             break;
@@ -113,10 +129,13 @@ export function createStdoutRowProjector(): {
       rows = next;
     },
 
+    renderError: (message) => {
+      writeLine(errorText(message));
+    },
+
     renderReply: async (replyOutput) => {
-      if (!atLineStart) output.write("\n");
-      printOutput("");
-      if (hasPrintedProgress) printOutput("");
+      writeLine("");
+      if (hasPrintedProgress) writeLine("");
       // reply.output is the authoritative answer, printed in full exactly once; the
       // streamed deltas are a preview, reused only when they equal it (no-op) or prefix
       // it (print the tail). reply.output is trimmed upstream while the preview keeps
@@ -125,8 +144,8 @@ export function createStdoutRowProjector(): {
       const streamed = agentStreamText.trimEnd();
       if (replyOutput === streamed) return;
       if (streamed.length > 0 && replyOutput.startsWith(streamed)) {
-        writeRaw(replyOutput.slice(streamed.length));
-        if (!atLineStart) output.write("\n");
+        writeStream(assistantRowId, assistantMarker, replyOutput.slice(streamed.length));
+        endLine();
         return;
       }
       const wrapWidth = Math.max(24, (output.columns ?? 120) - 4);

--- a/src/cli-stdout-projector.ts
+++ b/src/cli-stdout-projector.ts
@@ -11,9 +11,10 @@ import { errorText, formatMarkerLine, streamText, warningText, writeChunk } from
  * already emitted so growing tool output and streamed text print only their new tail —
  * the relocation of cli-prompt's hand-rolled `snapshotByCallId` logic.
  *
- * Every write goes through `writeLine`/`writeStream`, the sole owners of newline
- * discipline: streamed prose is the one emitter that can leave a line open, and any
- * whole-line emitter closes it first.
+ * Cursor state lives in `midLine`, owned by `endLine`/`writeLine`/`writeStream`: streamed
+ * prose is the one emitter that can leave a line open, and every whole-line emitter closes
+ * it first. The animated final answer is the one write outside that state machine, and only
+ * because it runs last, at line start, and terminates its own line.
  */
 export function createStdoutRowProjector(): {
   setRows: (updater: (current: ChatRow[]) => ChatRow[]) => void;

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -8,7 +8,7 @@ export function setUiSink(sink: ((chunk: string) => void) | null): void {
   uiSink = sink;
 }
 
-function write(chunk: string): void {
+export function writeChunk(chunk: string): void {
   if (uiSink) {
     uiSink(chunk);
     return;
@@ -43,40 +43,44 @@ export function tokenizeStreamContent(content: string): string[] {
 
 export async function streamText(content: string): Promise<void> {
   for (const token of tokenizeStreamContent(content)) {
-    write(token);
+    writeChunk(token);
     if (!/^\s+$/.test(token)) await Bun.sleep(12);
   }
-  if (!content.endsWith("\n")) write("\n");
+  if (!content.endsWith("\n")) writeChunk("\n");
 }
 
 export function printDim(content: string): void {
-  write(`${color.dim(content)}\n`);
+  writeChunk(`${color.dim(content)}\n`);
 }
 
 /** A dimmed line led by a marker glyph, tinted `glyphColor` (hex) when set — else dim. */
-export function printMarkerLine(glyph: string, glyphColor: string | undefined, rest: string): void {
+export function formatMarkerLine(glyph: string, glyphColor: string | undefined, rest: string): string {
   const head = glyphColor ? `${hexToAnsi(glyphColor)}${glyph}\x1b[39m` : color.dim(glyph);
-  write(`${head} ${color.dim(rest)}\n`);
+  return `${head} ${color.dim(rest)}`;
 }
+
+export const warningText = (content: string): string => color.dim(color.yellow(content));
+
+export const errorText = (content: string): string => color.red(content);
 
 export function printToolHeader(title: string, detail?: string): void {
   const base = color.bold(color.white(title));
   const suffix = detail ? ` ${color.dim(detail)}` : "";
-  write(`${base}${suffix}\n`);
+  writeChunk(`${base}${suffix}\n`);
 }
 
 export function printOutput(content: string): void {
-  write(`${content}\n`);
+  writeChunk(`${content}\n`);
 }
 
 export function printWarning(content: string): void {
-  write(`${color.dim(color.yellow(content))}\n`);
+  writeChunk(`${warningText(content)}\n`);
 }
 
 export function printError(content: string): void {
-  write(`${color.red(content)}\n`);
+  writeChunk(`${errorText(content)}\n`);
 }
 
 export function clearScreen(): void {
-  write(ansi.clearScreen);
+  writeChunk(ansi.clearScreen);
 }


### PR DESCRIPTION
## Motivation

Run mode tracked cursor position in a boolean that two stdout writers bypassed, so a tool row printed onto the end of the assistant's open prose line and the answer that followed lost its marker and fell to column 0.

## Summary

- route every run-mode emitter through one line-oriented writer that owns newline discipline
- turn the two writers that wrote behind the tracker's back into pure formatters
- send a turn's blocking and thrown errors through the projector so they start their own line
- drop one spurious blank line the stale flag inserted before the final answer
- pin line placement for prose, tool, notice and error rows with exact-output tests