### PR TITLE
fix(errors): derive tool error kind from code

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -10,9 +10,13 @@ Error codes and kinds are generic contracts shared across tools, lifecycle, and 
 
 Runtime code throws coded errors, not untyped string failures, when the failure should carry structured meaning. `ToolError` extends `CodedError` with a code and optional kind. Generic app/runtime failures may still be normalized into coded errors when they need stable handling downstream.
 
+## Codes, kinds, and categories
+
+A code identifies one failure, a kind classifies what sort of failure it is, and a category is the coarse bucket the turn's error stats count. Kind derives from the code, and every tool code declares one. A missing path is named at the tool boundary, where the filesystem's errno becomes `E_FILE_NOT_FOUND`.
+
 ## Lifecycle boundary
 
-Lifecycle consumes tool errors generically through error categories. Step budget exhaustion uses `E_BUDGET_EXHAUSTED` code.
+Lifecycle counts tool errors in the coarse categories and records the precise code and kind on each error event. Step budget exhaustion uses `E_BUDGET_EXHAUSTED` code.
 
 ## Transport boundary
 

--- a/src/code-ops.int.test.ts
+++ b/src/code-ops.int.test.ts
@@ -384,7 +384,7 @@ describe("editCode", () => {
         "call_12",
       ),
     ).rejects.toMatchObject({
-      code: TOOL_ERROR_CODES.editCodeNoMatch,
+      code: TOOL_ERROR_CODES.editCodeAmbiguousTarget,
       message: expect.stringContaining('target: "local" or target: "member"'),
     });
   });

--- a/src/code-ops.ts
+++ b/src/code-ops.ts
@@ -370,7 +370,7 @@ async function editCodeFile(absPath: string, workspace: string, edits: EditCodeE
     }
     if (isRenameEdit(edit) && !edit.target && hasRenameModeConflict(matches)) {
       throw createToolError(
-        TOOL_ERROR_CODES.editCodeNoMatch,
+        TOOL_ERROR_CODES.editCodeAmbiguousTarget,
         `Scoped rename target is ambiguous for ${edit.from}; retry with target: "local" or target: "member"${edit.withinSymbol ? ` withinSymbol: ${edit.withinSymbol}` : ""}`,
       );
     }

