### PR TITLE
fix(config): set feature flags from the cli

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -62,13 +62,14 @@ acolyte memory restore <id>...
 
 ## Config commands
 
-Read and write runtime configuration at user or project level.
+Read and write runtime configuration at user or project level. Nested config uses dotted keys, such as `features.mcp`.
 
 ```bash
 acolyte config list [--project]
 acolyte config list --json
 acolyte config set <key> <value>
 acolyte config set --project <key> <value>
+acolyte config set --project features.mcp true
 acolyte config unset <key>
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -135,6 +135,12 @@ Connect Acolyte to external services (Figma, Jira, Notion, Chrome DevTools, etc.
 
 MCP is disabled by default. Enable it explicitly with:
 
+```bash
+acolyte config set --project features.mcp true
+```
+
+The equivalent TOML is:
+
 ```toml
 [features]
 mcp = true
@@ -152,7 +158,7 @@ Installed plugins contribute servers too, namespaced by plugin name and requirin
 
 ## Feature flags
 
-Feature flags are opt-in toggles for experimental behavior, configured under `[features]` in `config.toml`.
+Feature flags are opt-in toggles for experimental behavior, configured under `[features]` in `config.toml` and set from the CLI with dotted keys.
 
 Enable via TOML:
 

--- a/src/cli-visual.int.test.ts
+++ b/src/cli-visual.int.test.ts
@@ -269,6 +269,25 @@ describe("cli visual regression", () => {
     });
   });
 
+  test("config set accepts dotted MCP feature flag keys", async () => {
+    await withCliTestEnv(async ({ run }) => {
+      const saved = await run(["config", "set", "--project", "features.mcp", "true"]);
+      expect(saved).toBe(
+        dedent(`
+        Saved config features.mcp (project).
+      `),
+      );
+
+      const listedProject = await run(["config", "list", "--project"]);
+      expect(listedProject).toBe(
+        dedent(`
+        scope:         project
+        features.mcp:  true
+      `),
+      );
+    });
+  });
+
   test("status shows formatted fields on success", async () => {
     await withDualTransportChatServer(async (baseUrl) => {
       await withCliTestEnv(async ({ run }) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -146,11 +146,10 @@ function serializeToml(config: Config): string {
   if (config.features && Object.keys(config.features).length > 0) {
     lines.push("");
     lines.push("[features]");
-    if (typeof config.features.syncAgents === "boolean") lines.push(`syncAgents = ${config.features.syncAgents}`);
-    if (typeof config.features.undoCheckpoints === "boolean")
-      lines.push(`undoCheckpoints = ${config.features.undoCheckpoints}`);
-    if (typeof config.features.workspaces === "boolean") lines.push(`workspaces = ${config.features.workspaces}`);
-    if (typeof config.features.cloudSync === "boolean") lines.push(`cloudSync = ${config.features.cloudSync}`);
+    for (const key of Object.keys(featureFlagsSchema.shape)) {
+      const value = config.features[key as keyof typeof config.features];
+      if (typeof value === "boolean") lines.push(`${key} = ${value}`);
+    }
   }
   return `${lines.join("\n")}${lines.length > 0 ? "\n" : ""}`;
 }
@@ -231,7 +230,7 @@ export async function writeConfig(config: Config, options?: ConfigOptions): Prom
 }
 
 const RECORD_VALID_KEYS: Partial<Record<keyof Config, Set<string>>> = {
-  features: new Set(["syncAgents", "undoCheckpoints", "workspaces", "cloudSync"]),
+  features: new Set(Object.keys(featureFlagsSchema.shape)),
 };
 
 function parseDottedKey(key: string): { section: keyof Config; subKey: string } | null {


### PR DESCRIPTION
## Summary

- derive the settable `features.*` keys and the TOML serializer from `featureFlagsSchema`, so `mcp` and `plugins` are no longer silently missing from both
- document the dotted-key form in the CLI reference and the MCP setup steps