### PR TITLE
feat(i18n): write replies in the configured language

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,7 +104,7 @@ It is deliberately not project-scoped: a repository-controlled config must not r
 
 ## Localization
 
-- `locale` — active UI language, and the language the model writes its replies in (defaults to `en`).
+- `locale` — active UI language, and the language the model writes its replies in (defaults to `en`). It is user-scoped: the language a person reads in follows them across projects, so a repository cannot set it.
 - Messages are authored in `src/i18n/*.arb` and compiled into the binary; see [localization](localization.md) for adding a language.
 
 ## Logging

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -104,7 +104,7 @@ It is deliberately not project-scoped: a repository-controlled config must not r
 
 ## Localization
 
-- `locale` — active UI language (defaults to `en`).
+- `locale` — active UI language, and the language the model writes its replies in (defaults to `en`).
 - Messages are authored in `src/i18n/*.arb` and compiled into the binary; see [localization](localization.md) for adding a language.
 
 ## Logging
@@ -181,7 +181,7 @@ acolyte config set features.syncAgents true
 | Key | Description |
 |---|---|
 | `port` | daemon server port (default: 6767) |
-| `locale` | UI language (default: `en`) |
+| `locale` | UI and reply language (default: `en`) |
 | `model` | model |
 | `reasoning` | reasoning level for supported models (`low`, `medium`, `high`) |
 | `openaiBaseUrl` | OpenAI API base URL |

--- a/docs/features.md
+++ b/docs/features.md
@@ -15,7 +15,7 @@ Acolyte combines a terminal-first client, headless daemon, lifecycle effects, pe
 - an always-available skill roster the agent activates and deactivates on demand
 - project and user skills from `.agents/skills`
 - Agent Plugins from `.agents/plugins`, contributing skills and MCP servers
-- translated interface, selected by locale
+- translated interface, selected by locale, with replies written in the same language
 - multi-line input
 - custom terminal renderer with React reconciler and structured output
 - syntax highlighting for fenced code and edit diffs

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -35,11 +35,11 @@ The compiler rejects a catalog that omits a key, adds an unknown one, uses a pla
 
 A key held in a field rather than written at the call site is typed as a `PlainTranslationKey`, so a name no catalog carries is a compile error instead of a blank surface. Prose belongs in the message, never in the literal beside it: a chord rendered as `ctrl + c twice` keeps that “twice” in English in every language, while `ctrl + c` plus a translated “twice to exit” reads everywhere.
 
-Call `t()` inside the function that renders, never at module scope. `setLocale` runs at the entrypoints (`cli.ts`, `server.ts`), so a string built while a module evaluates keeps the locale that happened to be active at import. A table of labels or help text is a thunk or a table of keys, resolved on read. Nothing enforces this — a frozen string is a half-translated screen, not an error — so a table that must hold rendered text is covered by a test that switches locale after import and asserts the new language.
+Call `t()` inside the function that renders, never at module scope. `setLocale` runs at the entrypoints (`cli.ts`, `server.ts`) and again on the daemon for each turn, so a string built while a module evaluates keeps the locale that happened to be active at import. A table of labels or help text is a thunk or a table of keys, resolved on read. Nothing enforces this — a frozen string is a half-translated screen, not an error — so a table that must hold rendered text is covered by a test that switches locale after import and asserts the new language.
 
 ## Selecting a language
 
-`acolyte config set locale <id>` chooses the interface language, writing user scope so the choice follows the person across projects. The value is validated against the bundled locales, and a wrong one is answered with the full list. The language applies from the next launch.
+`acolyte config set locale <id>` chooses the interface language, writing user scope so the choice follows the person across projects. The value is validated against the bundled locales, and a wrong one is answered with the full list. The language applies to the next command, and the daemon adopts it on the next turn: it resolves the locale from the same configuration the client did, so a long-running daemon never answers in the language it started with.
 
 ## Message syntax
 

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -19,6 +19,12 @@ Acolyte keeps user-facing copy translatable while protocol methods, payload keys
 
 A new protocol or tool contract takes an identifier-style name rather than a natural-language label, so translating a surface never changes a contract.
 