--- a/src/error-contract.ts
+++ b/src/error-contract.ts
@@ -4,9 +4,10 @@ export const TOOL_ERROR_CODES = {
   editFileBatchTooLarge: "E_EDIT_FILE_BATCH_TOO_LARGE",
   editFileFindTooLarge: "E_EDIT_FILE_FIND_TOO_LARGE",
   editFileFindNotFound: "E_EDIT_FILE_FIND_NOT_FOUND",
-  editFileLineRangeTooLarge: "E_EDIT_FILE_LINE_RANGE_TOO_LARGE",
+  editFileWouldClearFile: "E_EDIT_FILE_WOULD_CLEAR_FILE",
   editFileReplaceTooLarge: "E_EDIT_FILE_REPLACE_TOO_LARGE",
   editCodeNoMatch: "E_EDIT_CODE_NO_MATCH",
+  editCodeAmbiguousTarget: "E_EDIT_CODE_AMBIGUOUS_TARGET",
   editCodeReplacementMetaMismatch: "E_EDIT_CODE_REPLACEMENT_META_MISMATCH",
   editCodeUnsupportedFile: "E_EDIT_CODE_UNSUPPORTED_FILE",
   searchFilesEmptyScope: "E_SEARCH_FILES_EMPTY_SCOPE",
@@ -55,6 +56,11 @@ export const ERROR_KINDS = {
   budgetExhausted: "budget_exhausted",
   gitUnavailable: "git_unavailable",
   daemonLost: "daemon_lost",
+  noMatch: "no_match",
+  ambiguousMatch: "ambiguous_match",
+  tooLarge: "too_large",
+  unsupportedFile: "unsupported_file",
+  invalidRequest: "invalid_request",
   unknown: "unknown",
 } as const;
 export type ErrorKind = (typeof ERROR_KINDS)[keyof typeof ERROR_KINDS];

--- a/src/error-handling.test.ts
+++ b/src/error-handling.test.ts
@@ -8,6 +8,7 @@ import {
   createStreamError,
   errorCodeFromCategory,
   errorKindFromCategory,
+  errorKindFromErrorCode,
   parseError,
 } from "./error-handling";
 
@@ -94,6 +95,36 @@ describe("error handling helpers", () => {
       kind: ERROR_KINDS.embeddingUnavailable,
       source: "server",
     });
+  });
+
+  test("every tool error code carries a kind more precise than unknown", () => {
+    const unclassified = Object.values(TOOL_ERROR_CODES).filter(
+      (code) => (errorKindFromErrorCode(code) ?? "unknown") === "unknown",
+    );
+
+    expect(unclassified).toEqual([]);
+  });
+
+  test("tool error codes separate a missing match from an oversized input", () => {
+    expect(errorKindFromErrorCode(TOOL_ERROR_CODES.searchFilesNoMatch)).toBe("no_match");
+    expect(errorKindFromErrorCode(TOOL_ERROR_CODES.editFileFindNotFound)).toBe("no_match");
+    expect(errorKindFromErrorCode(TOOL_ERROR_CODES.editFileMultiMatch)).toBe("ambiguous_match");
+    expect(errorKindFromErrorCode(TOOL_ERROR_CODES.editFileFindTooLarge)).toBe("too_large");
+    expect(errorKindFromErrorCode(TOOL_ERROR_CODES.editFileBatchTooLarge)).toBe("too_large");
+    expect(errorKindFromErrorCode(TOOL_ERROR_CODES.scanCodeUnsupportedFile)).toBe("unsupported_file");
+    expect(errorKindFromErrorCode(TOOL_ERROR_CODES.readFileRangeInvalid)).toBe("invalid_request");
+    expect(errorKindFromErrorCode(TOOL_ERROR_CODES.sandboxViolation)).toBe("sandbox_violation");
+  });
+
+  test("an ambiguous rename target is not classified as a missing match", () => {
+    expect(errorKindFromErrorCode(TOOL_ERROR_CODES.editCodeAmbiguousTarget)).toBe("ambiguous_match");
+    expect(errorKindFromErrorCode(TOOL_ERROR_CODES.editCodeNoMatch)).toBe("no_match");
+  });
+
+  test("a code naming an inherited object property resolves to no kind", () => {
+    // A tool payload supplies this string unchecked, so a prototype member must not answer for a code.
+    expect(errorKindFromErrorCode("toString")).toBeUndefined();
+    expect(errorKindFromErrorCode("constructor")).toBeUndefined();
   });
 
   test("createErrorStats initializes all known categories", () => {

--- a/src/error-handling.ts
+++ b/src/error-handling.ts
@@ -6,6 +6,8 @@ import {
   type ErrorKind,
   LIFECYCLE_ERROR_CODES,
   MEMORY_ERROR_CODES,
+  TOOL_ERROR_CODES,
+  type ToolErrorCode,
 } from "./error-contract";
 import { domainIdSchema } from "./id-contract";
 import type { StreamError } from "./stream-error";
@@ -61,8 +63,31 @@ export function errorKindFromCategory(category: ErrorCategory): ErrorKind {
   return ERROR_MAP.find((e) => e.category === category)?.kind ?? ERROR_KINDS.unknown;
 }
 
+// Keyed by every tool code, so a new code cannot compile until it says what kind of failure it is.
+const TOOL_ERROR_KINDS: Record<ToolErrorCode, ErrorKind> = {
+  [TOOL_ERROR_CODES.sandboxViolation]: ERROR_KINDS.sandboxViolation,
+  [TOOL_ERROR_CODES.gitUnavailable]: ERROR_KINDS.gitUnavailable,
+  [TOOL_ERROR_CODES.editFileMultiMatch]: ERROR_KINDS.ambiguousMatch,
+  [TOOL_ERROR_CODES.editCodeAmbiguousTarget]: ERROR_KINDS.ambiguousMatch,
+  [TOOL_ERROR_CODES.editFileFindNotFound]: ERROR_KINDS.noMatch,
+  [TOOL_ERROR_CODES.editCodeNoMatch]: ERROR_KINDS.noMatch,
+  [TOOL_ERROR_CODES.searchFilesNoMatch]: ERROR_KINDS.noMatch,
+  [TOOL_ERROR_CODES.editFileBatchTooLarge]: ERROR_KINDS.tooLarge,
+  [TOOL_ERROR_CODES.editFileFindTooLarge]: ERROR_KINDS.tooLarge,
+  [TOOL_ERROR_CODES.editFileWouldClearFile]: ERROR_KINDS.invalidRequest,
+  [TOOL_ERROR_CODES.editFileReplaceTooLarge]: ERROR_KINDS.tooLarge,
+  [TOOL_ERROR_CODES.readFileTooLarge]: ERROR_KINDS.tooLarge,
+  [TOOL_ERROR_CODES.editCodeUnsupportedFile]: ERROR_KINDS.unsupportedFile,
+  [TOOL_ERROR_CODES.scanCodeUnsupportedFile]: ERROR_KINDS.unsupportedFile,
+  [TOOL_ERROR_CODES.searchFilesUnsearchable]: ERROR_KINDS.unsupportedFile,
+  [TOOL_ERROR_CODES.editCodeReplacementMetaMismatch]: ERROR_KINDS.invalidRequest,
+  [TOOL_ERROR_CODES.readFileRangeInvalid]: ERROR_KINDS.invalidRequest,
+  [TOOL_ERROR_CODES.searchFilesEmptyScope]: ERROR_KINDS.invalidRequest,
+};
+
 export function errorKindFromErrorCode(code?: string): ErrorKind | undefined {
   if (code === MEMORY_ERROR_CODES.embeddingUnavailable) return ERROR_KINDS.embeddingUnavailable;
+  if (code && Object.hasOwn(TOOL_ERROR_KINDS, code)) return TOOL_ERROR_KINDS[code as ToolErrorCode];
   return ERROR_MAP.find((e) => e.code === code)?.kind;
 }
 

--- a/src/file-ops.int.test.ts
+++ b/src/file-ops.int.test.ts
@@ -430,7 +430,7 @@ describe("editFile", () => {
     const { tools } = toolsForAgent({ workspace });
     await expect(
       tools.editFile.execute({ path: filePath, edits: [{ startLine: 1, endLine: 99, replace: "" }] }, "call_edit_lr8"),
-    ).rejects.toMatchObject({ code: TOOL_ERROR_CODES.editFileLineRangeTooLarge });
+    ).rejects.toMatchObject({ code: TOOL_ERROR_CODES.editFileWouldClearFile });
   });
 
   test("line-range rejects a whole-file clear stated in the line numbers a read reports", async () => {
@@ -441,7 +441,7 @@ describe("editFile", () => {
     // A read of this file reports 3 lines, so 1-3 is the honest way to name every line.
     await expect(
       tools.editFile.execute({ path: filePath, edits: [{ startLine: 1, endLine: 3, replace: "" }] }, "call_edit_lr9"),
-    ).rejects.toMatchObject({ code: TOOL_ERROR_CODES.editFileLineRangeTooLarge });
+    ).rejects.toMatchObject({ code: TOOL_ERROR_CODES.editFileWouldClearFile });
   });
 });
 

