### PR TITLE
fix(cli): report our own version and commit

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -44,9 +44,7 @@ fi
 
 echo "$old → $new"
 
-# Verify against the bumped version. Unset the stale npm_package_version the
-# outer `bun run` exported before the bump — resolveCliVersion prefers it.
-env -u npm_package_version bun run verify
+bun run verify
 
 # Where complexity sits in the release being cut. Reported, never a gate: the score is a
 # ratio, so removing simple code raises it, and a threshold would fail good releases.

--- a/src/cli-version.int.test.ts
+++ b/src/cli-version.int.test.ts
@@ -9,7 +9,16 @@ import { gitEnv } from "./test-utils";
 let root = "";
 
 const git = (cwd: string, ...args: string[]): string =>
-  execFileSync("git", args, { cwd, encoding: "utf8", env: gitEnv() }).trim();
+  execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: gitEnv({
+      GIT_AUTHOR_NAME: "T",
+      GIT_AUTHOR_EMAIL: "t@t.dev",
+      GIT_COMMITTER_NAME: "T",
+      GIT_COMMITTER_EMAIL: "t@t.dev",
+    }),
+  }).trim();
 
 beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), "acolyte-commit-"));

--- a/src/cli-version.int.test.ts
+++ b/src/cli-version.int.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveCliVersion, resolveCommitShortFor } from "./cli-version";
+import { gitEnv } from "./test-utils";
+
+let root = "";
+
+const git = (cwd: string, ...args: string[]): string =>
+  execFileSync("git", args, { cwd, encoding: "utf8", env: gitEnv() }).trim();
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "acolyte-commit-"));
+  git(root, "init", "-b", "main");
+  writeFileSync(join(root, "file.txt"), "one\n");
+  git(root, "add", "file.txt");
+  git(root, "commit", "--no-gpg-sign", "-m", "first");
+});
+
+afterEach(() => {
+  rmSync(root, { force: true, recursive: true });
+});
+
+test("the version comes from the install, not from a package.json in the working directory", () => {
+  const original = process.cwd();
+  const previousNpmVersion = process.env.npm_package_version;
+  try {
+    writeFileSync(join(root, "package.json"), '{"name":"a-site","version":"0.0.1"}');
+    process.chdir(root);
+    delete process.env.npm_package_version;
+    expect(resolveCliVersion()).not.toBe("0.0.1");
+    process.env.npm_package_version = "0.0.1";
+    expect(resolveCliVersion()).not.toBe("0.0.1");
+  } finally {
+    process.chdir(original);
+    if (previousNpmVersion === undefined) delete process.env.npm_package_version;
+    else process.env.npm_package_version = previousNpmVersion;
+  }
+});
+
+test("the commit resolves from a checkout", () => {
+  expect(resolveCommitShortFor(root)).toBe(git(root, "rev-parse", "--short=7", "HEAD"));
+});
+
+test("the commit resolves from a linked worktree, whose branch ref lives in the main git dir", () => {
+  const linked = join(root, "linked");
+  git(root, "worktree", "add", "-b", "topic", linked);
+  expect(resolveCommitShortFor(linked)).toBe(git(linked, "rev-parse", "--short=7", "HEAD"));
+});

--- a/src/cli-version.test.ts
+++ b/src/cli-version.test.ts
@@ -16,8 +16,7 @@ describe("cli-version", () => {
     expect(extractVersionFromPackageJsonText("{bad json}")).toBeNull();
   });
 