+## Reply language
+
+The prompt is authored and tuned in English and stays that way; the interface language reaches the model only as the language it writes its prose in. The output contract names that language whenever the interface is not English, so a reply follows `locale` without any instruction being translated.
+
+What the model writes into the repository — code, identifiers, comments, commit messages, file contents — stays English at every locale.
+
 ## Authoring
 
 Messages are authored in ARB (`src/i18n/<locale>.arb`) and compiled into TypeScript by `bun run messages`. Nothing reads ARB at runtime.

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -39,7 +39,7 @@ Call `t()` inside the function that renders, never at module scope. `setLocale` 
 
 ## Selecting a language
 
-`acolyte config set locale <id>` chooses the interface language, writing user scope so the choice follows the person across projects. The value is validated against the bundled locales, and a wrong one is answered with the full list. The language applies to the next command, and a running daemon adopts it on its next turn.
+`acolyte config set locale <id>` chooses the interface language. It is user-scoped, so the choice follows the person across projects and a repository cannot set it. The value is validated against the bundled locales, and a wrong one is answered with the full list. The language applies to the next command, and a running daemon adopts it on its next turn.
 
 ## Message syntax
 

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -39,7 +39,7 @@ Call `t()` inside the function that renders, never at module scope. `setLocale` 
 
 ## Selecting a language
 
-`acolyte config set locale <id>` chooses the interface language, writing user scope so the choice follows the person across projects. The value is validated against the bundled locales, and a wrong one is answered with the full list. The language applies to the next command, and the daemon adopts it on the next turn: it resolves the locale from the same configuration the client did, so a long-running daemon never answers in the language it started with.
+`acolyte config set locale <id>` chooses the interface language, writing user scope so the choice follows the person across projects. The value is validated against the bundled locales, and a wrong one is answered with the full list. The language applies to the next command, and a running daemon adopts it on its next turn.
 
 ## Message syntax
 

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -35,7 +35,7 @@ The compiler rejects a catalog that omits a key, adds an unknown one, uses a pla
 
 A key held in a field rather than written at the call site is typed as a `PlainTranslationKey`, so a name no catalog carries is a compile error instead of a blank surface. Prose belongs in the message, never in the literal beside it: a chord rendered as `ctrl + c twice` keeps that “twice” in English in every language, while `ctrl + c` plus a translated “twice to exit” reads everywhere.
 
-Call `t()` inside the function that renders, never at module scope. `setLocale` runs at the entrypoints (`cli.ts`, `server.ts`) and again on the daemon for each turn, so a string built while a module evaluates keeps the locale that happened to be active at import. A table of labels or help text is a thunk or a table of keys, resolved on read. Nothing enforces this — a frozen string is a half-translated screen, not an error — so a table that must hold rendered text is covered by a test that switches locale after import and asserts the new language.
+Call `t()` inside the function that renders, never at module scope. `setLocale` runs at the entrypoints (`cli.ts`, `server.ts`) and again on the daemon for each turn, so a string built while a module evaluates keeps the locale that happened to be active at import. The reply language is not read from that global: it travels with the turn, so a prompt cannot pick up another turn’s language. A table of labels or help text is a thunk or a table of keys, resolved on read. Nothing enforces this — a frozen string is a half-translated screen, not an error — so a table that must hold rendered text is covered by a test that switches locale after import and asserts the new language.
 
 ## Selecting a language
 

--- a/src/agent-instructions.test.ts
+++ b/src/agent-instructions.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { createInstructions } from "./agent-instructions";
+import { setLocale } from "./i18n";
 import { loadSoulPrompt } from "./soul";
 import { expectIntent } from "./test-utils";
 import { estimateTokens } from "./token-estimate";
