### PR TITLE
fix(git-show): read a file at a ref

### DIFF
--- a/src/git-ops.int.test.ts
+++ b/src/git-ops.int.test.ts
@@ -1,26 +1,81 @@
-import { expect, test } from "bun:test";
+import { afterAll, describe, expect, test } from "bun:test";
 import { mkdtempSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdir, writeFile } from "node:fs/promises";
+import { devNull, tmpdir } from "node:os";
 import { join } from "node:path";
 import { TOOL_ERROR_CODES } from "./error-contract";
+import { gitShow } from "./git-ops";
+import { gitEnv, tempDir } from "./test-utils";
+import { runCommand } from "./tool-utils";
 
-// The resolved version is memoized per process and the suite shares one, so any earlier git call
-// would satisfy this. A child process with an empty PATH is the only way to reach the cold path.
-test("names git as the missing prerequisite when it is not on PATH", async () => {
-  const script = `
-    const { requireGitVersion } = await import(${JSON.stringify(join(import.meta.dir, "git-ops.ts"))});
-    const failure = await requireGitVersion().catch((error) => error);
-    console.log(JSON.stringify({ code: failure.code, message: failure.message }));
-  `;
-  const child = Bun.spawn({
-    cmd: [process.execPath, "-e", script],
-    env: { ...process.env, PATH: mkdtempSync(join(tmpdir(), "acolyte-nogit-")) },
-    stdout: "pipe",
-    stderr: "pipe",
+const dirs = tempDir();
+const ISOLATED_GIT_CONFIG = { GIT_CONFIG_GLOBAL: devNull, GIT_CONFIG_SYSTEM: devNull };
+
+afterAll(() => {
+  dirs.cleanupDirs();
+});
+
+async function runGit(cwd: string, args: string[]): Promise<string> {
+  const { code, stdout, stderr } = await runCommand(["git", ...args], cwd, ISOLATED_GIT_CONFIG);
+  if (code !== 0) throw new Error(stderr.trim() || stdout.trim() || `git ${args.join(" ")} failed`);
+  return stdout.trim();
+}
+
+async function createTempRepo(prefix: string): Promise<string> {
+  const dirPath = dirs.createDir(prefix);
+  await runGit(dirPath, ["init", "-b", "main"]);
+  await runGit(dirPath, ["config", "user.email", "test@example.com"]);
+  await runGit(dirPath, ["config", "user.name", "Test"]);
+  return dirPath;
+}
+
+describe("requireGitVersion", () => {
+  // The resolved version is memoized per process and the suite shares one, so any earlier git call
+  // would satisfy this. A child process with an empty PATH is the only way to reach the cold path.
+  test("names git as the missing prerequisite when it is not on PATH", async () => {
+    const script = `
+      const { requireGitVersion } = await import(${JSON.stringify(join(import.meta.dir, "git-ops.ts"))});
+      const failure = await requireGitVersion().catch((error) => error);
+      console.log(JSON.stringify({ code: failure.code, message: failure.message }));
+    `;
+    const child = Bun.spawn({
+      cmd: [process.execPath, "-e", script],
+      env: gitEnv({ PATH: mkdtempSync(join(tmpdir(), "acolyte-nogit-")) }),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout] = await Promise.all([new Response(child.stdout).text(), child.exited]);
+    const failure = JSON.parse(stdout.trim());
+
+    expect(failure.code).toBe(TOOL_ERROR_CODES.gitUnavailable);
+    expect(failure.message).toContain("2.14");
   });
-  const [stdout] = await Promise.all([new Response(child.stdout).text(), child.exited]);
-  const failure = JSON.parse(stdout.trim());
+});
 
-  expect(failure.code).toBe(TOOL_ERROR_CODES.gitUnavailable);
-  expect(failure.message).toContain("2.14");
+describe("gitShow", () => {
+  test("reads file contents at a ref when the commit did not touch the path", async () => {
+    const dirPath = await createTempRepo("acolyte-gitshow-blob-");
+    await writeFile(join(dirPath, "tracked.txt"), "first version\n", "utf8");
+    await runGit(dirPath, ["add", "tracked.txt"]);
+    await runGit(dirPath, ["commit", "-m", "add tracked"]);
+    await writeFile(join(dirPath, "other.txt"), "unrelated\n", "utf8");
+    await runGit(dirPath, ["add", "other.txt"]);
+    await runGit(dirPath, ["commit", "-m", "touch other"]);
+
+    const output = await gitShow(dirPath, { ref: "HEAD", path: "tracked.txt" }, ISOLATED_GIT_CONFIG);
+
+    expect(output).toBe("first version");
+  });
+
+  test("reads file contents at a ref relative to a subdirectory workspace", async () => {
+    const dirPath = await createTempRepo("acolyte-gitshow-subdir-");
+    await mkdir(join(dirPath, "src"));
+    await writeFile(join(dirPath, "src", "tracked.txt"), "nested version\n", "utf8");
+    await runGit(dirPath, ["add", "src/tracked.txt"]);
+    await runGit(dirPath, ["commit", "-m", "add nested"]);
+
+    const output = await gitShow(join(dirPath, "src"), { ref: "HEAD", path: "tracked.txt" }, ISOLATED_GIT_CONFIG);
+
+    expect(output).toBe("nested version");
+  });
 });

--- a/src/git-ops.int.test.ts
+++ b/src/git-ops.int.test.ts
@@ -78,4 +78,17 @@ describe("gitShow", () => {
 
     expect(output).toBe("nested version");
   });
+
+  test("reads file contents at a ref after the file was deleted from the working tree", async () => {
+    const dirPath = await createTempRepo("acolyte-gitshow-deleted-");
+    await writeFile(join(dirPath, "gone.txt"), "old wording\n", "utf8");
+    await runGit(dirPath, ["add", "gone.txt"]);
+    await runGit(dirPath, ["commit", "-m", "add gone"]);
+    await runGit(dirPath, ["rm", "gone.txt"]);
+    await runGit(dirPath, ["commit", "-m", "remove gone"]);
+
+    const output = await gitShow(dirPath, { ref: "HEAD~1", path: "gone.txt" }, ISOLATED_GIT_CONFIG);
+
+    expect(output).toBe("old wording");
+  });
 });

--- a/src/git-ops.ts
+++ b/src/git-ops.ts
@@ -1,3 +1,5 @@
+import { existsSync, realpathSync } from "node:fs";
+import { basename, dirname, join, relative } from "node:path";
 import { ERROR_KINDS, TOOL_ERROR_CODES } from "./error-contract";
 import { createToolError } from "./tool-error";
 import { runCommand } from "./tool-utils";
@@ -19,6 +21,18 @@ export function hermeticGitEnv(overrides?: Record<string, string>): Record<strin
 }
 
 let gitVersion: string | null = null;
+
+function canonicalPathForGit(pathInput: string): string {
+  const missingSegments: string[] = [];
+  let current = pathInput;
+  while (!existsSync(current)) {
+    missingSegments.unshift(basename(current));
+    const parent = dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return join(realpathSync(current), ...missingSegments);
+}
 
 function gitUnavailable(message: string) {
   return createToolError(TOOL_ERROR_CODES.gitUnavailable, message, ERROR_KINDS.gitUnavailable);
@@ -86,10 +100,13 @@ export async function gitShow(
 ): Promise<string> {
   const contextLines = Math.max(0, Math.min(20, options?.contextLines ?? 3));
   const ref = options?.ref?.trim() ? options.ref.trim() : "HEAD";
-  const args = ["git", "show", "--no-color", `--unified=${contextLines}`, ref];
+  let args = ["git", "show", "--no-color", `--unified=${contextLines}`, ref];
   if (options?.path) {
-    ensurePathWithinSandbox(options.path, workspace);
-    args.push("--", options.path);
+    const absolutePath = ensurePathWithinSandbox(options.path, workspace);
+    const topLevel = await runCommand(["git", "rev-parse", "--show-toplevel"], workspace, envOverride);
+    if (topLevel.code !== 0) throw new Error(topLevel.stderr.trim() || "git rev-parse failed");
+    const repoPath = relative(canonicalPathForGit(topLevel.stdout.trim()), canonicalPathForGit(absolutePath));
+    args = ["git", "show", "--no-color", `${ref}:${repoPath}`];
   }
   const { code, stdout, stderr } = await runCommand(args, workspace, envOverride);
   if (code !== 0) throw new Error(stderr.trim() || "git show failed");

--- a/src/git-ops.ts
+++ b/src/git-ops.ts
@@ -22,6 +22,10 @@ export function hermeticGitEnv(overrides?: Record<string, string>): Record<strin
 
 let gitVersion: string | null = null;
 
+// Git compares its own realpath'd top level against the path it is handed, so an alias such as
+// macOS `/var` -> `/private/var` reads as a path outside the repository. Resolving both sides the
+// same way keeps a temp-directory workspace inside its own repo, and the segments that do not exist
+// on disk are carried through so a file deleted since the ref still resolves.
 function canonicalPathForGit(pathInput: string): string {
   const missingSegments: string[] = [];
   let current = pathInput;
@@ -93,21 +97,30 @@ export async function gitLog(
   return stdout.trim();
 }
 
+async function gitShowArgs(
+  workspace: string,
+  ref: string,
+  options?: { path?: string; contextLines?: number },
+  envOverride?: Record<string, string>,
+): Promise<string[]> {
+  if (!options?.path) {
+    const contextLines = Math.max(0, Math.min(20, options?.contextLines ?? 3));
+    return ["git", "show", "--no-color", `--unified=${contextLines}`, ref];
+  }
+  const absolutePath = ensurePathWithinSandbox(options.path, workspace);
+  const topLevel = await runCommand(["git", "rev-parse", "--show-toplevel"], workspace, envOverride);
+  if (topLevel.code !== 0) throw new Error(topLevel.stderr.trim() || "git rev-parse failed");
+  const repoPath = relative(canonicalPathForGit(topLevel.stdout.trim()), canonicalPathForGit(absolutePath));
+  return ["git", "show", "--no-color", `${ref}:${repoPath}`];
+}
+
 export async function gitShow(
   workspace: string,
   options?: { ref?: string; path?: string; contextLines?: number },
   envOverride?: Record<string, string>,
 ): Promise<string> {
-  const contextLines = Math.max(0, Math.min(20, options?.contextLines ?? 3));
   const ref = options?.ref?.trim() ? options.ref.trim() : "HEAD";
-  let args = ["git", "show", "--no-color", `--unified=${contextLines}`, ref];
-  if (options?.path) {
-    const absolutePath = ensurePathWithinSandbox(options.path, workspace);
-    const topLevel = await runCommand(["git", "rev-parse", "--show-toplevel"], workspace, envOverride);
-    if (topLevel.code !== 0) throw new Error(topLevel.stderr.trim() || "git rev-parse failed");
-    const repoPath = relative(canonicalPathForGit(topLevel.stdout.trim()), canonicalPathForGit(absolutePath));
-    args = ["git", "show", "--no-color", `${ref}:${repoPath}`];
-  }
+  const args = await gitShowArgs(workspace, ref, options, envOverride);
   const { code, stdout, stderr } = await runCommand(args, workspace, envOverride);
   if (code !== 0) throw new Error(stderr.trim() || "git show failed");
   return stdout.trim();

--- a/src/git-toolkit.ts
+++ b/src/git-toolkit.ts
@@ -195,7 +195,8 @@ function createGitShowTool(git: GitOps, input: ToolkitInput) {
     id: "git-show",
     toolkit: "git",
     category: "search",
-    description: "Show commit details and patch for a ref (default HEAD), optionally scoped to a path.",
+    description:
+      "Show commit details and patch for a ref (default HEAD). With a path, read that file's contents as of the ref, whether or not the commit touched it. `git-diff` covers a diff restricted to a path.",
     outputSchema: z.object({
       kind: z.literal("git-show"),
       ref: z.string().optional(),


### PR DESCRIPTION
## Summary

- a path reads that file's contents as of the ref, through `git show <ref>:<path>`
- a path missing at the ref fails instead of returning empty
- `git-diff` stays the way to get a diff restricted to a path
- the tool description states the contract the implementation follows