--- a/src/file-ops.ts
+++ b/src/file-ops.ts
@@ -275,7 +275,7 @@ export async function editFile(input: {
       const contentLineCount = lines[lines.length - 1] === "" ? lines.length - 1 : lines.length;
       if (startLine === 1 && clampedEnd >= contentLineCount && replace.trim().length === 0) {
         throw createToolError(
-          TOOL_ERROR_CODES.editFileLineRangeTooLarge,
+          TOOL_ERROR_CODES.editFileWouldClearFile,
           "line-range edit would clear the entire file. Use a bounded range edit, or file-delete if the file should be removed.",
           undefined,
         );

--- a/src/lifecycle-generate.test.ts
+++ b/src/lifecycle-generate.test.ts
@@ -367,6 +367,11 @@ describe("phaseGenerate", () => {
     expect(traceResult?.fields).toMatchObject({ tool: "file-edit", is_error: true });
     // A null would persist as an empty string; an unknown size has to be absent instead.
     expect(traceResult?.fields).not.toHaveProperty("result_chars");
+    const traceError = debugEvents.find((event) => event.event === "lifecycle.error");
+    expect(traceError?.fields).toMatchObject({
+      code: TOOL_ERROR_CODES.editFileMultiMatch,
+      kind: "ambiguous_match",
+    });
   });
 
   test("emits the embedding-unavailable kind for a failed memory search", async () => {

--- a/src/lifecycle-generate.ts
+++ b/src/lifecycle-generate.ts
@@ -86,7 +86,7 @@ function captureError(ctx: RunContext, message: string, meta?: CaptureErrorMeta)
     (kindCategory ? errorCodeFromCategory(kindCategory) : undefined) ??
     LIFECYCLE_ERROR_CODES.unknown;
   const category = categoryFromErrorCode(code) ?? kindCategory ?? "other";
-  const kind = meta?.kind ?? errorKindFromCategory(category);
+  const kind = meta?.kind ?? errorKindFromErrorCode(code) ?? errorKindFromCategory(category);
   const error: LifecycleError = { message, code, category, source: meta?.source, tool: meta?.tool };
   ctx.errorStats[category] += 1;
   ctx.debug("lifecycle.error", {

--- a/src/tool-execution.test.ts
+++ b/src/tool-execution.test.ts
@@ -23,6 +23,18 @@ describe("withToolError", () => {
       expect(wrapped.code).toBe("E_EDIT_FILE_MULTI_MATCH");
     }
   });
+
+  test("names a missing path instead of leaving the raw errno unclassified", async () => {
+    const source = Object.assign(new Error("no such file or directory, open 'src/gone.ts'"), { code: "ENOENT" });
+    try {
+      await withToolError("file-read", async () => Promise.reject(source));
+      invariant(false, "expected withToolError to throw");
+    } catch (error) {
+      const wrapped = error as Error & { code?: string; kind?: string };
+      expect(wrapped.code).toBe("E_FILE_NOT_FOUND");
+      expect(wrapped.kind).toBe("file_not_found");
+    }
+  });
 });
 
 describe("per-tool timeout", () => {

--- a/src/tool-execution.ts
+++ b/src/tool-execution.ts
@@ -195,7 +195,13 @@ export async function withToolError<T>(toolId: string, task: () => Promise<T>): 
       code?: string;
       kind?: string;
     };
+    // The filesystem raises a missing path itself, so the errno is the only place it is ever named.
     const code = field(error, "code");
+    if (code === "ENOENT") {
+      wrapped.code = LIFECYCLE_ERROR_CODES.fileNotFound;
+      wrapped.kind = ERROR_KINDS.fileNotFound;
+      throw wrapped;
+    }
     if (typeof code === "string" && code.length > 0) wrapped.code = code;
     const kind = field(error, "kind");
     if (typeof kind === "string" && kind.length > 0) wrapped.kind = kind;


### PR DESCRIPTION
## Motivation

Every tool failure reached the trace as `kind: "unknown"`, `category: "other"`, however specific its code — so nothing could key on the field `AGENTS.md` requires errors be classified by.

## Summary

- derive an error's kind from its code, not from the coarse category that collapsed every tool failure to `unknown`
- map all tool codes to kinds through a table keyed by the full code set, so a new code is a type error until it declares its kind
- add `no_match`, `ambiguous_match`, `too_large`, `unsupported_file` and `invalid_request`, and wire `sandbox_violation` and `git_unavailable` to the codes that already had them
- give an ambiguous scoped-rename target its own code instead of reporting it as a missing match
- document how codes, kinds, and categories divide the work
