### PR TITLE
fix(tools): gate the tool surface on feature flags

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,13 +27,13 @@ These must always hold.
 - When behavior and tests diverge, fix the implementation. Update expectations only when explicitly requested.
 - Verify every factual claim at its source before it ships, and cite it — `file:line` for code, a pinned revision for anything outside the repo. Inference, memory, and a plausible reading of a name are not verification.
 - A quantifier (`only`, `never`, `every`, `no other`) needs an exhaustive sweep, not a sample. Without one, weaken the claim to what was checked.
-- Commit only when explicitly requested.
+- Commit verified slices locally on the topic branch as you go; never commit unrequested on `main`.
 - Changes that affect agent behavior: dogfood with `acolyte run` before merge, not just tests.
 
 ## Workflow
 
 - Run: `bun run start` (dev with watch/restart: `bun run dev`).
-- Verify before every commit: `bun run verify` (lint, typecheck, test, audit).
+- Verify before pushing or opening a PR: `bun run verify` (lint, typecheck, test, audit). A slice commit runs the tests covering the slice.
 - Release: `bun run release <patch|minor|major>` — the script owns the gates (clean `main`, version bump, changelog, verify, tag).
 - Worktrees: do each branch's work in its own worktree so parallel branches never clobber the tree; `wt <branch>` creates one (`scripts/worktree-setup.sh`), `wt rm <branch>` removes it. Keep the primary `main` checkout for direct-to-`main` changes.
 

--- a/docs/skills/build.md
+++ b/docs/skills/build.md
@@ -12,7 +12,7 @@ Build in thin vertical slices. Implement one piece, verify it, and commit it whe
 1. **Pick the smallest slice** that delivers a complete, testable path through the change.
 2. **Read before writing.** Load the relevant files, understand existing patterns, check for utilities you can reuse. For external libraries and version-sensitive APIs, confirm behavior against the docs or upstream source for the version pinned in this repo — not memory, not blog posts (`web-fetch`/`web-search`).
 3. **Implement the slice.** Stay within its boundary — don't fix adjacent issues or refactor unrelated code.
-4. **Verify the slice.** Run the targeted tests (`test-run`), then the project's full verification. The build must pass after every slice.
+4. **Verify the slice.** Run the targeted tests (`test-run`); they must pass before the next slice starts. Run the project's full verification once before pushing or opening a PR.
 5. **Commit the slice (only if commits are in scope, via `git-add`/`git-commit`).** One logical change per commit.
 6. **Repeat.** Mark the finished slice done with `tasklist-update` if the plan left a tasklist. If commits are not in scope, pause after each verified slice and ask before starting the next one.
 

--- a/docs/skills/simplify.md
+++ b/docs/skills/simplify.md
@@ -27,7 +27,7 @@ Before changing or removing anything, understand why it exists. Check the histor
 
 ### 3. Apply incrementally
 
-One simplification at a time. Run tests (`test-run`) after each change. If tests fail, revert with `undo-restore` and reconsider. Separate refactoring from feature work.
+One simplification at a time. Run tests (`test-run`) after each change. If tests fail, revert the change and reconsider. Separate refactoring from feature work.
 
 ### 4. Verify
 

--- a/docs/tooling.md
+++ b/docs/tooling.md
@@ -18,7 +18,7 @@ lifecycle → budget → toolkit → registry
 |---------|---------|
 | `file` | File operations |
 | `code` | AST-aware code scanning and editing |
-| `undo` | Revert file edits |
+| `undo` | Revert file edits — registered only when `undoCheckpoints` is enabled |
 | `session` | Search current session history |
 | `memory` | Persistent cross-session knowledge |
 | `skill` | Skill activation and deactivation |

--- a/src/cli-tool.ts
+++ b/src/cli-tool.ts
@@ -1,5 +1,6 @@
 import { resolve } from "node:path";
 import { z } from "zod";
+import { appConfig } from "./app-config";
 import { printIndentedDim, printToolResult } from "./cli-format";
 import { errorMessage } from "./error-contract";
 import { t } from "./i18n";
@@ -60,7 +61,7 @@ export async function toolMode(args: string[], deps: ToolModeDeps): Promise<void
   }
 
   const workspace = resolve(process.cwd());
-  const { tools, session } = toolsForAgent({ workspace });
+  const { tools, session } = toolsForAgent({ workspace, features: appConfig.features });
   session.workspaceProfile = resolveWorkspaceProfile(workspace);
 
   const available = Object.values<ToolDefinition>(tools);