@@ -131,5 +132,35 @@ describe("createInstructions", () => {
   test("omits the skills section when no skills are active", () => {
     const out = createInstructions("Soul.");
     expect(out).not.toContain("Active skill (");
+  });
+});
+
+// The prompt is authored and tuned in English; only the language the model writes its prose in
+// follows the configured interface language.
+describe("createInstructions reply language", () => {
+  afterEach(() => setLocale("en"));
+
+  test("names the interface language, and keeps what lands in the repository English", () => {
+    setLocale("sv");
+    const out = createInstructions("Soul.");
+    expectIntent(out, [["Reply in Swedish"], ["stays English", "commit messages"]]);
+  });
+
+  test("names each bundled language rather than its locale id", () => {
+    setLocale("fi");
+    expect(createInstructions("Soul.")).toContain("in Finnish");
+  });
+
+  test("says nothing when the interface is already English", () => {
+    setLocale("en");
+    const out = createInstructions("Soul.");
+    expect(out).not.toContain("Reply in");
+  });
+
+  test("carries the language inside the output contract, not as a section of its own", () => {
+    setLocale("sv");
+    const out = createInstructions("Soul.");
+    const contractEnd = out.indexOf("\n\n", out.indexOf("Format as plain text"));
+    expect(out.indexOf("Reply in Swedish")).toBeLessThan(contractEnd);
   });
 });

--- a/src/agent-instructions.test.ts
+++ b/src/agent-instructions.test.ts
@@ -1,6 +1,5 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { createInstructions } from "./agent-instructions";
-import { setLocale } from "./i18n";
 import { loadSoulPrompt } from "./soul";
 import { expectIntent } from "./test-utils";
 import { estimateTokens } from "./token-estimate";