-  test("resolveCliVersion prefers the compiled-in version over npm_package_version and package.json", () => {
-    process.env.npm_package_version = "0.0.1-source";
+  test("resolveCliVersion prefers the compiled-in version over the install's package.json", () => {
     process.env.ACOLYTE_COMPILED_VERSION = "1.2.3";
     expect(resolveCliVersion()).toBe("1.2.3");
   });

--- a/src/cli-version.ts
+++ b/src/cli-version.ts
@@ -14,16 +14,13 @@ export function extractVersionFromPackageJsonText(text: string): string | null {
 export function resolveCliVersion(): string {
   const compiled = process.env.ACOLYTE_COMPILED_VERSION;
   if (compiled && compiled.trim().length > 0) return compiled.trim();
-  if (process.env.npm_package_version && process.env.npm_package_version.trim().length > 0)
-    return process.env.npm_package_version.trim();
-  const candidates = [`${process.cwd()}/package.json`, `${import.meta.dir}/../package.json`];
-  for (const path of candidates) {
-    try {
-      const version = extractVersionFromPackageJsonText(readFileSync(path, "utf8"));
-      if (version) return version;
-    } catch {
-      // Try next candidate.
-    }
+  // Only this install's own manifest can answer: the working directory and npm_package_version
+  // both describe the user's project, so reading them reports the workspace's version as ours.
+  try {
+    const version = extractVersionFromPackageJsonText(readFileSync(`${import.meta.dir}/../package.json`, "utf8"));
+    if (version) return version;
+  } catch {
+    // Fall through to the unknown-version marker.
   }
   return "dev";
 }
@@ -49,42 +46,57 @@ function gitDirFor(repoRoot: string): string | null {
   }
 }
 
+/** A linked worktree's git dir holds only HEAD and its own index; refs live in the main git dir,
+ *  which `commondir` points at. Git resolves refs through that pointer, so this must too. */
+function refSearchDirs(gitDir: string): string[] {
+  try {
+    const commonDir = readFileSync(join(gitDir, "commondir"), "utf8").trim();
+    if (!commonDir) return [gitDir];
+    return [gitDir, commonDir.startsWith("/") ? commonDir : join(gitDir, commonDir)];
+  } catch {
+    return [gitDir];
+  }
+}
+
+function resolveRef(gitDir: string, ref: string): string | null {
+  for (const dir of refSearchDirs(gitDir)) {
+    try {
+      const commit = shortCommit(readFileSync(join(dir, ref), "utf8"));
+      if (commit) return commit;
+    } catch {
+      // Loose ref absent here; try this dir's packed refs, then the next dir.
+    }
+    try {
+      const line = readFileSync(join(dir, "packed-refs"), "utf8")
+        .split("\n")
+        .find(
+          (value) => value.length > 0 && !value.startsWith("#") && !value.startsWith("^") && value.endsWith(` ${ref}`),
+        );
+      if (line) return shortCommit(line.split(" ")[0] ?? "");
+    } catch {
+      // No packed refs here either.
+    }
+  }
+  return null;
+}
+
 function resolveCommitFromGitDir(gitDir: string): string | null {
   try {
     const head = readFileSync(join(gitDir, "HEAD"), "utf8").trim();
-    if (head.startsWith("ref:")) {
-      const ref = head.slice("ref:".length).trim();
-      const refPath = join(gitDir, ref);
-      try {
-        return shortCommit(readFileSync(refPath, "utf8"));
-      } catch {
-        const packed = readFileSync(join(gitDir, "packed-refs"), "utf8");
-        const line = packed
-          .split("\n")
-          .find(
-            (value) =>
-              value.length > 0 && !value.startsWith("#") && !value.startsWith("^") && value.endsWith(` ${ref}`),
-          );
-        if (!line) return null;
-        const hash = line.split(" ")[0];
-        return shortCommit(hash ?? "");
-      }
-    }
+    if (head.startsWith("ref:")) return resolveRef(gitDir, head.slice("ref:".length).trim());
     return shortCommit(head);
   } catch {
     return null;
   }
 }
 
+export function resolveCommitShortFor(root: string): string | null {
+  const gitDir = gitDirFor(root);
+  return gitDir ? resolveCommitFromGitDir(gitDir) : null;
+}
+
 export function resolveCliCommitShort(): string | null {
-  const roots = [join(import.meta.dir, "..")];
-  for (const root of roots) {
-    const gitDir = gitDirFor(root);
-    if (!gitDir) continue;
-    const commit = resolveCommitFromGitDir(gitDir);
-    if (commit) return commit;
-  }
-  return null;
+  return resolveCommitShortFor(join(import.meta.dir, ".."));
 }
 
 export function formatVersionWithCommit(version: string, commit: string | null): string {


### PR DESCRIPTION
## Motivation

`acolyte --version` and the chat banner report the version of whatever project the user is standing in. In `~/code/acolyte.sh` (`"version": "0.0.1"`) a dev install prints `0.0.1 (6806c6e)` — the site's version paired with Acolyte's commit, which reads as a plausible Acolyte version rather than obvious nonsense. Found while dogfooding.

## Summary

- drop the `process.cwd()/package.json` candidate and the `npm_package_version` fallback from `resolveCliVersion`, leaving the install's own manifest as the only source
- remove the `env -u npm_package_version` workaround in `scripts/release.sh`, which existed only to compensate for that fallback
- resolve a branch ref through the git dir's `commondir` pointer, so a linked worktree reports its commit instead of dropping it
- keep searching when a loose ref is present but unparseable, instead of ending the lookup
- add `resolveCommitShortFor` so commit resolution is testable against a real repository
- cover both defects with tests, each confirmed failing against the old implementation