--- a/src/git-toolkit.ts
+++ b/src/git-toolkit.ts
@@ -277,7 +277,7 @@ function createGitCommitTool(git: GitOps, input: ToolkitInput) {
     toolkit: "git",
     category: "write",
     description:
-      "Create a git commit with a required subject line and optional body lines. Commit only when the user asks.",
+      "Create a git commit with a required subject line and optional body lines. Follow the project's rule on when to commit; with no such rule, commit when the user asks.",
     outputSchema: z.object({
       kind: z.literal("git-commit"),
       message: z.string().min(1),

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -76,6 +76,7 @@ export type PhasePrepareInput = {
   projectRulesPrompt?: string;
   model: string;
   policy: LifecyclePolicy;
+  features?: ResolvedFeatureFlags;
   debug: RunContext["debug"];
   onOutput: (event: ToolOutputEvent) => void;
   onTasklist: TasklistListener;

--- a/src/lifecycle-contract.ts
+++ b/src/lifecycle-contract.ts
@@ -76,7 +76,7 @@ export type PhasePrepareInput = {
   projectRulesPrompt?: string;
   model: string;
   policy: LifecyclePolicy;
-  features?: ResolvedFeatureFlags;
+  features: ResolvedFeatureFlags;
   debug: RunContext["debug"];
   onOutput: (event: ToolOutputEvent) => void;
   onTasklist: TasklistListener;

--- a/src/lifecycle-effects.ts
+++ b/src/lifecycle-effects.ts
@@ -4,7 +4,6 @@ import type { Effect, EffectInput, EffectResult, RunContext } from "./lifecycle-
 import type { EffectOutput, PostToolContext, PreToolContext, SessionContext } from "./tool-contract";
 import { type ShellLine, shellTailParts } from "./tool-output-format";
 import { OUTPUT_WINDOW_ROWS } from "./tool-policy";
-import { DISCOVERY_TOOL_SET } from "./tool-registry";
 import type { WorkspaceCommand } from "./workspace-contract";
 import {
   type CommandResult,
@@ -141,7 +140,7 @@ function mergeEffectOutputs(a: EffectOutput | undefined, b: EffectOutput | undef
 }
 
 async function preToolSideEffects(ctx: RunContext, preCtx: PreToolContext): Promise<void> {
-  if (DISCOVERY_TOOL_SET.has(preCtx.toolId)) return;
+  if (ctx.session.discoveryTools.has(preCtx.toolId)) return;
   for (const effect of PRE_EFFECTS) {
     await effect.run(ctx);
   }

--- a/src/lifecycle-effects.ts
+++ b/src/lifecycle-effects.ts
@@ -4,7 +4,7 @@ import type { Effect, EffectInput, EffectResult, RunContext } from "./lifecycle-
 import type { EffectOutput, PostToolContext, PreToolContext, SessionContext } from "./tool-contract";
 import { type ShellLine, shellTailParts } from "./tool-output-format";
 import { OUTPUT_WINDOW_ROWS } from "./tool-policy";
-import { DISCOVERY_TOOL_SET, WRITE_TOOL_SET } from "./tool-registry";
+import { DISCOVERY_TOOL_SET } from "./tool-registry";
 import type { WorkspaceCommand } from "./workspace-contract";
 import {
   type CommandResult,
@@ -151,7 +151,7 @@ async function preToolSideEffects(ctx: RunContext, preCtx: PreToolContext): Prom
 // write cannot start while a formatter is still rewriting the file this one produced.
 async function postToolSideEffects(ctx: RunContext, postCtx: PostToolContext): Promise<EffectOutput | undefined> {
   if (postCtx.status !== "succeeded") return undefined;
-  if (!WRITE_TOOL_SET.has(postCtx.toolId)) return undefined;
+  if (!ctx.session.writeTools.has(postCtx.toolId)) return undefined;
   const path = typeof postCtx.args.path === "string" ? postCtx.args.path.trim() : "";
   if (!path) return undefined;
   // A write that removed the file leaves nothing to format or lint, and a linter pointed at a path

--- a/src/lifecycle-finalize.test.ts
+++ b/src/lifecycle-finalize.test.ts
@@ -157,6 +157,29 @@ describe("phaseFinalize", () => {
     expect(summary?.pre_write_discovery_calls).toBe(2);
   });
 
+  test("counts writes and pre-write discovery from the session write set", () => {
+    const session = createSessionContext("task_1", new Set(["undo-restore"]));
+    session.callLog.push(
+      { toolName: "file-search", args: {}, taskId: "task_1", status: "succeeded" },
+      { toolName: "undo-restore", args: {}, taskId: "task_1", status: "succeeded" },
+      { toolName: "file-read", args: {}, taskId: "task_1", status: "succeeded" },
+    );
+    let summary: Record<string, unknown> | undefined;
+    const ctx = createRunContext({
+      taskId: "task_1",
+      session,
+      result: { text: "done", toolCalls: [] },
+      debug: (event, fields) => {
+        if (event === "lifecycle.summary") summary = fields;
+      },
+    });
+
+    phaseFinalize(ctx);
+
+    expect(summary?.write_calls).toBe(1);
+    expect(summary?.pre_write_discovery_calls).toBe(1);
+  });
+
   test("lifecycle.summary debug event has all catalog display fields", () => {
     const debugEvents: Array<{ event: string; fields: Record<string, unknown> }> = [];
     const ctx = createRunContext({

--- a/src/lifecycle-finalize.test.ts
+++ b/src/lifecycle-finalize.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { parseChatResponse } from "./client-contract";
+import { DEFAULT_FEATURE_FLAGS } from "./feature-flags-contract";
 import { phaseFinalize } from "./lifecycle-finalize";
 import { createRunContext } from "./test-utils";
-import { createSessionContext } from "./tool-session";
+import { toolsForAgent } from "./tool-registry";
 import { missingCatalogDisplayFields } from "./trace-event-catalog";
 
 describe("ChatResponse error field", () => {
@@ -127,7 +128,7 @@ describe("phaseFinalize", () => {
   });
 
   test("counts recall probes separately and keeps them out of search/discovery", () => {
-    const session = createSessionContext("task_1");
+    const { session } = toolsForAgent({ taskId: "task_1" });
     session.callLog.push(
       { toolName: "memory-search", args: {}, taskId: "task_1", status: "succeeded" },
       { toolName: "session-search", args: {}, taskId: "task_1", status: "succeeded" },
@@ -158,7 +159,10 @@ describe("phaseFinalize", () => {
   });
 
   test("counts writes and pre-write discovery from the session write set", () => {
-    const session = createSessionContext("task_1", new Set(["undo-restore"]));
+    const { session } = toolsForAgent({
+      taskId: "task_1",
+      features: { ...DEFAULT_FEATURE_FLAGS, undoCheckpoints: true },
+    });
     session.callLog.push(
       { toolName: "file-search", args: {}, taskId: "task_1", status: "succeeded" },
       { toolName: "undo-restore", args: {}, taskId: "task_1", status: "succeeded" },

--- a/src/lifecycle-finalize.ts
+++ b/src/lifecycle-finalize.ts
@@ -2,7 +2,6 @@ import type { ChatResponse } from "./api";
 import { t } from "./i18n";
 import { promptUsageTotalTokens, type RunContext } from "./lifecycle-contract";
 import { estimateTokens } from "./token-estimate";
-import { DISCOVERY_TOOL_SET, READ_TOOL_SET, SEARCH_TOOL_SET } from "./tool-registry";
 import { scopedCallLog } from "./tool-session";
 
 export function phaseFinalize(ctx: RunContext): ChatResponse {
@@ -34,10 +33,10 @@ export function phaseFinalize(ctx: RunContext): ChatResponse {
   // keep them off those axes so read/search/discovery stay a clean over-exploration signal.
   const isRecallProbe = (toolName: string) => toolName === "memory-search" || toolName === "session-search";
   const isCodeDiscovery = (entry: { toolName: string }) =>
-    DISCOVERY_TOOL_SET.has(entry.toolName) && !isRecallProbe(entry.toolName);
-  const readCalls = callLog.filter((entry) => READ_TOOL_SET.has(entry.toolName)).length;
+    ctx.session.discoveryTools.has(entry.toolName) && !isRecallProbe(entry.toolName);
+  const readCalls = callLog.filter((entry) => ctx.session.readTools.has(entry.toolName)).length;
   const searchCalls = callLog.filter(
-    (entry) => SEARCH_TOOL_SET.has(entry.toolName) && !isRecallProbe(entry.toolName),
+    (entry) => ctx.session.searchTools.has(entry.toolName) && !isRecallProbe(entry.toolName),
   ).length;
   const writeCalls = callLog.filter((entry) => ctx.session.writeTools.has(entry.toolName)).length;
   const memorySearchCalls = callLog.filter((entry) => entry.toolName === "memory-search").length;

--- a/src/lifecycle-finalize.ts
+++ b/src/lifecycle-finalize.ts
@@ -2,7 +2,7 @@ import type { ChatResponse } from "./api";
 import { t } from "./i18n";
 import { promptUsageTotalTokens, type RunContext } from "./lifecycle-contract";
 import { estimateTokens } from "./token-estimate";
-import { DISCOVERY_TOOL_SET, READ_TOOL_SET, SEARCH_TOOL_SET, WRITE_TOOL_SET } from "./tool-registry";
+import { DISCOVERY_TOOL_SET, READ_TOOL_SET, SEARCH_TOOL_SET } from "./tool-registry";
 import { scopedCallLog } from "./tool-session";
 
 export function phaseFinalize(ctx: RunContext): ChatResponse {
@@ -39,10 +39,10 @@ export function phaseFinalize(ctx: RunContext): ChatResponse {
   const searchCalls = callLog.filter(
     (entry) => SEARCH_TOOL_SET.has(entry.toolName) && !isRecallProbe(entry.toolName),
   ).length;
-  const writeCalls = callLog.filter((entry) => WRITE_TOOL_SET.has(entry.toolName)).length;
+  const writeCalls = callLog.filter((entry) => ctx.session.writeTools.has(entry.toolName)).length;
   const memorySearchCalls = callLog.filter((entry) => entry.toolName === "memory-search").length;
   const sessionSearchCalls = callLog.filter((entry) => entry.toolName === "session-search").length;
-  const firstWriteIndex = callLog.findIndex((entry) => WRITE_TOOL_SET.has(entry.toolName));
+  const firstWriteIndex = callLog.findIndex((entry) => ctx.session.writeTools.has(entry.toolName));
   const preWriteDiscoveryCalls =
     firstWriteIndex >= 0
       ? callLog.slice(0, firstWriteIndex).filter(isCodeDiscovery).length

--- a/src/lifecycle-generate.test.ts
+++ b/src/lifecycle-generate.test.ts
@@ -731,7 +731,8 @@ describe("phaseGenerate", () => {
   test("injects the budget notice once when the per-turn call count crosses the threshold", async () => {
     const promptCapture: LanguageModelV4Message[][] = [];
     const debugEvents: LifecycleDebugEvent[] = [];
-    const session = createSessionContext(undefined, writeTools);
+    const session = createSessionContext();
+    session.writeTools = writeTools;
     session.maxToolCallsPerRequest = 100;
     // Threshold is ceil(0.9 * 100) = 90; pre-fill the call log to the crossing point.
     for (let i = 0; i < 90; i++) session.callLog.push({ toolName: "file-read", args: {}, status: "succeeded" });
@@ -784,7 +785,8 @@ describe("phaseGenerate", () => {
     // rather than surfacing an empty answer.
     const promptCapture: LanguageModelV4Message[][] = [];
     const debugEvents: LifecycleDebugEvent[] = [];
-    const session = createSessionContext(undefined, writeTools);
+    const session = createSessionContext();
+    session.writeTools = writeTools;
 
     const turns: LanguageModelV4StreamPart[][] = [
       [{ type: "tool-call", toolCallId: "tc_1", toolName: "noop", input: "{}" }, finishPart("tool-calls")],
@@ -826,7 +828,8 @@ describe("phaseGenerate", () => {
   test("a written final response after tool work completes cleanly", async () => {
     const promptCapture: LanguageModelV4Message[][] = [];
     const debugEvents: LifecycleDebugEvent[] = [];
-    const session = createSessionContext(undefined, writeTools);
+    const session = createSessionContext();
+    session.writeTools = writeTools;
 
     const turns: LanguageModelV4StreamPart[][] = [
       [{ type: "tool-call", toolCallId: "tc_1", toolName: "noop", input: "{}" }, finishPart("tool-calls")],

--- a/src/lifecycle-generate.test.ts
+++ b/src/lifecycle-generate.test.ts
@@ -8,9 +8,10 @@ import type { LifecycleDebugEvent, RunContext } from "./lifecycle-contract";
 import { phaseGenerate } from "./lifecycle-generate";
 import type { RateLimiter } from "./rate-limiter";
 import { createRunContext } from "./test-utils";
-import { WRITE_TOOL_SET } from "./tool-registry";
 import { createSessionContext } from "./tool-session";
 import { traceEventDisplayFields } from "./trace-event-catalog";
+
+const writeTools = new Set(["code-edit", "file-create", "file-delete", "file-edit", "git-add", "git-commit"]);
 
 const noopRateLimiter: RateLimiter = {
   async beforeCall() {},
@@ -730,7 +731,7 @@ describe("phaseGenerate", () => {
   test("injects the budget notice once when the per-turn call count crosses the threshold", async () => {
     const promptCapture: LanguageModelV4Message[][] = [];
     const debugEvents: LifecycleDebugEvent[] = [];
-    const session = createSessionContext(undefined, WRITE_TOOL_SET);
+    const session = createSessionContext(undefined, writeTools);
     session.maxToolCallsPerRequest = 100;
     // Threshold is ceil(0.9 * 100) = 90; pre-fill the call log to the crossing point.
     for (let i = 0; i < 90; i++) session.callLog.push({ toolName: "file-read", args: {}, status: "succeeded" });
@@ -783,7 +784,7 @@ describe("phaseGenerate", () => {
     // rather than surfacing an empty answer.
     const promptCapture: LanguageModelV4Message[][] = [];
     const debugEvents: LifecycleDebugEvent[] = [];
-    const session = createSessionContext(undefined, WRITE_TOOL_SET);
+    const session = createSessionContext(undefined, writeTools);
 
     const turns: LanguageModelV4StreamPart[][] = [
       [{ type: "tool-call", toolCallId: "tc_1", toolName: "noop", input: "{}" }, finishPart("tool-calls")],
@@ -825,7 +826,7 @@ describe("phaseGenerate", () => {
   test("a written final response after tool work completes cleanly", async () => {
     const promptCapture: LanguageModelV4Message[][] = [];
     const debugEvents: LifecycleDebugEvent[] = [];
-    const session = createSessionContext(undefined, WRITE_TOOL_SET);
+    const session = createSessionContext(undefined, writeTools);
 
     const turns: LanguageModelV4StreamPart[][] = [
       [{ type: "tool-call", toolCallId: "tc_1", toolName: "noop", input: "{}" }, finishPart("tool-calls")],

--- a/src/lifecycle-generate.test.ts
+++ b/src/lifecycle-generate.test.ts
@@ -11,8 +11,6 @@ import { createRunContext } from "./test-utils";
 import { createSessionContext } from "./tool-session";
 import { traceEventDisplayFields } from "./trace-event-catalog";
 
-const writeTools = new Set(["code-edit", "file-create", "file-delete", "file-edit", "git-add", "git-commit"]);
-
 const noopRateLimiter: RateLimiter = {
   async beforeCall() {},
   onResponse() {},
@@ -732,7 +730,6 @@ describe("phaseGenerate", () => {
     const promptCapture: LanguageModelV4Message[][] = [];
     const debugEvents: LifecycleDebugEvent[] = [];
     const session = createSessionContext();
-    session.writeTools = writeTools;
     session.maxToolCallsPerRequest = 100;
     // Threshold is ceil(0.9 * 100) = 90; pre-fill the call log to the crossing point.
     for (let i = 0; i < 90; i++) session.callLog.push({ toolName: "file-read", args: {}, status: "succeeded" });
@@ -786,7 +783,6 @@ describe("phaseGenerate", () => {
     const promptCapture: LanguageModelV4Message[][] = [];
     const debugEvents: LifecycleDebugEvent[] = [];
     const session = createSessionContext();
-    session.writeTools = writeTools;
 
     const turns: LanguageModelV4StreamPart[][] = [
       [{ type: "tool-call", toolCallId: "tc_1", toolName: "noop", input: "{}" }, finishPart("tool-calls")],
@@ -829,7 +825,6 @@ describe("phaseGenerate", () => {
     const promptCapture: LanguageModelV4Message[][] = [];
     const debugEvents: LifecycleDebugEvent[] = [];
     const session = createSessionContext();
-    session.writeTools = writeTools;
 
     const turns: LanguageModelV4StreamPart[][] = [
       [{ type: "tool-call", toolCallId: "tc_1", toolName: "noop", input: "{}" }, finishPart("tool-calls")],

--- a/src/lifecycle-prepare.test.ts
+++ b/src/lifecycle-prepare.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { ChatRequest } from "./api";
 import { addActiveSkill } from "./chat-skill-activator";
+import { DEFAULT_FEATURE_FLAGS } from "./feature-flags-contract";
 import { MAX_RECENT_TURNS } from "./lifecycle-constants";
 import { defaultLifecyclePolicy } from "./lifecycle-policy";
 import { phasePrepare } from "./lifecycle-prepare";
@@ -30,6 +31,7 @@ describe("phasePrepare", () => {
       onTasklist: () => {},
       onSkillActivated: () => {},
       onSkillDeactivated: () => {},
+      features: DEFAULT_FEATURE_FLAGS,
       mcpListings: [],
     });
     expect(prepared.session.toolTimeoutMs).toBe(1_234);
@@ -50,6 +52,7 @@ describe("phasePrepare", () => {
       onTasklist: () => {},
       onSkillActivated: () => {},
       onSkillDeactivated: () => {},
+      features: DEFAULT_FEATURE_FLAGS,
       mcpListings: [],
     });
     const withRules = phasePrepare({
@@ -65,6 +68,7 @@ describe("phasePrepare", () => {
       onTasklist: () => {},
       onSkillActivated: () => {},
       onSkillDeactivated: () => {},
+      features: DEFAULT_FEATURE_FLAGS,
       mcpListings: [],
     });
     expect(withRules.promptUsage.systemPromptTokens).toBeGreaterThan(base.promptUsage.systemPromptTokens);
@@ -84,6 +88,7 @@ describe("phasePrepare", () => {
       onTasklist: () => {},
       onSkillActivated: () => {},
       onSkillDeactivated: () => {},
+      features: DEFAULT_FEATURE_FLAGS,
       mcpListings: [],
     });
     const drop = events.find((e) => e.event === "lifecycle.window.drop");
@@ -108,6 +113,7 @@ describe("phasePrepare", () => {
       onTasklist: () => {},
       onSkillActivated: () => {},
       onSkillDeactivated: () => {},
+      features: DEFAULT_FEATURE_FLAGS,
       mcpListings: [],
     });
     expect(prepared.session.activeSkills).toEqual(activeSkills);
@@ -128,6 +134,7 @@ describe("phasePrepare", () => {
       onTasklist: () => {},
       onSkillActivated: () => {},
       onSkillDeactivated: () => {},
+      features: DEFAULT_FEATURE_FLAGS,
       mcpListings: [],
     });
     expect(prepared.skillsForPrompt).toEqual(activeSkills);
@@ -152,6 +159,7 @@ describe("phasePrepare", () => {
       onTasklist: () => {},
       onSkillActivated: () => {},
       onSkillDeactivated: () => {},
+      features: DEFAULT_FEATURE_FLAGS,
       mcpListings: [],
     });
     expect(prepared.skillsForPrompt).toEqual([]);
@@ -180,6 +188,7 @@ describe("phasePrepare", () => {
       onTasklist: () => {},
       onSkillActivated: () => {},
       onSkillDeactivated: () => {},
+      features: DEFAULT_FEATURE_FLAGS,
       mcpListings: [],
     });
     addActiveSkill(prepared.session, { name: "tdd", instructions: "red green" });
@@ -199,6 +208,7 @@ describe("phasePrepare", () => {
       onTasklist: () => {},
       onSkillActivated: () => {},
       onSkillDeactivated: () => {},
+      features: DEFAULT_FEATURE_FLAGS,
       mcpListings: [],
     });
     expect(prepared.session.activeSkills).toBeUndefined();
@@ -218,6 +228,7 @@ describe("phasePrepare", () => {
       onTasklist: () => {},
       onSkillActivated: () => {},
       onSkillDeactivated: () => {},
+      features: DEFAULT_FEATURE_FLAGS,
       mcpListings: [],
     });
     expect(events).not.toContain("lifecycle.window.drop");

--- a/src/lifecycle-prepare.ts
+++ b/src/lifecycle-prepare.ts
@@ -25,6 +25,7 @@ export function phasePrepare(input: PhasePrepareInput): PhasePrepareResult {
     taskId: input.taskId,
     sessionId: input.request.sessionId,
     mcpListings: input.mcpListings,
+    features: input.features,
   });
   const toolTokens = estimateToolTokens(tools);
   const { policy } = input;

--- a/src/lifecycle.int.test.ts
+++ b/src/lifecycle.int.test.ts
@@ -11,8 +11,10 @@ import {
   startFakeProviderServer,
 } from "../scripts/fake-provider-server";
 import { appConfig } from "./app-config";
+import { DEFAULT_FEATURE_FLAGS } from "./feature-flags-contract";
 import { runLifecycle } from "./lifecycle";
 import { createRunControl } from "./lifecycle-contract";
+import { phasePrepare } from "./lifecycle-prepare";
 import { PLUGIN_MCP_SCHEMA_ID } from "./plugin-contract";
 import { resetPluginCache } from "./plugin-ops";
 import { createLifecycleDeps, createLifecycleInput, tempDir, writePlugin } from "./test-utils";
@@ -260,6 +262,36 @@ printf '%s\n' "$@" > "${formatLog}"
     );
 
     expect(reply.output).toBe("Yielding to a newer pending message.");
+  });
+
+  test("offers the undo tools only when checkpoints are enabled", async () => {
+    async function toolIdsForFlag(undoCheckpoints: boolean): Promise<string[]> {
+      let offered: string[] = [];
+      const deps = createLifecycleDeps({
+        phasePrepare,
+        phaseGenerate: mock(async (ctx: { tools: Record<string, unknown>; result?: unknown }) => {
+          offered = Object.keys(ctx.tools);
+          ctx.result = { text: "done", toolCalls: [] };
+        }),
+      });
+      await runLifecycle(
+        createLifecycleInput({
+          request: { model: "gpt-5-mini", message: "test", history: [] },
+          workspace,
+          features: { ...DEFAULT_FEATURE_FLAGS, undoCheckpoints },
+        }),
+        deps,
+      );
+      return offered;
+    }
+
+    const withoutUndo = await toolIdsForFlag(false);
+    expect(withoutUndo).not.toContain("listUndo");
+    expect(withoutUndo).not.toContain("restoreUndo");
+
+    const withUndo = await toolIdsForFlag(true);
+    expect(withUndo).toContain("listUndo");
+    expect(withUndo).toContain("restoreUndo");
   });
 
   test("captures undo checkpoint after write tool when enabled", async () => {

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -15,7 +15,7 @@ import { resolveScopeKey } from "./memory-ops";
 import { createTaskActivity } from "./task-activity";
 import { createInMemoryTaskQueue } from "./task-queue";
 import { ensureRealTokenEncoder } from "./token-estimate";
-import { DISCOVERY_TOOL_SET, WRITE_TOOL_SET } from "./tool-registry";
+import { DISCOVERY_TOOL_SET } from "./tool-registry";
 import { scopedCallLog } from "./tool-session";
 import { attachUndoCheckpointSideEffects } from "./undo-checkpoints-effects";
 import { formatWorkspaceCommand, resolveWorkspaceProfile } from "./workspace-profile";
@@ -153,7 +153,7 @@ function createRunContext(
         workspace: ctx.workspace,
         sessionId,
         session,
-        writeToolSet: WRITE_TOOL_SET,
+        writeToolSet: session.writeTools,
       });
     }
   }
@@ -172,7 +172,11 @@ function commitMemory(ctx: RunContext, input: LifecycleInput): void {
     ...ctx.request.history.map((m) => ({ role: m.role, content: m.content })),
     { role: "user", content: ctx.request.message },
   ];
-  const activity = createTaskActivity(scopedCallLog(ctx.session, ctx.taskId), WRITE_TOOL_SET, DISCOVERY_TOOL_SET);
+  const activity = createTaskActivity(
+    scopedCallLog(ctx.session, ctx.taskId),
+    ctx.session.writeTools,
+    DISCOVERY_TOOL_SET,
+  );
   // The commit runs in the background, so the turn can only estimate, and this one is a floor: it
   // covers at most one window and omits the recall candidates the distiller is shown, whose size is
   // known only once the commit runs. Exact accounting needs the real usage carried back from it.
@@ -276,6 +280,7 @@ export async function runLifecycle(input: LifecycleInput, deps: LifecycleDeps = 
     projectRulesPrompt: input.projectRulesPrompt,
     model,
     policy,
+    features: input.features,
     debug,
     onOutput: (event: ToolOutputEvent) => {
       ctxRef?.sideEffectSink?.({ type: "tool-output", ...event });

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -15,7 +15,6 @@ import { resolveScopeKey } from "./memory-ops";
 import { createTaskActivity } from "./task-activity";
 import { createInMemoryTaskQueue } from "./task-queue";
 import { ensureRealTokenEncoder } from "./token-estimate";
-import { DISCOVERY_TOOL_SET } from "./tool-registry";
 import { scopedCallLog } from "./tool-session";
 import { attachUndoCheckpointSideEffects } from "./undo-checkpoints-effects";
 import { formatWorkspaceCommand, resolveWorkspaceProfile } from "./workspace-profile";
@@ -175,7 +174,7 @@ function commitMemory(ctx: RunContext, input: LifecycleInput): void {
   const activity = createTaskActivity(
     scopedCallLog(ctx.session, ctx.taskId),
     ctx.session.writeTools,
-    DISCOVERY_TOOL_SET,
+    ctx.session.discoveryTools,
   );
   // The commit runs in the background, so the turn can only estimate, and this one is a floor: it
   // covers at most one window and omits the recall candidates the distiller is shown, whose size is

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -13,11 +13,11 @@ import type { Client, PendingState, StreamEvent } from "./client-contract";
 import { createErrorStats } from "./error-handling";
 import { DEFAULT_FEATURE_FLAGS } from "./feature-flags-contract";
 import type { LifecycleDeps } from "./lifecycle";
-import type { LifecycleInput, RunContext } from "./lifecycle-contract";
+import type { LifecycleInput, PhasePrepareInput, RunContext } from "./lifecycle-contract";
 import { defaultLifecyclePolicy } from "./lifecycle-policy";
 import { PLUGIN_MANIFEST_SCHEMA_ID } from "./plugin-contract";
 import type { Session, SessionState, SessionTokenUsageEntry } from "./session-contract";
-import type { Toolset } from "./tool-registry";
+import { type Toolset, toolsForAgent } from "./tool-registry";
 import { createSessionContext } from "./tool-session";
 
 export function mockFetch(handler: (...args: Parameters<typeof fetch>) => Promise<Response>): {
@@ -531,8 +531,13 @@ export function createLifecycleDeps(overrides?: Partial<LifecycleDeps>): Lifecyc
       stepTimeoutMs: 1000,
       maxToolCallsPerRequest: 12,
     }),
-    phasePrepare: mock(() => ({
-      session: createSessionContext(),
+    phasePrepare: mock((input: PhasePrepareInput) => ({
+      session: toolsForAgent({
+        workspace: input.workspace,
+        taskId: input.taskId,
+        sessionId: input.request.sessionId,
+        features: input.features,
+      }).session,
       tools: {} as unknown as Toolset,
       baseAgentInput: "BASE_INPUT",
       skillsForPrompt: [],

--- a/src/tool-contract.ts
+++ b/src/tool-contract.ts
@@ -79,6 +79,9 @@ export type SessionContext = {
   maxToolCallsPerRequest?: number;
   budgetNoticeAnnounced?: boolean;
   writeTools: ReadonlySet<string>;
+  readTools: ReadonlySet<string>;
+  searchTools: ReadonlySet<string>;
+  discoveryTools: ReadonlySet<string>;
   toolTimeoutMs?: number;
   featureFlags?: ResolvedFeatureFlags;
   onDebug?: (event: `lifecycle.${string}`, data: Record<string, unknown>) => void;

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { DEFAULT_FEATURE_FLAGS } from "./feature-flags-contract";
 import { ghInstalled } from "./gh-ops";
 import { expectIntent } from "./test-utils";
 import { renderToolOutput } from "./tool-output-render";
@@ -22,12 +23,10 @@ describe("toolsets", () => {
       "gitLog",
       "gitShow",
       "gitStatus",
-      "listUndo",
       "memoryAdd",
       "memoryObserve",
       "memorySearch",
       "readFile",
-      "restoreUndo",
       "runCommand",
       "runTests",
       "scanCode",
@@ -42,6 +41,14 @@ describe("toolsets", () => {
     expect(Object.keys(tools).sort()).toEqual(expected);
     expect(session).toBeDefined();
     expect(session.callLog).toEqual([]);
+    expect(session.writeTools.has("undo-restore")).toBe(false);
+  });
+
+  test("includes undo tools and write classification when undo checkpoints are enabled", () => {
+    const { tools, session } = toolsForAgent({ features: { ...DEFAULT_FEATURE_FLAGS, undoCheckpoints: true } });
+    expect(Object.keys(tools)).toContain("listUndo");
+    expect(Object.keys(tools)).toContain("restoreUndo");
+    expect(session.writeTools.has("undo-restore")).toBe(true);
   });
 });
 
@@ -51,8 +58,8 @@ describe("toolIds", () => {
     expect(ids).toEqual([...ids].sort());
     expect(ids).toContain("file-read");
     expect(ids).toContain("file-edit");
-    expect(ids).toContain("undo-list");
-    expect(ids).toContain("undo-restore");
+    expect(ids).not.toContain("undo-list");
+    expect(ids).not.toContain("undo-restore");
     expect(ids).toContain("shell-run");
     expect(ids).toContain("web-search");
     expect(ids).toContain("git-add");
@@ -69,7 +76,7 @@ describe("toolIdsByCategory", () => {
     expect(ids).toContain("file-delete");
     expect(ids).toContain("git-add");
     expect(ids).toContain("git-commit");
-    expect(ids).toContain("undo-restore");
+    expect(ids).not.toContain("undo-restore");
     expect(ids).not.toContain("tasklist-update");
     expect(ids).not.toContain("file-read");
     expect(ids).not.toContain("shell-run");
@@ -102,8 +109,11 @@ describe("model-facing tool text", () => {
       )?.properties;
       return properties?.[param]?.description ?? "";
     };
-    expectIntent(described("undo-restore", "checkpointId"), [["undo-list"]]);
-    expectIntent(described("undo-restore", "paths"), [["undo-list"]]);
+    const { tools } = toolsForAgent({ features: { ...DEFAULT_FEATURE_FLAGS, undoCheckpoints: true } });
+    const undoRestore = Object.values(tools).find((tool) => tool.id === "undo-restore");
+    const undoProperties = undoRestore?.inputSchema as { properties?: Record<string, { description?: string }> };
+    expectIntent(undoProperties?.properties?.checkpointId?.description ?? "", [["undo-list"]]);
+    expectIntent(undoProperties?.properties?.paths?.description ?? "", [["undo-list"]]);
     expectIntent(described("file-read", "offset"), [["too large to read whole"]]);
   });
 

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -53,7 +53,7 @@ describe("toolsets", () => {
 });
 
 describe("toolIds", () => {
-  test("returns all registered tool ids in sorted order", () => {
+  test("returns the default tool ids in sorted order", () => {
     const ids = toolIds();
     expect(ids).toEqual([...ids].sort());
     expect(ids).toContain("file-read");
@@ -68,7 +68,7 @@ describe("toolIds", () => {
 });
 
 describe("toolIdsByCategory", () => {
-  test("write category returns write tools only", () => {
+  test("write category returns the default write tools only", () => {
     const ids = toolIdsByCategory("write");
     expect(ids).toContain("file-edit");
     expect(ids).toContain("code-edit");
@@ -87,8 +87,9 @@ describe("toolIdsByCategory", () => {
 describe("localization baseline", () => {
   test("tool ids stay language-neutral", () => {
     const toolNamePattern = /^[a-z][a-z0-9]*(?:[-_][a-z0-9]+)*$/;
-    for (const name of Object.keys(toolDefinitionsById)) {
-      expect(name).toMatch(toolNamePattern);
+    const everyTool = toolsForAgent({ features: { ...DEFAULT_FEATURE_FLAGS, undoCheckpoints: true } }).tools;
+    for (const tool of Object.values(everyTool)) {
+      expect(tool.id).toMatch(toolNamePattern);
     }
   });
 

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, test } from "bun:test";
 import { DEFAULT_FEATURE_FLAGS } from "./feature-flags-contract";
 import { ghInstalled } from "./gh-ops";
 import { expectIntent } from "./test-utils";
+import type { ToolDefinition } from "./tool-contract";
 import { renderToolOutput } from "./tool-output-render";
-import { toolDefinitionsById, toolIds, toolIdsByCategory, toolsForAgent } from "./tool-registry";
+import { toolsForAgent } from "./tool-registry";
 
 describe("toolsets", () => {
   test("returns all tools", () => {
@@ -52,9 +53,17 @@ describe("toolsets", () => {
   });
 });
 
+function defaultToolsById(): Record<string, ToolDefinition> {
+  return Object.fromEntries(Object.values(toolsForAgent().tools).map((tool) => [tool.id, tool]));
+}
+
+function defaultToolIds(): string[] {
+  return Object.keys(defaultToolsById()).sort();
+}
+
 describe("toolIds", () => {
   test("returns the default tool ids in sorted order", () => {
-    const ids = toolIds();
+    const ids = defaultToolIds();
     expect(ids).toEqual([...ids].sort());
     expect(ids).toContain("file-read");
     expect(ids).toContain("file-edit");
@@ -67,9 +76,11 @@ describe("toolIds", () => {
   });
 });
 
-describe("toolIdsByCategory", () => {
+describe("write category", () => {
   test("write category returns the default write tools only", () => {
-    const ids = toolIdsByCategory("write");
+    const ids = Object.values(defaultToolsById())
+      .filter((tool) => tool.category === "write")
+      .map((tool) => tool.id);
     expect(ids).toContain("file-edit");
     expect(ids).toContain("code-edit");
     expect(ids).toContain("file-create");
@@ -106,7 +117,7 @@ describe("model-facing tool text", () => {
   test("parameter contracts ship on their own parameters", () => {
     const described = (id: string, param: string): string => {
       const properties = (
-        toolDefinitionsById[id]?.inputSchema as { properties?: Record<string, { description?: string }> }
+        defaultToolsById()[id]?.inputSchema as { properties?: Record<string, { description?: string }> }
       )?.properties;
       return properties?.[param]?.description ?? "";
     };
@@ -121,17 +132,17 @@ describe("model-facing tool text", () => {
   // Whether to commit at all is the user's call, and no other surface carries it: soul.md is
   // silent, and a workspace without an equivalent project rule would lose it entirely.
   test("git-commit states that committing waits for the user", () => {
-    expectIntent(toolDefinitionsById["git-commit"]?.description ?? "", [["only when the user asks"]]);
+    expectIntent(defaultToolsById()["git-commit"]?.description ?? "", [["only when the user asks"]]);
   });
 
   // Vocabulary a tool no longer supports must be gone from the schema surface, not merely
   // de-emphasized, and a tool's trigger ships with its schema rather than in the system prompt.
   test("tool descriptions carry each tool's own contract", () => {
-    const readDescription = toolDefinitionsById["file-read"]?.description ?? "";
+    const readDescription = defaultToolsById()["file-read"]?.description ?? "";
     expect(readDescription).not.toContain("aroundLine");
     expect(readDescription).not.toContain("contextLines");
     expectIntent(readDescription, [["offset"], ["limit"], ["token ceiling"]]);
-    expectIntent(toolDefinitionsById["session-search"]?.description ?? "", [
+    expectIntent(defaultToolsById()["session-search"]?.description ?? "", [
       ["keyword"],
       ["already in context"],
       ["rather than asking the user to repeat"],

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -130,10 +130,10 @@ describe("model-facing tool text", () => {
     expectIntent(described("file-read", "offset"), [["too large to read whole"]]);
   });
 
-  // Whether to commit at all is the user's call, and no other surface carries it: soul.md is
-  // silent, and a workspace without an equivalent project rule would lose it entirely.
-  test("git-commit states that committing waits for the user", () => {
-    expectIntent(defaultToolsById()["git-commit"]?.description ?? "", [["only when the user asks"]]);
+  // A workspace with no project rule on committing would otherwise lose the default entirely:
+  // soul.md is silent, so the fallback ships on the tool itself.
+  test("git-commit defers to the project rule and falls back to asking", () => {
+    expectIntent(defaultToolsById()["git-commit"]?.description ?? "", [["project's rule"], ["when the user asks"]]);
   });
 
   // Vocabulary a tool no longer supports must be gone from the schema surface, not merely

--- a/src/tool-registry.test.ts
+++ b/src/tool-registry.test.ts
@@ -98,7 +98,8 @@ describe("write category", () => {
 describe("localization baseline", () => {
   test("tool ids stay language-neutral", () => {
     const toolNamePattern = /^[a-z][a-z0-9]*(?:[-_][a-z0-9]+)*$/;
-    const everyTool = toolsForAgent({ features: { ...DEFAULT_FEATURE_FLAGS, undoCheckpoints: true } }).tools;
+    const allFlagsOn = Object.fromEntries(Object.keys(DEFAULT_FEATURE_FLAGS).map((flag) => [flag, true]));
+    const everyTool = toolsForAgent({ features: allFlagsOn as typeof DEFAULT_FEATURE_FLAGS }).tools;
     for (const tool of Object.values(everyTool)) {
       expect(tool.id).toMatch(toolNamePattern);
     }

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -163,14 +163,6 @@ export function toolIdsByCategory(category: ToolCategory): string[] {
     .sort();
 }
 
-export const READ_TOOLS: readonly string[] = toolIdsByCategory("read");
-export const SEARCH_TOOLS: readonly string[] = toolIdsByCategory("search");
-export const DISCOVERY_TOOLS: readonly string[] = [...READ_TOOLS, ...SEARCH_TOOLS].sort();
-
-export const READ_TOOL_SET = new Set<string>(READ_TOOLS);
-export const SEARCH_TOOL_SET = new Set<string>(SEARCH_TOOLS);
-export const DISCOVERY_TOOL_SET = new Set<string>(DISCOVERY_TOOLS);
-
 export function toolsForAgent(options?: {
   workspace?: string;
   onOutput?: ToolOutputListener;
@@ -203,11 +195,16 @@ export function toolsForAgent(options?: {
     const nativeIds = new Set(Object.keys(base));
     Object.assign(base, bindMcpTools(options.mcpListings, session, nativeIds, options.sessionId));
   }
-  session.writeTools = new Set(
-    Object.values(base)
-      .filter((tool) => tool.category === "write")
-      .map((tool) => tool.id),
-  );
+  const idsInCategory = (category: ToolCategory): ReadonlySet<string> =>
+    new Set(
+      Object.values(base)
+        .filter((tool) => tool.category === category)
+        .map((tool) => tool.id),
+    );
+  session.writeTools = idsInCategory("write");
+  session.readTools = idsInCategory("read");
+  session.searchTools = idsInCategory("search");
+  session.discoveryTools = new Set([...session.readTools, ...session.searchTools]);
   return {
     tools: base as unknown as Toolset,
     session,

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -136,31 +136,11 @@ function collectTools(
   return combined;
 }
 
-function asToolDefinitionsById(entries: ToolMap): Record<string, ToolDefinition> {
-  const byId: Record<string, ToolDefinition> = {};
+function assertToolsAreIdentified(entries: ToolMap): void {
   for (const tool of Object.values(entries)) {
     invariant(typeof tool.id === "string" && tool.id.trim().length > 0, "tool id is required");
     invariant(typeof tool.category === "string" && tool.category.trim().length > 0, `tool ${tool.id} missing category`);
-    byId[tool.id] = tool;
   }
-  return byId;
-}
-
-export const toolDefinitionsById = asToolDefinitionsById(
-  collectTools(resolve(process.cwd()), createSessionContext(), DEFAULT_FEATURE_FLAGS),
-);
-
-export function toolIds(): string[] {
-  return Object.values(toolDefinitionsById)
-    .map((tool) => tool.id)
-    .sort();
-}
-
-export function toolIdsByCategory(category: ToolCategory): string[] {
-  return Object.values(toolDefinitionsById)
-    .filter((tool) => tool.category === category)
-    .map((tool) => tool.id)
-    .sort();
 }
 
 export function toolsForAgent(options?: {
@@ -195,6 +175,7 @@ export function toolsForAgent(options?: {
     const nativeIds = new Set(Object.keys(base));
     Object.assign(base, bindMcpTools(options.mcpListings, session, nativeIds, options.sessionId));
   }
+  assertToolsAreIdentified(base);
   const idsInCategory = (category: ToolCategory): ReadonlySet<string> =>
     new Set(
       Object.values(base)

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -1,6 +1,8 @@
 import { resolve } from "node:path";
 import { invariant } from "./assert";
 import { createCodeToolkit } from "./code-toolkit";
+import type { ResolvedFeatureFlags } from "./feature-flags-contract";
+import { DEFAULT_FEATURE_FLAGS } from "./feature-flags-contract";
 import { createFileToolkit } from "./file-toolkit";
 import { createGhToolkit } from "./gh-toolkit";
 import { createGitToolkit } from "./git-toolkit";
@@ -46,6 +48,7 @@ export type Toolset = {
 
 export const TOOLKIT_REGISTRY: {
   id: string;
+  featureFlag?: keyof ResolvedFeatureFlags;
   createToolkit: (input: ToolkitInput) => ToolMap;
 }[] = [
   {
@@ -58,6 +61,7 @@ export const TOOLKIT_REGISTRY: {
   },
   {
     id: "undo",
+    featureFlag: "undoCheckpoints",
     createToolkit: (input) => createUndoToolkit(input),
   },
   {
@@ -106,6 +110,7 @@ const noopSkillDeactivated: SkillDeactivatedListener = () => {};
 function collectTools(
   workspace: string,
   session: SessionContext,
+  features: ResolvedFeatureFlags,
   onOutput: ToolOutputListener = noopOutput,
   onTasklist: TasklistListener = noopTasklist,
   onSkillActivated: SkillActivatedListener = noopSkillActivated,
@@ -114,6 +119,7 @@ function collectTools(
 ): ToolMap {
   const combined: ToolMap = {};
   for (const toolkit of TOOLKIT_REGISTRY) {
+    if (toolkit.featureFlag && !features[toolkit.featureFlag]) continue;
     Object.assign(
       combined,
       toolkit.createToolkit({
@@ -140,7 +146,9 @@ function asToolDefinitionsById(entries: ToolMap): Record<string, ToolDefinition>
   return byId;
 }
 
-export const toolDefinitionsById = asToolDefinitionsById(collectTools(resolve(process.cwd()), createSessionContext()));
+export const toolDefinitionsById = asToolDefinitionsById(
+  collectTools(resolve(process.cwd()), createSessionContext(), DEFAULT_FEATURE_FLAGS),
+);
 
 export function toolIds(): string[] {
   return Object.values(toolDefinitionsById)
@@ -155,12 +163,10 @@ export function toolIdsByCategory(category: ToolCategory): string[] {
     .sort();
 }
 
-export const WRITE_TOOLS: readonly string[] = toolIdsByCategory("write");
 export const READ_TOOLS: readonly string[] = toolIdsByCategory("read");
 export const SEARCH_TOOLS: readonly string[] = toolIdsByCategory("search");
 export const DISCOVERY_TOOLS: readonly string[] = [...READ_TOOLS, ...SEARCH_TOOLS].sort();
 
-export const WRITE_TOOL_SET = new Set<string>(WRITE_TOOLS);
 export const READ_TOOL_SET = new Set<string>(READ_TOOLS);
 export const SEARCH_TOOL_SET = new Set<string>(SEARCH_TOOLS);
 export const DISCOVERY_TOOL_SET = new Set<string>(DISCOVERY_TOOLS);
@@ -174,15 +180,19 @@ export function toolsForAgent(options?: {
   taskId?: string;
   sessionId?: string;
   mcpListings?: McpToolListing[];
+  features?: ResolvedFeatureFlags;
 }): {
   tools: Toolset;
   session: SessionContext;
 } {
   const workspace = options?.workspace ?? resolve(process.cwd());
-  const session = createSessionContext(options?.taskId, WRITE_TOOL_SET);
+  const features = options?.features ?? DEFAULT_FEATURE_FLAGS;
+  const session = createSessionContext(options?.taskId);
+  session.featureFlags = features;
   const base = collectTools(
     workspace,
     session,
+    features,
     options?.onOutput,
     options?.onTasklist,
     options?.onSkillActivated,
@@ -193,6 +203,11 @@ export function toolsForAgent(options?: {
     const nativeIds = new Set(Object.keys(base));
     Object.assign(base, bindMcpTools(options.mcpListings, session, nativeIds, options.sessionId));
   }
+  session.writeTools = new Set(
+    Object.values(base)
+      .filter((tool) => tool.category === "write")
+      .map((tool) => tool.id),
+  );
   return {
     tools: base as unknown as Toolset,
     session,

--- a/src/tool-registry.ts
+++ b/src/tool-registry.ts
@@ -143,6 +143,19 @@ function assertToolsAreIdentified(entries: ToolMap): void {
   }
 }
 
+function indexToolCategories(session: SessionContext, entries: ToolMap): void {
+  const idsInCategory = (category: ToolCategory): ReadonlySet<string> =>
+    new Set(
+      Object.values(entries)
+        .filter((tool) => tool.category === category)
+        .map((tool) => tool.id),
+    );
+  session.writeTools = idsInCategory("write");
+  session.readTools = idsInCategory("read");
+  session.searchTools = idsInCategory("search");
+  session.discoveryTools = new Set([...session.readTools, ...session.searchTools]);
+}
+
 export function toolsForAgent(options?: {
   workspace?: string;
   onOutput?: ToolOutputListener;
@@ -176,16 +189,7 @@ export function toolsForAgent(options?: {
     Object.assign(base, bindMcpTools(options.mcpListings, session, nativeIds, options.sessionId));
   }
   assertToolsAreIdentified(base);
-  const idsInCategory = (category: ToolCategory): ReadonlySet<string> =>
-    new Set(
-      Object.values(base)
-        .filter((tool) => tool.category === category)
-        .map((tool) => tool.id),
-    );
-  session.writeTools = idsInCategory("write");
-  session.readTools = idsInCategory("read");
-  session.searchTools = idsInCategory("search");
-  session.discoveryTools = new Set([...session.readTools, ...session.searchTools]);
+  indexToolCategories(session, base);
   return {
     tools: base as unknown as Toolset,
     session,

--- a/src/tool-session.ts
+++ b/src/tool-session.ts
@@ -1,11 +1,11 @@
 import { MAX_TOOL_CALLS_PER_REQUEST, TOOL_TIMEOUT_MS } from "./lifecycle-constants";
 import type { SessionContext, ToolCallRecord, ToolCallStatus } from "./tool-contract";
 
-export function createSessionContext(taskId?: string, writeTools: ReadonlySet<string> = new Set()): SessionContext {
+export function createSessionContext(taskId?: string): SessionContext {
   return {
     callLog: [],
     taskId,
-    writeTools,
+    writeTools: new Set(),
     readTools: new Set(),
     searchTools: new Set(),
     discoveryTools: new Set(),

--- a/src/tool-session.ts
+++ b/src/tool-session.ts
@@ -6,6 +6,9 @@ export function createSessionContext(taskId?: string, writeTools: ReadonlySet<st
     callLog: [],
     taskId,
     writeTools,
+    readTools: new Set(),
+    searchTools: new Set(),
+    discoveryTools: new Set(),
     toolTimeoutMs: TOOL_TIMEOUT_MS,
   };
 }

--- a/src/undo-toolkit.ts
+++ b/src/undo-toolkit.ts
@@ -8,7 +8,7 @@ function createUndoListTool(input: ToolkitInput) {
     id: "undo-list",
     toolkit: "undo",
     category: "meta",
-    description: "List recent undo checkpoints for the current session (if enabled).",
+    description: "List recent undo checkpoints for the current session.",
     inputSchema: z.object({
       limit: z.number().int().min(1).max(50).optional(),
     }),

--- a/src/undo-toolkit.ts
+++ b/src/undo-toolkit.ts
@@ -30,12 +30,12 @@ function createUndoListTool(input: ToolkitInput) {
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "undo-list", toolCallId, toolInput, async () => {
         const sessionId = input.sessionId ?? "";
-        if (!sessionId || !input.session.featureFlags?.undoCheckpoints) {
+        if (!sessionId) {
           return {
             kind: "undo-list" as const,
             sessionId: sessionId || "unknown",
             entries: [],
-            output: "Undo checkpoints disabled.",
+            output: "No session, so no checkpoints were recorded.",
           };
         }
         const entries = await listUndoCheckpoints({
@@ -71,13 +71,13 @@ function createUndoRestoreTool(input: ToolkitInput) {
     execute: async (toolInput, toolCallId) => {
       return runTool(input.session, "undo-restore", toolCallId, toolInput, async () => {
         const sessionId = input.sessionId ?? "";
-        if (!sessionId || !input.session.featureFlags?.undoCheckpoints) {
+        if (!sessionId) {
           return {
             kind: "undo-restore" as const,
             checkpointId: toolInput.checkpointId,
             restored: [],
             conflicts: [],
-            output: "Undo checkpoints disabled.",
+            output: "No session, so no checkpoints were recorded.",
           };
         }
         const result = await restoreUndoCheckpoint({

--- a/src/undo-toolkit.ts
+++ b/src/undo-toolkit.ts
@@ -33,7 +33,7 @@ function createUndoListTool(input: ToolkitInput) {
         if (!sessionId) {
           return {
             kind: "undo-list" as const,
-            sessionId: sessionId || "unknown",
+            sessionId: "unknown",
             entries: [],
             output: "No session, so no checkpoints were recorded.",
           };


### PR DESCRIPTION
## Summary

- register a toolkit only when its feature flag is on, resolved per session instead of at module load
- move the write/read/search/discovery classification onto the session so it reflects the tools actually offered
- `git-commit` now defers to the project's rule on when to commit, falling back to the user's ask when there is none
- drop the undo tools' disabled branch, unreachable once registration is gated
- tool mode honors configured flags instead of defaults