### PR TITLE
fix(chat): hang wrapped list continuations

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -169,6 +169,7 @@ A second premise is that completion belongs to the model, not the host. The runt
 - **TUI-14** — A typed prompt wraps inside the input box: no row exceeds the box interior, wrapping preserves every character, and a run too long for one row breaks across rows. Vertical cursor motion steps between visual rows at the caret's display column.
 - **TUI-15** — Consecutive blocks of assistant prose render as one transcript row separated by a paragraph break, and that break is preserved in the answer text kept for model history; a row is sealed only by an interruption such as a tool call, and text resumed after a length cutoff continues the same block rather than opening a new one.
 - **TUI-16** — Every turn closes with one footer line reporting elapsed time, tool count, and token counts, however fast the turn was. An interrupted turn closes with the same line and the same detail, labelled as interrupted in the text rather than in colour alone.
+- **TUI-17** — A wrapped list item in assistant prose hangs its continuation rows under the item's text, so a continuation never reads as a new top-level line. Ordered and unordered markers are treated alike.
 
 ## 8. Observability requirements (OBS)
 

--- a/src/chat-content.test.ts
+++ b/src/chat-content.test.ts
@@ -42,6 +42,45 @@ describe("chat-content helpers", () => {
       expect(line.startsWith("   ")).toBe(true);
     }
   });
+
+  test("wrapAssistantContent aligns continuations under the item text for every marker", () => {
+    for (const marker of ["-", "*", "+", "•", "1.", "2)"]) {
+      const prefix = `${marker} `;
+      const wrapped = wrapAssistantContent(`${prefix}hello world next line here and so on`, 16);
+      const lines = wrapped.split("\n");
+      expect(lines.length).toBeGreaterThan(1);
+      expect(lines[0]?.startsWith(prefix)).toBe(true);
+      for (const line of lines.slice(1)) {
+        expect(line.slice(0, prefix.length)).toBe(" ".repeat(prefix.length));
+        expect(line[prefix.length]).not.toBe(" ");
+      }
+    }
+  });
+
+  test("wrapAssistantContent hangs a nested bullet under its own text", () => {
+    const wrapped = wrapAssistantContent("  - hello world next line here and so on", 16);
+    const lines = wrapped.split("\n");
+    expect(lines.length).toBeGreaterThan(1);
+    for (const line of lines.slice(1)) {
+      expect(line.slice(0, 4)).toBe("    ");
+      expect(line[4]).not.toBe(" ");
+    }
+  });
+
+  test("wrapAssistantContent keeps a wide marker gap in the continuation", () => {
+    const wrapped = wrapAssistantContent("-   hello world next line here and so on", 16);
+    for (const line of wrapped.split("\n").slice(1)) {
+      expect(line.slice(0, 4)).toBe("    ");
+      expect(line[4]).not.toBe(" ");
+    }
+  });
+
+  test("wrapAssistantContent does not treat emphasis as a bullet marker", () => {
+    const wrapped = wrapAssistantContent("*emphasis* hello world next line here and so on", 16);
+    for (const line of wrapped.split("\n").slice(1)) {
+      expect(line.startsWith(" ")).toBe(false);
+    }
+  });
 });
 
 describe("segmentAssistantContent", () => {

--- a/src/chat-content.ts
+++ b/src/chat-content.ts
@@ -199,10 +199,10 @@ function wrapWithIndent(prefix: string, continuationPrefix: string, body: string
 function wrapSingleLine(line: string, width: number): string[] {
   if (line.length <= width) return [line];
 
-  const numbered = line.match(/^(\s*\d+\.\s+)(.*)$/);
-  if (numbered) {
-    const prefix = numbered[1] ?? "";
-    const body = numbered[2] ?? "";
+  const listItem = line.match(/^(\s*(?:\d+[.)]|[-*+•])\s+)(.*)$/);
+  if (listItem) {
+    const prefix = listItem[1] ?? "";
+    const body = listItem[2] ?? "";
     return wrapWithIndent(prefix, " ".repeat(prefix.length), body, width);
   }
 


### PR DESCRIPTION
## Summary

- wrapped list items continue under the item text instead of at the marker column; previously only ordered items hung, so bullets read as new top-level lines
- one shared marker match covers `-`, `*`, `+`, `•`, `1.` and `1)`
- adds TUI-17, which had no requirement covering assistant list wrapping