### PR TITLE
fix(chat): keep nested list items indented

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -169,7 +169,7 @@ A second premise is that completion belongs to the model, not the host. The runt
 - **TUI-14** — A typed prompt wraps inside the input box: no row exceeds the box interior, wrapping preserves every character, and a run too long for one row breaks across rows. Vertical cursor motion steps between visual rows at the caret's display column.
 - **TUI-15** — Consecutive blocks of assistant prose render as one transcript row separated by a paragraph break, and that break is preserved in the answer text kept for model history; a row is sealed only by an interruption such as a tool call, and text resumed after a length cutoff continues the same block rather than opening a new one.
 - **TUI-16** — Every turn closes with one footer line reporting elapsed time, tool count, and token counts, however fast the turn was. An interrupted turn closes with the same line and the same detail, labelled as interrupted in the text rather than in colour alone.
-- **TUI-17** — A wrapped list item in assistant prose hangs its continuation rows under the item's text, so a continuation never reads as a new top-level line. Ordered and unordered markers are treated alike.
+- **TUI-17** — A wrapped list item in assistant prose hangs its continuation rows under the item's text, so a continuation never reads as a new top-level line. Ordered and unordered markers are treated alike, and a list item keeps the indentation it was written with, so nesting survives rendering.
 
 ## 8. Observability requirements (OBS)
 

--- a/src/chat-content.test.ts
+++ b/src/chat-content.test.ts
@@ -1,19 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import {
-  sanitizeAssistantContent,
-  segmentAssistantContent,
-  wrapAssistantContent,
-  wrapCodeText,
-  wrapText,
-  wrapUserText,
-} from "./chat-content";
+import { segmentAssistantContent, wrapAssistantContent, wrapCodeText, wrapText, wrapUserText } from "./chat-content";
 
 describe("chat-content helpers", () => {
-  test("sanitizeAssistantContent left-aligns numbered findings", () => {
-    const raw = ["  1. First finding", "    2. Second finding"].join("\n");
-    expect(sanitizeAssistantContent(raw)).toBe(["1. First finding", "2. Second finding"].join("\n"));
-  });
-
   test("wrapText wraps long lines at word boundaries", () => {
     const text = "one two three four five six seven eight nine ten";
     const wrapped = wrapText(text, 30);

--- a/src/chat-content.ts
+++ b/src/chat-content.ts
@@ -12,9 +12,9 @@ function stripIndent(line: string, max: number): string {
 }
 
 // Fenced-code pre-pass over raw assistant text. Runs before the line-oriented tokenizer because a
-// fence spans multiple lines; splitting prose from code first keeps prose-only transforms (the
-// numbered-list dedent in sanitizeAssistantContent, inline markup in tokenize) off code, which must
-// survive character-for-character. Shared by the chat layout and the CLI reply formatter.
+// fence spans multiple lines; splitting prose from code first keeps prose-only transforms (list
+// hang-indent in wrapAssistantContent, inline markup in tokenize) off code, which must survive
+// character-for-character. Shared by the chat layout and the CLI reply formatter.
 export function segmentAssistantContent(text: string): AssistantSegment[] {
   const lines = text.split("\n");
   const segments: AssistantSegment[] = [];
@@ -161,15 +161,6 @@ export function wrapUserText(text: string, budget: number): string[] {
     .replace(/\r\n?/g, "\n")
     .split("\n")
     .flatMap((logical) => wrapUserLine(expandTabs(logical), limit));
-}
-
-export function sanitizeAssistantContent(content: string): string {
-  const cleaned = content
-    .split("\n")
-    .map((line) => line.replace(/^\s+(\d+\.\s)/, "$1"))
-    .join("\n")
-    .trimEnd();
-  return cleaned;
 }
 
 function wrapWithIndent(prefix: string, continuationPrefix: string, body: string, width: number): string[] {

--- a/src/terminal-chat-layout.test.ts
+++ b/src/terminal-chat-layout.test.ts
@@ -156,3 +156,26 @@ describe("layoutTranscriptMessage user messages", () => {
     expect(roles).toContain("syntax-deletion");
   });
 });
+
+describe("layoutTranscriptMessage assistant lists", () => {
+  const bodyOf = (text: string, columns = 80): string =>
+    layoutTranscriptMessage({ text, kind: "assistant", columns })
+      .lines.map((line) => line.spans.map((span) => span.text).join(""))
+      .join("\n");
+
+  test("keeps a nested numbered item indented under its parent bullet", () => {
+    const body = bodyOf("- parent bullet\n  1. nested numbered child");
+    const child = body.split("\n").find((line) => line.includes("nested numbered child")) ?? "";
+    const parent = body.split("\n").find((line) => line.includes("parent bullet")) ?? "";
+    expect(child.indexOf("1.") - parent.indexOf("- parent")).toBe(2);
+  });
+
+  test("preserves the indent of a numbered item at any depth", () => {
+    const body = bodyOf("intro\n    3. deeply indented item");
+    expect(body).toContain("    3. deeply indented item");
+  });
+
+  test("drops trailing blank rows from an answer", () => {
+    expect(bodyOf("answer\n\n\n")).toBe(bodyOf("answer"));
+  });
+});

--- a/src/terminal-chat-layout.ts
+++ b/src/terminal-chat-layout.ts
@@ -1,7 +1,7 @@
 import { extname } from "node:path";
 import { z } from "zod";
 import { unreachable } from "./assert";
-import { sanitizeAssistantContent, segmentAssistantContent, wrapAssistantContent, wrapUserText } from "./chat-content";
+import { segmentAssistantContent, wrapAssistantContent, wrapUserText } from "./chat-content";
 import { alignCols, formatCommandOutput, formatCompactNumber } from "./chat-format";
 import { GLYPH_FILLED, GLYPH_FISHEYE, GLYPH_HOLLOW, GLYPH_USER } from "./chat-glyphs";
 import { PICKER_LABEL_WIDTH, PICKER_PAGE_SIZE } from "./chat-picker";
@@ -201,7 +201,7 @@ export function layoutTranscriptMessage(input: {
     segmentAssistantContent(input.text).forEach((segment, index) => {
       if (index > 0) contentLines.push([]);
       if (segment.kind === "prose") {
-        for (const line of wrapAssistantContent(sanitizeAssistantContent(segment.text), textWrap).split("\n")) {
+        for (const line of wrapAssistantContent(segment.text.trimEnd(), textWrap).split("\n")) {
           contentLines.push(tokenize(line).map((token) => assistantTokenSpan(token, role)));
         }
       } else {


### PR DESCRIPTION
## Summary

- nested numbered items keep the indentation they were written with, so nesting survives rendering
- removes `sanitizeAssistantContent`, whose remaining body was a `trimEnd` inlined at its single caller
- extends TUI-17 to cover indentation