@@ -138,28 +137,22 @@ describe("createInstructions", () => {
 // The prompt is authored and tuned in English; only the language the model writes its prose in
 // follows the configured interface language.
 describe("createInstructions reply language", () => {
-  afterEach(() => setLocale("en"));
-
   test("names the interface language, and keeps what lands in the repository English", () => {
-    setLocale("sv");
-    const out = createInstructions("Soul.");
+    const out = createInstructions("Soul.", undefined, "", [], "sv");
     expectIntent(out, [["Reply in Swedish"], ["stays English", "commit messages"]]);
   });
 
   test("names each bundled language rather than its locale id", () => {
-    setLocale("fi");
-    expect(createInstructions("Soul.")).toContain("in Finnish");
+    expect(createInstructions("Soul.", undefined, "", [], "fi")).toContain("in Finnish");
   });
 
   test("says nothing when the interface is already English", () => {
-    setLocale("en");
-    const out = createInstructions("Soul.");
+    const out = createInstructions("Soul.", undefined, "", [], "en");
     expect(out).not.toContain("Reply in");
   });
 
   test("carries the language inside the output contract, not as a section of its own", () => {
-    setLocale("sv");
-    const out = createInstructions("Soul.");
+    const out = createInstructions("Soul.", undefined, "", [], "sv");
     const contractEnd = out.indexOf("\n\n", out.indexOf("Format as plain text"));
     expect(out.indexOf("Reply in Swedish")).toBeLessThan(contractEnd);
   });

--- a/src/agent-instructions.ts
+++ b/src/agent-instructions.ts
@@ -1,4 +1,4 @@
-import { currentLocale } from "./i18n";
+import type { TranslationLocale } from "./i18n/locales";
 import type { ActiveSkill } from "./skill-contract";
 import { toolDefinitionsById, toolIds } from "./tool-registry";
 import { createWorkspaceInstructions, resolveWorkspaceProfile } from "./workspace-profile";
@@ -12,8 +12,7 @@ const OUTPUT_CONTRACT =
 
 // The prompt itself stays English so model behavior does not vary by locale; the interface language
 // reaches the model only as the language its prose is written in.
-function createReplyLanguage(): string {
-  const locale = currentLocale();
+function createReplyLanguage(locale: TranslationLocale): string {
   if (locale === "en") return "";
   const language = new Intl.DisplayNames(["en"], { type: "language" }).of(locale) ?? locale;
   return ` Reply in ${language}. What you write into the repository — code, identifiers, comments, commit messages, file contents — stays English.`;
@@ -51,6 +50,7 @@ export function createInstructions(
   workspace?: string,
   projectRulesPrompt = "",
   activeSkills: ActiveSkill[] = [],
+  locale: TranslationLocale = "en",
 ): string {
   const runtimeInstructions = createRuntimeInstructions(workspace);
   const projectRulesSection =
@@ -58,7 +58,7 @@ export function createInstructions(
   const skillsSection = createSkillsSection(activeSkills);
   const sections = [
     soulPrompt,
-    `${OUTPUT_CONTRACT}${createReplyLanguage()}`,
+    `${OUTPUT_CONTRACT}${createReplyLanguage(locale)}`,
     projectRulesSection,
     skillsSection,
     runtimeInstructions,

--- a/src/agent-instructions.ts
+++ b/src/agent-instructions.ts
@@ -1,3 +1,4 @@
+import { currentLocale } from "./i18n";
 import type { ActiveSkill } from "./skill-contract";
 import { toolDefinitionsById, toolIds } from "./tool-registry";
 import { createWorkspaceInstructions, resolveWorkspaceProfile } from "./workspace-profile";
@@ -8,6 +9,15 @@ import { createWorkspaceInstructions, resolveWorkspaceProfile } from "./workspac
 // leaving a long turn silent through every discovery in it.
 const OUTPUT_CONTRACT =
   "Format as plain text. Use `backticks` for code identifiers and **bold** for emphasis; no headings or links. A fenced code block is only for a short illustrative snippet or a command to run — never file contents or a change you could make with a tool. Keep reasoning, structure, and how things connect in prose, even when it names many files or steps. Use a list only for a short, flat set of items with nothing to explain between them. Before your first action, say in one line what you are about to do. When you find something load-bearing mid-task — a root cause, a wrong assumption, a change of direction — say that as you find it, not only in the final answer.";
+
+// The prompt itself stays English so model behavior does not vary by locale; the interface language
+// reaches the model only as the language its prose is written in.
+function createReplyLanguage(): string {
+  const locale = currentLocale();
+  if (locale === "en") return "";
+  const language = new Intl.DisplayNames(["en"], { type: "language" }).of(locale) ?? locale;
+  return ` Reply in ${language}. What you write into the repository — code, identifiers, comments, commit messages, file contents — stays English.`;
+}
 
 const PROJECT_RULES_PRECEDENCE = "Project rules take precedence over generic guidance when they conflict.";
 
@@ -46,8 +56,12 @@ export function createInstructions(
   const projectRulesSection =
     projectRulesPrompt.trim().length > 0 ? `${PROJECT_RULES_PRECEDENCE}\n\n${projectRulesPrompt}` : "";
   const skillsSection = createSkillsSection(activeSkills);
-  const sections = [soulPrompt, OUTPUT_CONTRACT, projectRulesSection, skillsSection, runtimeInstructions].filter(
-    (section) => section.trim().length > 0,
-  );
+  const sections = [
+    soulPrompt,
+    `${OUTPUT_CONTRACT}${createReplyLanguage()}`,
+    projectRulesSection,
+    skillsSection,
+    runtimeInstructions,
+  ].filter((section) => section.trim().length > 0);
   return sections.join("\n\n");
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,7 +59,7 @@ function shallowMerge<T extends object>(base: T, override: T): T {
 }
 
 function mergeConfig(userConfig: Config, projectConfig: Config): Config {
-  const { embeddingBaseUrl: _, ...projectSafe } = projectConfig;
+  const { embeddingBaseUrl: _, locale: __, ...projectSafe } = projectConfig;
   return shallowMerge(userConfig, projectSafe);
 }
 
@@ -274,8 +274,8 @@ function invalidValueError(key: string, value: string, error: z.ZodError): Error
 
 export async function setConfigValue(key: string, value: string, options?: ConfigOptions): Promise<void> {
   const scope = options?.scope ?? "user";
-  if (key === "embeddingBaseUrl" && scope === "project") {
-    throw new Error("embeddingBaseUrl is user-scoped");
+  if ((key === "embeddingBaseUrl" || key === "locale") && scope === "project") {
+    throw new Error(`${key} is user-scoped`);
   }
   const dotted = parseDottedKey(key);
   if (dotted) {
@@ -302,8 +302,8 @@ export async function setConfigValue(key: string, value: string, options?: Confi
 
 export async function unsetConfigValue(key: string, options?: ConfigOptions): Promise<void> {
   const scope = options?.scope ?? "user";
-  if (key === "embeddingBaseUrl" && scope === "project") {
-    throw new Error("embeddingBaseUrl is user-scoped");
+  if ((key === "embeddingBaseUrl" || key === "locale") && scope === "project") {
+    throw new Error(`${key} is user-scoped`);
   }
   const dotted = parseDottedKey(key);
   if (dotted) {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -45,11 +45,6 @@ export function setLocale(locale: TranslationLocale): void {
   activeLocale = locale;
 }
 
-/** The interface language in effect, for the surfaces that must name it rather than render through `t()`. */
-export function currentLocale(): TranslationLocale {
-  return activeLocale;
-}
-
 export function t<K extends TranslationKey>(key: K, ...args: TranslationArgs<K>): string {
   return render(TRANSLATIONS[activeLocale][key], args[0] as Record<string, TranslationValue> | undefined, activeLocale);
 }

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -45,6 +45,11 @@ export function setLocale(locale: TranslationLocale): void {
   activeLocale = locale;
 }
 
+/** The interface language in effect, for the surfaces that must name it rather than render through `t()`. */
+export function currentLocale(): TranslationLocale {
+  return activeLocale;
+}
+
 export function t<K extends TranslationKey>(key: K, ...args: TranslationArgs<K>): string {
   return render(TRANSLATIONS[activeLocale][key], args[0] as Record<string, TranslationValue> | undefined, activeLocale);
 }

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -5,6 +5,7 @@ import type { ReasoningLevel } from "./config-contract";
 import type { ErrorCode } from "./error-contract";
 import type { ErrorCategory, ErrorSource } from "./error-handling";
 import type { ResolvedFeatureFlags } from "./feature-flags-contract";
+import type { TranslationLocale } from "./i18n/locales";
 import type { LifecyclePolicy } from "./lifecycle-policy";
 import type { McpToolListing } from "./mcp-client";
 import type { MemoryCommitMetrics } from "./memory-contract";
@@ -120,6 +121,7 @@ export type LifecycleInput = {
   taskId?: string;
   features: ResolvedFeatureFlags;
   reasoning?: ReasoningLevel;
+  locale: TranslationLocale;
   authRoute?: AuthRoute;
   lifecyclePolicy?: Partial<LifecyclePolicy>;
   runControl?: RunControl;

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -16,6 +16,7 @@ import {
   parseError,
 } from "./error-handling";
 import { t } from "./i18n";
+import type { TranslationLocale } from "./i18n/locales";
 import {
   createFinishPolicyState,
   decideFinish,
@@ -116,10 +117,17 @@ export function createRunAgent(input: {
   model: string;
   tools: Toolset;
   activeSkills: ActiveSkill[];
+  locale: TranslationLocale;
 }): Agent {
   return createAgent({
     model: input.model,
-    instructions: createInstructions(input.soulPrompt, input.workspace, input.projectRulesPrompt, input.activeSkills),
+    instructions: createInstructions(
+      input.soulPrompt,
+      input.workspace,
+      input.projectRulesPrompt,
+      input.activeSkills,
+      input.locale,
+    ),
     tools: input.tools,
   });
 }

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -109,6 +109,7 @@ function createRunContext(
     model: params.model,
     tools: params.prepared.tools,
     activeSkills: params.prepared.skillsForPrompt,
+    locale: input.locale,
   });
 
   const ctx: RunContext = {

--- a/src/server-chat-runtime.int.test.ts
+++ b/src/server-chat-runtime.int.test.ts
@@ -1,9 +1,9 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { createMessagePayload, startFakeProviderServer } from "../scripts/fake-provider-server";
 import { appConfig } from "./app-config";
-import { currentLocale, setLocale } from "./i18n";
-import * as lifecycleModule from "./lifecycle";
+import { setLocale } from "./i18n";
 import { logLifecycleDebugEntry, runChatRequest } from "./server-chat-runtime";
 import { tempDir } from "./test-utils";
 import { createTraceStore } from "./trace-store";
@@ -35,29 +35,34 @@ describe("server chat runtime", () => {
 });
 
 describe("turn language", () => {
-  test("a turn follows the workspace config locale, not the one the daemon booted with", async () => {
+  test("a turn instructs the model in the workspace's configured language", async () => {
     const workspace = createDir("acolyte-locale-srv-");
     mkdirSync(join(workspace, ".acolyte"), { recursive: true });
     writeFileSync(join(workspace, ".acolyte", "config.json"), JSON.stringify({ locale: "sv" }), "utf8");
 
-    const realLifecycle = { ...lifecycleModule };
-    mock.module("./lifecycle", () => ({
-      ...realLifecycle,
-      runLifecycle: async () => ({ output: "hej", outputStreamed: false, model: "gpt-5-mini" }),
-    }));
+    const savedBaseUrl = appConfig.openai.baseUrl;
+    const savedApiKey = appConfig.openai.apiKey;
+    let systemPrompt = "";
+    const fake = startFakeProviderServer({
+      handleRequest: (ctx) => {
+        systemPrompt = JSON.stringify(ctx.body.input);
+        return createMessagePayload(ctx.model, ctx.responseCounter, "hej");
+      },
+    });
+    (appConfig.openai as { baseUrl: string }).baseUrl = fake.baseUrl;
+    (appConfig.openai as { apiKey: string | undefined }).apiKey = "fake-key";
 
-    const savedKey = appConfig.openai.apiKey;
-    (appConfig.openai as { apiKey: string | undefined }).apiKey = "test-key";
     try {
       await runChatRequest(
         { model: "gpt-5-mini", message: "hej", history: [], workspace },
         { path: "/test", method: "POST", onEvent: () => {}, onDone: () => {}, onError: () => {} },
       );
-      expect(currentLocale()).toBe("sv");
+      expect(systemPrompt).toContain("Reply in Swedish");
     } finally {
-      (appConfig.openai as { apiKey: string | undefined }).apiKey = savedKey;
+      fake.stop();
+      (appConfig.openai as { baseUrl: string }).baseUrl = savedBaseUrl;
+      (appConfig.openai as { apiKey: string | undefined }).apiKey = savedApiKey;
       setLocale("en");
-      mock.module("./lifecycle", () => realLifecycle);
     }
   });
 });

--- a/src/server-chat-runtime.int.test.ts
+++ b/src/server-chat-runtime.int.test.ts
@@ -1,6 +1,10 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { logLifecycleDebugEntry } from "./server-chat-runtime";
+import { appConfig } from "./app-config";
+import { currentLocale, setLocale } from "./i18n";
+import * as lifecycleModule from "./lifecycle";
+import { logLifecycleDebugEntry, runChatRequest } from "./server-chat-runtime";
 import { tempDir } from "./test-utils";
 import { createTraceStore } from "./trace-store";
 
@@ -27,5 +31,33 @@ describe("server chat runtime", () => {
     expect(lines[0]?.fields.event).toBe("lifecycle.start");
     expect(lines[0]?.fields.model).toBe("gpt-5");
     store.close();
+  });
+});
+
+describe("turn language", () => {
+  test("a turn follows the workspace config locale, not the one the daemon booted with", async () => {
+    const workspace = createDir("acolyte-locale-srv-");
+    mkdirSync(join(workspace, ".acolyte"), { recursive: true });
+    writeFileSync(join(workspace, ".acolyte", "config.json"), JSON.stringify({ locale: "sv" }), "utf8");
+
+    const realLifecycle = { ...lifecycleModule };
+    mock.module("./lifecycle", () => ({
+      ...realLifecycle,
+      runLifecycle: async () => ({ output: "hej", outputStreamed: false, model: "gpt-5-mini" }),
+    }));
+
+    const savedKey = appConfig.openai.apiKey;
+    (appConfig.openai as { apiKey: string | undefined }).apiKey = "test-key";
+    try {
+      await runChatRequest(
+        { model: "gpt-5-mini", message: "hej", history: [], workspace },
+        { path: "/test", method: "POST", onEvent: () => {}, onDone: () => {}, onError: () => {} },
+      );
+      expect(currentLocale()).toBe("sv");
+    } finally {
+      (appConfig.openai as { apiKey: string | undefined }).apiKey = savedKey;
+      setLocale("en");
+      mock.module("./lifecycle", () => realLifecycle);
+    }
   });
 });

--- a/src/server-chat-runtime.int.test.ts
+++ b/src/server-chat-runtime.int.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { createMessagePayload, startFakeProviderServer } from "../scripts/fake-provider-server";
 import { appConfig } from "./app-config";
 import { setLocale } from "./i18n";
+import { configDir } from "./paths";
 import { logLifecycleDebugEntry, runChatRequest } from "./server-chat-runtime";
 import { tempDir } from "./test-utils";
 import { createTraceStore } from "./trace-store";
@@ -35,10 +36,12 @@ describe("server chat runtime", () => {
 });
 
 describe("turn language", () => {
-  test("a turn instructs the model in the workspace's configured language", async () => {
+  test("a turn instructs the model in the configured language", async () => {
     const workspace = createDir("acolyte-locale-srv-");
-    mkdirSync(join(workspace, ".acolyte"), { recursive: true });
-    writeFileSync(join(workspace, ".acolyte", "config.json"), JSON.stringify({ locale: "sv" }), "utf8");
+    const userConfig = join(configDir(), "config.json");
+    const savedConfig = existsSync(userConfig) ? readFileSync(userConfig, "utf8") : null;
+    mkdirSync(configDir(), { recursive: true });
+    writeFileSync(userConfig, JSON.stringify({ locale: "sv" }), "utf8");
 
     const savedBaseUrl = appConfig.openai.baseUrl;
     const savedApiKey = appConfig.openai.apiKey;
@@ -62,6 +65,8 @@ describe("turn language", () => {
       fake.stop();
       (appConfig.openai as { baseUrl: string }).baseUrl = savedBaseUrl;
       (appConfig.openai as { apiKey: string | undefined }).apiKey = savedApiKey;
+      if (savedConfig === null) rmSync(userConfig, { force: true });
+      else writeFileSync(userConfig, savedConfig, "utf8");
       setLocale("en");
     }
   });

--- a/src/server-chat-runtime.ts
+++ b/src/server-chat-runtime.ts
@@ -286,6 +286,7 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
       workspace: workspaceResolution.workspacePath,
       features: config.features,
       reasoning: config.reasoning,
+      locale: config.locale,
       authRoute: authRouteForModel(chatRequest.model, providerCredentials),
       taskId: handlers.taskId,
       runControl,

--- a/src/server-chat-runtime.ts
+++ b/src/server-chat-runtime.ts
@@ -7,6 +7,7 @@ import { readResolvedConfigSync } from "./config";
 import { createDebugLogger } from "./debug-flags";
 import { createStreamError, errorIdSchema, parseError } from "./error-handling";
 import { field } from "./field";
+import { setLocale } from "./i18n";
 import { runLifecycle } from "./lifecycle";
 import { VERBOSE_ONLY_EVENTS } from "./lifecycle-constants";
 import { errorToLogFields, log } from "./log";
@@ -267,6 +268,8 @@ export async function runChatRequest(chatRequest: ChatRequest, handlers: RunChat
   try {
     await loadSkills(workspaceResolution.workspacePath);
     const config = readResolvedConfigSync({ cwd: workspaceResolution.workspacePath });
+    // The daemon outlives a locale change, so its boot locale goes stale.
+    setLocale(config.locale);
     if (config.features.syncAgents) {
       await syncAgentsMdToProjectMemory({ workspace: workspaceResolution.workspacePath });
     }

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -577,6 +577,7 @@ export function createLifecycleInput(overrides: Partial<LifecycleInput> = {}): L
     request: { model: "gpt-5-mini", message: "test", history: [] },
     soulPrompt: "",
     features: DEFAULT_FEATURE_FLAGS,
+    locale: "en",
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- name the configured interface language in the output contract so replies follow `locale`
- keep the prompt itself English so model behavior does not vary by locale
- carry the locale with the turn, alongside `features` and `reasoning`, so a concurrent turn cannot change the language a prompt is built in
- resolve the locale per turn on the daemon rather than pinning it at process start
- keep `locale` out of project scope so a repository cannot set the language a person reads in
- cover the outgoing prompt language end-to-end against a fake provider